### PR TITLE
fix(sw): broadcast activation + version-check reload

### DIFF
--- a/apps/web/public/sw.js
+++ b/apps/web/public/sw.js
@@ -19,11 +19,13 @@
 //
 // Cache version bumps on schema changes. Bump CACHE_VERSION to invalidate.
 
-// Bumped to v3 (2026-05-03) to invalidate v2 page caches that were
-// serving stale Next.js RSC payloads from cacheFirstWithRefresh, which
-// silently broke client-side navigation inside the terminal layout.
-// See the RSC short-circuit below.
-const CACHE_VERSION = "v3";
+// Bumped to v4 (2026-05-03):
+//   * v3 added the RSC short-circuit so Next.js client-side navigation
+//     stops hitting the cache.
+//   * v4 broadcasts an SW_ACTIVATED message to all open clients on
+//     activate, so already-open tabs auto-reload onto the new SW
+//     instead of staying stuck on whatever the old SW was doing.
+const CACHE_VERSION = "v4";
 const SHELL_CACHE = `rokki-shell-${CACHE_VERSION}`;
 const API_CACHE = "rokki-api-v1";
 const PAGES_CACHE = `rokki-pages-${CACHE_VERSION}`;
@@ -47,6 +49,21 @@ self.addEventListener("install", (event) => {
   self.skipWaiting();
 });
 
+// Respond to version-check pings from the page so ServiceWorkerRegister
+// can detect "I'm controlled by an old SW" and force a reload. The
+// message arrives with a transferred MessagePort; reply through it so
+// the page resolves its versionPromise.
+self.addEventListener("message", (event) => {
+  const data = event.data;
+  if (!data || typeof data !== "object") return;
+  if (data.type === "VERSION_CHECK") {
+    const port = event.ports?.[0];
+    if (port) {
+      port.postMessage({ type: "VERSION", version: CACHE_VERSION });
+    }
+  }
+});
+
 self.addEventListener("activate", (event) => {
   const expected = new Set([
     SHELL_CACHE,
@@ -62,7 +79,20 @@ self.addEventListener("activate", (event) => {
           keys.filter((k) => !expected.has(k)).map((k) => caches.delete(k)),
         ),
       )
-      .then(() => self.clients.claim()),
+      .then(() => self.clients.claim())
+      .then(() => self.clients.matchAll({ type: "window" }))
+      .then((clients) => {
+        // Broadcast to every open tab that a new SW just took over.
+        // The page-side listener (ServiceWorkerRegister) reloads on
+        // receipt so the tab picks up the new SW's responses without
+        // the user having to manually refresh / unregister.
+        for (const client of clients) {
+          client.postMessage({
+            type: "SW_ACTIVATED",
+            version: CACHE_VERSION,
+          });
+        }
+      }),
   );
 });
 

--- a/apps/web/public/sw.js
+++ b/apps/web/public/sw.js
@@ -53,7 +53,22 @@ self.addEventListener("install", (event) => {
 // can detect "I'm controlled by an old SW" and force a reload. The
 // message arrives with a transferred MessagePort; reply through it so
 // the page resolves its versionPromise.
+//
+// Origin check: a SW only receives postMessage from clients within its
+// scope, but a malicious iframe loaded into one of those clients could
+// still call postMessage on its window's controller. Reject anything
+// whose source isn't a same-origin window client.
 self.addEventListener("message", (event) => {
+  const source = event.source;
+  // Ignore messages without a source (e.g. broadcast channel forwards).
+  if (!source) return;
+  // Only accept from same-origin window clients on our own scope.
+  try {
+    const sourceUrl = new URL(source.url);
+    if (sourceUrl.origin !== self.location.origin) return;
+  } catch {
+    return;
+  }
   const data = event.data;
   if (!data || typeof data !== "object") return;
   if (data.type === "VERSION_CHECK") {

--- a/apps/web/src/components/ServiceWorkerRegister.tsx
+++ b/apps/web/src/components/ServiceWorkerRegister.tsx
@@ -2,20 +2,90 @@
 
 import { useEffect } from "react";
 
+const EXPECTED_SW_VERSION = "v4";
+
 /**
  * Registers the PWA service worker on mount, in production only. Dev runs
  * without the SW so source-map/HMR aren't masked by stale cache.
+ *
+ * Also handles two recovery flows:
+ *
+ * 1. **Auto-reload on SW activation.** When a new SW takes over via
+ *    skipWaiting + clients.claim, it broadcasts an SW_ACTIVATED
+ *    message. Open tabs reload so they immediately use the new SW's
+ *    responses instead of staying stuck on whatever the old SW had
+ *    cached.
+ *
+ * 2. **Mismatch fallback.** If the SW currently controlling the page
+ *    is not the version this build expects (e.g. user has been on the
+ *    same tab through multiple deploys), force-unregister + reload.
+ *    Belt-and-suspenders behind #1 for cases where the activation
+ *    broadcast was missed.
  */
 export function ServiceWorkerRegister() {
   useEffect(() => {
     if (typeof window === "undefined") return;
     if (!("serviceWorker" in navigator)) return;
     if (process.env.NODE_ENV !== "production") return;
-    navigator.serviceWorker
+
+    let reloaded = false;
+    const reloadOnce = (reason: string) => {
+      if (reloaded) return;
+      reloaded = true;
+      console.info("[pwa] reloading:", reason);
+      window.location.reload();
+    };
+
+    const onMessage = (event: MessageEvent) => {
+      const data = event.data as { type?: string; version?: string } | null;
+      if (!data || typeof data !== "object") return;
+      if (data.type === "SW_ACTIVATED") {
+        reloadOnce(`SW_ACTIVATED ${data.version ?? "?"}`);
+      }
+    };
+    navigator.serviceWorker.addEventListener("message", onMessage);
+
+    void navigator.serviceWorker
       .register("/sw.js", { scope: "/" })
+      .then(async (reg) => {
+        try {
+          await reg.update();
+        } catch {
+          /* non-fatal */
+        }
+        const controller = navigator.serviceWorker.controller;
+        if (!controller) return;
+        const channel = new MessageChannel();
+        const versionPromise = new Promise<string | null>((resolve) => {
+          const t = window.setTimeout(() => resolve(null), 1500);
+          channel.port1.onmessage = (ev) => {
+            window.clearTimeout(t);
+            const v =
+              (ev.data as { version?: string } | null)?.version ?? null;
+            resolve(v);
+          };
+        });
+        controller.postMessage({ type: "VERSION_CHECK" }, [channel.port2]);
+        const version = await versionPromise;
+        if (version && version !== EXPECTED_SW_VERSION) {
+          console.warn(
+            `[pwa] sw version mismatch: page expects ${EXPECTED_SW_VERSION}, controller is ${version}; unregistering`,
+          );
+          try {
+            await reg.unregister();
+          } catch {
+            /* non-fatal */
+          }
+          reloadOnce("version mismatch");
+        }
+      })
       .catch((err) => {
         console.warn("[pwa] service worker failed to register:", err);
       });
+
+    return () => {
+      navigator.serviceWorker.removeEventListener("message", onMessage);
+    };
   }, []);
   return null;
 }


### PR DESCRIPTION
Companion to PR #76. v3 fixed the RSC caching bug but couldn't recover users already running an old SW in an open tab. v4 adds a SW->page broadcast on activate (auto-reload) and a page->SW version handshake (force-reload on mismatch).