### PR TITLE
feat(calendar): id_token email + cron-driven sync

### DIFF
--- a/.github/workflows/calendar-sync.yml
+++ b/.github/workflows/calendar-sync.yml
@@ -1,0 +1,50 @@
+name: Calendar sync tick
+
+# Vercel's Hobby tier only allows daily cron, so we drive the calendar
+# sync from GitHub Actions instead. Every 15 minutes, POST to the cron
+# endpoint with the shared secret. The endpoint refreshes any expired
+# Microsoft/Google access tokens, fetches the next 14 days of events
+# for each connected calendar, and upserts them into calendar_events.
+#
+# Secrets required:
+#   ROKKI_CRON_SECRET — must match the CRON_SECRET env var on Vercel.
+#
+# Manual run: Actions tab → "Calendar sync tick" → Run workflow.
+on:
+  schedule:
+    - cron: "*/15 * * * *"
+  workflow_dispatch:
+
+# Limit to one in-flight run at a time. If a tick is slow we'd rather
+# skip the next one than stack them up.
+concurrency:
+  group: calendar-sync
+  cancel-in-progress: false
+
+jobs:
+  tick:
+    name: POST /api/v1/cron/calendar-sync
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Trigger sync
+        env:
+          CRON_SECRET: ${{ secrets.ROKKI_CRON_SECRET }}
+        run: |
+          if [ -z "$CRON_SECRET" ]; then
+            echo "::warning::ROKKI_CRON_SECRET not set; skipping tick"
+            exit 0
+          fi
+          STATUS=$(curl -sS -o /tmp/body -w "%{http_code}" \
+            -X POST \
+            -H "x-cron-secret: $CRON_SECRET" \
+            -H "content-type: application/json" \
+            --max-time 90 \
+            https://rokki.ai/api/v1/cron/calendar-sync)
+          BODY=$(cat /tmp/body)
+          echo "HTTP $STATUS"
+          echo "$BODY"
+          if [ "$STATUS" != "200" ]; then
+            echo "::error::sync tick failed with HTTP $STATUS: $BODY"
+            exit 1
+          fi

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -45,6 +45,25 @@ AXIOM_TOKEN=
 AXIOM_DATASET=
 POSTHOG_KEY=
 
+# Calendar OAuth (per-user opt-in for Outlook / Google Calendar sync).
+# Leave blank to keep the provider as "not configured" on /settings/calendars.
+# Token encryption uses TOKEN_ENCRYPTION_KEY (set above) — same key for
+# encrypt and decrypt across the web + indexer.
+GOOGLE_OAUTH_CLIENT_ID=
+GOOGLE_OAUTH_CLIENT_SECRET=
+MICROSOFT_OAUTH_CLIENT_ID=
+MICROSOFT_OAUTH_CLIENT_SECRET=
+# `common` for multi-tenant + personal MSA, your specific tenant GUID
+# for single-tenant Entra apps.
+MICROSOFT_OAUTH_TENANT=common
+TOKEN_ENCRYPTION_KEY=
+
+# Cron secret — required on production for /api/v1/cron/* endpoints.
+# Generate 32+ random bytes (e.g. `openssl rand -hex 32`). Must match
+# the value in GitHub repo secrets as `ROKKI_CRON_SECRET` so the
+# scheduled GH Actions workflow can call the endpoint.
+CRON_SECRET=
+
 # Misc
 NODE_ENV=development
 LOG_LEVEL=debug

--- a/apps/web/src/app/api/v1/calendar/callback/[provider]/route.ts
+++ b/apps/web/src/app/api/v1/calendar/callback/[provider]/route.ts
@@ -3,6 +3,7 @@ import { cookies } from "next/headers";
 import { createClient as createAdminClient } from "@supabase/supabase-js";
 import { createClient } from "@/lib/supabase/server";
 import {
+  emailFromIdToken,
   exchangeCode,
   fetchProfileEmail,
   providerConfig,
@@ -71,12 +72,22 @@ export async function GET(request: NextRequest, { params }: Props) {
     return settings("error", "token_exchange_failed");
   }
 
-  let email: string;
-  try {
-    email = await fetchProfileEmail(config, tokens.access_token);
-  } catch (e) {
-    console.error("[calendar] profile fetch failed:", e);
-    email = "(unknown)";
+  // Prefer the id_token claim — it's returned alongside the access
+  // token by both Google and Microsoft when `openid email profile`
+  // scopes are requested, and avoids an extra network call. Falls back
+  // to the provider's profile endpoint if no id_token was returned or
+  // the claim was missing/malformed.
+  let email: string | null = null;
+  if (tokens.id_token) {
+    email = emailFromIdToken(tokens.id_token);
+  }
+  if (!email) {
+    try {
+      email = await fetchProfileEmail(config, tokens.access_token);
+    } catch (e) {
+      console.error("[calendar] profile fetch failed:", e);
+      email = "(unknown)";
+    }
   }
 
   const accessEnc = encryptToken(tokens.access_token);

--- a/apps/web/src/app/api/v1/cron/calendar-sync/route.ts
+++ b/apps/web/src/app/api/v1/cron/calendar-sync/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { runCalendarSyncTick } from "@/lib/calendar-sync";
+
+/**
+ * POST /api/v1/cron/calendar-sync
+ *
+ * Runs one calendar-sync tick: refresh tokens as needed, fetch the next
+ * 14 days of events from each provider, upsert into calendar_events.
+ *
+ * Auth: requires `x-cron-secret` header matching CRON_SECRET, OR an
+ * `Authorization: Bearer <CRON_SECRET>` header (Vercel Cron / GitHub
+ * Actions style). The /api/v1/cron/* prefix is allowlisted in the auth
+ * middleware specifically so cron callers (no user session) reach this
+ * handler — the secret check is therefore the only thing standing
+ * between an attacker and a sync trigger, and CRON_SECRET must be set
+ * in production.
+ *
+ * Response: { data: { attempted, succeeded, failed, events } }
+ */
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+export async function POST(request: NextRequest) {
+  if (!authorize(request)) return unauthorized();
+
+  const result = await runCalendarSyncTick();
+  return NextResponse.json({ data: result });
+}
+
+// Also accept GET so a curl smoke test works without a body. The
+// secret check still gates it.
+export async function GET(request: NextRequest) {
+  if (!authorize(request)) return unauthorized();
+  const result = await runCalendarSyncTick();
+  return NextResponse.json({ data: result });
+}
+
+function authorize(request: NextRequest): boolean {
+  const expected = process.env.CRON_SECRET;
+  if (!expected) return false; // no secret configured = endpoint disabled
+  const cronHeader = request.headers.get("x-cron-secret");
+  if (cronHeader === expected) return true;
+  const auth = request.headers.get("authorization") ?? "";
+  if (auth === `Bearer ${expected}`) return true;
+  return false;
+}
+
+function unauthorized(): NextResponse {
+  return NextResponse.json(
+    {
+      errors: [
+        { code: "unauthenticated", message: "Supply a valid cron secret" },
+      ],
+    },
+    { status: 401 },
+  );
+}

--- a/apps/web/src/lib/calendar-oauth.ts
+++ b/apps/web/src/lib/calendar-oauth.ts
@@ -134,3 +134,39 @@ export async function fetchProfileEmail(
   };
   return body.email ?? body.mail ?? body.userPrincipalName ?? "unknown";
 }
+
+/**
+ * Pull the user's email from an OIDC id_token.
+ *
+ * Both Google and Microsoft return id_tokens alongside access tokens
+ * when `openid email profile` are in the requested scopes (which we
+ * always request). The id_token is a JWT — we don't need to verify the
+ * signature here because we just received it directly from the token
+ * endpoint over TLS, so the issuer chain is implicit. We only ever use
+ * the email claim for display, not for authorization.
+ *
+ * Microsoft puts the email in different claims depending on the
+ * account type: work/school accounts use `preferred_username` (which is
+ * the UPN, almost always an email), personal MSA accounts use `email`.
+ * Google uses `email`.
+ */
+export function emailFromIdToken(idToken: string): string | null {
+  const parts = idToken.split(".");
+  if (parts.length < 2) return null;
+  try {
+    const payloadJson = Buffer.from(parts[1], "base64url").toString("utf8");
+    const payload = JSON.parse(payloadJson) as {
+      email?: string;
+      preferred_username?: string;
+      upn?: string;
+    };
+    const candidate =
+      payload.email ?? payload.preferred_username ?? payload.upn ?? null;
+    // Sanity-check: only return strings that look like emails. UPNs in
+    // some tenants aren't email-shaped (rare, but cheap to guard).
+    if (candidate && /.+@.+\..+/.test(candidate)) return candidate;
+    return null;
+  } catch {
+    return null;
+  }
+}

--- a/apps/web/src/lib/calendar-sync.ts
+++ b/apps/web/src/lib/calendar-sync.ts
@@ -1,0 +1,363 @@
+import { createClient as createAdminClient } from "@supabase/supabase-js";
+import type { Database } from "@rokki/db";
+import { decryptToken, encryptToken, type Encrypted } from "@/lib/token-crypto";
+
+/**
+ * In-process calendar sync.
+ *
+ * This is a port of the standalone indexer worker (apps/indexer/src/
+ * calendar-sync.ts) into the Next.js app, so we can drive sync from a
+ * Vercel function on a cron schedule (GitHub Actions for now, since
+ * Vercel Hobby tier limits cron to daily — see
+ * .github/workflows/calendar-sync.yml).
+ *
+ * Per tick:
+ *   1. pick the N connections with the oldest last_sync_at
+ *   2. refresh the access token if expired
+ *   3. fetch events between (today, today+14d) from Graph / Calendar
+ *   4. upsert rows into calendar_events
+ *   5. soft-delete events we no longer see
+ *   6. record last_sync_at + any error
+ *
+ * Fails soft: one bad connection doesn't stop the rest.
+ */
+
+const BATCH_SIZE = 8;
+
+type AdminClient = ReturnType<typeof createAdminClient<Database>>;
+
+let cached: AdminClient | null = null;
+function admin(): AdminClient | null {
+  if (cached) return cached;
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) return null;
+  cached = createAdminClient<Database>(url, key, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+  return cached;
+}
+
+interface Connection {
+  id: string;
+  user_id: string;
+  provider: "google" | "microsoft";
+  account_email: string;
+  access_token_ciphertext: string;
+  access_token_iv: string;
+  access_token_tag: string;
+  access_token_expires_at: string | null;
+  refresh_token_ciphertext: string | null;
+  refresh_token_iv: string | null;
+  refresh_token_tag: string | null;
+}
+
+interface NormalizedEvent {
+  external_id: string;
+  title: string;
+  description: string | null;
+  location: string | null;
+  starts_at: string;
+  ends_at: string | null;
+  all_day: boolean;
+  source_calendar: string | null;
+  html_link: string | null;
+  raw: unknown;
+}
+
+export interface TickResult {
+  attempted: number;
+  succeeded: number;
+  failed: number;
+  events: number;
+}
+
+export async function runCalendarSyncTick(
+  batchSize = BATCH_SIZE,
+): Promise<TickResult> {
+  const result: TickResult = { attempted: 0, succeeded: 0, failed: 0, events: 0 };
+  const a = admin();
+  if (!a) return result;
+
+  const { data, error } = await a
+    .from("calendar_connections")
+    .select(
+      "id, user_id, provider, account_email, access_token_ciphertext, access_token_iv, access_token_tag, access_token_expires_at, refresh_token_ciphertext, refresh_token_iv, refresh_token_tag",
+    )
+    .is("revoked_at", null)
+    .order("last_sync_at", { ascending: true, nullsFirst: true })
+    .limit(batchSize);
+  if (error) {
+    console.error("[calendar-sync] connection lookup failed:", error.message);
+    return result;
+  }
+  const conns = (data ?? []) as Connection[];
+  result.attempted = conns.length;
+  if (conns.length === 0) return result;
+
+  // Sequential rather than Promise.all — cheap, easier to reason about,
+  // and we don't want a stampede of refresh-token requests if many tokens
+  // expired at once.
+  for (const c of conns) {
+    try {
+      const events = await syncConnection(a, c);
+      result.events += events;
+      result.succeeded += 1;
+    } catch (e) {
+      result.failed += 1;
+      console.error(
+        `[calendar-sync] ${c.provider}/${c.account_email} failed:`,
+        e instanceof Error ? e.message : e,
+      );
+    }
+  }
+  return result;
+}
+
+async function syncConnection(a: AdminClient, c: Connection): Promise<number> {
+  try {
+    const accessToken = await ensureAccessToken(a, c);
+    const events = await fetchEvents(c, accessToken);
+    await upsertEvents(a, c.id, events);
+    await a
+      .from("calendar_connections")
+      // eslint-disable-next-line
+      .update({
+        last_sync_at: new Date().toISOString(),
+        last_sync_error: null,
+      } as any)
+      .eq("id", c.id);
+    return events.length;
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    await a
+      .from("calendar_connections")
+      // eslint-disable-next-line
+      .update({ last_sync_error: msg.slice(0, 500) } as any)
+      .eq("id", c.id);
+    throw e;
+  }
+}
+
+async function ensureAccessToken(
+  a: AdminClient,
+  c: Connection,
+): Promise<string> {
+  const expires = c.access_token_expires_at
+    ? new Date(c.access_token_expires_at).getTime()
+    : 0;
+  // Reuse the stored token if it still has >2 minutes of life.
+  if (expires - Date.now() > 2 * 60 * 1000) {
+    return decryptToken({
+      ciphertext: c.access_token_ciphertext,
+      iv: c.access_token_iv,
+      tag: c.access_token_tag,
+    });
+  }
+  if (
+    !c.refresh_token_ciphertext ||
+    !c.refresh_token_iv ||
+    !c.refresh_token_tag
+  ) {
+    throw new Error("access token expired and no refresh token stored");
+  }
+  const refresh = decryptToken({
+    ciphertext: c.refresh_token_ciphertext,
+    iv: c.refresh_token_iv,
+    tag: c.refresh_token_tag,
+  });
+
+  const tokenUrl =
+    c.provider === "google"
+      ? "https://oauth2.googleapis.com/token"
+      : `https://login.microsoftonline.com/${
+          process.env.MICROSOFT_OAUTH_TENANT ?? "common"
+        }/oauth2/v2.0/token`;
+  const clientId =
+    c.provider === "google"
+      ? process.env.GOOGLE_OAUTH_CLIENT_ID
+      : process.env.MICROSOFT_OAUTH_CLIENT_ID;
+  const clientSecret =
+    c.provider === "google"
+      ? process.env.GOOGLE_OAUTH_CLIENT_SECRET
+      : process.env.MICROSOFT_OAUTH_CLIENT_SECRET;
+  if (!clientId || !clientSecret) {
+    throw new Error(`${c.provider} OAuth client not configured`);
+  }
+
+  const res = await fetch(tokenUrl, {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      grant_type: "refresh_token",
+      refresh_token: refresh,
+      client_id: clientId,
+      client_secret: clientSecret,
+    }),
+  });
+  if (!res.ok) {
+    throw new Error(
+      `refresh failed (${res.status}): ${(await res.text()).slice(0, 200)}`,
+    );
+  }
+  const body = (await res.json()) as {
+    access_token: string;
+    expires_in?: number;
+    refresh_token?: string;
+  };
+  const newExpires = body.expires_in
+    ? new Date(Date.now() + body.expires_in * 1000).toISOString()
+    : null;
+  const newAccess: Encrypted = encryptToken(body.access_token);
+  const newRefresh: Encrypted | null = body.refresh_token
+    ? encryptToken(body.refresh_token)
+    : null;
+  await a
+    .from("calendar_connections")
+    // eslint-disable-next-line
+    .update({
+      access_token_ciphertext: newAccess.ciphertext,
+      access_token_iv: newAccess.iv,
+      access_token_tag: newAccess.tag,
+      access_token_expires_at: newExpires,
+      ...(newRefresh
+        ? {
+            refresh_token_ciphertext: newRefresh.ciphertext,
+            refresh_token_iv: newRefresh.iv,
+            refresh_token_tag: newRefresh.tag,
+          }
+        : {}),
+    } as any)
+    .eq("id", c.id);
+  return body.access_token;
+}
+
+async function fetchEvents(
+  c: Connection,
+  accessToken: string,
+): Promise<NormalizedEvent[]> {
+  const from = new Date();
+  from.setHours(0, 0, 0, 0);
+  const to = new Date(from);
+  to.setDate(to.getDate() + 14);
+
+  if (c.provider === "google") {
+    const url = new URL(
+      "https://www.googleapis.com/calendar/v3/calendars/primary/events",
+    );
+    url.searchParams.set("timeMin", from.toISOString());
+    url.searchParams.set("timeMax", to.toISOString());
+    url.searchParams.set("singleEvents", "true");
+    url.searchParams.set("orderBy", "startTime");
+    url.searchParams.set("maxResults", "100");
+    const res = await fetch(url, {
+      headers: { authorization: `Bearer ${accessToken}` },
+    });
+    if (!res.ok) {
+      throw new Error(
+        `google events fetch ${res.status}: ${(await res.text()).slice(0, 200)}`,
+      );
+    }
+    type Item = {
+      id: string;
+      summary?: string;
+      description?: string;
+      location?: string;
+      start?: { dateTime?: string; date?: string };
+      end?: { dateTime?: string; date?: string };
+      htmlLink?: string;
+    };
+    const body = (await res.json()) as { items?: Item[] };
+    return (body.items ?? []).map((it) => ({
+      external_id: it.id,
+      title: it.summary ?? "(untitled)",
+      description: it.description ?? null,
+      location: it.location ?? null,
+      starts_at: it.start?.dateTime ?? it.start?.date ?? from.toISOString(),
+      ends_at: it.end?.dateTime ?? it.end?.date ?? null,
+      all_day: !!it.start?.date && !it.start?.dateTime,
+      source_calendar: "primary",
+      html_link: it.htmlLink ?? null,
+      raw: it,
+    }));
+  }
+
+  // Microsoft Graph
+  const url = new URL("https://graph.microsoft.com/v1.0/me/calendarView");
+  url.searchParams.set("startDateTime", from.toISOString());
+  url.searchParams.set("endDateTime", to.toISOString());
+  url.searchParams.set("$top", "100");
+  const res = await fetch(url, {
+    headers: { authorization: `Bearer ${accessToken}` },
+  });
+  if (!res.ok) {
+    throw new Error(
+      `microsoft events fetch ${res.status}: ${(await res.text()).slice(0, 200)}`,
+    );
+  }
+  type GraphItem = {
+    id: string;
+    subject?: string;
+    bodyPreview?: string;
+    location?: { displayName?: string };
+    start?: { dateTime?: string };
+    end?: { dateTime?: string };
+    isAllDay?: boolean;
+    webLink?: string;
+  };
+  const body = (await res.json()) as { value?: GraphItem[] };
+  return (body.value ?? []).map((it) => ({
+    external_id: it.id,
+    title: it.subject ?? "(untitled)",
+    description: it.bodyPreview ?? null,
+    location: it.location?.displayName ?? null,
+    starts_at: it.start?.dateTime ?? from.toISOString(),
+    ends_at: it.end?.dateTime ?? null,
+    all_day: !!it.isAllDay,
+    source_calendar: "primary",
+    html_link: it.webLink ?? null,
+    raw: it,
+  }));
+}
+
+async function upsertEvents(
+  a: AdminClient,
+  connectionId: string,
+  events: NormalizedEvent[],
+): Promise<void> {
+  if (events.length === 0) return;
+  const rows = events.map((e) => ({
+    connection_id: connectionId,
+    external_id: e.external_id,
+    title: e.title,
+    description: e.description,
+    location: e.location,
+    starts_at: e.starts_at,
+    ends_at: e.ends_at,
+    all_day: e.all_day,
+    source_calendar: e.source_calendar,
+    html_link: e.html_link,
+    raw: e.raw as Record<string, unknown>,
+    fetched_at: new Date().toISOString(),
+    deleted_at: null,
+  }));
+  const { error } = await a
+    .from("calendar_events")
+    // eslint-disable-next-line
+    .upsert(rows as any, { onConflict: "connection_id,external_id" });
+  if (error) throw new Error(`upsert: ${error.message}`);
+
+  // Soft-delete events we no longer see in the window (cancelled,
+  // moved out, deleted in the source). Quoting matters: external_id
+  // values can contain commas, so we wrap each in double quotes per
+  // PostgREST `not.in` syntax.
+  const ids = events.map((e) => `"${e.external_id.replace(/"/g, '\\"')}"`);
+  const { error: delErr } = await a
+    .from("calendar_events")
+    // eslint-disable-next-line
+    .update({ deleted_at: new Date().toISOString() } as any)
+    .eq("connection_id", connectionId)
+    .is("deleted_at", null)
+    .not("external_id", "in", `(${ids.join(",")})`);
+  if (delErr) console.warn("[calendar-sync] cleanup delete failed:", delErr.message);
+}

