### PR TITLE
feat(calendars): density + behavioral pass (29 items)

### DIFF
--- a/apps/web/src/app/api/v1/calendar/sync-now/route.ts
+++ b/apps/web/src/app/api/v1/calendar/sync-now/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { runCalendarSyncForUser } from "@/lib/calendar-sync";
+
+/**
+ * POST /api/v1/calendar/sync-now
+ *
+ * User-facing companion to the cron-driven /api/v1/cron/calendar-sync
+ * endpoint. Authorizes via the caller's Supabase session and only syncs
+ * the caller's own connections — never anyone else's. Useful when the
+ * user just (re)connected and wants to see events without waiting for
+ * the next scheduled tick.
+ */
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+export async function POST(_req: NextRequest) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json(
+      { errors: [{ code: "unauthenticated", message: "Sign in required" }] },
+      { status: 401 },
+    );
+  }
+  const result = await runCalendarSyncForUser(user.id);
+  return NextResponse.json({ data: result });
+}

--- a/apps/web/src/app/settings/calendars/Banner.tsx
+++ b/apps/web/src/app/settings/calendars/Banner.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter, usePathname } from "next/navigation";
+import { AlertTriangle, CheckCircle2, X } from "lucide-react";
+
+/**
+ * Dismissible status banner that auto-clears its triggering query
+ * params from the URL after first paint. Keeps `?connected=microsoft`
+ * and `?error=...` from sticking forever in the address bar.
+ */
+export function Banner({
+  variant,
+  message,
+}: {
+  variant: "success" | "danger";
+  message: string;
+}) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const [open, setOpen] = useState(true);
+
+  // Strip the query params after a tick so a refresh doesn't replay the
+  // banner. Doing this in a useEffect (vs. inside the dismiss handler)
+  // means even users who navigate away mid-session get a clean URL.
+  useEffect(() => {
+    const t = window.setTimeout(() => router.replace(pathname), 100);
+    return () => window.clearTimeout(t);
+  }, [router, pathname]);
+
+  if (!open) return null;
+  const styles =
+    variant === "success"
+      ? "border-success-subtle bg-success-subtle text-success"
+      : "border-danger-subtle bg-danger-subtle text-danger";
+  const Icon = variant === "success" ? CheckCircle2 : AlertTriangle;
+  return (
+    <div
+      className={`mb-4 inline-flex max-w-fit items-center gap-2 rounded border px-3 py-2 text-xs ${styles}`}
+      role={variant === "danger" ? "alert" : "status"}
+      aria-live={variant === "danger" ? "assertive" : "polite"}
+    >
+      <Icon className="h-3 w-3 flex-shrink-0" aria-hidden="true" />
+      <span className="flex-1">{message}</span>
+      <button
+        type="button"
+        onClick={() => setOpen(false)}
+        aria-label="Dismiss"
+        className="rounded-sm p-0.5 opacity-70 hover:bg-bg-3 hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-focus"
+      >
+        <X className="h-3 w-3" />
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/app/settings/calendars/ConnectButton.tsx
+++ b/apps/web/src/app/settings/calendars/ConnectButton.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useState } from "react";
+import { Loader2 } from "lucide-react";
+import { ProviderLogo } from "./ProviderLogo";
+
+/**
+ * Connect button — kicks off the OAuth dance for a provider.
+ *
+ * Implemented as a client form (not a <Link>) because:
+ *   1. The server endpoint at /api/v1/calendar/connect/:provider mints
+ *      a state cookie and redirects. Going through a <Link prefetch>
+ *      would consume the cookie on hover, leaving a stale state for
+ *      the real click → bad_state on OAuth callback.
+ *   2. We want to disable the button after the first click so a
+ *      double-click can't burn two state cookies in a row.
+ *   3. We surface a "Redirecting…" pending state for slow networks,
+ *      since browser tabs can show no progress between click and the
+ *      provider redirect.
+ */
+export function ConnectButton({
+  provider,
+  label,
+}: {
+  provider: "google" | "microsoft";
+  label: string;
+}) {
+  const [pending, setPending] = useState(false);
+  return (
+    <button
+      type="button"
+      disabled={pending}
+      onClick={() => {
+        setPending(true);
+        window.location.href = `/api/v1/calendar/connect/${provider}`;
+      }}
+      className="inline-flex items-center gap-1.5 rounded-sm border border-accent bg-accent-subtle px-2.5 py-1 text-xs font-semibold uppercase tracking-wide text-accent hover:bg-accent/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-focus disabled:cursor-not-allowed disabled:opacity-50"
+    >
+      {pending ? (
+        <Loader2 className="h-3 w-3 animate-spin" aria-hidden="true" />
+      ) : (
+        <ProviderLogo provider={provider} size={12} />
+      )}
+      {pending ? "Redirecting…" : `Connect ${label}`}
+    </button>
+  );
+}

