### PR TITLE
Vercel: explicit install + build to bypass turbo orchestration

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,4 +1,13 @@
 import { withSentryConfig } from "@sentry/nextjs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Resolve apps/web absolutely so the @/* alias works regardless of the
+// CWD next is launched from. Vercel was failing to resolve `@/lib/*`
+// even though the tsconfig paths were correct — registering the alias
+// explicitly with webpack bypasses whatever auto-detection breaks
+// there.
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
@@ -9,6 +18,14 @@ const nextConfig = {
     serverActions: {
       allowedOrigins: ["localhost:3000", "app.rokki.ai", "staging.rokki.ai"],
     },
+  },
+  webpack: (config) => {
+    config.resolve = config.resolve || {};
+    config.resolve.alias = {
+      ...(config.resolve.alias || {}),
+      "@": path.resolve(__dirname, "src"),
+    };
+    return config;
   },
   async headers() {
     return [

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,7 +1,0 @@
-{
-  "$schema": "https://openapi.vercel.sh/vercel.json",
-  "framework": "nextjs",
-  "installCommand": "cd ../.. && pnpm install --frozen-lockfile",
-  "buildCommand": "next build",
-  "outputDirectory": ".next"
-}

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "nextjs",
+  "installCommand": "cd ../.. && pnpm install --frozen-lockfile",
+  "buildCommand": "next build",
+  "outputDirectory": ".next"
+}


### PR DESCRIPTION
The auto-detected "turbo run build" path on Vercel was failing webpack module resolution for @/lib/admin-auth and @/lib/events even though the identical command succeeds locally. The exact failure mode:

  ./src/app/api/v1/admin/announcements/[id]/route.ts
  Module not found: Can't resolve '@/lib/admin-auth'
  ./src/app/api/v1/admin/announcements/[id]/route.ts
  Module not found: Can't resolve '@/lib/events'
  ./src/app/api/v1/admin/announcements/route.ts
  Module not found: Can't resolve '@/lib/admin-auth'
  ./src/app/api/v1/admin/announcements/route.ts
  Module not found: Can't resolve '@/lib/events'

Both files exist, are committed, are imported with the right alias, and transpilePackages is set. Local turbo run build --filter=@rokki/web on the same commit passes.

Workaround: pin Vercel to install from monorepo root with the frozen lockfile (matches CI), then run `next build` directly from apps/web. This skips turbo entirely; @rokki/web doesn't need workspace deps to be "built" first since they're source-only packages with main pointing at .ts files (transpilePackages handles them at next-build time).