### PR TITLE
chore(terminal): drop side-rail Tips/Keyboard/Roles panels

### DIFF
--- a/apps/web/src/components/ProjectTerminal.tsx
+++ b/apps/web/src/components/ProjectTerminal.tsx
@@ -80,16 +80,19 @@ function resolvePanes({
   overviewLeft: ReactNode;
   overviewMain: ReactNode;
 }): { mainPane: ReactNode; leftPane: ReactNode } {
+  // Files / Tasks / Team don't have a side rail — the previous "Tips",
+  // "Keyboard", and "Roles" reference panels weren't earning their
+  // rail width. Only the Overview tab keeps a contextual rail.
   switch (activeKey) {
     case "F2":
       return {
         mainPane: <FilesPane ticker={ticker} projectId={projectId} />,
-        leftPane: <FilesSideRail />,
+        leftPane: null,
       };
     case "F3":
       return {
         mainPane: <TasksPane ticker={ticker} projectId={projectId} />,
-        leftPane: <TasksSideRail />,
+        leftPane: null,
       };
     case "F4":
       return {
@@ -100,101 +103,10 @@ function resolvePanes({
             canInvite={isOwnerOrManager}
           />
         ),
-        leftPane: <TeamSideRail canInvite={isOwnerOrManager} />,
+        leftPane: null,
       };
     default:
       return { mainPane: overviewMain, leftPane: overviewLeft };
   }
 }
 
-function FilesSideRail() {
-  return (
-    <div className="space-y-6 p-4">
-      <section>
-        <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-text-3">
-          Tips
-        </h3>
-        <ul className="space-y-1.5 text-xs text-text-2">
-          <li>Drag files onto this pane to upload.</li>
-          <li>Max 25 MB per file in this slice.</li>
-          <li>Hover a row to download or delete.</li>
-        </ul>
-      </section>
-    </div>
-  );
-}
-
-function TasksSideRail() {
-  return (
-    <div className="space-y-6 p-4">
-      <section>
-        <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-text-3">
-          Keyboard
-        </h3>
-        <dl className="space-y-1.5 text-xs">
-          <Shortcut keys={["J", "K"]} label="Navigate" />
-          <Shortcut keys={["Enter"]} label="Toggle complete" />
-          <Shortcut keys={["⌘", "Enter"]} label="Mark done" />
-          <Shortcut keys={["C"]} label="New task" />
-          <Shortcut keys={["Esc"]} label="Cancel" />
-        </dl>
-      </section>
-    </div>
-  );
-}
-
-function TeamSideRail({ canInvite }: { canInvite: boolean }) {
-  return (
-    <div className="space-y-6 p-4">
-      <section>
-        <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-text-3">
-          Roles
-        </h3>
-        <dl className="space-y-1.5 text-xs">
-          <RoleLine role="Owner" note="Full control, can delete the space" />
-          <RoleLine role="Manager" note="Manage team and settings" />
-          <RoleLine role="Member" note="Edit tasks, upload files" />
-          <RoleLine role="Guest" note="Scoped read access" />
-        </dl>
-      </section>
-      {canInvite ? (
-        <section>
-          <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-text-3">
-            Keyboard
-          </h3>
-          <dl className="space-y-1.5 text-xs">
-            <Shortcut keys={["I"]} label="Invite someone" />
-            <Shortcut keys={["Esc"]} label="Close dialog" />
-          </dl>
-        </section>
-      ) : null}
-    </div>
-  );
-}
-
-function Shortcut({ keys, label }: { keys: string[]; label: string }) {
-  return (
-    <div className="flex items-center justify-between gap-3">
-      <dt className="text-text-1">{label}</dt>
-      <dd className="flex items-center gap-1">
-        {keys.map((k, i) => (
-          <kbd
-            key={i}
-            className="rounded-sm border border-border bg-bg-2 px-1.5 py-0.5 font-mono text-[10px] text-text-1"
-          >
-            {k}
-          </kbd>
-        ))}
-      </dd>
-    </div>
-  );
-}
-
-function RoleLine({ role, note }: { role: string; note: string }) {
-  return (
-    <div className="flex flex-col gap-0.5">
-      <dt className="font-medium text-text-1">{role}</dt>
-      <dd className="text-text-3">{note}</dd>
-    </div>
-  );
-}

--- a/apps/web/src/components/TerminalShell.tsx
+++ b/apps/web/src/components/TerminalShell.tsx
@@ -81,7 +81,7 @@ export function TerminalShell({
         <TickerTape items={tickerItems} projectId={tickerProjectId} />
       </div>
       <div className="flex flex-1 flex-col overflow-hidden sm:flex-row">
-        {leftOpen ? (
+        {leftOpen && leftPane ? (
           <div className="hidden overflow-y-auto border-r border-border bg-bg-0 lg:block lg:w-[28%] lg:min-w-[240px]">
             {leftPane}
           </div>


### PR DESCRIPTION
Per user feedback. Removes the static reference panels next to F2 Files, F3 Tasks, and F4 Team. Overview rail (Status + team summary) is kept.