### PR TITLE
fix(commandbar): suppressHydrationWarning on the live clock

### DIFF
--- a/apps/web/src/components/CommandBar.tsx
+++ b/apps/web/src/components/CommandBar.tsx
@@ -89,7 +89,17 @@ export function CommandBar({ label, onSubmit }: CommandBarProps) {
           <span className="truncate">{status.text}</span>
         </span>
       ) : (
-        <span className="text-text-3">{nowLabel()}</span>
+        // suppressHydrationWarning: nowLabel() returns HH:MM:SS computed
+        // at render time. Server and client render milliseconds apart, so
+        // the second value usually differs — without this attribute,
+        // React's hydration mismatch errors out the whole TerminalShell
+        // subtree. Symptom: Link clicks in the explorer rail (and
+        // anywhere else inside the terminal) silently no-op because
+        // event handlers never get attached after the failed hydration.
+        // Re: react.dev/errors/418
+        <span className="text-text-3" suppressHydrationWarning>
+          {nowLabel()}
+        </span>
       )}
     </form>
   );


### PR DESCRIPTION
Root cause of 'clicks dont navigate from terminal pages'. CommandBar renders the bottom-right clock as nowLabel() inline; server and client render milliseconds apart so the seconds digit almost always differs, React #418 hydration mismatch errors out TerminalShell subtree, click handlers never attach. Fix: suppressHydrationWarning on the live-clock span.