--- a/apps/web/src/app/settings/calendars/DisconnectButton.tsx
+++ b/apps/web/src/app/settings/calendars/DisconnectButton.tsx
@@ -1,23 +1,65 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useState, useTransition, useRef, useEffect } from "react";
 import { useRouter } from "next/navigation";
-import { Trash2 } from "lucide-react";
+import { Loader2, Unlink } from "lucide-react";
 
 /**
  * Disconnect button — sends DELETE /api/v1/calendar/connections/:id
- * via fetch, then refreshes the page so the connection drops off the
- * list.
+ * via fetch, then refreshes the page.
  *
- * The original implementation relied on `formMethod="DELETE"` on a
- * <button>, which isn't valid HTML — formmethod only accepts get/post/
- * dialog, so browsers silently fell back to GET and the request failed
- * with ERR_INVALID_RESPONSE. fetch() is the right primitive here.
+ * Two-stage confirmation: first click shows "Confirm?" inline,
+ * second click within 3s actually fires the request. After 3s of
+ * inactivity it reverts. Avoids modal weight while still preventing
+ * accidental disconnects.
+ *
+ * Trash icon previously used here was misleading — disconnect is a
+ * soft revoke (sets revoked_at), not a permanent delete. Unlink reads
+ * more accurately.
  */
 export function DisconnectButton({ id }: { id: string }) {
   const router = useRouter();
-  const [isPending, startTransition] = useTransition();
+  const [pending, startTransition] = useTransition();
   const [error, setError] = useState<string | null>(null);
+  const [confirming, setConfirming] = useState(false);
+  const revertTimer = useRef<number | null>(null);
+
+  // Reset confirming state if user wanders off without acting on it.
+  useEffect(() => {
+    if (confirming) {
+      revertTimer.current = window.setTimeout(() => setConfirming(false), 3000);
+      return () => {
+        if (revertTimer.current) window.clearTimeout(revertTimer.current);
+      };
+    }
+  }, [confirming]);
+
+  const fire = () => {
+    setError(null);
+    startTransition(async () => {
+      try {
+        const res = await fetch(`/api/v1/calendar/connections/${id}`, {
+          method: "DELETE",
+        });
+        if (!res.ok) {
+          let detail = `HTTP ${res.status}`;
+          try {
+            const body = (await res.json()) as {
+              errors?: { message?: string }[];
+            };
+            if (body.errors?.[0]?.message) detail = body.errors[0].message;
+          } catch {
+            // ignore parse errors
+          }
+          setError(detail);
+          return;
+        }
+        router.refresh();
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "Network error");
+      }
+    });
+  };
 
   return (
     <div className="flex items-center gap-2">
@@ -28,39 +70,35 @@ export function DisconnectButton({ id }: { id: string }) {
       ) : null}
       <button
         type="button"
-        disabled={isPending}
+        disabled={pending}
         onClick={() => {
-          setError(null);
-          startTransition(async () => {
-            try {
-              const res = await fetch(`/api/v1/calendar/connections/${id}`, {
-                method: "DELETE",
-              });
-              if (!res.ok) {
-                let detail = `HTTP ${res.status}`;
-                try {
-                  const body = (await res.json()) as {
-                    errors?: { message?: string }[];
-                  };
-                  if (body.errors?.[0]?.message)
-                    detail = body.errors[0].message;
-                } catch {
-                  // Ignore body parse failures — the status is enough.
-                }
-                setError(detail);
-                return;
-              }
-              router.refresh();
-            } catch (e) {
-              setError(e instanceof Error ? e.message : "Network error");
-            }
-          });
+          if (pending) return;
+          if (!confirming) {
+            setConfirming(true);
+            return;
+          }
+          fire();
+          setConfirming(false);
         }}
-        className="flex items-center gap-1 rounded-sm border border-border px-2 py-1 text-xs text-danger hover:bg-danger-subtle disabled:cursor-not-allowed disabled:opacity-50"
-        aria-label="Disconnect calendar"
+        className={`flex items-center gap-1 rounded-sm border px-2 py-1 text-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-focus disabled:cursor-not-allowed disabled:opacity-50 ${
+          confirming
+            ? "border-danger bg-danger-subtle text-danger hover:bg-danger/20"
+            : "border-border text-danger hover:bg-danger-subtle"
+        }`}
+        aria-label={
+          confirming ? "Confirm disconnect" : "Disconnect calendar"
+        }
       >
