### PR TITLE
admin: hide back-link on overview, fix activity-count table mismatch

### DIFF
--- a/apps/web/src/app/admin/AdminBackLink.tsx
+++ b/apps/web/src/app/admin/AdminBackLink.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+/**
+ * "← Dashboard" link in the admin TopBar. Hidden when the user is
+ * already on the admin overview (/admin) since "back to dashboard" is
+ * meaningless when you're at the root of admin.
+ *
+ * Pathname check is also strictly less-than-or-equal — anywhere deeper
+ * than /admin (like /admin/users), the link is useful again.
+ */
+export function AdminBackLink() {
+  const pathname = usePathname();
+  if (pathname === "/admin") return null;
+  return (
+    <Link href="/admin" className="text-text-3 hover:text-text-1">
+      ← Admin overview
+    </Link>
+  );
+}

--- a/apps/web/src/app/admin/layout.tsx
+++ b/apps/web/src/app/admin/layout.tsx
@@ -26,6 +26,7 @@ import {
 } from "lucide-react";
 import { createClient } from "@/lib/supabase/server";
 import { TopBar } from "@/components/TopBar";
+import { AdminBackLink } from "./AdminBackLink";
 
 /**
  * Platform admin shell.
@@ -60,10 +61,7 @@ export default async function AdminLayout({
   return (
     <div className="flex min-h-screen flex-col bg-bg-0">
       <TopBar>
-        <Link href="/" className="text-text-3 hover:text-text-1">
-          ← Dashboard
-        </Link>
-        <span className="text-text-3">·</span>
+        <AdminBackLink />
         <span className="font-mono text-xs uppercase tracking-wider text-accent">
           Platform admin
         </span>

--- a/apps/web/src/app/admin/page.tsx
+++ b/apps/web/src/app/admin/page.tsx
@@ -85,10 +85,14 @@ export default async function AdminOverviewPage() {
       .select("id", { count: "exact", head: true })
       .eq("virus_scan_status", "infected")
       .is("deleted_at", null),
+    // Count from `activity` (the table the /admin/activity page reads
+    // from), NOT `domain_events`. Counting domain_events here while the
+    // page reads activity meant the stat could say "4 events" while the
+    // page below it sat empty.
     admin
-      .from("domain_events")
+      .from("activity")
       .select("id", { count: "exact", head: true })
-      .gte("occurred_at", oneHourAgo),
+      .gte("created_at", oneHourAgo),
   ]);
 
   const [
@@ -266,7 +270,7 @@ export default async function AdminOverviewPage() {
             <Stat
               href="/admin/activity"
               icon={<Zap />}
-              label="Events / hour"
+              label="Activity / hour"
               value={lastHourEvents ?? 0}
             />
           </div>


### PR DESCRIPTION
Two small admin-console bugs the user hit on first prod use:

1. The "← Dashboard" link in the admin TopBar was showing on every admin page including /admin itself, which is the admin overview. Going "back to dashboard" from the dashboard is meaningless. Pulled the link into a small AdminBackLink client component that uses usePathname() to hide itself when pathname === "/admin", and relabeled it "← Admin overview" so the destination is clearer (it still goes to /admin, not the user's home, since that's where admins actually want to land).

2. The "Events / hour" stat on the admin overview was counting from `domain_events` while /admin/activity reads from the `activity` table. They're separate tables, so the stat could read "4" while the page below sat empty. Switched the count to read from `activity` so the stat and page agree, and renamed the label "Activity / hour" to match.