### PR TITLE
debug: ClickProbe server-logged + auto-activated on /p/*

### DIFF
--- a/apps/web/src/app/api/v1/health/click-log/route.ts
+++ b/apps/web/src/app/api/v1/health/click-log/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { createClient as createAdminClient } from "@supabase/supabase-js";
+import type { Database } from "@rokki/db";
+
+/**
+ * POST /api/v1/health/click-log
+ *
+ * Diagnostic sink for the ClickProbe. Inserts a single click event
+ * into _debug_click_log. Auth-free (under the /api/v1/health/* path
+ * that bypasses the supabase middleware) so the probe can fire even
+ * when sessions are odd. Body shape:
+ *   { url: string, payload: object }
+ *
+ * REMOVE both this route and the table once the navigation bug is
+ * resolved. The table is namespaced with a leading underscore so
+ * "everything in public starts with underscore is debug" is the
+ * convention if more diagnostic tables get added.
+ */
+export const dynamic = "force-dynamic";
+
+interface IncomingBody {
+  url?: string;
+  payload?: Record<string, unknown>;
+}
+
+export async function POST(request: NextRequest) {
+  let body: IncomingBody = {};
+  try {
+    body = (await request.json()) as IncomingBody;
+  } catch {
+    return NextResponse.json({ ok: false, error: "bad json" }, { status: 400 });
+  }
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    return NextResponse.json({ ok: false, error: "no admin client" });
+  }
+  const admin = createAdminClient<Database>(url, key, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+  // eslint-disable-next-line
+  const { error } = await admin
+    .from("_debug_click_log" as never)
+    .insert({
+      url: body.url ?? null,
+      user_agent: request.headers.get("user-agent"),
+      payload: body.payload ?? null,
+    } as never);
+  if (error) {
+    return NextResponse.json({ ok: false, error: error.message }, { status: 500 });
+  }
+  return NextResponse.json({ ok: true });
+}

--- a/apps/web/src/components/ClickProbe.tsx
+++ b/apps/web/src/components/ClickProbe.tsx
@@ -30,9 +30,15 @@ export function ClickProbe() {
   const beforeUrlRef = useRef<string>("");
 
   useEffect(() => {
+    // Auto-activate on terminal pages (/p/*) while we're chasing the
+    // "clicks don't navigate" bug. Anywhere else, opt-in via URL or
+    // localStorage as before.
+    const onTerminalPage = window.location.pathname.startsWith("/p/");
     const isOptedIn =
+      onTerminalPage ||
       new URLSearchParams(window.location.search).get("debug-click") ===
-        "1" || window.localStorage.getItem("rokki:debug-click") === "1";
+        "1" ||
+      window.localStorage.getItem("rokki:debug-click") === "1";
     setEnabled(isOptedIn);
   }, []);
 
@@ -96,6 +102,20 @@ export function ClickProbe() {
           // Anchor was clicked but URL didn't change — that's the bug
           // we're chasing.
           console.warn("[ClickProbe] anchor click without navigation:", ev);
+        }
+        // POST to the diagnostic sink AFTER the 250ms verdict so the
+        // recorded event includes both the click context (target,
+        // anchor href, defaultPrevented) and whether navigation
+        // actually succeeded. Single POST per click, no spam.
+        try {
+          void fetch("/api/v1/health/click-log", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ url: ev.urlBefore, payload: ev }),
+            keepalive: true,
+          });
+        } catch {
+          // ignore
         }
       }, 250);
     };


### PR DESCRIPTION
Diagnostic improvement: probe now auto-activates on terminal pages and POSTs every click event to a Supabase _debug_click_log table that I can query directly. No user interaction needed beyond clicking around.