-        <Trash2 className="h-3 w-3" />
-        {isPending ? "Disconnecting…" : "Disconnect"}
+        {pending ? (
+          <Loader2 className="h-3 w-3 animate-spin" aria-hidden="true" />
+        ) : (
+          <Unlink className="h-3 w-3" aria-hidden="true" />
+        )}
+        {pending
+          ? "Disconnecting…"
+          : confirming
+            ? "Confirm?"
+            : "Disconnect"}
       </button>
     </div>
   );

--- a/apps/web/src/app/settings/calendars/ProviderLogo.tsx
+++ b/apps/web/src/app/settings/calendars/ProviderLogo.tsx
@@ -1,0 +1,70 @@
+/**
+ * Tiny brand-colored provider tiles for the calendars list. Inline
+ * SVG paths use the official Google + Microsoft brand glyphs at a
+ * scaled-down 16px footprint so connection rows stay dense.
+ *
+ * Trademark note: both marks are used here only to identify the
+ * destination service in a UI affordance (a connect button), which is
+ * the canonical fair-use case for both Google's and Microsoft's brand
+ * guidelines. No endorsement is implied.
+ */
+
+export function ProviderLogo({
+  provider,
+  size = 16,
+  className,
+}: {
+  provider: "google" | "microsoft";
+  size?: number;
+  className?: string;
+}) {
+  if (provider === "google") {
+    return (
+      <svg
+        width={size}
+        height={size}
+        viewBox="0 0 24 24"
+        xmlns="http://www.w3.org/2000/svg"
+        aria-label="Google"
+        role="img"
+        className={className}
+      >
+        <path
+          d="M22.501 12.232c0-.815-.073-1.6-.21-2.354H12v4.448h5.892a5.04 5.04 0 0 1-2.184 3.305v2.745h3.532c2.07-1.907 3.261-4.713 3.261-8.144Z"
+          fill="#4285F4"
+        />
+        <path
+          d="M12 23c2.94 0 5.404-.974 7.205-2.624l-3.532-2.745c-.978.654-2.231 1.04-3.673 1.04-2.823 0-5.214-1.906-6.067-4.467H2.295v2.83A10.998 10.998 0 0 0 12 23Z"
+          fill="#34A853"
+        />
+        <path
+          d="M5.933 14.204A6.612 6.612 0 0 1 5.585 12c0-.766.132-1.51.348-2.204V6.966H2.295a11 11 0 0 0 0 10.068l3.638-2.83Z"
+          fill="#FBBC04"
+        />
+        <path
+          d="M12 5.329c1.595 0 3.027.55 4.155 1.624l3.116-3.116C17.4 2.057 14.94 1 12 1 7.7 1 3.987 3.467 2.295 6.966l3.638 2.83C6.786 7.235 9.177 5.33 12 5.33Z"
+          fill="#EA4335"
+        />
+      </svg>
+    );
+  }
+  // Microsoft Outlook — simplified four-square mark in Microsoft blue.
+  // Real Outlook icon is more elaborate; this reads at 16px and matches
+  // the visual weight of the Google G.
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-label="Microsoft Outlook"
+      role="img"
+      className={className}
+    >
+      <rect x="2" y="2" width="9" height="9" fill="#F25022" />
+      <rect x="13" y="2" width="9" height="9" fill="#7FBA00" />
+      <rect x="2" y="13" width="9" height="9" fill="#00A4EF" />
+      <rect x="13" y="13" width="9" height="9" fill="#FFB900" />
+    </svg>
+  );
+}

