### PR TITLE
feat(dashboard): explorer rail density + a11y (15 items)

### DIFF
--- a/apps/web/src/components/AccountBlock.tsx
+++ b/apps/web/src/components/AccountBlock.tsx
@@ -197,7 +197,12 @@ export function AccountBlock({
         </span>
         <span className="min-w-0 flex-1">
           <span className="flex items-center gap-1.5">
-            <span className="block truncate text-xs text-text-0">{name}</span>
+            <span
+              className="block truncate text-xs text-text-0"
+              title={name}
+            >
+              {name}
+            </span>
             {isPlatformAdmin ? (
               <ShieldCheck
                 className="h-3 w-3 flex-shrink-0 text-accent"
@@ -205,7 +210,10 @@ export function AccountBlock({
               />
             ) : null}
           </span>
-          <span className="block truncate font-mono text-[10px] text-text-3">
+          <span
+            className="block truncate font-mono text-[10px] text-text-3"
+            title={email}
+          >
             {email}
           </span>
         </span>

--- a/apps/web/src/components/DashboardClient.tsx
+++ b/apps/web/src/components/DashboardClient.tsx
@@ -99,6 +99,16 @@ export function DashboardClient({
           <TopBar>
             <span className="text-text-3">/</span>
             <span className="text-text-1">{greeting(userName)}</span>
+            {/* Subtle Cmd+K hint — replaces nothing, just adds a
+                discoverable shortcut for power users. The palette
+                itself is wired up in <CommandPalette> and triggered
+                by the global keydown handler. */}
+            <span className="ml-auto hidden items-center gap-1 text-[10px] text-text-3 sm:flex">
+              <kbd className="rounded-sm border border-border bg-bg-2 px-1 font-mono text-text-2">
+                ⌘K
+              </kbd>
+              <span>to search</span>
+            </span>
           </TopBar>
         }
         ticker={<TickerTape items={tickerItems} />}

--- a/apps/web/src/components/dashboard/ExplorerRail.tsx
+++ b/apps/web/src/components/dashboard/ExplorerRail.tsx
@@ -3,7 +3,6 @@
 import Link from "next/link";
 import { useEffect, useMemo, useRef, useState } from "react";
 import {
-  Building2,
   ChevronDown,
   ChevronRight,
   Clock,
@@ -33,16 +32,24 @@ interface ExplorerRailProps {
 
 /**
  * The left-rail Explorer. Three regions, top to bottom:
- *   - Search/filter input — narrows the tree to spaces + terminals whose
- *     name or ticker matches.
- *   - Recently-viewed terminals — local-only ring of the last 5 the user
- *     opened, click to jump.
+ *   - Search/filter input (sticky to the top of the scroll region)
+ *   - Recently-viewed terminals — local-only ring of the last 5 the
+ *     user opened, click to jump.
  *   - Two-level tree of spaces → their terminals. Collapse state
  *     persists per-device via localStorage.
  *
  * Bottom region:
- *   - Subtle Tools pill (count → /tools)
+ *   - Tools tile (count → /tools)
  *   - AccountBlock dropdown (full account-action surface)
+ *
+ * Density principles:
+ *   - Per-row leading content is the chevron only — no provider/space
+ *     glyph cluttering the leading area. Names carry the visual weight.
+ *   - Settings + new-terminal actions are always visible (subtle), not
+ *     opacity-0 on hover, so members can see they exist and admins
+ *     don't have to discover the feature.
+ *   - Tickers render in a fixed-width column so terminal names align
+ *     vertically across rows regardless of ticker length.
  */
 export function ExplorerRail({
   spaces,
@@ -142,10 +149,6 @@ export function ExplorerRail({
       window.removeEventListener("rokki:recent-terminals-changed", onChange);
   }, []);
 
-  // Skip recents that no longer correspond to a terminal the user can
-  // see (e.g. they were removed from the terminal). Looking up against
-  // the live terminals list also lets us decorate with the real name
-  // in case it was renamed since the visit.
   const liveRecents = useMemo(() => {
     if (recents.length === 0) return [];
     const byTicker = new Map(terminals.map((t) => [t.ticker, t]));
@@ -159,160 +162,232 @@ export function ExplorerRail({
 
   const filterRef = useRef<HTMLInputElement>(null);
 
+  // `/` global shortcut → focus the filter. Skip when the user is
+  // already typing into another input/textarea/contenteditable so we
+  // don't steal their slash from a chat box.
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key !== "/") return;
+      const t = e.target as HTMLElement | null;
+      const tag = t?.tagName;
+      if (
+        tag === "INPUT" ||
+        tag === "TEXTAREA" ||
+        tag === "SELECT" ||
+        t?.isContentEditable
+      ) {
+        return;
+      }
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+      e.preventDefault();
+      filterRef.current?.focus();
+      filterRef.current?.select();
+    }
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, []);
+
   return (
     <div className="flex h-full flex-col bg-bg-0">
       <div className="flex h-9 flex-shrink-0 items-center justify-between border-b border-border px-3">
         <span className="text-xs font-semibold uppercase tracking-wide text-text-3">
           Explorer
         </span>
+        {/* Plus is always rendered — disabled with a tooltip for
+            non-admins so the affordance is visible (and the tooltip
+            tells them why it's grayed out). */}
         {canCreateSpace ? (
           <Link
             href="/?new=space"
             aria-label="New space"
-            className="rounded-sm p-1 text-text-3 hover:bg-bg-2 hover:text-text-0"
+            className="rounded-sm p-1 text-text-3 hover:bg-bg-2 hover:text-text-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-focus"
             title="New space (admin)"
           >
             <Plus className="h-3 w-3" />
           </Link>
-        ) : null}
+        ) : (
+          <span
+            aria-label="New space (admin only)"
+            title="Only platform admins can create spaces"
+            className="rounded-sm p-1 text-text-3/50"
+          >
+            <Plus className="h-3 w-3" />
+          </span>
+        )}
       </div>
 
-      {/* Filter input — appears whenever there's anything to filter. */}
-      {spaces.length > 0 ? (
-        <div className="flex-shrink-0 border-b border-border px-2 py-1.5">
-          <div className="relative">
-            <Search
-              className="pointer-events-none absolute left-2 top-1/2 h-3 w-3 -translate-y-1/2 text-text-3"
-              aria-hidden="true"
-            />
-            <input
-              ref={filterRef}
-              type="text"
-              value={filter}
-              onChange={(e) => setFilter(e.target.value)}
-              placeholder="Filter spaces & terminals"
-              aria-label="Filter explorer"
-              className="h-7 w-full rounded-sm border border-border bg-bg-1 pl-7 pr-7 text-xs text-text-0 placeholder:text-text-3 focus:border-border-focus focus:outline-none"
-            />
-            {filter ? (
-              <button
-                type="button"
-                onClick={() => {
-                  setFilter("");
-                  filterRef.current?.focus();
-                }}
-                aria-label="Clear filter"
-                className="absolute right-1 top-1/2 -translate-y-1/2 rounded p-0.5 text-text-3 hover:bg-bg-3 hover:text-text-1"
-              >
-                <X className="h-3 w-3" />
-              </button>
-            ) : null}
-          </div>
-        </div>
-      ) : null}
-
-      <div className="flex-1 overflow-y-auto px-1 py-2">
-        {/* Recently-viewed — only when not filtering, and only if there's
-            anything in the ring. */}
-        {!isFiltering && liveRecents.length > 0 ? (
-          <div className="mb-3">
-            <p className="px-3 pb-1 text-[9px] font-semibold uppercase tracking-[0.18em] text-text-3">
-              Recent
-            </p>
-            <ul className="space-y-0.5">
-              {liveRecents.map((r) => (
-                <li key={r.ticker}>
-                  <Link
-                    href={`/p/${r.ticker}`}
-                    className="flex items-center gap-2 rounded-sm px-2 py-0.5 text-text-1 hover:bg-bg-2 hover:text-text-0"
-                  >
-                    <Clock className="h-3 w-3 flex-shrink-0 text-text-3" />
-                    <span className="font-mono text-[10px] text-text-3">
-                      {r.ticker}
-                    </span>
-                    <span className="flex-1 truncate text-xs">{r.name}</span>
-                  </Link>
-                </li>
-              ))}
-            </ul>
-            <div className="mx-2 mt-2 border-t border-border" />
+      <div className="flex-1 overflow-y-auto">
+        {/* Filter input is sticky to the top of the scroll region so it
+            stays in view as the tree scrolls. */}
+        {spaces.length > 0 ? (
+          <div className="sticky top-0 z-10 flex-shrink-0 border-b border-border bg-bg-0 px-2 py-1.5">
+            <div className="relative">
+              <Search
+                className="pointer-events-none absolute left-2 top-1/2 h-3 w-3 -translate-y-1/2 text-text-3"
+                aria-hidden="true"
+              />
+              <input
+                ref={filterRef}
+                type="text"
+                value={filter}
+                onChange={(e) => setFilter(e.target.value)}
+                placeholder="Filter / press / to focus"
+                aria-label="Filter explorer"
+                className="h-7 w-full rounded-sm border border-border bg-bg-1 pl-7 pr-7 text-xs text-text-0 placeholder:text-text-3 focus:border-border-focus focus:outline-none focus-visible:ring-2 focus-visible:ring-border-focus"
+              />
+              {filter ? (
+                <button
+                  type="button"
+                  onClick={() => {
+                    setFilter("");
+                    filterRef.current?.focus();
+                  }}
+                  aria-label="Clear filter"
+                  className="absolute right-1 top-1/2 -translate-y-1/2 rounded p-0.5 text-text-3 hover:bg-bg-3 hover:text-text-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-focus"
+                >
+                  <X className="h-3 w-3" />
+                </button>
+              ) : (
+                <kbd
+                  className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 rounded-sm border border-border bg-bg-2 px-1 font-mono text-[9px] text-text-3"
+                  aria-hidden="true"
+                >
+                  /
+                </kbd>
+              )}
+            </div>
           </div>
         ) : null}
 
-        {spaces.length === 0 ? (
-          <p className="px-3 py-4 text-xs text-text-3">
-            You&apos;re not in any spaces yet.
-          </p>
-        ) : visibleSpaces.length === 0 ? (
-          <p className="px-3 py-4 text-xs text-text-3">
-            No spaces or terminals match{" "}
-            <span className="font-mono text-text-2">&ldquo;{filter}&rdquo;</span>
-            .
-          </p>
-        ) : (
-          <ul className="space-y-1 text-sm">
-            {visibleSpaces.map((s) => {
-              const children =
-                filteredTerminalsBySpace.get(s.id) ??
-                terminalsBySpace.get(s.id) ??
-                [];
-              // When filtering, force-expand every visible space so
-              // the matched terminals show.
-              const isCollapsed = isFiltering ? false : collapsed.has(s.id);
-              const canMakeTerminal = s.role === "owner" || s.role === "admin";
-              return (
-                <li key={s.id}>
-                  <div className="group flex items-center gap-1 rounded-sm px-2 py-1 hover:bg-bg-2">
-                    <button
-                      onClick={() => toggle(s.id)}
-                      aria-label={isCollapsed ? "Expand" : "Collapse"}
-                      className="flex h-4 w-4 flex-shrink-0 items-center justify-center text-text-3 hover:text-text-0"
+        <div className="px-1 py-2">
+          {/* Recently-viewed — only when not filtering, and only if
+              there's anything in the ring. Heading style now matches
+              the "Explorer" heading at the top — same density. */}
+          {!isFiltering && liveRecents.length > 0 ? (
+            <div className="mb-3">
+              <p className="px-3 pb-1 text-xs font-semibold uppercase tracking-wide text-text-3">
+                Recent
+              </p>
+              <ul className="space-y-0.5">
+                {liveRecents.map((r) => (
+                  <li key={r.ticker}>
+                    <Link
+                      href={`/p/${r.ticker}`}
+                      className="flex items-center gap-2 rounded-sm px-2 py-0.5 text-text-1 hover:bg-bg-2 hover:text-text-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-focus"
                     >
-                      {isCollapsed ? (
-                        <ChevronRight className="h-3 w-3" />
-                      ) : (
-                        <ChevronDown className="h-3 w-3" />
-                      )}
-                    </button>
-                    <Building2
-                      className="h-3.5 w-3.5 flex-shrink-0 text-text-3"
-                      aria-hidden="true"
-                    />
-                    <span className="flex-1 truncate text-text-1">{s.name}</span>
-                    {canMakeTerminal ? (
-                      <>
-                        <Link
-                          href={`/s/${s.slug}/settings`}
-                          aria-label={`Settings for ${s.name}`}
-                          title="Space settings"
-                          className="rounded-sm p-0.5 text-text-3 opacity-0 transition-opacity hover:bg-bg-3 hover:text-text-0 group-hover:opacity-100"
-                        >
-                          <Settings className="h-3 w-3" />
-                        </Link>
-                        <Link
-                          href={`/?new=terminal&space=${s.slug}`}
-                          aria-label="New terminal"
-                          className="rounded-sm p-0.5 text-text-3 opacity-0 transition-opacity hover:bg-bg-3 hover:text-text-0 group-hover:opacity-100"
-                        >
-                          <Plus className="h-3 w-3" />
-                        </Link>
-                      </>
-                    ) : null}
-                  </div>
-                  {!isCollapsed ? (
-                    <ul className="mt-0.5 space-y-0.5">
+                      <Clock className="h-3 w-3 flex-shrink-0 text-text-3" />
+                      <span className="w-12 flex-shrink-0 truncate font-mono text-[10px] text-text-3">
+                        {r.ticker}
+                      </span>
+                      <span className="flex-1 truncate text-xs">{r.name}</span>
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+              <div className="mx-2 mt-2 border-t border-border" />
+            </div>
+          ) : null}
+
+          {spaces.length === 0 ? (
+            <p className="px-3 py-4 text-xs text-text-3">
+              You&apos;re not in any spaces yet.
+            </p>
+          ) : visibleSpaces.length === 0 ? (
+            <p className="px-3 py-4 text-xs text-text-3">
+              No spaces or terminals match{" "}
+              <span className="font-mono text-text-2">&ldquo;{filter}&rdquo;</span>
+              .
+            </p>
+          ) : (
+            <ul className="space-y-0.5 text-sm">
+              {visibleSpaces.map((s) => {
+                const children =
+                  filteredTerminalsBySpace.get(s.id) ??
+                  terminalsBySpace.get(s.id) ??
+                  [];
+                const isCollapsed = isFiltering ? false : collapsed.has(s.id);
+                const canMakeTerminal = s.role === "owner" || s.role === "admin";
+                const roleAbbr =
+                  s.role === "owner"
+                    ? "OWN"
+                    : s.role === "admin"
+                      ? "ADM"
+                      : "MEM";
+                return (
+                  <li key={s.id}>
+                    <div className="group flex items-center gap-1 rounded-sm px-1 py-0.5 hover:bg-bg-2">
+                      <button
+                        onClick={() => toggle(s.id)}
+                        aria-label={isCollapsed ? "Expand" : "Collapse"}
+                        className="flex h-3.5 w-3.5 flex-shrink-0 items-center justify-center text-text-3 hover:text-text-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-focus"
+                      >
+                        {isCollapsed ? (
+                          <ChevronRight className="h-3 w-3" />
+                        ) : (
+                          <ChevronDown className="h-3 w-3" />
+                        )}
+                      </button>
+                      <span
+                        className="flex-1 truncate text-text-1"
+                        title={s.name}
+                      >
+                        {s.name}
+                      </span>
+                      {/* Inline "empty" hint when this space has no
+                          terminals. Cheaper than rendering a separate
+                          row in the tree below. */}
                       {children.length === 0 ? (
-                        <li className="px-8 text-[11px] text-text-3">
-                          No terminals yet.
-                        </li>
-                      ) : (
-                        children.map((t) => (
+                        <span
+                          className="font-mono text-[9px] italic text-text-3"
+                          aria-hidden="true"
+                        >
+                          empty
+                        </span>
+                      ) : null}
+                      <span
+                        className={`font-mono text-[9px] uppercase tracking-wide ${
+                          s.role === "owner"
+                            ? "text-accent"
+                            : s.role === "admin"
+                              ? "text-text-2"
+                              : "text-text-3"
+                        }`}
+                        aria-label={`Role: ${s.role}`}
+                        title={`Your role: ${s.role}`}
+                      >
+                        {roleAbbr}
+                      </span>
+                      {canMakeTerminal ? (
+                        <>
+                          <Link
+                            href={`/s/${s.slug}/settings`}
+                            aria-label={`Settings for ${s.name}`}
+                            title="Space settings"
+                            className="rounded-sm p-0.5 text-text-3 hover:bg-bg-3 hover:text-text-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-focus"
+                          >
+                            <Settings className="h-3 w-3" />
+                          </Link>
+                          <Link
+                            href={`/?new=terminal&space=${s.slug}`}
+                            aria-label="New terminal"
+                            title="New terminal"
+                            className="rounded-sm p-0.5 text-text-3 hover:bg-bg-3 hover:text-text-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-focus"
+                          >
+                            <Plus className="h-3 w-3" />
+                          </Link>
+                        </>
+                      ) : null}
+                    </div>
+                    {!isCollapsed && children.length > 0 ? (
+                      <ul className="mt-0.5 space-y-0.5">
+                        {children.map((t) => (
                           <li key={t.id}>
                             <Link
                               href={`/p/${t.ticker}`}
-                              className="flex items-center gap-2 rounded-sm py-0.5 pl-8 pr-2 text-text-1 hover:bg-bg-2 hover:text-text-0"
+                              className="flex items-center gap-2 rounded-sm py-0.5 pl-7 pr-2 text-text-1 hover:bg-bg-2 hover:text-text-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-focus"
+                              title={t.name}
                             >
-                              <span className="font-mono text-[10px] text-text-3">
+                              <span className="w-12 flex-shrink-0 truncate font-mono text-[10px] text-text-3">
                                 {t.ticker}
                               </span>
                               <span className="flex-1 truncate text-xs">
@@ -320,27 +395,29 @@ export function ExplorerRail({
                               </span>
                             </Link>
                           </li>
-                        ))
-                      )}
-                    </ul>
-                  ) : null}
-                </li>
-              );
-            })}
-          </ul>
-        )}
+                        ))}
+                      </ul>
+                    ) : null}
+                  </li>
+                );
+              })}
+            </ul>
+          )}
 
-        <div className="mt-4 px-2">
-          <Link
-            href="/tools"
-            className="flex items-center gap-2 rounded-sm px-2 py-1 text-xs text-text-2 hover:bg-bg-2 hover:text-text-0"
-          >
-            <Sparkles className="h-3 w-3 text-accent" />
-            <span className="flex-1">Tools</span>
-            <span className="font-mono text-[10px] text-text-3">
-              {toolCount}
-            </span>
-          </Link>
+          {/* Tools — promoted from a buried muted row to a small
+              panel-like tile so users actually find it. */}
+          <div className="mt-4 px-2">
+            <Link
+              href="/tools"
+              className="flex items-center gap-2 rounded-sm border border-border bg-bg-1 px-2 py-1.5 text-xs text-text-1 hover:bg-bg-2 hover:text-text-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-focus"
+            >
+              <Sparkles className="h-3 w-3 text-accent" />
+              <span className="flex-1">Tools</span>
+              <span className="rounded-sm bg-bg-2 px-1.5 font-mono text-[10px] text-text-2 group-hover:bg-bg-3">
+                {toolCount}
+              </span>
+            </Link>
+          </div>
         </div>
       </div>
 


### PR DESCRIPTION
Second of three polish PRs. Targets the dashboard left rail (the screen Zack flagged) plus the top-bar greeting and the AccountBlock truncation. Items: drop Building2, shrink chevron, always-visible space actions, sticky filter, '/' shortcut, role badges, fixed-width ticker column, inline empty hints, Plus always rendered, Tools elevation, AccountBlock tooltips, ⌘K hint in top bar, focus-visible rings everywhere.