### PR TITLE
auth: close self-signup, password-only login (admin-provisioned accou…

### DIFF
--- a/apps/web/src/app/api/v1/auth/send-link/route.ts
+++ b/apps/web/src/app/api/v1/auth/send-link/route.ts
@@ -1,121 +1,31 @@
 import { NextResponse, type NextRequest } from "next/server";
-import { createClient as createAdminClient } from "@supabase/supabase-js";
-import type { Database } from "@rokki/db";
-import { rateLimitCheck, rateLimitToken } from "@/lib/ratelimit";
-import { logEvent, withObservability } from "@/lib/observability";
+import { withObservability } from "@/lib/observability";
 
 /**
- * POST /api/v1/auth/send-link  { email, redirect_to? }
+ * POST /api/v1/auth/send-link
  *
- * Rate-limited magic-link sender. Caps at 5 attempts per minute per
- * (IP, email) pair — tight enough to stop scripted abuse, loose enough
- * that a real user hitting "resend" a couple times works.
+ * Disabled. Rokki is a closed system — accounts are provisioned by
+ * platform admins only. Magic-link self-service was removed; password
+ * login (POST /api/v1/auth/password-login) is the only authentication
+ * path for end users.
  *
- * Errors are deliberately vague on non-existent accounts: we don't leak
- * whether an email is registered. Supabase itself won't create a user
- * from `signInWithOtp` unless `shouldCreateUser` is true — which we leave
- * at the Supabase default (true).
- *
- * Wrapped in withObservability so the request lifecycle (status, latency)
- * is logged to Axiom and any thrown exception traces to Sentry. Rate-limit
- * trips emit their own structured event for abuse-pattern detection.
+ * Returning 410 Gone (rather than 404) so any old client code that
+ * still calls this endpoint sees a clear "this is intentionally
+ * removed" signal instead of a generic not-found.
  */
-async function handler(request: NextRequest) {
-  const body = (await request.json().catch(() => ({}))) as {
-    email?: string;
-    redirect_to?: string;
-  };
-
-  const email = body.email?.trim().toLowerCase();
-  if (!email || !/^\S+@\S+\.\S+$/.test(email)) {
-    return NextResponse.json(
-      { errors: [{ code: "invalid_request", message: "Valid email required" }] },
-      { status: 400 },
-    );
-  }
-
-  // Two windows: 5/min per IP+email, 30/hour per IP (catches mass abuse).
-  const emailBucket = rateLimitToken(request, email);
-  const ipBucket = rateLimitToken(request);
-
-  const [perEmail, perIp] = await Promise.all([
-    rateLimitCheck({
-      bucket: "magic_link_email",
-      token: emailBucket,
-      max: 5,
-      windowSeconds: 60,
-    }),
-    rateLimitCheck({
-      bucket: "magic_link_ip",
-      token: ipBucket,
-      max: 30,
-      windowSeconds: 3600,
-    }),
-  ]);
-
-  if (!perEmail.ok || !perIp.ok) {
-    const retry = Math.max(perEmail.retryAfterSeconds, perIp.retryAfterSeconds);
-    logEvent("warn", "auth.send_link.rate_limited", {
-      email_hash: emailBucket, // already hashed by rateLimitToken
-      bucket: !perEmail.ok ? "email" : "ip",
-      retry_after_s: retry,
-    });
-    return NextResponse.json(
-      {
-        errors: [
-          {
-            code: "rate_limited",
-            message: `Too many sign-in attempts. Try again in ${retry} seconds.`,
-          },
-        ],
-      },
-      {
-        status: 429,
-        headers: { "Retry-After": String(retry) },
-      },
-    );
-  }
-
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
-  if (!url || !anonKey) {
-    return NextResponse.json(
-      { errors: [{ code: "config_error", message: "Auth is not configured." }] },
-      { status: 500 },
-    );
-  }
-
-  // Use the anon client for signInWithOtp — Supabase needs the anon key path
-  // because it doesn't expose this as an admin API. Still server-side.
-  const client = createAdminClient<Database>(url, anonKey, {
-    auth: { autoRefreshToken: false, persistSession: false },
-  });
-
-  const origin = request.headers.get("origin") ?? process.env.NEXT_PUBLIC_APP_URL;
-  const redirectTo = body.redirect_to ?? "/";
-  const emailRedirectTo = `${origin}/auth/callback?redirect_to=${encodeURIComponent(redirectTo)}`;
-
-  const { error } = await client.auth.signInWithOtp({
-    email,
-    options: { emailRedirectTo },
-  });
-
-  if (error) {
-    // Don't surface Supabase's message unfiltered (can leak schema detail).
-    return NextResponse.json(
-      {
-        errors: [
-          {
-            code: "send_failed",
-            message: "Could not send sign-in link. Please try again.",
-          },
-        ],
-      },
-      { status: 502 },
-    );
-  }
-
-  return NextResponse.json({ data: { sent: true } });
+async function handler(_request: NextRequest) {
+  return NextResponse.json(
+    {
+      errors: [
+        {
+          code: "endpoint_removed",
+          message:
+            "Magic-link sign-in has been disabled. Contact your administrator for an account.",
+        },
+      ],
+    },
+    { status: 410 },
+  );
 }
 
 export const POST = withObservability(handler, "POST /api/v1/auth/send-link");

--- a/apps/web/src/app/login/LoginForm.tsx
+++ b/apps/web/src/app/login/LoginForm.tsx
@@ -6,20 +6,18 @@ import { Button } from "@/components/ui/Button";
 import { Input } from "@/components/ui/Input";
 
 /**
- * Login form. Handles two flows side-by-side:
+ * Login form. Closed system — accounts are created by platform admins
+ * only. There is no self-signup, no magic-link path, no "request access"
+ * affordance. The only way in is with credentials an admin already
+ * provisioned for you.
  *
- *   1. Email magic link — the primary flow for everyday users. Types a
- *      valid email, we POST /api/v1/auth/send-link, they click the
- *      link in Mailpit / their inbox.
+ * Identifier is either:
+ *   - An email (admin@rokki.local, you@example.com, …)
+ *   - A short allow-listed username (e.g. `admin`) the password-login
+ *     endpoint maps to a pseudo-email.
  *
- *   2. Username + password — a narrow backdoor for operators (today:
- *      `admin`). Typed as a bare word (no `@`), we reveal a password
- *      field and POST /api/v1/auth/password-login. Rate-limited
- *      tighter than the magic-link path.
- *
- * We detect which flow by whether the identifier contains `@`. That's
- * crude but it matches user intuition — nobody types their admin
- * username with an @ in it.
+ * Both paths POST to /api/v1/auth/password-login. The endpoint
+ * disambiguates by which field is present (email vs username).
  */
 export function LoginForm() {
   const router = useRouter();
@@ -29,71 +27,42 @@ export function LoginForm() {
 
   const [identifier, setIdentifier] = useState("");
   const [password, setPassword] = useState("");
-  const [state, setState] = useState<
-    "idle" | "sending" | "sent" | "error"
-  >(callbackError ? "error" : "idle");
+  const [state, setState] = useState<"idle" | "sending" | "error">(
+    callbackError ? "error" : "idle",
+  );
   const [errorMessage, setErrorMessage] = useState(
     callbackError ? humanizeAuthError(callbackError) : "",
   );
 
-  const isEmail = identifier.includes("@");
-  const showPassword = identifier.trim().length > 0 && !isEmail;
-
   async function onSubmit(e: React.FormEvent) {
     e.preventDefault();
     const id = identifier.trim();
-    if (!id) return;
+    if (!id || !password) return;
 
     setState("sending");
     setErrorMessage("");
 
-    if (showPassword) {
-      // Username + password path.
-      const r = await fetch("/api/v1/auth/password-login", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ username: id, password }),
-      });
-      if (!r.ok) {
-        setState("error");
-        setErrorMessage(await messageOf(r));
-        return;
-      }
-      // Session cookie is set on the response. Push to the intended
-      // destination and let the server components pick up the session.
-      router.replace(redirectTo);
-      router.refresh();
-      return;
-    }
+    // If the identifier looks like an email, send it as `email`; otherwise
+    // pass it as `username` and let the server map it via its allow-list.
+    const isEmail = id.includes("@");
+    const body = isEmail
+      ? { email: id, password }
+      : { username: id, password };
 
-    // Magic link path.
-    const r = await fetch("/api/v1/auth/send-link", {
+    const r = await fetch("/api/v1/auth/password-login", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ email: id, redirect_to: redirectTo }),
+      body: JSON.stringify(body),
     });
-
     if (!r.ok) {
       setState("error");
       setErrorMessage(await messageOf(r));
       return;
     }
-    setState("sent");
-  }
-
-  if (state === "sent") {
-    return (
-      <div className="rounded border border-border bg-bg-1 p-4 text-center">
-        <p className="text-sm text-text-0">Check your email.</p>
-        <p className="mt-1 text-xs text-text-2">
-          We sent a sign-in link to{" "}
-          <span className="font-mono text-text-1">{identifier}</span>.
-        </p>
-        <p className="mt-3 text-xs text-text-3">
-          The link expires in 15 minutes and can only be used once.
-        </p>
-      </div>
-    );
+    // Session cookie is set on the response. Push to the intended
+    // destination and let the server components pick up the session.
+    router.replace(redirectTo);
+    router.refresh();
   }
 
   return (
@@ -107,21 +76,18 @@ export function LoginForm() {
         label="Email or username"
         value={identifier}
         onChange={(e) => setIdentifier(e.target.value)}
-        error={!showPassword && state === "error" ? errorMessage : undefined}
       />
-      {showPassword ? (
-        <Input
-          name="password"
-          type="password"
-          autoComplete="current-password"
-          required
-          placeholder="••••••••"
-          label="Password"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-          error={state === "error" ? errorMessage : undefined}
-        />
-      ) : null}
+      <Input
+        name="password"
+        type="password"
+        autoComplete="current-password"
+        required
+        placeholder="••••••••"
+        label="Password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        error={state === "error" ? errorMessage : undefined}
+      />
       <Button
         type="submit"
         variant="accent"
@@ -129,8 +95,11 @@ export function LoginForm() {
         className="w-full"
         loading={state === "sending"}
       >
-        {showPassword ? "Sign in" : "Send sign-in link"}
+        Sign in
       </Button>
+      <p className="pt-1 text-center text-[11px] text-text-3">
+        Accounts are provisioned by your administrator. No self-signup.
+      </p>
     </form>
   );
 }
@@ -147,7 +116,7 @@ async function messageOf(r: Response): Promise<string> {
 function humanizeAuthError(raw: string): string {
   const lower = raw.toLowerCase();
   if (lower.includes("expired") || lower.includes("invalid")) {
-    return "That sign-in link is expired or has already been used. Request a fresh one.";
+    return "That sign-in link is expired or has already been used. Ask your administrator to issue a new one.";
   }
   if (lower.includes("rate") || lower.includes("too many")) {
     return "Too many attempts. Wait a minute and try again.";

--- a/apps/web/tests/e2e/smoke.spec.ts
+++ b/apps/web/tests/e2e/smoke.spec.ts
@@ -1,8 +1,12 @@
 import { test, expect } from "@playwright/test";
 
 /**
- * Smoke: the login page renders, has an email input, and accepts input.
- * No actual Supabase round-trip — that's in `acceptance.spec.ts`.
+ * Smoke: the login page renders, has an email/username + password input,
+ * and accepts input. No actual Supabase round-trip — that's in
+ * `acceptance.spec.ts`.
+ *
+ * Magic-link sign-in was removed (closed system, admins provision
+ * accounts). The form is now password-only.
  */
 
 test.describe("public pages", () => {
@@ -14,8 +18,9 @@ test.describe("public pages", () => {
     await expect(
       page.getByRole("textbox", { name: /email or username/i }),
     ).toBeVisible();
+    await expect(page.getByLabel(/password/i)).toBeVisible();
     await expect(
-      page.getByRole("button", { name: /send sign-in link/i }),
+      page.getByRole("button", { name: /^sign in$/i }),
     ).toBeVisible();
   });
 
@@ -36,17 +41,31 @@ test.describe("public pages", () => {
     await expect(page.getByRole("dialog")).not.toBeVisible();
   });
 
-  test("rate limit responds 429 after 6 rapid requests", async ({ request }) => {
+  test("send-link endpoint returns 410 Gone (magic-link removed)", async ({
+    request,
+  }) => {
+    // The endpoint was deliberately disabled (closed-system policy).
+    // Anything other than 410 means the disabling regressed.
+    const r = await request.post("/api/v1/auth/send-link", {
+      data: { email: `e2e-${Date.now()}@example.com` },
+    });
+    expect(r.status()).toBe(410);
+  });
+
+  test("password-login rate-limits after 11 rapid requests", async ({
+    request,
+  }) => {
+    // Same shape as the old send-link rate-limit test, just pointed at
+    // the password-login endpoint that's now the only auth path.
+    // 10/10min per (IP, email) — the 11th must 429.
     const email = `e2e-rate-${Date.now()}@example.com`;
-    const url = "/api/v1/auth/send-link";
-    // Burst past the 5/min cap for a fresh email.
     const codes: number[] = [];
-    for (let i = 0; i < 7; i++) {
-      const r = await request.post(url, { data: { email } });
+    for (let i = 0; i < 12; i++) {
+      const r = await request.post("/api/v1/auth/password-login", {
+        data: { email, password: "wrong-on-purpose" },
+      });
       codes.push(r.status());
     }
-    // At least one of those should be 429; earlier successful ones can be
-    // 200 or 502 (if SMTP isn't wired in test), but one must be rate-limited.
     expect(codes).toContain(429);
   });
 });


### PR DESCRIPTION
…nts)

Rokki is now a closed system — accounts are created by platform admins only. There is no self-signup, no magic-link path, and no "request access" affordance from the login page.

Changes:

- LoginForm.tsx: removed the magic-link branch entirely. The form now shows email/username + password side-by-side at all times. On submit it always POSTs to /api/v1/auth/password-login, picking the email vs username field based on whether the identifier contains "@". Adds a small "Accounts are provisioned by your administrator" footnote.

- /api/v1/auth/send-link/route.ts: rewritten to return HTTP 410 Gone with a clear "endpoint_removed" error code. Kept the route file (vs deleting) so old client code gets a deliberate "this is intentionally removed" signal instead of a generic 404, and so the next-route manifest stays stable.

- smoke.spec.ts: updated to assert the new login UI (password field + "Sign in" button), added a 410 assertion on send-link, and replaced the magic-link rate-limit test with the equivalent against password-login (10/10min per IP+email).

Operational follow-up (NOT in this commit, has to be done in Supabase dashboard): turn OFF "Allow new users to sign up" in Settings → Authentication → User Signups. That's the actual hardening — this PR removes the UI, but Supabase's signup endpoint stays open unless that toggle is flipped.