### PR TITLE
ux: relocate account dropdown + extend ExplorerRail to terminals

### DIFF
--- a/apps/web/src/app/p/[ticker]/budget/page.tsx
+++ b/apps/web/src/app/p/[ticker]/budget/page.tsx
@@ -50,7 +50,7 @@ export default async function BudgetPage({ params }: Props) {
     .order("name", { ascending: true });
 
   return (
-    <div className="flex min-h-screen flex-col bg-bg-0">
+    <div className="flex h-full min-h-0 flex-col overflow-hidden bg-bg-0">
       <TopBar>
         <Link href={`/p/${t.ticker}`} className="text-text-3 hover:text-text-1">
           ← {t.name}
@@ -58,7 +58,7 @@ export default async function BudgetPage({ params }: Props) {
         <span className="text-text-3">·</span>
         <span className="text-text-0">Budget</span>
       </TopBar>
-      <main className="mx-auto w-full max-w-5xl flex-1 p-6">
+      <main className="mx-auto w-full max-w-5xl flex-1 overflow-y-auto p-6">
         <header className="mb-4">
           <h1 className="flex items-center gap-2 text-xl font-semibold text-text-0">
             <DollarSign className="h-5 w-5 text-accent" />

--- a/apps/web/src/app/p/[ticker]/drawings/[fileId]/page.tsx
+++ b/apps/web/src/app/p/[ticker]/drawings/[fileId]/page.tsx
@@ -95,7 +95,7 @@ export default async function DrawingPage({ params }: Props) {
   }
 
   return (
-    <div className="flex h-[100dvh] flex-col bg-bg-0">
+    <div className="flex h-full min-h-0 flex-col overflow-hidden bg-bg-0">
       <TopBar>
         <Link href="/" className="text-text-3 hover:text-text-1">
           ← Dashboard

--- a/apps/web/src/app/p/[ticker]/layout.tsx
+++ b/apps/web/src/app/p/[ticker]/layout.tsx
@@ -1,0 +1,85 @@
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { DensityProvider, type Density } from "@/lib/density";
+import { ExplorerRail } from "@/components/dashboard/ExplorerRail";
+import {
+  loadDashSpaces,
+  loadDashTerminals,
+} from "@/lib/dashboard-queries";
+
+/**
+ * Layout for /p/[ticker]/* — terminal pages.
+ *
+ * Mounts the same left-rail Explorer that the dashboard uses, so the user
+ * can jump between spaces/terminals or back to the dashboard without
+ * having to click the wordmark. Spaces + terminals are fetched here (not
+ * inside ExplorerRail) so the rail can render server-side.
+ *
+ * The rail's bottom AccountBlock is the single home for account-level
+ * actions (sign out, switch ring, settings, density, admin toggle).
+ *
+ * Each terminal page still renders its own TopBar and TerminalShell to the
+ * right of the rail.
+ */
+export default async function TerminalLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) redirect("/login");
+
+  const [spaces, terminals, toolsResult, profileResult] = await Promise.all([
+    loadDashSpaces(supabase, user.id),
+    loadDashTerminals(supabase),
+    supabase
+      .from("tools")
+      .select("id", { count: "exact", head: true })
+      .is("deleted_at", null),
+    supabase
+      .from("profiles")
+      .select("full_name, is_platform_admin, settings")
+      .eq("user_id", user.id)
+      .maybeSingle(),
+  ]);
+
+  const profile = profileResult.data as
+    | {
+        full_name: string | null;
+        is_platform_admin: boolean;
+        settings: Record<string, unknown> | null;
+      }
+    | null;
+  const userName =
+    profile?.full_name ?? user.email?.split("@")[0] ?? "there";
+  const initialDensity: Density =
+    profile?.settings?.density === "compact" ? "compact" : "cozy";
+  const isPlatformAdmin = Boolean(profile?.is_platform_admin);
+
+  return (
+    <DensityProvider initial={initialDensity}>
+      <div className="flex h-[100dvh] overflow-hidden bg-bg-0">
+        <aside
+          aria-label="Explorer"
+          className="hidden h-full w-[260px] flex-shrink-0 border-r border-border lg:flex lg:flex-col"
+        >
+          <ExplorerRail
+            spaces={spaces}
+            terminals={terminals}
+            toolCount={toolsResult.count ?? 0}
+            userName={userName}
+            userEmail={user.email ?? ""}
+            isPlatformAdmin={isPlatformAdmin}
+            canCreateSpace={isPlatformAdmin}
+          />
+        </aside>
+        <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
+          {children}
+        </div>
+      </div>
+    </DensityProvider>
+  );
+}

--- a/apps/web/src/app/p/[ticker]/permits/page.tsx
+++ b/apps/web/src/app/p/[ticker]/permits/page.tsx
@@ -39,7 +39,7 @@ export default async function PermitsPage({ params }: Props) {
     .order("created_at", { ascending: false });
 
   return (
-    <div className="flex min-h-screen flex-col bg-bg-0">
+    <div className="flex h-full min-h-0 flex-col overflow-hidden bg-bg-0">
       <TopBar>
         <Link href={`/p/${t.ticker}`} className="text-text-3 hover:text-text-1">
           ← {t.name}
@@ -47,7 +47,7 @@ export default async function PermitsPage({ params }: Props) {
         <span className="text-text-3">·</span>
         <span className="text-text-0">Permits</span>
       </TopBar>
-      <main className="mx-auto w-full max-w-5xl flex-1 p-6">
+      <main className="mx-auto w-full max-w-5xl flex-1 overflow-y-auto p-6">
         <header className="mb-4">
           <h1 className="flex items-center gap-2 text-xl font-semibold text-text-0">
             <FileCheck2 className="h-5 w-5 text-accent" />

--- a/apps/web/src/app/p/[ticker]/schedule/page.tsx
+++ b/apps/web/src/app/p/[ticker]/schedule/page.tsx
@@ -39,7 +39,7 @@ export default async function SchedulePage({ params }: Props) {
     .order("position", { ascending: true });
 
   return (
-    <div className="flex min-h-screen flex-col bg-bg-0">
+    <div className="flex h-full min-h-0 flex-col overflow-hidden bg-bg-0">
       <TopBar>
         <Link href={`/p/${t.ticker}`} className="text-text-3 hover:text-text-1">
           ← {t.name}
@@ -47,7 +47,7 @@ export default async function SchedulePage({ params }: Props) {
         <span className="text-text-3">·</span>
         <span className="text-text-0">Schedule</span>
       </TopBar>
-      <main className="mx-auto w-full max-w-6xl flex-1 p-6">
+      <main className="mx-auto w-full max-w-6xl flex-1 overflow-y-auto p-6">
         <header className="mb-4">
           <h1 className="flex items-center gap-2 text-xl font-semibold text-text-0">
             <Calendar className="h-5 w-5 text-accent" />

--- a/apps/web/src/app/p/[ticker]/settings/page.tsx
+++ b/apps/web/src/app/p/[ticker]/settings/page.tsx
@@ -118,7 +118,7 @@ export default async function TerminalSettingsPage({ params }: Props) {
   }));
 
   return (
-    <div className="flex min-h-screen flex-col bg-bg-0">
+    <div className="flex h-full min-h-0 flex-col overflow-hidden bg-bg-0">
       <TopBar>
         <Link href="/" className="text-text-3 hover:text-text-1">
           Dashboard
@@ -137,7 +137,7 @@ export default async function TerminalSettingsPage({ params }: Props) {
         <span className="text-text-3">·</span>
         <span className="text-text-0">Settings</span>
       </TopBar>
-      <main className="mx-auto w-full max-w-3xl flex-1 p-6">
+      <main className="mx-auto w-full max-w-3xl flex-1 overflow-y-auto p-6">
         <header className="mb-6">
           <div className="mb-1 flex items-center gap-2">
             <span className="font-mono text-xs font-semibold uppercase tracking-wide text-accent">

--- a/apps/web/src/app/p/[ticker]/task/[seq]/page.tsx
+++ b/apps/web/src/app/p/[ticker]/task/[seq]/page.tsx
@@ -88,7 +88,7 @@ export default async function TaskDetailPage({ params }: Props) {
   }[];
 
   return (
-    <div className="flex min-h-screen flex-col bg-bg-0">
+    <div className="flex h-full min-h-0 flex-col overflow-hidden bg-bg-0">
       <TopBar>
         <Link href="/" className="text-text-3 hover:text-text-1">
           ← Dashboard
@@ -105,7 +105,7 @@ export default async function TaskDetailPage({ params }: Props) {
           {term.ticker}-{(taskRow as { ticker_seq: number }).ticker_seq}
         </span>
       </TopBar>
-      <main className="mx-auto w-full max-w-5xl flex-1 p-6">
+      <main className="mx-auto w-full max-w-5xl flex-1 overflow-y-auto p-6">
         <TaskDetail
           initialTask={
             taskRow as {

--- a/apps/web/src/components/DashboardClient.tsx
+++ b/apps/web/src/components/DashboardClient.tsx
@@ -105,6 +105,7 @@ export function DashboardClient({
             toolCount={toolCount}
             userName={userName}
             userEmail={userEmail}
+            isPlatformAdmin={isPlatformAdmin}
             canCreateSpace={isPlatformAdmin}
           />
         }

--- a/apps/web/src/components/TerminalShell.tsx
+++ b/apps/web/src/components/TerminalShell.tsx
@@ -72,7 +72,7 @@ export function TerminalShell({
   }
 
   return (
-    <div className="flex h-[100dvh] flex-col overflow-hidden">
+    <div className="flex h-full min-h-0 flex-col overflow-hidden">
       {topBar}
       <div className="hidden sm:block">
         <FunctionKeys keys={functionKeys} active={active} onSelect={handle} />

--- a/apps/web/src/components/TopBar.tsx
+++ b/apps/web/src/components/TopBar.tsx
@@ -1,6 +1,5 @@
 import Link from "next/link";
 import { Wordmark } from "./Wordmark";
-import { AccountSwitcher } from "./AccountSwitcher";
 
 interface TopBarProps {
   children?: React.ReactNode;
@@ -8,11 +7,11 @@ interface TopBarProps {
 
 /**
  * Top bar — §6.3 BUILD_SPEC and §08.5.4 UI design.
- * 44px tall, Rokki wordmark at left, slot for breadcrumb, account
- * switcher + ⌘K hint at right.
+ * 44px tall, Rokki wordmark at left, slot for breadcrumb, ⌘K hint at right.
  *
- * The AccountSwitcher folds the former AdminChip into a richer dropdown
- * that handles sign-in / sign-out / multi-account stacking.
+ * Account-related actions (multi-account ring, sign out, settings, density,
+ * admin console toggle) live in the bottom-left ExplorerRail's AccountBlock
+ * so the top-right stays uncluttered.
  */
 export function TopBar({ children }: TopBarProps) {
   return (
@@ -31,7 +30,6 @@ export function TopBar({ children }: TopBarProps) {
         {children}
       </div>
       <div className="flex items-center gap-2">
-        <AccountSwitcher />
         <kbd className="rounded-sm border border-border bg-bg-2 px-1.5 py-0.5 font-mono text-xs text-text-2">
           ⌘K
         </kbd>

--- a/apps/web/src/components/dashboard/ExplorerRail.tsx
+++ b/apps/web/src/components/dashboard/ExplorerRail.tsx
@@ -1,20 +1,24 @@
 "use client";
 
 import Link from "next/link";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { usePathname } from "next/navigation";
 import {
+  AlertCircle,
+  Building2,
   ChevronDown,
   ChevronRight,
-  Plus,
-  Settings,
+  KeyRound,
   LogOut,
-  Sparkles,
-  Building2,
+  Plus,
+  RefreshCw,
   Rows3,
   Rows4,
+  Settings,
+  ShieldCheck,
+  Sparkles,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { createClient } from "@/lib/supabase/client";
 import { useDensity } from "@/lib/density";
 import type { DashSpace, DashTerminal } from "@/lib/dashboard-queries";
 
@@ -24,6 +28,7 @@ interface ExplorerRailProps {
   toolCount: number;
   userEmail: string;
   userName: string;
+  isPlatformAdmin: boolean;
   canCreateSpace: boolean;
 }
 
@@ -31,7 +36,7 @@ interface ExplorerRailProps {
  * The left-rail Explorer. A two-level tree: space → its terminals. Each
  * terminal link takes you to the terminal's detail page. At the bottom:
  *   - a subtle `🛠 N tools` pill to /tools
- *   - user account block with settings + logout
+ *   - the AccountBlock dropdown — see component for the full menu surface
  */
 export function ExplorerRail({
   spaces,
@@ -39,6 +44,7 @@ export function ExplorerRail({
   toolCount,
   userEmail,
   userName,
+  isPlatformAdmin,
   canCreateSpace,
 }: ExplorerRailProps) {
   const terminalsBySpace = useMemo(() => {
@@ -57,12 +63,6 @@ export function ExplorerRail({
       next.has(id) ? next.delete(id) : next.add(id);
       return next;
     });
-
-  async function signOut() {
-    const supabase = createClient();
-    await supabase.auth.signOut();
-    window.location.href = "/login";
-  }
 
   return (
     <div className="flex h-full flex-col bg-bg-0">
@@ -180,35 +180,155 @@ export function ExplorerRail({
       <AccountBlock
         name={userName}
         email={userEmail}
-        onSignOut={signOut}
+        isPlatformAdmin={isPlatformAdmin}
       />
     </div>
   );
 }
 
+interface RingEntry {
+  user_id: string;
+  email: string;
+  added_at: string;
+}
+
+/**
+ * The bottom-left dropdown. Single source of truth for every account-related
+ * action — multi-account ring switching, add/sign-out, settings, density,
+ * and the admin-console toggle.
+ *
+ * Header pins the active account's email + admin chip prominently so the
+ * user can see at a glance which identity they're operating as.
+ *
+ * The ring (other accounts) is loaded lazily on first dropdown open to keep
+ * the rail's render path cheap.
+ */
 function AccountBlock({
   name,
   email,
-  onSignOut,
+  isPlatformAdmin,
 }: {
   name: string;
   email: string;
-  onSignOut: () => void;
+  isPlatformAdmin: boolean;
 }) {
-  const { density, toggle } = useDensity();
-  const initials = name
-    .split(/\s+/)
-    .map((s) => s[0])
-    .filter(Boolean)
-    .slice(0, 2)
-    .join("")
-    .toUpperCase();
+  const { density, toggle: toggleDensity } = useDensity();
+  const pathname = usePathname();
+  const inAdmin = pathname?.startsWith("/admin") ?? false;
+
   const [open, setOpen] = useState(false);
+  const [ring, setRing] = useState<RingEntry[]>([]);
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const [ringLoaded, setRingLoaded] = useState(false);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [showAdd, setShowAdd] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const initials =
+    (name || email || "?")
+      .split(/\s+/)
+      .map((s) => s[0])
+      .filter(Boolean)
+      .slice(0, 2)
+      .join("")
+      .toUpperCase() || "?";
+
+  // Lazy-load the account ring when the dropdown first opens.
+  useEffect(() => {
+    if (!open || ringLoaded) return;
+    setError(null);
+    fetch("/api/v1/auth/accounts", { credentials: "include" })
+      .then((r) => r.json())
+      .then(
+        (b: {
+          data?: { accounts?: RingEntry[]; active_user_id?: string | null };
+        }) => {
+          setRing(b.data?.accounts ?? []);
+          setActiveId(b.data?.active_user_id ?? null);
+        },
+      )
+      .catch((e: unknown) =>
+        setError(e instanceof Error ? e.message : "load failed"),
+      )
+      .finally(() => setRingLoaded(true));
+  }, [open, ringLoaded]);
+
+  // Click-outside to close.
+  useEffect(() => {
+    if (!open) return;
+    function onDoc(e: MouseEvent) {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(e.target as Node)
+      ) {
+        setOpen(false);
+        setShowAdd(false);
+      }
+    }
+    document.addEventListener("mousedown", onDoc);
+    return () => document.removeEventListener("mousedown", onDoc);
+  }, [open]);
+
+  async function switchTo(userId: string) {
+    setBusy(userId);
+    setError(null);
+    try {
+      const r = await fetch("/api/v1/auth/accounts/switch", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({ user_id: userId }),
+      });
+      if (!r.ok) {
+        const body = (await r.json().catch(() => ({}))) as {
+          errors?: { message: string }[];
+        };
+        setError(body.errors?.[0]?.message ?? `HTTP ${r.status}`);
+        return;
+      }
+      window.location.href = "/";
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function signOut(scope: "current" | "all") {
+    setBusy(scope);
+    try {
+      const r = await fetch(`/api/v1/auth/sign-out?scope=${scope}`, {
+        method: "POST",
+        credentials: "include",
+      });
+      if (!r.ok) {
+        const body = (await r.json().catch(() => ({}))) as {
+          errors?: { message: string }[];
+        };
+        setError(body.errors?.[0]?.message ?? `HTTP ${r.status}`);
+        return;
+      }
+      const body = (await r.json()) as {
+        data?: { switched_to?: { user_id?: string } | null };
+      };
+      if (body.data?.switched_to) {
+        window.location.href = "/";
+      } else {
+        window.location.href = "/login";
+      }
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  const otherAccounts = ring.filter((r) => r.user_id !== activeId);
 
   return (
-    <div className="relative flex-shrink-0 border-t border-border">
+    <div className="relative flex-shrink-0 border-t border-border" ref={containerRef}>
       <button
+        type="button"
         onClick={() => setOpen((o) => !o)}
+        aria-haspopup="menu"
+        aria-expanded={open}
         className={cn(
           "flex w-full items-center gap-2 px-3 py-2 text-left hover:bg-bg-2",
           open && "bg-bg-2",
@@ -218,50 +338,297 @@ function AccountBlock({
           {initials}
         </span>
         <span className="min-w-0 flex-1">
-          <span className="block truncate text-xs text-text-0">{name}</span>
+          <span className="flex items-center gap-1.5">
+            <span className="block truncate text-xs text-text-0">{name}</span>
+            {isPlatformAdmin ? (
+              <ShieldCheck
+                className="h-3 w-3 flex-shrink-0 text-accent"
+                aria-label="admin"
+              />
+            ) : null}
+          </span>
           <span className="block truncate font-mono text-[10px] text-text-3">
             {email}
           </span>
         </span>
+        <ChevronDown
+          className={cn(
+            "h-3 w-3 flex-shrink-0 text-text-3 transition-transform",
+            open && "rotate-180",
+          )}
+        />
       </button>
+
       {open ? (
-        <div className="absolute bottom-full left-0 right-0 border border-border bg-bg-1 text-xs">
-          <Link
-            href="/settings"
-            className="flex items-center gap-2 px-3 py-2 text-text-1 hover:bg-bg-2"
-            onClick={() => setOpen(false)}
-          >
-            <Settings className="h-3.5 w-3.5" /> Settings
-          </Link>
-          <Link
-            href="/settings/tokens"
-            className="flex items-center gap-2 px-3 py-2 text-text-1 hover:bg-bg-2"
-            onClick={() => setOpen(false)}
-          >
-            <Sparkles className="h-3.5 w-3.5" /> API tokens
-          </Link>
-          <button
-            onClick={() => {
-              toggle();
-              setOpen(false);
-            }}
-            className="flex w-full items-center gap-2 px-3 py-2 text-left text-text-1 hover:bg-bg-2"
-          >
-            {density === "cozy" ? (
-              <Rows3 className="h-3.5 w-3.5" />
-            ) : (
-              <Rows4 className="h-3.5 w-3.5" />
-            )}
-            Density: {density === "cozy" ? "Cozy" : "Compact"}
-          </button>
-          <button
-            onClick={onSignOut}
-            className="flex w-full items-center gap-2 px-3 py-2 text-left text-text-1 hover:bg-bg-2"
-          >
-            <LogOut className="h-3.5 w-3.5" /> Sign out
-          </button>
+        <div
+          role="menu"
+          className="absolute bottom-full left-0 right-0 z-30 mb-0 max-h-[80vh] overflow-y-auto border border-border bg-bg-1 text-xs shadow-lg"
+        >
+          {/* Identity header — large, so the user knows which account
+              this dropdown is operating in. */}
+          <div className="border-b border-border bg-bg-2 px-3 py-2">
+            <div className="flex items-center gap-2">
+              <span className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-bg-3 text-xs font-semibold text-text-0">
+                {initials}
+              </span>
+              <div className="min-w-0 flex-1">
+                <div className="truncate text-sm text-text-0">{name}</div>
+                <div className="truncate font-mono text-[10px] text-text-3">
+                  {email}
+                </div>
+              </div>
+              {isPlatformAdmin ? (
+                <span className="inline-flex items-center gap-1 rounded-sm border border-accent/40 bg-accent-subtle px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wide text-accent">
+                  <ShieldCheck className="h-3 w-3" /> admin
+                </span>
+              ) : null}
+            </div>
+          </div>
+
+          {error ? (
+            <p className="flex items-center gap-1 border-b border-border bg-danger-subtle px-3 py-1.5 text-[11px] text-danger">
+              <AlertCircle className="h-3 w-3" /> {error}
+            </p>
+          ) : null}
+
+          {/* Switch-to (other ring accounts) — only visible when there's
+              somewhere to switch. */}
+          {otherAccounts.length > 0 ? (
+            <div className="border-b border-border py-1">
+              <p className="px-3 pt-1 pb-0.5 text-[9px] font-semibold uppercase tracking-[0.18em] text-text-3">
+                Switch to
+              </p>
+              <ul role="none">
+                {otherAccounts.map((r) => (
+                  <li key={r.user_id} role="none">
+                    <button
+                      role="menuitem"
+                      type="button"
+                      onClick={() => void switchTo(r.user_id)}
+                      disabled={busy === r.user_id}
+                      className={cn(
+                        "flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs hover:bg-bg-2",
+                        busy === r.user_id && "opacity-60",
+                      )}
+                    >
+                      <RefreshCw className="h-3 w-3 flex-shrink-0 text-text-3" />
+                      <span className="flex-1 truncate font-mono text-[11px] text-text-1">
+                        {r.email}
+                      </span>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+
+          {/* Add another account — inline form swaps into this slot. */}
+          {showAdd ? (
+            <AddAccountForm
+              onSuccess={() => {
+                window.location.href = "/";
+              }}
+              onError={setError}
+              onCancel={() => setShowAdd(false)}
+            />
+          ) : (
+            <div className="border-b border-border py-1">
+              <button
+                role="menuitem"
+                type="button"
+                onClick={() => setShowAdd(true)}
+                className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs text-text-1 hover:bg-bg-2"
+              >
+                <Plus className="h-3 w-3 flex-shrink-0 text-text-3" />
+                Add another account
+              </button>
+            </div>
+          )}
+
+          {/* Preferences */}
+          <div className="border-b border-border py-1">
+            <Link
+              href="/settings"
+              role="menuitem"
+              className="flex items-center gap-2 px-3 py-1.5 text-text-1 hover:bg-bg-2"
+              onClick={() => setOpen(false)}
+            >
+              <Settings className="h-3 w-3 flex-shrink-0 text-text-3" />{" "}
+              Settings
+            </Link>
+            <Link
+              href="/settings/tokens"
+              role="menuitem"
+              className="flex items-center gap-2 px-3 py-1.5 text-text-1 hover:bg-bg-2"
+              onClick={() => setOpen(false)}
+            >
+              <KeyRound className="h-3 w-3 flex-shrink-0 text-text-3" /> API
+              tokens
+            </Link>
+            <button
+              role="menuitem"
+              type="button"
+              onClick={() => {
+                toggleDensity();
+                setOpen(false);
+              }}
+              className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-text-1 hover:bg-bg-2"
+            >
+              {density === "cozy" ? (
+                <Rows3 className="h-3 w-3 flex-shrink-0 text-text-3" />
+              ) : (
+                <Rows4 className="h-3 w-3 flex-shrink-0 text-text-3" />
+              )}
+              Density: {density === "cozy" ? "Cozy" : "Compact"}
+            </button>
+          </div>
+
+          {/* Admin console toggle — only visible to platform admins. */}
+          {isPlatformAdmin ? (
+            <div className="border-b border-border py-1">
+              {inAdmin ? (
+                <Link
+                  href="/"
+                  role="menuitem"
+                  className="flex items-center gap-2 px-3 py-1.5 text-text-1 hover:bg-bg-2"
+                  onClick={() => setOpen(false)}
+                >
+                  <ShieldCheck className="h-3 w-3 flex-shrink-0 text-accent" />
+                  Exit admin → Dashboard
+                </Link>
+              ) : (
+                <Link
+                  href="/admin"
+                  role="menuitem"
+                  className="flex items-center gap-2 px-3 py-1.5 text-text-1 hover:bg-bg-2"
+                  onClick={() => setOpen(false)}
+                >
+                  <ShieldCheck className="h-3 w-3 flex-shrink-0 text-accent" />
+                  Open admin console
+                </Link>
+              )}
+            </div>
+          ) : null}
+
+          {/* Sign out actions */}
+          <div className="py-1">
+            <button
+              role="menuitem"
+              type="button"
+              onClick={() => void signOut("current")}
+              disabled={busy === "current"}
+              className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-text-1 hover:bg-bg-2"
+            >
+              <LogOut className="h-3 w-3 flex-shrink-0 text-text-3" />
+              Sign out
+              {otherAccounts.length > 0 ? " (switch to next)" : ""}
+            </button>
+            {ring.length > 1 ? (
+              <button
+                role="menuitem"
+                type="button"
+                onClick={() => void signOut("all")}
+                disabled={busy === "all"}
+                className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-danger hover:bg-bg-2"
+              >
+                <LogOut className="h-3 w-3 flex-shrink-0" />
+                Sign out of all accounts
+              </button>
+            ) : null}
+          </div>
         </div>
       ) : null}
     </div>
+  );
+}
+
+function AddAccountForm({
+  onSuccess,
+  onError,
+  onCancel,
+}: {
+  onSuccess: () => void;
+  onError: (m: string) => void;
+  onCancel: () => void;
+}) {
+  const [identifier, setIdentifier] = useState("");
+  const [password, setPassword] = useState("");
+  const [busy, setBusy] = useState(false);
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!identifier.trim() || !password) return;
+    setBusy(true);
+    try {
+      const isEmail = identifier.includes("@");
+      const r = await fetch("/api/v1/auth/accounts/add", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({
+          [isEmail ? "email" : "username"]: identifier.trim(),
+          password,
+        }),
+      });
+      if (!r.ok) {
+        const body = (await r.json().catch(() => ({}))) as {
+          errors?: { message: string }[];
+        };
+        onError(body.errors?.[0]?.message ?? `HTTP ${r.status}`);
+        return;
+      }
+      onSuccess();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <form
+      onSubmit={submit}
+      className="flex flex-col gap-2 border-b border-border p-3"
+    >
+      <p className="text-[10px] uppercase tracking-wide text-text-3">
+        Add another account
+      </p>
+      <input
+        autoFocus
+        value={identifier}
+        onChange={(e) => setIdentifier(e.target.value)}
+        placeholder="Email or username"
+        className="rounded-sm border border-border bg-bg-0 px-2 py-1 text-xs text-text-0 outline-none focus:border-border-focus"
+      />
+      <input
+        type="password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        placeholder="Password"
+        className="rounded-sm border border-border bg-bg-0 px-2 py-1 font-mono text-xs text-text-0 outline-none focus:border-border-focus"
+      />
+      <p className="text-[10px] text-text-3">
+        Magic-link sign-in only stacks one account at a time. Use a password
+        (admins) or sign in here once via the regular flow first.
+      </p>
+      <div className="flex justify-end gap-2">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="rounded-sm border border-border bg-bg-2 px-2.5 py-1 text-xs text-text-1 hover:bg-bg-3"
+        >
+          Cancel
+        </button>
+        <button
+          type="submit"
+          disabled={busy || !identifier.trim() || !password}
+          className={cn(
+            "rounded-sm border border-accent bg-accent px-2.5 py-1 text-xs font-semibold uppercase tracking-wide text-bg-0 hover:bg-accent-hover",
+            (busy || !identifier.trim() || !password) &&
+              "cursor-not-allowed opacity-60",
+          )}
+        >
+          {busy ? "Adding…" : "Add"}
+        </button>
+      </div>
+    </form>
   );
 }


### PR DESCRIPTION
- Strip the account switcher off the top-right TopBar and consolidate every account-related control in the bottom-left ExplorerRail AccountBlock dropdown:
    * email + admin chip pinned at the top so the active identity is always visible
    * multi-account ring switching ("Switch to <other account>")
    * "Add another account" inline form
    * Settings (always /settings — never bumps into /admin/users)
    * API tokens (/settings/tokens)
    * Density toggle
    * "Open admin console" / "Exit admin -> Dashboard" toggle, gated on is_platform_admin and contextual on usePathname()
    * Sign out / Sign out all
- TopBar keeps only the wordmark + breadcrumb slot + Cmd-K hint.
- ExplorerRail now appears on /p/[ticker]/* via a new layout that fetches loadDashSpaces + loadDashTerminals server-side. Terminal pages can now navigate back to the dashboard or to other terminals without having to click the wordmark.
- Adjust per-terminal sub-pages (budget, permits, schedule, settings, task, drawings) to fit inside the new layout's column with internal scrolling rather than min-h-screen.
- TerminalShell now uses h-full so it fills its parent column.