### PR TITLE
fix(dashboard): silence timezone/locale hydration mismatches

### DIFF
--- a/apps/web/src/components/DashboardClient.tsx
+++ b/apps/web/src/components/DashboardClient.tsx
@@ -98,7 +98,19 @@ export function DashboardClient({
         topBar={
           <TopBar>
             <span className="text-text-3">/</span>
-            <span className="text-text-1">{greeting(userName)}</span>
+            {/* suppressHydrationWarning: greeting() reads new Date().getHours()
+                which uses the runtime's local timezone — UTC on Vercel's
+                Node server, local on the user's browser. SSR and client
+                disagree any time the local hour and UTC hour fall in
+                different greeting buckets (e.g. server says "evening" at
+                21 UTC, client says "afternoon" at 17 EDT). The mismatch
+                triggered React #418, which detaches all event handlers in
+                the subtree — symptom: every Link in the dashboard
+                silently no-op'd. The greeting is cosmetic; let the client
+                win after hydration. */}
+            <span className="text-text-1" suppressHydrationWarning>
+              {greeting(userName)}
+            </span>
             {/* Subtle Cmd+K hint — replaces nothing, just adds a
                 discoverable shortcut for power users. The palette
                 itself is wired up in <CommandPalette> and triggered

--- a/apps/web/src/components/dashboard/WeekCard.tsx
+++ b/apps/web/src/components/dashboard/WeekCard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Diamond, Calendar as CalIcon } from "lucide-react";
 import { DashboardCard } from "./DashboardCard";
 import type { WeekItem } from "@/lib/dashboard-queries";
@@ -19,7 +19,22 @@ interface WeekCardProps {
  * events land in a later slice when the sync connector is live.
  */
 export function WeekCard({ items }: WeekCardProps) {
+  // Defer the grouped/rendered content to client mount. The grouping
+  // depends on `new Date()` (server's UTC vs. browser's local TZ) and
+  // the day/time labels go through toLocaleDateString /
+  // toLocaleTimeString, which use the runtime's locale. Both diverge
+  // between SSR and CSR — and the divergence used to throw React
+  // #418, which detached every event handler in the dashboard
+  // subtree (Link clicks silently no-op'd). Rendering only after
+  // mount sidesteps the mismatch entirely; the placeholder during
+  // SSR is the empty card shell.
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
   const grouped = useMemo(() => {
+    if (!mounted) return [];
     const days = new Map<string, WeekItem[]>();
     for (const it of items) {
       const key = it.when.slice(0, 10);
@@ -43,7 +58,7 @@ export function WeekCard({ items }: WeekCardProps) {
       });
     }
     return out;
-  }, [items]);
+  }, [items, mounted]);
 
   return (
     <DashboardCard


### PR DESCRIPTION
## Summary

PR #90 cleared the SW's page cache, eliminating one source of React #418 hydration crashes on terminal pages. But the SAME crash was still firing on the dashboard from two **different** sources, both rooted in server-vs-client clock/locale divergence:

- `DashboardClient.greeting()` reads `new Date().getHours()` to pick "Good morning / afternoon / evening". For any user whose local timezone offset crosses a greeting boundary (12 PM, 6 PM) relative to UTC, server and client disagree. Verified live: at 5:15 PM EDT the server says "evening" (21 UTC) and the client says "afternoon" — `text` mismatch, #418 thrown, every Link in the subtree's handlers detach.
- `WeekCard` calls `new Date()` to seed the 7-day grid and `toLocaleDateString` / `toLocaleTimeString` to render labels. All three diverge between SSR (UTC, server locale) and CSR (browser local TZ + locale).

## Fix

- Greeting: wrap in `suppressHydrationWarning` (matches the live-clock fix in PR #83). Cosmetic field; client wins after hydration.
- WeekCard: defer the grouped computation behind a `mounted` flag. SSR renders the empty card shell (count badge intact); the day-by-day breakdown materialises after mount. Brief flash, no hydration crash.

## Test plan

- [ ] Deploy hits prod
- [ ] Open https://rokki.ai/
- [ ] Console clean of `Minified React error #418`
- [ ] Click any Link on the dashboard (Tools tile, terminal in the rail, settings) — navigates without a hard reload (no `[NavigationFallback] router.push silently no-op'd` warning)
- [ ] /p/<ticker> already verified clean in PR #90 — re-confirm round trip dashboard → terminal → dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)