--- a/apps/web/src/lib/calendar-sync.ts
+++ b/apps/web/src/lib/calendar-sync.ts
@@ -347,17 +347,41 @@ async function upsertEvents(
     .upsert(rows as any, { onConflict: "connection_id,external_id" });
   if (error) throw new Error(`upsert: ${error.message}`);
 
-  // Soft-delete events we no longer see in the window (cancelled,
-  // moved out, deleted in the source). Quoting matters: external_id
-  // values can contain commas, so we wrap each in double quotes per
-  // PostgREST `not.in` syntax.
-  const ids = events.map((e) => `"${e.external_id.replace(/"/g, '\\"')}"`);
+  // Soft-delete events we no longer see in the window (cancelled, moved
+  // out, deleted in the source).
+  //
+  // Earlier revisions used PostgREST's `.not("external_id", "in", "(…)")`
+  // filter built from a comma-joined string, which required escaping
+  // every quote/backslash in the external_id (CodeQL flagged it as a
+  // string-escape sink). The two-step approach below is safer: query the
+  // current live IDs for this connection, diff them in JS against the
+  // events we just upserted, and soft-delete by primary key. Both reads
+  // and writes use parameterised filters, no manual string interpolation.
+  const { data: live, error: liveErr } = await a
+    .from("calendar_events")
+    .select("id, external_id")
+    .eq("connection_id", connectionId)
+    .is("deleted_at", null);
+  if (liveErr) {
+    console.warn("[calendar-sync] cleanup lookup failed:", liveErr.message);
+    return;
+  }
+  const seen = new Set(events.map((e) => e.external_id));
+  const stale = (live ?? [])
+    .filter((r): r is { id: string; external_id: string } =>
+      typeof r === "object" &&
+      r !== null &&
+      "external_id" in r &&
+      typeof (r as { external_id?: unknown }).external_id === "string",
+    )
+    .filter((r) => !seen.has(r.external_id))
+    .map((r) => r.id);
+  if (stale.length === 0) return;
   const { error: delErr } = await a
     .from("calendar_events")
     // eslint-disable-next-line
     .update({ deleted_at: new Date().toISOString() } as any)
-    .eq("connection_id", connectionId)
-    .is("deleted_at", null)
-    .not("external_id", "in", `(${ids.join(",")})`);
-  if (delErr) console.warn("[calendar-sync] cleanup delete failed:", delErr.message);
+    .in("id", stale);
+  if (delErr)
+    console.warn("[calendar-sync] cleanup delete failed:", delErr.message);
 }

--- a/apps/web/src/lib/supabase/middleware.ts
+++ b/apps/web/src/lib/supabase/middleware.ts
@@ -61,6 +61,7 @@ export async function updateSession(request: NextRequest) {
     pathname.startsWith("/auth/") ||
     pathname.startsWith("/api/v1/auth/") ||
     pathname.startsWith("/api/v1/health") ||
+    pathname.startsWith("/api/v1/cron/") ||
     pathname.startsWith("/api/v1/share/") ||
     pathname.startsWith("/r/") ||
     pathname === "/help" ||


### PR DESCRIPTION
Closes the two follow-ups from tonight's Outlook integration: (1) account_email is read from the OIDC id_token instead of /me (no User.Read scope needed); (2) sync runs from a GitHub Actions cron that POSTs /api/v1/cron/calendar-sync every 15 min.