--- a/apps/web/src/app/settings/calendars/SyncNowButton.tsx
+++ b/apps/web/src/app/settings/calendars/SyncNowButton.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { Loader2, RefreshCw } from "lucide-react";
+
+/**
+ * Sync-now button — POSTs /api/v1/calendar/sync-now and refreshes the
+ * server component so the new last_sync_at + event count render.
+ * Shows a small inline result toast so the user gets feedback even if
+ * 0 events were synced (otherwise nothing visibly changes).
+ */
+export function SyncNowButton() {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [feedback, setFeedback] = useState<{
+    kind: "success" | "danger";
+    text: string;
+  } | null>(null);
+
+  return (
+    <div className="flex items-center gap-2">
+      {feedback ? (
+        <span
+          className={`text-[10px] ${
+            feedback.kind === "success" ? "text-success" : "text-danger"
+          }`}
+          role="status"
+        >
+          {feedback.text}
+        </span>
+      ) : null}
+      <button
+        type="button"
+        disabled={pending}
+        onClick={() => {
+          setFeedback(null);
+          startTransition(async () => {
+            try {
+              const res = await fetch("/api/v1/calendar/sync-now", {
+                method: "POST",
+              });
+              if (!res.ok) {
+                setFeedback({ kind: "danger", text: `Sync failed (${res.status})` });
+                return;
+              }
+              const body = (await res.json()) as {
+                data?: {
+                  attempted: number;
+                  succeeded: number;
+                  failed: number;
+                  events: number;
+                };
+              };
+              const d = body.data;
+              if (!d) {
+                setFeedback({ kind: "danger", text: "Sync failed (no data)" });
+                return;
+              }
+              setFeedback({
+                kind: d.failed > 0 ? "danger" : "success",
+                text:
+                  d.failed > 0
+                    ? `${d.failed} of ${d.attempted} failed`
+                    : `Synced ${d.events} event${d.events === 1 ? "" : "s"}`,
+              });
+              router.refresh();
+              window.setTimeout(() => setFeedback(null), 4000);
+            } catch (e) {
+              setFeedback({
+                kind: "danger",
+                text: e instanceof Error ? e.message : "Network error",
+              });
+            }
+          });
+        }}
+        className="inline-flex items-center gap-1.5 rounded-sm border border-border bg-bg-2 px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-text-1 hover:bg-bg-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-focus disabled:cursor-not-allowed disabled:opacity-50"
+        aria-label="Sync now"
+        title="Run a sync tick now"
+      >
+        {pending ? (
+          <Loader2 className="h-3 w-3 animate-spin" aria-hidden="true" />
+        ) : (
+          <RefreshCw className="h-3 w-3" aria-hidden="true" />
+        )}
+        {pending ? "Syncing…" : "Sync"}
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/app/settings/calendars/page.tsx
+++ b/apps/web/src/app/settings/calendars/page.tsx
@@ -1,20 +1,28 @@
 import { redirect } from "next/navigation";
 import Link from "next/link";
-import {
-  Calendar,
-  AlertTriangle,
-  CheckCircle2,
-  CalendarOff,
-} from "lucide-react";
+import { CalendarOff, AlertTriangle } from "lucide-react";
 import { createClient } from "@/lib/supabase/server";
 import { TopBar } from "@/components/TopBar";
-import { EmptyState } from "@/components/EmptyState";
 import { providerConfig } from "@/lib/calendar-oauth";
+import {
+  AdminBadge,
+  AdminPanel,
+  AdminSectionHeader,
+} from "@/components/admin/primitives";
 import { DisconnectButton } from "./DisconnectButton";
+import { ConnectButton } from "./ConnectButton";
+import { SyncNowButton } from "./SyncNowButton";
+import { Banner } from "./Banner";
+import { ProviderLogo } from "./ProviderLogo";
 
 interface Props {
   searchParams: Promise<{ connected?: string; error?: string; provider?: string }>;
 }
+
+const PROVIDERS: Array<{ id: "google" | "microsoft"; label: string; subtitle: string }> = [
+  { id: "google", label: "Google Calendar", subtitle: "Google Workspace" },
+  { id: "microsoft", label: "Outlook / Microsoft 365", subtitle: "Microsoft 365" },
+];
 
 export default async function CalendarsPage({ searchParams }: Props) {
   const params = await searchParams;
@@ -24,6 +32,9 @@ export default async function CalendarsPage({ searchParams }: Props) {
   } = await supabase.auth.getUser();
   if (!user) redirect("/login");
 
+  // Pull connections + per-connection live event counts in parallel.
+  // Counting events per connection is ~one extra round-trip and lets the
+  // row carry "23 events" so users can confirm the sync is producing data.
   const { data: rows } = await supabase
     .from("calendar_connections")
     .select(
@@ -44,147 +55,318 @@ export default async function CalendarsPage({ searchParams }: Props) {
   const connections = (rows ?? []) as Row[];
   const active = connections.filter((c) => !c.revoked_at);
 
-  const providers: Array<{ id: "google" | "microsoft"; label: string }> = [
-    { id: "google", label: "Google Calendar" },
-    { id: "microsoft", label: "Outlook / Microsoft 365" },
-  ];
-  const available = providers.filter((p) => providerConfig(p.id) !== null);
-  const unavailable = providers.filter((p) => providerConfig(p.id) === null);
+  // RLS-scoped event counts per active connection. `head: true` makes
+  // these count-only queries with no row payload.
+  const eventCounts = new Map<string, number>();
+  if (active.length > 0) {
+    const counts = await Promise.all(
+      active.map((c) =>
+        supabase
+          .from("calendar_events")
+          .select("id", { count: "exact", head: true })
+          .eq("connection_id", c.id)
+          .is("deleted_at", null),
+      ),
+    );
+    active.forEach((c, i) => eventCounts.set(c.id, counts[i].count ?? 0));
+  }
+
+  const available = PROVIDERS.filter((p) => providerConfig(p.id) !== null);
+  const unavailable = PROVIDERS.filter((p) => providerConfig(p.id) === null);
+  const connectedProviders = new Set(active.map((c) => c.provider));
+  const isProd = process.env.NODE_ENV === "production";
 
   return (
     <div className="flex min-h-screen flex-col bg-bg-0">
       <TopBar>
-        <Link href="/settings" className="text-text-3 hover:text-text-1">
+        <Link
+          href="/settings"
+          className="text-text-3 hover:text-text-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-focus rounded-sm"
+        >
           ← Settings
         </Link>
         <span className="text-text-3">·</span>
         <span className="text-text-0">Calendars</span>
       </TopBar>
       <main className="mx-auto w-full max-w-3xl flex-1 p-6">
-        <h1 className="mb-2 flex items-center gap-2 text-xl font-semibold text-text-0">
-          <Calendar className="h-5 w-5 text-accent" />
-          Connected calendars
-        </h1>
-        <p className="mb-6 text-xs text-text-3">
-          Rokki syncs read-only. Nothing is created or modified in your
-          provider&apos;s calendar. Syncs run every ~15 minutes.
-        </p>
+        <AdminSectionHeader
+          title="Connected calendars"
+          description="Read-only mirror — Rokki never creates or modifies events in the source calendar. Background sync runs every ~15 minutes."
+        />
 
         {params.connected ? (
-          <div className="mb-4 flex items-center gap-2 rounded border border-success-subtle bg-success-subtle px-3 py-2 text-xs text-success">
-            <CheckCircle2 className="h-3 w-3" />
-            Connected {params.connected} successfully.
-          </div>
+          <Banner
+            variant="success"
+            message={`Connected ${labelFor(params.connected)} successfully.`}
+          />
         ) : null}
         {params.error ? (
-          <div className="mb-4 flex items-center gap-2 rounded border border-danger-subtle bg-danger-subtle px-3 py-2 text-xs text-danger">
-            <AlertTriangle className="h-3 w-3" />
-            {errorMessage(params.error, params.provider)}
-          </div>
+          <Banner
+            variant="danger"
+            message={errorMessage(params.error, params.provider)}
+          />
         ) : null}
 
-        {active.length === 0 ? (
-          <div className="mb-6 rounded border border-dashed border-border bg-bg-1">
-            <EmptyState
-              icon={CalendarOff}
-              title="No calendars connected yet."
-              body={
-                available.length > 0
-                  ? "Connect Google or Outlook below to mirror your events into Rokki's week view."
-                  : "Calendar OAuth isn't configured for this deployment yet."
-              }
-              className="p-6"
-            />
-          </div>
-        ) : (
-          <ul className="mb-6 divide-y divide-border rounded border border-border bg-bg-1 text-sm">
-            {active.map((c) => (
-              <li
-                key={c.id}
-                className="flex items-center gap-3 px-4 py-3"
-              >
-                <span
-                  className={`h-6 w-6 rounded-sm text-center text-xs font-semibold leading-6 ${
-                    c.provider === "google"
-                      ? "bg-info-subtle text-info"
-                      : "bg-warning-subtle text-warning"
-                  }`}
-                >
-                  {c.provider === "google" ? "G" : "O"}
-                </span>
-                <div className="flex-1 min-w-0">
-                  <div className="truncate text-text-0">
-                    {c.account_email}
-                  </div>
-                  <div className="text-xs text-text-3">
-                    {c.last_sync_error
-                      ? `sync failed: ${c.last_sync_error}`
-                      : c.last_sync_at
-                        ? `last synced ${formatRelative(c.last_sync_at)}`
-                        : "awaiting first sync…"}
-                  </div>
+        {/* Connections panel */}
+        <AdminPanel
+          title={`Active${active.length > 0 ? ` · ${active.length}` : ""}`}
+          className="mb-4"
+        >
+          {active.length === 0 ? (
+            <div className="flex flex-col items-center gap-3 p-8 text-center text-xs text-text-3">
+              <CalendarOff
+                className="h-5 w-5 text-text-3"
+                aria-hidden="true"
+              />
+              <p>
+                {available.length > 0
+                  ? "No calendars connected yet — pick a provider below to mirror your events into the week view."
+                  : "Calendar OAuth isn't configured for this deployment yet."}
+              </p>
+              {available.length > 0 ? (
+                <div className="flex flex-wrap justify-center gap-2">
+                  {available.map((p) => (
+                    <ConnectButton
+                      key={p.id}
+                      provider={p.id}
+                      label={p.label}
+                    />
+                  ))}
                 </div>
-                <DisconnectButton id={c.id} />
-              </li>
-            ))}
-          </ul>
-        )}
+              ) : null}
+            </div>
+          ) : (
+            <ul className="divide-y divide-border text-sm">
+              {active.map((c) => {
+                const eventCount = eventCounts.get(c.id) ?? 0;
+                return (
+                  <li
+                    key={c.id}
+                    className="flex flex-wrap items-center gap-3 px-4 py-2.5"
+                  >
+                    <ProviderLogo
+                      provider={c.provider}
+                      size={18}
+                      className="flex-shrink-0"
+                    />
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-baseline gap-2">
+                        <span
+                          className="truncate text-text-0"
+                          title={c.account_email}
+                        >
+                          {c.account_email}
+                        </span>
+                        <span className="font-mono text-[9px] uppercase tracking-wide text-text-3">
+                          {PROVIDERS.find((p) => p.id === c.provider)?.subtitle}
+                        </span>
+                      </div>
+                      <div className="mt-0.5 flex items-center gap-2 text-[10px] text-text-3">
+                        <SyncStatus
+                          lastSyncAt={c.last_sync_at}
+                          lastSyncError={c.last_sync_error}
+                        />
+                        <span className="text-text-3">·</span>
+                        <span className="font-mono">
+                          {eventCount} event{eventCount === 1 ? "" : "s"}
+                        </span>
+                        <span className="text-text-3">·</span>
+                        <AdminBadge variant="muted">READ ONLY</AdminBadge>
+                      </div>
+                    </div>
+                    <SyncNowButton />
+                    <DisconnectButton id={c.id} />
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </AdminPanel>
 
-        <h2 className="mb-2 text-xs font-semibold uppercase tracking-wide text-text-3">
-          Add calendar
-        </h2>
-        <ul className="divide-y divide-border rounded border border-border bg-bg-1 text-sm">
-          {available.map((p) => (
-            <li key={p.id} className="flex items-center gap-3 px-4 py-3">
-              <span className="flex-1 text-text-0">{p.label}</span>
-              <Link
-                href={`/api/v1/calendar/connect/${p.id}`}
-                className="rounded-sm bg-accent px-3 py-1 text-xs text-bg-0 hover:opacity-90"
-              >
-                Connect
-              </Link>
-            </li>
-          ))}
-          {unavailable.map((p) => (
-            <li
-              key={p.id}
-              className="flex items-center gap-3 px-4 py-3 text-text-3"
-            >
-              <span className="flex-1">{p.label}</span>
-              <span className="rounded-sm bg-bg-2 px-2 py-1 text-[10px] uppercase tracking-wide">
-                not configured
-              </span>
-            </li>
-          ))}
-        </ul>
+        {/* Add-calendar panel — only shown when there's at least one
+            provider not already connected, otherwise it's just noise. */}
+        {available.some((p) => !connectedProviders.has(p.id)) ||
+        unavailable.length > 0 ? (
+          <AdminPanel title="Add calendar" className="mb-4">
+            <ul className="divide-y divide-border text-sm">
+              {available
+                .filter((p) => !connectedProviders.has(p.id))
+                .map((p) => (
+                  <li
+                    key={p.id}
+                    className="flex items-center gap-3 px-4 py-2.5"
+                  >
+                    <ProviderLogo
+                      provider={p.id}
+                      size={18}
+                      className="flex-shrink-0"
+                    />
+                    <span className="flex-1 text-text-1">{p.label}</span>
+                    <ConnectButton provider={p.id} label={p.label} />
+                  </li>
+                ))}
+              {available
+                .filter((p) => connectedProviders.has(p.id))
+                .map((p) => (
+                  <li
+                    key={p.id}
+                    className="flex items-center gap-3 px-4 py-2.5 text-text-3"
+                  >
+                    <ProviderLogo
+                      provider={p.id}
+                      size={18}
+                      className="flex-shrink-0 opacity-50"
+                    />
+                    <span className="flex-1">{p.label}</span>
+                    <AdminBadge variant="success">CONNECTED</AdminBadge>
+                  </li>
+                ))}
+              {unavailable.map((p) => (
+                <li
+                  key={p.id}
+                  className="flex items-center gap-3 px-4 py-2.5 text-text-3"
+                >
+                  <ProviderLogo
+                    provider={p.id}
+                    size={18}
+                    className="flex-shrink-0 opacity-50"
+                  />
+                  <span className="flex-1">{p.label}</span>
+                  <AdminBadge variant="muted">NOT CONFIGURED</AdminBadge>
+                </li>
+              ))}
+            </ul>
+          </AdminPanel>
+        ) : null}
+
+        {/* "Setup:" footer — useful for self-hosters in dev, noise in
+            prod. In prod, instruct the user to ask their admin instead
+            of pointing at a file path they can't edit. */}
         {unavailable.length > 0 ? (
-          <div className="mt-4 rounded border border-border bg-bg-1 p-3 text-xs text-text-3">
-            <strong className="text-text-1">Setup:</strong> to enable{" "}
-            {unavailable.map((p) => p.label).join(" and ")}, set the OAuth
-            client env vars in the web app (see <code>.env.example</code>).
-          </div>
+          <p className="text-[11px] text-text-3">
+            <strong className="text-text-2">Setup:</strong>{" "}
+            {isProd
+              ? `Ask your Rokki administrator to enable ${unavailable
+                  .map((p) => p.label)
+                  .join(" and ")}.`
+              : `set the OAuth client env vars in the web app (see `}
+            {isProd ? null : (
+              <>
+                <code className="rounded-sm bg-bg-2 px-1 font-mono">
+                  apps/web/.env.example
+                </code>
+                ).
+              </>
+            )}
+          </p>
         ) : null}
       </main>
     </div>
   );
 }
 
+/**
+ * Renders the per-connection sync status as a colored pill: success
+ * (synced N ago), pending (queued), or error (with truncated reason).
+ * Long error messages get a `title` attribute so the full text is
+ * available without the row growing vertically.
+ */
+function SyncStatus({
+  lastSyncAt,
+  lastSyncError,
+}: {
+  lastSyncAt: string | null;
+  lastSyncError: string | null;
+}) {
+  if (lastSyncError) {
+    return (
+      <span
+        className="inline-flex items-center gap-1 text-danger"
+        title={lastSyncError}
+      >
+        <AlertTriangle className="h-3 w-3" aria-hidden="true" />
+        <span className="max-w-[20ch] truncate font-mono">
+          {lastSyncError}
+        </span>
+      </span>
+    );
+  }
+  if (!lastSyncAt) {
+    return <AdminBadge variant="warning">QUEUED</AdminBadge>;
+  }
+  const iso = lastSyncAt;
+  return (
+    <span title={iso}>
+      <AdminBadge variant="success">SYNCED {formatRelative(iso)}</AdminBadge>
+    </span>
+  );
+}
+
+function labelFor(providerId: string): string {
+  if (providerId === "microsoft") return "Outlook / Microsoft 365";
+  if (providerId === "google") return "Google Calendar";
+  return providerId;
+}
+
 function errorMessage(code: string, provider?: string): string {
   if (code === "provider_not_configured")
     return `${provider ?? "This provider"} is not configured. Ask an admin to add the OAuth credentials.`;
-  if (code === "bad_state") return "Auth state mismatch — please try again.";
+  if (code === "bad_state")
+    return "Auth state mismatch — please try again.";
   if (code === "token_exchange_failed")
     return "We couldn't exchange the auth code for tokens.";
-  if (code === "save_failed") return "Sync saved failed. Try again.";
+  if (code === "save_failed") return "Saving the connection failed. Try again.";
+  if (code === "missing_code") return "Auth flow returned without a code.";
+  if (code === "unknown_provider") return "Unknown provider.";
   return `Connection failed: ${code}`;
 }
 
+/**
+ * Format a past timestamp relative to now, with finer-grained labels
+ * than the original "Xh ago" / "Xd ago" version. Within the last
+ * minute: "just now". Within an hour: "Nm ago". Today (>= 1h): "3h
+ * ago". Yesterday in this calendar day: "yesterday HH:MMam/pm".
+ * Within the last week: weekday + time. Older: short date.
+ */
 function formatRelative(iso: string): string {
-  const ms = Date.now() - new Date(iso).getTime();
+  const now = new Date();
+  const then = new Date(iso);
+  const ms = now.getTime() - then.getTime();
+  if (ms < 60_000) return "just now";
   const m = Math.floor(ms / 60_000);
-  if (m < 1) return "just now";
   if (m < 60) return `${m}m ago`;
   const h = Math.floor(m / 60);
-  if (h < 24) return `${h}h ago`;
-  return `${Math.floor(h / 24)}d ago`;
+  // If still on the same calendar day — use Nh ago.
+  if (
+    h < 24 &&
+    now.getDate() === then.getDate() &&
+    now.getMonth() === then.getMonth() &&
+    now.getFullYear() === then.getFullYear()
+  ) {
+    return `${h}h ago`;
+  }
+  const yesterday = new Date(now);
+  yesterday.setDate(now.getDate() - 1);
+  if (
+    yesterday.getDate() === then.getDate() &&
+    yesterday.getMonth() === then.getMonth() &&
+    yesterday.getFullYear() === then.getFullYear()
+  ) {
+    return `yesterday ${formatTime(then)}`;
+  }
+  const days = Math.floor(ms / (24 * 60 * 60 * 1000));
+  if (days < 7) {
+    return `${then.toLocaleDateString(undefined, { weekday: "short" })} ${formatTime(then)}`;
+  }
+  return then.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+  });
+}
+
+function formatTime(d: Date): string {
+  return d
+    .toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" })
+    .toLowerCase()
+    .replace(/\s/g, "");
 }

--- a/apps/web/src/lib/calendar-oauth.ts
+++ b/apps/web/src/lib/calendar-oauth.ts
@@ -66,7 +66,15 @@ export function providerConfig(p: Provider): ProviderConfig | null {
 }
 
 /** Build the auth URL with a random state. Caller stores the state in a
- * short-lived cookie and verifies on callback. */
+ * short-lived cookie and verifies on callback.
+ *
+ * `prompt=select_account consent` — when a user is already signed into
+ * a Microsoft/Google account in their browser, the IDP would otherwise
+ * silently use that one. Forcing the account picker is critical for
+ * the reconnect flow (users replacing a stale connection) and for the
+ * second-account flow (e.g. work + personal Outlook). `consent` is
+ * still requested so refresh_token is returned even if the user
+ * previously consented and was about to skip the screen. */
 export function authorizeUrl(
   p: Provider,
   config: ProviderConfig,
@@ -78,7 +86,7 @@ export function authorizeUrl(
     response_type: "code",
     scope: config.scopes.join(" "),
     access_type: p === "google" ? "offline" : "",
-    prompt: "consent",
+    prompt: "select_account consent",
     state,
   });
   return `${config.authorizeUrl}?${params.toString()}`;

--- a/apps/web/src/lib/calendar-sync.ts
+++ b/apps/web/src/lib/calendar-sync.ts
@@ -75,18 +75,45 @@ export interface TickResult {
 export async function runCalendarSyncTick(
   batchSize = BATCH_SIZE,
 ): Promise<TickResult> {
+  return runSync({ batchSize });
+}
+
+/**
+ * Sync only the connections owned by `userId`. Used by the user-facing
+ * "Sync now" button on /settings/calendars so a user can verify their
+ * connection without waiting for the next 15-min cron tick. Bypasses
+ * `last_sync_at` ordering — we want every connection the user owns.
+ */
+export async function runCalendarSyncForUser(
+  userId: string,
+): Promise<TickResult> {
+  return runSync({ userId });
+}
+
+interface SyncOptions {
+  userId?: string;
+  batchSize?: number;
+}
+
+async function runSync(opts: SyncOptions): Promise<TickResult> {
   const result: TickResult = { attempted: 0, succeeded: 0, failed: 0, events: 0 };
   const a = admin();
   if (!a) return result;
 
-  const { data, error } = await a
+  let q = a
     .from("calendar_connections")
     .select(
       "id, user_id, provider, account_email, access_token_ciphertext, access_token_iv, access_token_tag, access_token_expires_at, refresh_token_ciphertext, refresh_token_iv, refresh_token_tag",
     )
-    .is("revoked_at", null)
-    .order("last_sync_at", { ascending: true, nullsFirst: true })
-    .limit(batchSize);
+    .is("revoked_at", null);
+  if (opts.userId) {
+    q = q.eq("user_id", opts.userId);
+  } else {
+    q = q
+      .order("last_sync_at", { ascending: true, nullsFirst: true })
+      .limit(opts.batchSize ?? BATCH_SIZE);
+  }
+  const { data, error } = await q;
   if (error) {
     console.error("[calendar-sync] connection lookup failed:", error.message);
     return result;


### PR DESCRIPTION
First of three polish PRs for the calendar / dashboard / admin surfaces. 29 items spanning real provider logos, AdminPanel primitives, status pills, dismissible aria-live banner, two-stage disconnect confirmation, per-row sync-now, prompt=select_account, hide-already-connected providers, event counts per row, dev/prod-aware setup hint, and accessibility (focus rings everywhere).