### PR TITLE
feat(tasks): expanded inline composer + dashboard quick-create dialog

### DIFF
--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -182,6 +182,20 @@ export function CommandPalette({ children }: { children: ReactNode }) {
     }));
     const create: Command[] = [
       {
+        id: "create/task",
+        title: "New task",
+        subtitle: "Pick a terminal + chips inline",
+        category: "action",
+        shortcut: "⌘N",
+        icon: <Plus className="h-3.5 w-3.5" />,
+        // Route to the dashboard with ?new=task so DashboardClient
+        // opens the QuickTaskDialog. From a terminal page this means
+        // a one-hop nav back to dashboard, but keeps a single entry
+        // point for now — when terminal pages get an inline composer
+        // toggle we'll branch on pathname.
+        onRun: go("/?new=task"),
+      },
+      {
         id: "create/terminal",
         title: "New terminal",
         subtitle: "A working context — project, matter, goal, client",

--- a/apps/web/src/components/DashboardClient.tsx
+++ b/apps/web/src/components/DashboardClient.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
+import { Plus } from "lucide-react";
 import { CreateOrgDialog } from "./CreateOrgDialog";
 import { CreateProjectDialog } from "./CreateProjectDialog";
 import { DashboardShell } from "./dashboard/DashboardShell";
@@ -14,6 +15,8 @@ import { TickerTape } from "./TickerTape";
 import { DensityProvider, type Density } from "@/lib/density";
 import { TimezoneProbe } from "./TimezoneProbe";
 import { BriefingCard } from "./dashboard/BriefingCard";
+import { QuickTaskDialog } from "./QuickTaskDialog";
+import { isEditableTarget } from "@/lib/shortcuts";
 import type {
   DashSpace,
   DashTerminal,
@@ -62,12 +65,13 @@ export function DashboardClient({
   const searchParams = useSearchParams();
   const [spaceDialog, setSpaceDialog] = useState(false);
   const [terminalDialog, setTerminalDialog] = useState(false);
+  const [taskDialog, setTaskDialog] = useState(false);
   const [preferredSpaceSlug, setPreferredSpaceSlug] = useState<string | null>(
     null,
   );
 
-  // Respect ?new=space / ?new=terminal&space=<slug> from the palette or
-  // explorer.
+  // Respect ?new=space / ?new=terminal&space=<slug> / ?new=task from the
+  // palette or explorer.
   useEffect(() => {
     const want = searchParams.get("new");
     const spaceHint = searchParams.get("space");
@@ -76,6 +80,7 @@ export function DashboardClient({
       setPreferredSpaceSlug(spaceHint);
       setTerminalDialog(true);
     }
+    if (want === "task" && terminals.length > 0) setTaskDialog(true);
     if (want) {
       const params = new URLSearchParams(searchParams.toString());
       params.delete("new");
@@ -84,6 +89,23 @@ export function DashboardClient({
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchParams]);
+
+  // ⌘N / Ctrl+N → open the quick-task dialog from anywhere on the
+  // dashboard. Skip when typing in an input/textarea/contenteditable
+  // so the shortcut doesn't fight a real keystroke.
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (!(e.metaKey || e.ctrlKey)) return;
+      if (e.shiftKey || e.altKey) return;
+      if (e.key.toLowerCase() !== "n") return;
+      if (isEditableTarget(e.target)) return;
+      if (terminals.length === 0) return;
+      e.preventDefault();
+      setTaskDialog(true);
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [terminals.length]);
 
   const tickerById: Record<string, string> = {};
   const terminalNameById: Record<string, string> = {};
@@ -115,11 +137,35 @@ export function DashboardClient({
                 discoverable shortcut for power users. The palette
                 itself is wired up in <CommandPalette> and triggered
                 by the global keydown handler. */}
-            <span className="ml-auto hidden items-center gap-1 text-[10px] text-text-3 sm:flex">
-              <kbd className="rounded-sm border border-border bg-bg-2 px-1 font-mono text-text-2">
-                ⌘K
-              </kbd>
-              <span>to search</span>
+            <span className="ml-auto flex items-center gap-2">
+              {/* "+ New task" — opens the quick-create dialog so the
+                  user can pick a terminal + chips without leaving the
+                  dashboard. ⌘N also works (see the keydown effect). */}
+              <button
+                type="button"
+                onClick={() => {
+                  if (terminals.length > 0) setTaskDialog(true);
+                }}
+                disabled={terminals.length === 0}
+                title={
+                  terminals.length === 0
+                    ? "No terminals yet — create a terminal first"
+                    : "New task (⌘N)"
+                }
+                className="flex items-center gap-1 rounded-sm border border-border bg-bg-2 px-2 py-1 text-[11px] text-text-1 hover:border-accent/40 hover:bg-bg-3 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                <Plus className="h-3 w-3" aria-hidden="true" />
+                <span>New task</span>
+                <kbd className="ml-1 hidden font-mono text-[9px] text-text-3 sm:inline">
+                  ⌘N
+                </kbd>
+              </button>
+              <span className="hidden items-center gap-1 text-[10px] text-text-3 sm:flex">
+                <kbd className="rounded-sm border border-border bg-bg-2 px-1 font-mono text-text-2">
+                  ⌘K
+                </kbd>
+                <span>to search</span>
+              </span>
             </span>
           </TopBar>
         }
@@ -167,6 +213,12 @@ export function DashboardClient({
         }}
         orgs={spaces}
         preferredSlug={preferredSpaceSlug ?? undefined}
+      />
+      <QuickTaskDialog
+        open={taskDialog}
+        onClose={() => setTaskDialog(false)}
+        terminals={terminals}
+        spaces={spaces}
       />
       <TimezoneProbe currentTimezone={savedTimezone} />
     </DensityProvider>

--- a/apps/web/src/components/QuickTaskDialog.tsx
+++ b/apps/web/src/components/QuickTaskDialog.tsx
@@ -1,0 +1,361 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { ChevronDown, Search } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Dialog } from "./Dialog";
+import { TaskComposer, type TaskComposerMember } from "./TaskComposer";
+import type { DashSpace, DashTerminal } from "@/lib/dashboard-queries";
+
+interface QuickTaskDialogProps {
+  open: boolean;
+  onClose: () => void;
+  /** All terminals visible to the user (from the explorer-rail query). */
+  terminals: DashTerminal[];
+  /** Spaces, used to label terminal options by their parent space name. */
+  spaces: DashSpace[];
+  /** Optional pre-selected terminal id (e.g. "+ task in this terminal"). */
+  defaultTerminalId?: string | null;
+}
+
+/**
+ * Dashboard-side "+ Quick task" dialog.
+ *
+ * Lets the user create a task without first navigating into a
+ * terminal — pick which terminal it lands in, fill the title and
+ * chips, hit Create. Reuses `TaskComposer` for the fields; this
+ * wrapper only adds the terminal picker (rendered in the composer's
+ * `prefixSlot`) and routes the submitted payload to the right
+ * project-scoped POST endpoint.
+ *
+ * Members for the assignee chip are fetched lazily once a terminal
+ * is selected, so the request only fires when needed and updates
+ * automatically if the user switches terminals before submitting.
+ */
+export function QuickTaskDialog({
+  open,
+  onClose,
+  terminals,
+  spaces,
+  defaultTerminalId = null,
+}: QuickTaskDialogProps) {
+  const [terminalId, setTerminalId] = useState<string | null>(
+    defaultTerminalId,
+  );
+  const [members, setMembers] = useState<TaskComposerMember[]>([]);
+  const [composerKey, setComposerKey] = useState(0);
+
+  // Reset selection on open so a stale value from a previous
+  // open doesn't leak in. Honour the optional default each time.
+  useEffect(() => {
+    if (open) {
+      setTerminalId(defaultTerminalId);
+      setMembers([]);
+      // Bump the composer key to force a fresh, empty composer state
+      // every time the dialog reopens.
+      setComposerKey((k) => k + 1);
+    }
+  }, [open, defaultTerminalId]);
+
+  // Fetch members for the selected terminal — feeds the assignee chip.
+  useEffect(() => {
+    if (!open || !terminalId) {
+      setMembers([]);
+      return;
+    }
+    const terminal = terminals.find((t) => t.id === terminalId);
+    if (!terminal) return;
+    let cancelled = false;
+    void fetch(`/api/v1/projects/${terminal.ticker}/members`, {
+      credentials: "include",
+    })
+      .then((r) => r.json() as Promise<{
+        data?: {
+          members?: {
+            user_id: string;
+            profiles: { full_name: string | null } | null;
+          }[];
+        };
+      }>)
+      .then((body) => {
+        if (cancelled) return;
+        const ms = (body.data?.members ?? []).map((m) => ({
+          user_id: m.user_id,
+          full_name: m.profiles?.full_name ?? null,
+        }));
+        setMembers(ms);
+      })
+      .catch(() => {
+        // Non-fatal — composer will just hide the assignee chip.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, terminalId, terminals]);
+
+  const selectedTerminal = useMemo(
+    () => terminals.find((t) => t.id === terminalId) ?? null,
+    [terminalId, terminals],
+  );
+
+  async function handleSubmit(input: {
+    title: string;
+    priority: number;
+    due_date: string | null;
+    labels: string[];
+    assignee_ids: string[];
+  }) {
+    if (!selectedTerminal) {
+      throw new Error("Pick a terminal first");
+    }
+    const r = await fetch(
+      `/api/v1/projects/${selectedTerminal.ticker}/tasks`,
+      {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          title: input.title,
+          priority: input.priority,
+          due_date: input.due_date,
+          labels: input.labels,
+          assignee_ids:
+            input.assignee_ids.length > 0 ? input.assignee_ids : undefined,
+        }),
+      },
+    );
+    if (!r.ok) {
+      const body = (await r.json().catch(() => ({}))) as {
+        errors?: { message: string }[];
+      };
+      throw new Error(
+        body.errors?.[0]?.message ?? `Failed to create (HTTP ${r.status})`,
+      );
+    }
+    onClose();
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      title="New task"
+      className="max-w-xl"
+    >
+      <TaskComposer
+        key={composerKey}
+        members={members}
+        variant="dialog"
+        autoFocus={Boolean(terminalId)}
+        placeholder="Task title…"
+        submitDisabled={!terminalId}
+        submitLabel={
+          selectedTerminal
+            ? `Create in ${selectedTerminal.ticker}`
+            : "Pick a terminal first"
+        }
+        onSubmit={handleSubmit}
+        onCancel={onClose}
+        prefixSlot={
+          <TerminalPicker
+            terminals={terminals}
+            spaces={spaces}
+            selectedId={terminalId}
+            onSelect={setTerminalId}
+          />
+        }
+      />
+    </Dialog>
+  );
+}
+
+/* ----------------------------------------------------------------- */
+/* Terminal picker                                                    */
+/* ----------------------------------------------------------------- */
+
+function TerminalPicker({
+  terminals,
+  spaces,
+  selectedId,
+  onSelect,
+}: {
+  terminals: DashTerminal[];
+  spaces: DashSpace[];
+  selectedId: string | null;
+  onSelect: (id: string) => void;
+}) {
+  const spaceById = useMemo(
+    () => new Map(spaces.map((s) => [s.id, s])),
+    [spaces],
+  );
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const containerRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    function onDoc(e: MouseEvent) {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(e.target as Node)
+      ) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", onDoc);
+    return () => document.removeEventListener("mousedown", onDoc);
+  }, [open]);
+
+  useEffect(() => {
+    if (open) inputRef.current?.focus();
+  }, [open]);
+
+  const selected = useMemo(
+    () => terminals.find((t) => t.id === selectedId) ?? null,
+    [terminals, selectedId],
+  );
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return terminals;
+    return terminals.filter(
+      (t) =>
+        t.name.toLowerCase().includes(q) ||
+        t.ticker.toLowerCase().includes(q),
+    );
+  }, [terminals, query]);
+
+  // Group by space for visual hierarchy.
+  const grouped = useMemo(() => {
+    const groups = new Map<
+      string,
+      { name: string; items: DashTerminal[] }
+    >();
+    for (const t of filtered) {
+      const space = spaceById.get(t.space_id);
+      const spaceName = space?.name ?? "Unknown space";
+      const g = groups.get(t.space_id) ?? { name: spaceName, items: [] };
+      g.items.push(t);
+      groups.set(t.space_id, g);
+    }
+    return Array.from(groups.values());
+  }, [filtered, spaceById]);
+
+  return (
+    <div ref={containerRef} className="relative">
+      <label
+        className="mb-1 block text-[10px] font-semibold uppercase tracking-wide text-text-3"
+        htmlFor="quick-task-terminal"
+      >
+        Terminal
+      </label>
+      <button
+        id="quick-task-terminal"
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        className={cn(
+          "flex w-full items-center justify-between rounded-sm border bg-bg-2 px-2 py-1.5 text-left text-xs",
+          selected
+            ? "border-accent/40 text-text-0"
+            : "border-border text-text-2 hover:border-border-focus",
+        )}
+      >
+        {selected ? (
+          <span className="flex items-center gap-2 truncate">
+            <span className="font-mono text-[10px] text-accent">
+              {selected.ticker}
+            </span>
+            <span className="truncate text-text-1">{selected.name}</span>
+            <span className="truncate font-mono text-[10px] text-text-3">
+              · {spaceById.get(selected.space_id)?.name ?? ""}
+            </span>
+          </span>
+        ) : (
+          <span>Pick a terminal…</span>
+        )}
+        <ChevronDown
+          className={cn(
+            "h-3 w-3 flex-shrink-0 text-text-3 transition-transform",
+            open && "rotate-180",
+          )}
+        />
+      </button>
+
+      {open ? (
+        <div
+          role="listbox"
+          aria-label="Terminals"
+          className="absolute left-0 right-0 top-full z-50 mt-1 max-h-72 overflow-y-auto rounded-sm border border-border bg-bg-1 shadow-lg"
+        >
+          <div className="sticky top-0 z-10 flex items-center gap-2 border-b border-border bg-bg-1 px-2 py-1.5">
+            <Search
+              className="h-3 w-3 flex-shrink-0 text-text-3"
+              aria-hidden="true"
+            />
+            <input
+              ref={inputRef}
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Filter terminals…"
+              aria-label="Filter terminals"
+              className="flex-1 bg-transparent text-xs text-text-0 placeholder:text-text-3 outline-none"
+            />
+          </div>
+          {grouped.length === 0 ? (
+            <p className="px-3 py-3 text-xs text-text-3">
+              No terminals match{" "}
+              <span className="font-mono text-text-2">
+                &ldquo;{query}&rdquo;
+              </span>
+              .
+            </p>
+          ) : (
+            grouped.map((g, gi) => (
+              <div
+                key={gi}
+                className="border-b border-border last:border-b-0"
+              >
+                <p className="px-3 pt-1.5 text-[9px] font-semibold uppercase tracking-[0.18em] text-text-3">
+                  {g.name}
+                </p>
+                <ul role="none" className="py-1">
+                  {g.items.map((t) => {
+                    const isSelected = t.id === selectedId;
+                    return (
+                      <li key={t.id} role="none">
+                        <button
+                          role="option"
+                          type="button"
+                          aria-selected={isSelected}
+                          onClick={() => {
+                            onSelect(t.id);
+                            setOpen(false);
+                            setQuery("");
+                          }}
+                          className={cn(
+                            "flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs",
+                            isSelected
+                              ? "bg-accent-subtle text-text-0"
+                              : "text-text-1 hover:bg-bg-2",
+                          )}
+                        >
+                          <span className="w-12 flex-shrink-0 truncate font-mono text-[10px] text-accent">
+                            {t.ticker}
+                          </span>
+                          <span className="flex-1 truncate">{t.name}</span>
+                        </button>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </div>
+            ))
+          )}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/components/TaskComposer.tsx
+++ b/apps/web/src/components/TaskComposer.tsx
@@ -1,0 +1,574 @@
+"use client";
+
+import {
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type FormEvent,
+} from "react";
+import {
+  AlertCircle,
+  Calendar,
+  Circle,
+  Flag,
+  Tag,
+  UserPlus,
+  X,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import {
+  formatDueLabel,
+  parseDueDate,
+} from "@/lib/parse-due-date";
+
+export interface TaskComposerMember {
+  user_id: string;
+  full_name: string | null;
+}
+
+export interface TaskComposerSubmit {
+  title: string;
+  priority: number;
+  due_date: string | null;
+  labels: string[];
+  assignee_ids: string[];
+}
+
+interface TaskComposerProps {
+  /** Members available for assignee selection. Empty = no picker. */
+  members?: TaskComposerMember[];
+  /** Pre-fill the priority chip. Defaults to 3 (the API default). */
+  initialPriority?: number;
+  /** Pre-fill assignees. */
+  initialAssigneeIds?: string[];
+  /** Pre-fill labels. */
+  initialLabels?: string[];
+  /**
+   * Render variant. `inline` uses a tight horizontal layout suited to
+   * the task list itself; `dialog` uses a roomier vertical layout.
+   */
+  variant?: "inline" | "dialog";
+  /** Auto-focus the title input on mount. Default true. */
+  autoFocus?: boolean;
+  /** Optional placeholder for the title input. */
+  placeholder?: string;
+  /** Async submit handler. Throws to surface an error in the composer. */
+  onSubmit: (input: TaskComposerSubmit) => Promise<void>;
+  /** Cancel handler — closes the composer / clears the dialog. */
+  onCancel?: () => void;
+  /**
+   * Optional extra slot rendered between the chips and the action
+   * buttons. The dashboard quick-create uses this for the terminal
+   * picker, which has no equivalent in the inline variant.
+   */
+  prefixSlot?: React.ReactNode;
+  /**
+   * Disable submission — useful when the prefix slot has a required
+   * value that hasn't been filled yet (e.g. terminal not picked).
+   */
+  submitDisabled?: boolean;
+  /** Custom label for the submit button. Defaults to "Create". */
+  submitLabel?: string;
+}
+
+/**
+ * Reusable rich task composer.
+ *
+ * Renders a single-line title input plus four chips — priority, due
+ * date, assignees, labels — that can be edited inline without leaving
+ * the composer. Submitting the form posts a single `TaskComposerSubmit`
+ * to `onSubmit`; the parent decides which terminal it lands in.
+ *
+ * Used in two places (so far):
+ *   - `TasksPane` inline composer (replaces the title-only form)
+ *   - `QuickTaskDialog` dashboard pop-up (with a prefixSlot for the
+ *     terminal picker)
+ *
+ * Keyboard:
+ *   - Enter — submit
+ *   - Esc — cancel
+ *   - Tab — cycle through title → chips → submit
+ */
+export function TaskComposer({
+  members = [],
+  initialPriority = 3,
+  initialAssigneeIds = [],
+  initialLabels = [],
+  variant = "inline",
+  autoFocus = true,
+  placeholder = "New task… Enter to save, Esc to cancel",
+  onSubmit,
+  onCancel,
+  prefixSlot,
+  submitDisabled = false,
+  submitLabel = "Create",
+}: TaskComposerProps) {
+  const [title, setTitle] = useState("");
+  const [priority, setPriority] = useState(initialPriority);
+  const [dueRaw, setDueRaw] = useState("");
+  const [dueIso, setDueIso] = useState<string | null>(null);
+  const [assigneeIds, setAssigneeIds] = useState<string[]>(initialAssigneeIds);
+  const [labels, setLabels] = useState<string[]>(initialLabels);
+  const [labelDraft, setLabelDraft] = useState("");
+  const [showAssignees, setShowAssignees] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const titleRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (autoFocus) titleRef.current?.focus();
+  }, [autoFocus]);
+
+  // Parse the due-date input as the user finishes typing it. We tolerate
+  // anything in the field while focused but commit the parsed value on
+  // blur or Enter so the chip text reflects what'll actually be saved.
+  function commitDue() {
+    if (!dueRaw.trim()) {
+      setDueIso(null);
+      return;
+    }
+    const parsed = parseDueDate(dueRaw);
+    if (parsed) {
+      setDueIso(parsed);
+      setDueRaw(formatDueLabel(parsed));
+    }
+  }
+
+  function commitLabel() {
+    const next = labelDraft.trim().replace(/^#/, "");
+    if (!next) return;
+    setLabels((prev) => (prev.includes(next) ? prev : [...prev, next]));
+    setLabelDraft("");
+  }
+
+  async function handleSubmit(e?: FormEvent) {
+    e?.preventDefault();
+    if (submitting || submitDisabled) return;
+    if (!title.trim()) {
+      setError("Title is required");
+      titleRef.current?.focus();
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+
+    // Make sure any pending label/due input gets committed before submit.
+    let dueFinal = dueIso;
+    if (dueRaw.trim() && !dueFinal) {
+      dueFinal = parseDueDate(dueRaw);
+    }
+    const labelsFinal = labelDraft.trim()
+      ? Array.from(
+          new Set([...labels, labelDraft.trim().replace(/^#/, "")]),
+        )
+      : labels;
+
+    try {
+      await onSubmit({
+        title: title.trim(),
+        priority,
+        due_date: dueFinal,
+        labels: labelsFinal,
+        assignee_ids: assigneeIds,
+      });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to create");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  const isInline = variant === "inline";
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className={cn(
+        "flex flex-col gap-2 border-border bg-bg-1",
+        isInline ? "border-t px-4 py-2.5" : "rounded-md p-3",
+      )}
+      aria-label="New task"
+    >
+      {prefixSlot}
+
+      {/* Row 1: status icon + title */}
+      <div className="flex items-center gap-3">
+        <Circle
+          className="h-3.5 w-3.5 flex-shrink-0 text-text-3"
+          aria-hidden="true"
+        />
+        <input
+          ref={titleRef}
+          value={title}
+          onChange={(e) => {
+            setTitle(e.target.value);
+            if (error) setError(null);
+          }}
+          onKeyDown={(e) => {
+            if (e.key === "Escape") {
+              e.preventDefault();
+              onCancel?.();
+            }
+          }}
+          placeholder={placeholder}
+          aria-label="Task title"
+          className="flex-1 bg-transparent text-sm text-text-0 placeholder:text-text-3 outline-none"
+          disabled={submitting}
+        />
+      </div>
+
+      {/* Row 2: chips */}
+      <div className="flex flex-wrap items-center gap-1.5 pl-7">
+        <PriorityChip
+          priority={priority}
+          onChange={setPriority}
+          disabled={submitting}
+        />
+        <DueChipInput
+          raw={dueRaw}
+          iso={dueIso}
+          onRawChange={setDueRaw}
+          onCommit={commitDue}
+          onClear={() => {
+            setDueRaw("");
+            setDueIso(null);
+          }}
+          disabled={submitting}
+        />
+        {members.length > 0 ? (
+          <AssigneeChip
+            members={members}
+            selected={assigneeIds}
+            open={showAssignees}
+            onToggleOpen={() => setShowAssignees((v) => !v)}
+            onChange={setAssigneeIds}
+            disabled={submitting}
+          />
+        ) : null}
+        <LabelsChip
+          labels={labels}
+          draft={labelDraft}
+          onDraftChange={setLabelDraft}
+          onCommit={commitLabel}
+          onRemove={(l) =>
+            setLabels((prev) => prev.filter((x) => x !== l))
+          }
+          disabled={submitting}
+        />
+
+        {/* Action buttons pin to the right on inline; stack on dialog. */}
+        <div className="ml-auto flex items-center gap-2">
+          {onCancel ? (
+            <button
+              type="button"
+              onClick={onCancel}
+              className="text-xs text-text-3 hover:text-text-1"
+              disabled={submitting}
+            >
+              Esc
+            </button>
+          ) : null}
+          <button
+            type="submit"
+            disabled={submitting || submitDisabled || !title.trim()}
+            className={cn(
+              "rounded-sm border px-2.5 py-1 text-xs font-semibold uppercase tracking-wide",
+              submitting || submitDisabled || !title.trim()
+                ? "cursor-not-allowed border-border bg-bg-2 text-text-3"
+                : "border-accent bg-accent text-bg-0 hover:bg-accent-hover",
+            )}
+          >
+            {submitting ? "…" : submitLabel}
+          </button>
+        </div>
+      </div>
+
+      {error ? (
+        <p className="flex items-center gap-1 pl-7 text-xs text-danger">
+          <AlertCircle className="h-3 w-3" aria-hidden="true" />
+          {error}
+        </p>
+      ) : null}
+    </form>
+  );
+}
+
+/* --------------------------------------------------------------- */
+/* Chip primitives                                                  */
+/* --------------------------------------------------------------- */
+
+const PRIORITY_LABEL: Record<number, string> = {
+  1: "P1 · Critical",
+  2: "P2 · High",
+  3: "P3 · Normal",
+  4: "P4 · Low",
+};
+
+function PriorityChip({
+  priority,
+  onChange,
+  disabled,
+}: {
+  priority: number;
+  onChange: (p: number) => void;
+  disabled: boolean;
+}) {
+  const cycle = () => onChange(priority === 4 ? 1 : priority + 1);
+  return (
+    <button
+      type="button"
+      onClick={cycle}
+      disabled={disabled}
+      title={`${PRIORITY_LABEL[priority]} (click to cycle)`}
+      aria-label={`Priority ${priority} of 4 — click to change`}
+      className="flex items-center gap-1 rounded-sm border border-border bg-bg-2 px-2 py-1 text-[11px] text-text-1 hover:bg-bg-3"
+    >
+      <Flag className="h-3 w-3 text-text-3" aria-hidden="true" />
+      <span className="font-mono">P{priority}</span>
+    </button>
+  );
+}
+
+function DueChipInput({
+  raw,
+  iso,
+  onRawChange,
+  onCommit,
+  onClear,
+  disabled,
+}: {
+  raw: string;
+  iso: string | null;
+  onRawChange: (v: string) => void;
+  onCommit: () => void;
+  onClear: () => void;
+  disabled: boolean;
+}) {
+  const id = useId();
+  return (
+    <span
+      className={cn(
+        "flex items-center gap-1 rounded-sm border border-border bg-bg-2 px-2 py-1 text-[11px] text-text-1",
+        iso && "border-accent/40",
+      )}
+    >
+      <label htmlFor={id} className="contents">
+        <Calendar className="h-3 w-3 text-text-3" aria-hidden="true" />
+      </label>
+      <input
+        id={id}
+        value={raw}
+        onChange={(e) => onRawChange(e.target.value)}
+        onBlur={onCommit}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            e.preventDefault();
+            onCommit();
+            // Don't bubble — we don't want Enter in this field to
+            // submit the outer form until the user explicitly hits
+            // submit / re-tabs back to the title.
+          }
+        }}
+        placeholder="due"
+        aria-label="Due date — accepts today, tomorrow, fri, in 3d, 5/14"
+        title="today · tomorrow · fri · next mon · in 3d · 5/14 · 2026-05-14"
+        className="w-20 bg-transparent text-[11px] outline-none placeholder:text-text-3"
+        disabled={disabled}
+      />
+      {iso ? (
+        <button
+          type="button"
+          onClick={onClear}
+          aria-label="Clear due date"
+          className="rounded-sm text-text-3 hover:text-text-0"
+          disabled={disabled}
+        >
+          <X className="h-3 w-3" aria-hidden="true" />
+        </button>
+      ) : null}
+    </span>
+  );
+}
+
+function AssigneeChip({
+  members,
+  selected,
+  open,
+  onToggleOpen,
+  onChange,
+  disabled,
+}: {
+  members: TaskComposerMember[];
+  selected: string[];
+  open: boolean;
+  onToggleOpen: () => void;
+  onChange: (ids: string[]) => void;
+  disabled: boolean;
+}) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Click outside to close.
+  useEffect(() => {
+    if (!open) return;
+    function onDoc(e: MouseEvent) {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(e.target as Node)
+      ) {
+        onToggleOpen();
+      }
+    }
+    document.addEventListener("mousedown", onDoc);
+    return () => document.removeEventListener("mousedown", onDoc);
+  }, [open, onToggleOpen]);
+
+  const selectedNames = useMemo(() => {
+    return selected
+      .map((id) => members.find((m) => m.user_id === id))
+      .filter((m): m is TaskComposerMember => Boolean(m))
+      .map((m) => m.full_name ?? "—");
+  }, [selected, members]);
+
+  function toggle(id: string) {
+    onChange(
+      selected.includes(id)
+        ? selected.filter((x) => x !== id)
+        : [...selected, id],
+    );
+  }
+
+  const label =
+    selected.length === 0
+      ? "Assign"
+      : selected.length === 1
+        ? (selectedNames[0] ?? "1 assigned")
+        : `${selected.length} assigned`;
+
+  return (
+    <div ref={containerRef} className="relative">
+      <button
+        type="button"
+        onClick={onToggleOpen}
+        disabled={disabled}
+        title="Assignees"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        className={cn(
+          "flex items-center gap-1 rounded-sm border bg-bg-2 px-2 py-1 text-[11px] text-text-1 hover:bg-bg-3",
+          selected.length > 0 ? "border-accent/40" : "border-border",
+        )}
+      >
+        <UserPlus className="h-3 w-3 text-text-3" aria-hidden="true" />
+        <span className="max-w-[120px] truncate">{label}</span>
+      </button>
+      {open ? (
+        <div
+          role="menu"
+          className="absolute left-0 top-full z-50 mt-1 max-h-60 w-56 overflow-y-auto rounded-sm border border-border bg-bg-1 py-1 shadow-lg"
+        >
+          {members.length === 0 ? (
+            <p className="px-3 py-2 text-xs text-text-3">No members yet.</p>
+          ) : (
+            members.map((m) => {
+              const checked = selected.includes(m.user_id);
+              return (
+                <button
+                  key={m.user_id}
+                  role="menuitem"
+                  type="button"
+                  onClick={() => toggle(m.user_id)}
+                  className={cn(
+                    "flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs hover:bg-bg-2",
+                    checked && "bg-bg-2 text-text-0",
+                  )}
+                >
+                  <span
+                    className={cn(
+                      "h-3 w-3 flex-shrink-0 rounded-sm border",
+                      checked
+                        ? "border-accent bg-accent"
+                        : "border-border bg-bg-0",
+                    )}
+                    aria-hidden="true"
+                  />
+                  <span className="flex-1 truncate text-text-1">
+                    {m.full_name ?? "—"}
+                  </span>
+                </button>
+              );
+            })
+          )}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function LabelsChip({
+  labels,
+  draft,
+  onDraftChange,
+  onCommit,
+  onRemove,
+  disabled,
+}: {
+  labels: string[];
+  draft: string;
+  onDraftChange: (v: string) => void;
+  onCommit: () => void;
+  onRemove: (l: string) => void;
+  disabled: boolean;
+}) {
+  const id = useId();
+  return (
+    <span className="flex items-center gap-1 rounded-sm border border-border bg-bg-2 px-2 py-1 text-[11px] text-text-1">
+      <label htmlFor={id} className="contents">
+        <Tag className="h-3 w-3 text-text-3" aria-hidden="true" />
+      </label>
+      {labels.map((l) => (
+        <span
+          key={l}
+          className="flex items-center gap-1 rounded-sm bg-bg-3 px-1 font-mono text-[10px] text-text-1"
+        >
+          {l}
+          <button
+            type="button"
+            onClick={() => onRemove(l)}
+            aria-label={`Remove ${l}`}
+            disabled={disabled}
+            className="text-text-3 hover:text-text-0"
+          >
+            <X className="h-2.5 w-2.5" aria-hidden="true" />
+          </button>
+        </span>
+      ))}
+      <input
+        id={id}
+        value={draft}
+        onChange={(e) => onDraftChange(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === ",") {
+            e.preventDefault();
+            onCommit();
+          } else if (
+            e.key === "Backspace" &&
+            draft === "" &&
+            labels.length > 0
+          ) {
+            // Backspace on an empty draft pops the most recent label —
+            // standard chip-input affordance.
+            e.preventDefault();
+            onRemove(labels[labels.length - 1]);
+          }
+        }}
+        onBlur={onCommit}
+        placeholder={labels.length === 0 ? "labels" : ""}
+        aria-label="Labels — comma or Enter to add"
+        className="w-16 bg-transparent text-[11px] outline-none placeholder:text-text-3"
+        disabled={disabled}
+      />
+    </span>
+  );
+}

--- a/apps/web/src/components/TasksPane.tsx
+++ b/apps/web/src/components/TasksPane.tsx
@@ -1,14 +1,15 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
-import { Plus, Check, Circle, MessageSquare, Maximize2, ListTodo } from "lucide-react";
+import { Plus, Check, MessageSquare, Maximize2, ListTodo } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { EmptyState } from "./EmptyState";
 import { useRealtimeTable } from "@/lib/supabase/realtime";
 import { useRegisterCommands } from "@/lib/use-register-commands";
 import { offlineFetch } from "@/lib/offline-fetch";
 import { CommentThread } from "./CommentThread";
+import { TaskComposer, type TaskComposerMember } from "./TaskComposer";
 import {
   PriorityDots,
   StatusPill,
@@ -57,11 +58,8 @@ export function TasksPane({ ticker, projectId }: TasksPaneProps) {
   const [error, setError] = useState<string | null>(null);
   const [selectedIdx, setSelectedIdx] = useState(0);
   const [creating, setCreating] = useState(false);
-  const [draftTitle, setDraftTitle] = useState("");
-  const [submitting, setSubmitting] = useState(false);
   const [commentTaskId, setCommentTaskId] = useState<string | null>(null);
   const [mentionables, setMentionables] = useState<Mentionable[]>([]);
-  const createRef = useRef<HTMLInputElement>(null);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -175,10 +173,6 @@ export function TasksPane({ ticker, projectId }: TasksPaneProps) {
     },
   );
 
-  useEffect(() => {
-    if (creating) createRef.current?.focus();
-  }, [creating]);
-
   // Keyboard shortcuts (scoped — only fire when focus isn't in an input)
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -247,37 +241,47 @@ export function TasksPane({ ticker, projectId }: TasksPaneProps) {
     }
   }
 
-  async function createTask(e?: React.FormEvent) {
-    e?.preventDefault();
-    if (!draftTitle.trim() || submitting) return;
-    setSubmitting(true);
-    try {
-      const r = await offlineFetch(`/api/v1/projects/${ticker}/tasks`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ title: draftTitle.trim() }),
-        label: `Create task: ${draftTitle.trim()}`,
-      });
-      if (!r.ok && r.status !== 202) {
-        const body = (await r.json().catch(() => ({}))) as {
-          errors?: { message: string }[];
-        };
-        setError(body.errors?.[0]?.message ?? "Failed to create");
-        return;
-      }
-      setDraftTitle("");
-      // Queued mutations won't appear in the list until they sync; the
-      // realtime channel handles the post-sync insert. Reload only when
-      // the request actually landed.
-      if (r.status !== 202) await load();
-    } finally {
-      setSubmitting(false);
+  /**
+   * POST a fully-formed task (title + chips) to the project's tasks
+   * endpoint. The TaskComposer hands us the structured payload; we
+   * just translate it into the API's body shape and reload on
+   * success. Throws on failure so the composer can surface the error
+   * inline.
+   */
+  async function createTask(input: {
+    title: string;
+    priority: number;
+    due_date: string | null;
+    labels: string[];
+    assignee_ids: string[];
+  }) {
+    const r = await offlineFetch(`/api/v1/projects/${ticker}/tasks`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        title: input.title,
+        priority: input.priority,
+        due_date: input.due_date,
+        labels: input.labels,
+        assignee_ids:
+          input.assignee_ids.length > 0 ? input.assignee_ids : undefined,
+      }),
+      label: `Create task: ${input.title}`,
+    });
+    if (!r.ok && r.status !== 202) {
+      const body = (await r.json().catch(() => ({}))) as {
+        errors?: { message: string }[];
+      };
+      throw new Error(
+        body.errors?.[0]?.message ?? `Failed to create (HTTP ${r.status})`,
+      );
     }
+    setCreating(false);
+    if (r.status !== 202) await load();
   }
 
   function cancelCreate() {
     setCreating(false);
-    setDraftTitle("");
   }
 
   const commentTask = tasks.find((t) => t.id === commentTaskId) ?? null;
@@ -328,31 +332,12 @@ export function TasksPane({ ticker, projectId }: TasksPaneProps) {
         )}
 
         {creating ? (
-          <form onSubmit={createTask} className="flex items-center gap-3 border-t border-border bg-bg-1 px-4 py-2.5">
-            <Circle className="h-3.5 w-3.5 flex-shrink-0 text-text-3" aria-hidden="true" />
-            <input
-              ref={createRef}
-              value={draftTitle}
-              onChange={(e) => setDraftTitle(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === "Escape") {
-                  e.preventDefault();
-                  cancelCreate();
-                }
-              }}
-              placeholder="New task… Enter to save, Esc to cancel"
-              aria-label="New task title"
-              className="flex-1 bg-transparent text-sm text-text-0 placeholder:text-text-3 outline-none"
-              disabled={submitting}
-            />
-            <button
-              type="button"
-              onClick={cancelCreate}
-              className="text-xs text-text-3 hover:text-text-1"
-            >
-              Esc
-            </button>
-          </form>
+          <TaskComposer
+            members={mentionables as TaskComposerMember[]}
+            onSubmit={createTask}
+            onCancel={cancelCreate}
+            submitLabel="Create"
+          />
         ) : null}
       </div>
       </div>

--- a/apps/web/src/lib/parse-due-date.ts
+++ b/apps/web/src/lib/parse-due-date.ts
@@ -1,0 +1,193 @@
+/**
+ * Natural-language date parser for the inline due-date chip in the
+ * task composer.
+ *
+ * Returns the resolved date as a `YYYY-MM-DD` string in the user's
+ * local calendar, or `null` if the input doesn't match any known
+ * shape. Empty / whitespace-only input also returns `null`.
+ *
+ * Supported shapes:
+ *   - "today"
+ *   - "tomorrow" / "tmrw" / "tom"
+ *   - "yesterday"
+ *   - day of week: "fri", "friday", "mon", "monday" → next occurrence
+ *     (today is *not* counted; "fri" on a Friday means next Friday)
+ *   - "next <day>": forces the next-week occurrence even when the
+ *     short form would otherwise be sooner
+ *   - "in 3d", "in 2 weeks", "in 1m" (days/weeks/months)
+ *   - "eow" (end of work week → Friday), "eom" (end of month)
+ *   - YYYY-MM-DD, M/D, M/D/YY, M/D/YYYY
+ *
+ * Case-insensitive. Trims whitespace.
+ */
+export function parseDueDate(input: string): string | null {
+  const s = input.trim().toLowerCase();
+  if (!s) return null;
+
+  const today = startOfDay(new Date());
+
+  // Single-word shortcuts.
+  if (s === "today" || s === "now") return toISODate(today);
+  if (s === "tomorrow" || s === "tmrw" || s === "tom") {
+    return toISODate(addDays(today, 1));
+  }
+  if (s === "yesterday") return toISODate(addDays(today, -1));
+  if (s === "eow") {
+    // End of work week — Friday. If today is Sat/Sun, go to next Fri.
+    const dow = today.getDay();
+    const delta = dow <= 5 ? 5 - dow : 7 - dow + 5;
+    return toISODate(addDays(today, delta));
+  }
+  if (s === "eom") {
+    const d = new Date(today.getFullYear(), today.getMonth() + 1, 0);
+    return toISODate(d);
+  }
+
+  // Day of week (with optional "next " prefix).
+  let dayKey = s;
+  let forceNextWeek = false;
+  if (dayKey.startsWith("next ")) {
+    forceNextWeek = true;
+    dayKey = dayKey.slice(5).trim();
+  }
+  const targetDow = DAY_OF_WEEK[dayKey];
+  if (targetDow !== undefined) {
+    const dow = today.getDay();
+    let delta = (targetDow - dow + 7) % 7;
+    // "fri" on a Friday means *next* Friday — same-day today isn't
+    // a useful default for a due date.
+    if (delta === 0) delta = 7;
+    if (forceNextWeek && delta < 7) delta += 7;
+    return toISODate(addDays(today, delta));
+  }
+
+  // "in 3d" / "in 2 weeks" / "in 1m"
+  const inMatch = s.match(/^in\s+(\d+)\s*(d|day|days|w|wk|wks|week|weeks|m|mo|mos|month|months)$/);
+  if (inMatch) {
+    const n = Number(inMatch[1]);
+    const unit = inMatch[2];
+    if (unit.startsWith("d")) return toISODate(addDays(today, n));
+    if (unit.startsWith("w")) return toISODate(addDays(today, n * 7));
+    if (unit.startsWith("m")) {
+      const d = new Date(today);
+      d.setMonth(d.getMonth() + n);
+      return toISODate(d);
+    }
+  }
+
+  // "3d" / "2w" — bare delta without "in"
+  const bareMatch = s.match(/^(\d+)\s*(d|w|m)$/);
+  if (bareMatch) {
+    const n = Number(bareMatch[1]);
+    const unit = bareMatch[2];
+    if (unit === "d") return toISODate(addDays(today, n));
+    if (unit === "w") return toISODate(addDays(today, n * 7));
+    if (unit === "m") {
+      const d = new Date(today);
+      d.setMonth(d.getMonth() + n);
+      return toISODate(d);
+    }
+  }
+
+  // YYYY-MM-DD (already canonical — pad and validate).
+  const isoMatch = s.match(/^(\d{4})-(\d{1,2})-(\d{1,2})$/);
+  if (isoMatch) {
+    const [, y, m, d] = isoMatch;
+    return formatYMD(Number(y), Number(m), Number(d));
+  }
+
+  // M/D or M/D/YY or M/D/YYYY
+  const slashMatch = s.match(/^(\d{1,2})\/(\d{1,2})(?:\/(\d{2,4}))?$/);
+  if (slashMatch) {
+    const [, mm, dd, yy] = slashMatch;
+    const year = yy
+      ? yy.length === 2
+        ? 2000 + Number(yy)
+        : Number(yy)
+      : today.getFullYear();
+    return formatYMD(year, Number(mm), Number(dd));
+  }
+
+  return null;
+}
+
+const DAY_OF_WEEK: Record<string, number> = {
+  sunday: 0,
+  sun: 0,
+  monday: 1,
+  mon: 1,
+  tuesday: 2,
+  tue: 2,
+  tues: 2,
+  wednesday: 3,
+  wed: 3,
+  thursday: 4,
+  thu: 4,
+  thur: 4,
+  thurs: 4,
+  friday: 5,
+  fri: 5,
+  saturday: 6,
+  sat: 6,
+};
+
+function startOfDay(d: Date): Date {
+  const r = new Date(d);
+  r.setHours(0, 0, 0, 0);
+  return r;
+}
+
+function addDays(d: Date, n: number): Date {
+  const r = new Date(d);
+  r.setDate(r.getDate() + n);
+  return r;
+}
+
+/**
+ * Format a Date as `YYYY-MM-DD` using the *local* calendar — not
+ * UTC. `Date.toISOString()` would convert to UTC first, which can
+ * shift the date by a day for users east of GMT in the morning or
+ * west of GMT in the evening.
+ */
+function toISODate(d: Date): string {
+  return formatYMD(d.getFullYear(), d.getMonth() + 1, d.getDate());
+}
+
+function formatYMD(y: number, m: number, d: number): string {
+  return `${y}-${String(m).padStart(2, "0")}-${String(d).padStart(2, "0")}`;
+}
+
+/**
+ * Render a YYYY-MM-DD date as a short human label for the chip — the
+ * inverse of `parseDueDate` for display purposes. Examples:
+ *   today     "today"
+ *   tomorrow  "tomorrow"
+ *   +2..6 days "fri", "mon", etc.
+ *   anything else  "May 14"
+ */
+export function formatDueLabel(iso: string): string {
+  const m = iso.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (!m) return iso;
+  const [, y, mm, dd] = m;
+  const target = startOfDay(new Date(Number(y), Number(mm) - 1, Number(dd)));
+  const today = startOfDay(new Date());
+  const delta = Math.round((target.getTime() - today.getTime()) / 86_400_000);
+  if (delta === 0) return "today";
+  if (delta === 1) return "tomorrow";
+  if (delta === -1) return "yesterday";
+  if (delta > 1 && delta <= 6) {
+    return [
+      "sun",
+      "mon",
+      "tue",
+      "wed",
+      "thu",
+      "fri",
+      "sat",
+    ][target.getDay()];
+  }
+  return target.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+  });
+}


### PR DESCRIPTION
## Summary

Closes the gap between what the task-create API has always supported and what the UI exposed. Three coordinated pieces:

1. **`TaskComposer`** — reusable component with title + four chips (priority, due date, assignee, labels). Replaces the title-only inline form.
2. **`TasksPane` inline use** — same C-key / "+ New task" button trigger, just richer. Set everything up front; no detail-page round trip.
3. **`QuickTaskDialog`** — dashboard pop-up triggered by the new "+ New task" button in the topbar, ⌘N anywhere on the dashboard, or `?new=task`. Adds a terminal-picker prefix slot so you can create a task in any terminal without navigating into it.

Plus a "New task" entry in the command palette (⌘K → "new task") listed alongside "New terminal" / "New space".

## Notable details

- Due-date chip parses natural language: `today`, `tomorrow`, `fri`, `next mon`, `in 3d`, `5/14`, `2026-05-14`, `eow`, `eom`. Renders the resolved date as a short label (e.g. `tue` if it's the next Tuesday).
- Priority chip cycles 1→2→3→4→1 on click. Lives in the API at `priority: 1-4`.
- Assignees come from the terminal's members API; populated lazily once a terminal is selected in the dialog.
- Labels chip uses standard chip-input UX: Enter or comma adds, Backspace on empty draft pops the last one.
- ⌘N is gated by `isEditableTarget` so it doesn't fight typing inside inputs.

## Test plan

- [ ] /p/CSBLNC F3 (Tasks): press `C` or click "+ New task" — composer expands with chips. Type title, set priority+due+assignee, hit Create. Task lands in the list with the expected metadata.
- [ ] On dashboard: click the new "+ New task" button in the topbar (or press ⌘N). Modal opens with terminal picker. Filter by name/ticker, pick one, the assignee chip populates. Submit → task appears in the chosen terminal.
- [ ] ⌘K → "new task" → routes to dashboard with `?new=task` and opens the dialog.
- [ ] No new console errors / no React #418 / no NavigationFallback warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)