### PR TITLE
fix(error): escape-hatch anchors + server error log

### DIFF
--- a/apps/web/src/app/api/v1/health/error-log/route.ts
+++ b/apps/web/src/app/api/v1/health/error-log/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { createClient as createAdminClient } from "@supabase/supabase-js";
+import type { Database } from "@rokki/db";
+
+/**
+ * POST /api/v1/health/error-log
+ *
+ * Diagnostic sink for runtime errors caught by error.tsx. Inserts a
+ * row into _debug_error_log with the URL, digest, message, and a
+ * truncated stack so we can read the actual error remotely. Auth-free
+ * (under /api/v1/health/* which is allowlisted).
+ *
+ * REMOVE both this route and the table once we've identified the
+ * navigation-stuck root cause.
+ */
+export const dynamic = "force-dynamic";
+
+interface IncomingBody {
+  url?: string;
+  digest?: string | null;
+  message?: string | null;
+  stack?: string | null;
+}
+
+export async function POST(request: NextRequest) {
+  let body: IncomingBody = {};
+  try {
+    body = (await request.json()) as IncomingBody;
+  } catch {
+    return NextResponse.json({ ok: false, error: "bad json" }, { status: 400 });
+  }
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    return NextResponse.json({ ok: false, error: "no admin client" });
+  }
+  const admin = createAdminClient<Database>(url, key, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+  // eslint-disable-next-line
+  const { error } = await admin
+    .from("_debug_error_log" as never)
+    .insert({
+      url: body.url ?? null,
+      digest: body.digest ?? null,
+      message: body.message?.slice(0, 1000) ?? null,
+      stack: body.stack?.slice(0, 4000) ?? null,
+      user_agent: request.headers.get("user-agent"),
+    } as never);
+  if (error) {
+    return NextResponse.json(
+      { ok: false, error: error.message },
+      { status: 500 },
+    );
+  }
+  return NextResponse.json({ ok: true });
+}

--- a/apps/web/src/app/error.tsx
+++ b/apps/web/src/app/error.tsx
@@ -61,6 +61,7 @@ export default function ErrorBoundary({
             intercepted by the broken router that put us on the error
             page in the first place. Hard browser navigation always
             works as a last-resort escape hatch. */}
+        {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
         <a
           href="/"
           className="flex items-center gap-3 rounded px-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-focus"
@@ -106,6 +107,7 @@ export default function ErrorBoundary({
               >
                 <RotateCcw className="h-3 w-3" /> Try again
               </button>
+              {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
               <a
                 href="/"
                 className="inline-flex items-center gap-1.5 rounded-sm border border-border bg-bg-2 px-3 py-1.5 text-xs font-semibold uppercase tracking-wide text-text-1 hover:bg-bg-3"

--- a/apps/web/src/app/error.tsx
+++ b/apps/web/src/app/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
 import * as Sentry from "@sentry/nextjs";
 import { ArrowLeft, RotateCcw, AlertTriangle, Mail } from "lucide-react";
 import { Wordmark } from "@/components/Wordmark";
@@ -26,6 +25,25 @@ export default function ErrorBoundary({
 }) {
   useEffect(() => {
     Sentry.captureException(error);
+    // Server-side log so we can see the actual error message + stack
+    // remotely — Sentry covers this in theory, but having a parallel
+    // sink decoupled from Sentry config makes the next "what threw"
+    // debugging session a single SQL query.
+    try {
+      void fetch("/api/v1/health/error-log", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          url: typeof window !== "undefined" ? window.location.href : null,
+          digest: error.digest ?? null,
+          message: error.message ?? null,
+          stack: error.stack?.split("\n").slice(0, 20).join("\n") ?? null,
+        }),
+        keepalive: true,
+      });
+    } catch {
+      /* ignore */
+    }
   }, [error]);
 
   const digest = error.digest ?? "—";
@@ -39,13 +57,17 @@ export default function ErrorBoundary({
   return (
     <div className="flex min-h-screen flex-col bg-bg-0">
       <header className="flex h-11 flex-shrink-0 items-center border-b border-border bg-bg-1 px-4">
-        <Link
+        {/* Plain anchor (not next/link) so this navigation is not
+            intercepted by the broken router that put us on the error
+            page in the first place. Hard browser navigation always
+            works as a last-resort escape hatch. */}
+        <a
           href="/"
           className="flex items-center gap-3 rounded px-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-focus"
           aria-label="Rokki home"
         >
           <Wordmark size="md" />
-        </Link>
+        </a>
       </header>
       <main className="flex flex-1 items-center justify-center px-4 py-10">
         <section
@@ -84,12 +106,12 @@ export default function ErrorBoundary({
               >
                 <RotateCcw className="h-3 w-3" /> Try again
               </button>
-              <Link
+              <a
                 href="/"
                 className="inline-flex items-center gap-1.5 rounded-sm border border-border bg-bg-2 px-3 py-1.5 text-xs font-semibold uppercase tracking-wide text-text-1 hover:bg-bg-3"
               >
                 <ArrowLeft className="h-3 w-3" /> Back to dashboard
-              </Link>
+              </a>
             </div>
           </div>
           <footer className="border-t border-border px-4 py-2 text-[11px] text-text-3">


### PR DESCRIPTION
Plain <a> tags in error.tsx so users can ALWAYS navigate out via the error page even when the router is broken (which is exactly the case that lands them on the error page). Plus error-log POST endpoint so we can see what's actually throwing.