### PR TITLE
fix(terminal): topbar spans full width like dashboard

### DIFF
--- a/apps/web/src/app/p/[ticker]/layout.tsx
+++ b/apps/web/src/app/p/[ticker]/layout.tsx
@@ -1,25 +1,23 @@
 import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import { DensityProvider, type Density } from "@/lib/density";
-import { ExplorerRail } from "@/components/dashboard/ExplorerRail";
-import {
-  loadDashSpaces,
-  loadDashTerminals,
-} from "@/lib/dashboard-queries";
 
 /**
  * Layout for /p/[ticker]/* — terminal pages.
  *
- * Mounts the same left-rail Explorer that the dashboard uses, so the user
- * can jump between spaces/terminals or back to the dashboard without
- * having to click the wordmark. Spaces + terminals are fetched here (not
- * inside ExplorerRail) so the rail can render server-side.
+ * Thin wrapper now: just auth gate + DensityProvider. The ExplorerRail
+ * + topbar layout used to live here as a flex row (aside | children),
+ * which made the topbar (rendered inside children) sit *next to* the
+ * rail rather than spanning over it. Result: the rail visually started
+ * at the very top of the page, ahead of the topbar — inconsistent
+ * with the dashboard, where the topbar spans the full viewport width
+ * and the rail begins below it.
  *
- * The rail's bottom AccountBlock is the single home for account-level
- * actions (sign out, switch ring, settings, density, admin toggle).
- *
- * Each terminal page still renders its own TopBar and TerminalShell to the
- * right of the rail.
+ * To match the dashboard's shape, ExplorerRail mounting moved into
+ * TerminalShell (apps/web/src/components/TerminalShell.tsx) so the
+ * shell renders: topbar (full width) → ticker (full width) → flex
+ * row [ExplorerRail | center | right]. Same vertical alignment as
+ * DashboardShell.
  */
 export default async function TerminalLayout({
   children,
@@ -32,55 +30,16 @@ export default async function TerminalLayout({
   } = await supabase.auth.getUser();
   if (!user) redirect("/login");
 
-  const [spaces, terminals, toolsResult, profileResult] = await Promise.all([
-    loadDashSpaces(supabase, user.id),
-    loadDashTerminals(supabase),
-    supabase
-      .from("tools")
-      .select("id", { count: "exact", head: true })
-      .is("deleted_at", null),
-    supabase
-      .from("profiles")
-      .select("full_name, is_platform_admin, settings")
-      .eq("user_id", user.id)
-      .maybeSingle(),
-  ]);
-
-  const profile = profileResult.data as
-    | {
-        full_name: string | null;
-        is_platform_admin: boolean;
-        settings: Record<string, unknown> | null;
-      }
-    | null;
-  const userName =
-    profile?.full_name ?? user.email?.split("@")[0] ?? "there";
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("settings")
+    .eq("user_id", user.id)
+    .maybeSingle();
   const initialDensity: Density =
-    profile?.settings?.density === "compact" ? "compact" : "cozy";
-  const isPlatformAdmin = Boolean(profile?.is_platform_admin);
+    (profile as { settings?: { density?: string } } | null)?.settings
+      ?.density === "compact"
+      ? "compact"
+      : "cozy";
 
-  return (
-    <DensityProvider initial={initialDensity}>
-      <div className="flex h-[100dvh] overflow-hidden bg-bg-0">
-        <aside
-          aria-label="Explorer"
-          data-print-hide="true"
-          className="hidden h-full w-[260px] flex-shrink-0 border-r border-border lg:flex lg:flex-col print:hidden"
-        >
-          <ExplorerRail
-            spaces={spaces}
-            terminals={terminals}
-            toolCount={toolsResult.count ?? 0}
-            userName={userName}
-            userEmail={user.email ?? ""}
-            isPlatformAdmin={isPlatformAdmin}
-            canCreateSpace={isPlatformAdmin}
-          />
-        </aside>
-        <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
-          {children}
-        </div>
-      </div>
-    </DensityProvider>
-  );
+  return <DensityProvider initial={initialDensity}>{children}</DensityProvider>;
 }

--- a/apps/web/src/app/p/[ticker]/page.tsx
+++ b/apps/web/src/app/p/[ticker]/page.tsx
@@ -8,6 +8,11 @@ import { createClient } from "@/lib/supabase/server";
 import { TopBar } from "@/components/TopBar";
 import { ProjectTerminal } from "@/components/ProjectTerminal";
 import { TerminalPresence } from "@/components/dashboard/TerminalPresence";
+import { ExplorerRail } from "@/components/dashboard/ExplorerRail";
+import {
+  loadDashSpaces,
+  loadDashTerminals,
+} from "@/lib/dashboard-queries";
 import { CORE_MODULE_CARDS, SPACE_TAGLINE } from "@/lib/project-templates";
 import type { ProjectStatus } from "@rokki/db";
 
@@ -128,6 +133,9 @@ export default async function ProjectTerminalPage({ params }: Props) {
     { data: rawMembers },
     { data: org },
     { data: callerProfile },
+    explorerSpaces,
+    explorerTerminals,
+    toolsResult,
   ] = await Promise.all([
     supabase
       .from("activity")
@@ -142,9 +150,18 @@ export default async function ProjectTerminalPage({ params }: Props) {
     supabase.from("spaces").select("slug, name").eq("id", p.space_id).single(),
     supabase
       .from("profiles")
-      .select("full_name")
+      .select("full_name, is_platform_admin")
       .eq("user_id", user.id)
       .maybeSingle(),
+    // ExplorerRail data — was being fetched in the layout, now the
+    // page owns it so the rail can be passed through the shell and
+    // rendered below the topbar (instead of beside it as an aside).
+    loadDashSpaces(supabase, user.id),
+    loadDashTerminals(supabase),
+    supabase
+      .from("tools")
+      .select("id", { count: "exact", head: true })
+      .is("deleted_at", null),
   ]);
 
   const activities = (activity ?? []) as ActivityRow[];
@@ -177,10 +194,14 @@ export default async function ProjectTerminalPage({ params }: Props) {
   const isOwnerOrManager =
     callerMembership?.role === "owner" || callerMembership?.role === "manager";
 
+  const callerProfileTyped = callerProfile as
+    | { full_name: string | null; is_platform_admin: boolean }
+    | null;
   const callerName =
-    (callerProfile as { full_name: string | null } | null)?.full_name ??
+    callerProfileTyped?.full_name ??
     user.email?.split("@")[0] ??
     "—";
+  const isPlatformAdmin = Boolean(callerProfileTyped?.is_platform_admin);
 
   const tickerItems = activities.map((a) => ({
     id: a.id,
@@ -228,6 +249,17 @@ export default async function ProjectTerminalPage({ params }: Props) {
       overviewLeft={<OverviewLeft project={p} members={memberRows} />}
       overviewMain={<OverviewMain project={p} />}
       rightPane={<AIChatStub project={p} />}
+      leftRail={
+        <ExplorerRail
+          spaces={explorerSpaces}
+          terminals={explorerTerminals}
+          toolCount={toolsResult.count ?? 0}
+          userName={callerName}
+          userEmail={user.email ?? ""}
+          isPlatformAdmin={isPlatformAdmin}
+          canCreateSpace={isPlatformAdmin}
+        />
+      }
     />
   );
 }

--- a/apps/web/src/components/ProjectTerminal.tsx
+++ b/apps/web/src/components/ProjectTerminal.tsx
@@ -13,6 +13,14 @@ interface ProjectTerminalProps {
   overviewLeft: ReactNode;
   overviewMain: ReactNode;
   rightPane: ReactNode;
+  /**
+   * Global ExplorerRail (spaces → terminals tree, recents, tools,
+   * AccountBlock). Rendered as the left column of the shell below the
+   * topbar. Pre-PR-#88 this lived in the route layout's aside which
+   * sat *next to* the topbar instead of below it; hoisting it here
+   * matches the dashboard's column-then-row shape.
+   */
+  leftRail: ReactNode;
   ticker: string;
   project: {
     id: string;
@@ -34,6 +42,7 @@ export function ProjectTerminal({
   overviewLeft,
   overviewMain,
   rightPane,
+  leftRail,
   ticker,
   project,
   tickerItems,
@@ -58,6 +67,7 @@ export function ProjectTerminal({
       onFunctionKey={setActiveKey}
       tickerItems={tickerItems}
       tickerProjectId={project.id}
+      leftRail={leftRail}
       leftPane={leftPane}
       mainPane={mainPane}
       rightPane={rightPane}

--- a/apps/web/src/components/TerminalShell.tsx
+++ b/apps/web/src/components/TerminalShell.tsx
@@ -15,6 +15,18 @@ interface TerminalShellProps {
   tickerItems: { id: string; text: string; when: string }[];
   /** When set, the ticker tape receives live INSERT events for that project. */
   tickerProjectId?: string;
+  /**
+   * Global ExplorerRail (spaces tree, recents, tools, AccountBlock).
+   * Rendered as the leftmost column of the shell, below the topbar +
+   * function keys + ticker. Mirrors DashboardShell's left aside.
+   */
+  leftRail?: ReactNode;
+  /**
+   * Per-pane contextual rail (e.g. Status + Team summary on the
+   * Overview tab). Renders to the right of leftRail when present.
+   * F2/F3/F4 panes typically pass null here so the main content gets
+   * the full remaining width.
+   */
   leftPane: ReactNode;
   mainPane: ReactNode;
   rightPane?: ReactNode;
@@ -37,6 +49,7 @@ export function TerminalShell({
   commandLabel,
   tickerItems,
   tickerProjectId,
+  leftRail,
   leftPane,
   mainPane,
   rightPane,
@@ -81,6 +94,14 @@ export function TerminalShell({
         <TickerTape items={tickerItems} projectId={tickerProjectId} />
       </div>
       <div className="flex flex-1 flex-col overflow-hidden sm:flex-row">
+        {leftOpen && leftRail ? (
+          <aside
+            aria-label="Explorer"
+            className="hidden flex-shrink-0 overflow-y-auto border-r border-border bg-bg-0 lg:flex lg:w-[260px] lg:flex-col"
+          >
+            {leftRail}
+          </aside>
+        ) : null}
         {leftOpen && leftPane ? (
           <div className="hidden overflow-y-auto border-r border-border bg-bg-0 lg:block lg:w-[28%] lg:min-w-[240px]">
             {leftPane}


### PR DESCRIPTION
Restructures the terminal page so the topbar spans the full viewport (over the ExplorerRail column) and the rail starts below it, matching the dashboard shape. Hoists ExplorerRail mounting from the layout's aside into TerminalShell.