### PR TITLE
feat(tasks): inline subtasks under each expanded task row

### DIFF
--- a/apps/web/src/components/SubtasksList.tsx
+++ b/apps/web/src/components/SubtasksList.tsx
@@ -1,0 +1,234 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { Check, Plus, Trash2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export interface Subtask {
+  id: string;
+  task_id: string;
+  label: string;
+  done: boolean;
+  position: number;
+  created_at: string;
+  updated_at: string;
+}
+
+interface SubtasksListProps {
+  taskId: string;
+  /** Already-loaded subtasks. Empty array = "loaded but none yet". */
+  subtasks: Subtask[] | null;
+  /** Called when the parent's subtasks state should be replaced. */
+  onChange: (next: Subtask[]) => void;
+}
+
+/**
+ * Inline subtask checklist for an expanded task row in `TasksPane`.
+ *
+ * Renders below the parent row, indented, with:
+ *   - one row per subtask: checkbox + label + delete button
+ *   - a "+ subtask" composer at the bottom
+ *   - roll-up "{done} / {total}" count to the right of "+ subtask"
+ *
+ * The component is dumb — it owns no fetch logic. The parent
+ * (`TasksPane`) is responsible for fetching the initial list and
+ * for replacing it after mutations succeed. We use optimistic
+ * updates locally so the UI stays responsive while the network
+ * call finishes; on error we ask the parent to reload.
+ */
+export function SubtasksList({
+  taskId,
+  subtasks,
+  onChange,
+}: SubtasksListProps) {
+  const [draft, setDraft] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Auto-focus the composer when the subtask section mounts. Mirrors
+  // the parent task composer's behaviour — feels natural after the
+  // user just clicked the chevron to expand.
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, [taskId]);
+
+  const list = subtasks ?? [];
+  const done = list.filter((s) => s.done).length;
+  const total = list.length;
+
+  async function addSubtask() {
+    const label = draft.trim();
+    if (!label || submitting) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const r = await fetch(`/api/v1/tasks/${taskId}/subtasks`, {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ label }),
+      });
+      const body = (await r.json().catch(() => ({}))) as {
+        data?: Subtask;
+        errors?: { message: string }[];
+      };
+      if (!r.ok || !body.data) {
+        setError(
+          body.errors?.[0]?.message ?? `Failed to add (HTTP ${r.status})`,
+        );
+        return;
+      }
+      onChange([...list, body.data]);
+      setDraft("");
+      inputRef.current?.focus();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Network error");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function toggleDone(s: Subtask) {
+    const next = !s.done;
+    // Optimistic flip.
+    onChange(list.map((x) => (x.id === s.id ? { ...x, done: next } : x)));
+    try {
+      const r = await fetch(
+        `/api/v1/tasks/${taskId}/subtasks/${s.id}`,
+        {
+          method: "PATCH",
+          credentials: "include",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ done: next }),
+        },
+      );
+      if (!r.ok) {
+        // Roll back on failure — surface a toast in a follow-up.
+        onChange(list);
+        const body = (await r.json().catch(() => ({}))) as {
+          errors?: { message: string }[];
+        };
+        setError(body.errors?.[0]?.message ?? "Failed to update");
+      }
+    } catch {
+      onChange(list);
+      setError("Network error");
+    }
+  }
+
+  async function deleteSubtask(s: Subtask) {
+    // Optimistic remove.
+    onChange(list.filter((x) => x.id !== s.id));
+    try {
+      const r = await fetch(
+        `/api/v1/tasks/${taskId}/subtasks/${s.id}`,
+        { method: "DELETE", credentials: "include" },
+      );
+      if (!r.ok && r.status !== 204) {
+        onChange(list);
+        setError(`Delete failed (HTTP ${r.status})`);
+      }
+    } catch {
+      onChange(list);
+      setError("Network error");
+    }
+  }
+
+  return (
+    <div className="border-t border-border bg-bg-1/40 pl-12 pr-4">
+      {subtasks === null ? (
+        <p className="py-2 text-[11px] text-text-3">Loading subtasks…</p>
+      ) : null}
+
+      {list.length > 0 ? (
+        <ul className="divide-y divide-border/40 py-1">
+          {list.map((s) => (
+            <li
+              key={s.id}
+              className="group flex items-center gap-3 py-1.5 text-xs"
+            >
+              <button
+                type="button"
+                onClick={() => void toggleDone(s)}
+                aria-label={s.done ? "Mark as not done" : "Mark as done"}
+                className={cn(
+                  "flex h-3.5 w-3.5 flex-shrink-0 items-center justify-center rounded-sm border",
+                  s.done
+                    ? "border-success bg-success-subtle text-success"
+                    : "border-border hover:border-accent",
+                )}
+              >
+                {s.done ? (
+                  <Check className="h-2.5 w-2.5" aria-hidden="true" />
+                ) : null}
+              </button>
+              <span
+                className={cn(
+                  "flex-1 truncate",
+                  s.done ? "text-text-3 line-through" : "text-text-1",
+                )}
+              >
+                {s.label}
+              </span>
+              <button
+                type="button"
+                onClick={() => void deleteSubtask(s)}
+                aria-label={`Delete subtask "${s.label}"`}
+                className="rounded-sm p-1 text-text-3 opacity-0 transition-opacity hover:bg-bg-3 hover:text-danger group-hover:opacity-100 focus-visible:opacity-100"
+              >
+                <Trash2 className="h-3 w-3" aria-hidden="true" />
+              </button>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          void addSubtask();
+        }}
+        className="flex items-center gap-2 py-1.5 text-xs"
+      >
+        <Plus
+          className="h-3 w-3 flex-shrink-0 text-text-3"
+          aria-hidden="true"
+        />
+        <input
+          ref={inputRef}
+          value={draft}
+          onChange={(e) => {
+            setDraft(e.target.value);
+            if (error) setError(null);
+          }}
+          placeholder="Add a subtask…"
+          aria-label="New subtask"
+          className="flex-1 bg-transparent text-xs text-text-0 placeholder:text-text-3 outline-none"
+          disabled={submitting}
+        />
+        {total > 0 ? (
+          <span className="font-mono text-[10px] text-text-3">
+            {done} / {total}
+          </span>
+        ) : null}
+        <button
+          type="submit"
+          disabled={submitting || !draft.trim()}
+          className={cn(
+            "rounded-sm px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide",
+            submitting || !draft.trim()
+              ? "cursor-not-allowed text-text-3"
+              : "text-accent hover:bg-accent-subtle",
+          )}
+        >
+          Add
+        </button>
+      </form>
+
+      {error ? (
+        <p className="pb-2 text-[11px] text-danger">{error}</p>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/components/TasksPane.tsx
+++ b/apps/web/src/components/TasksPane.tsx
@@ -2,7 +2,15 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
-import { Plus, Check, MessageSquare, Maximize2, ListTodo } from "lucide-react";
+import {
+  ChevronDown,
+  ChevronRight,
+  Plus,
+  Check,
+  MessageSquare,
+  Maximize2,
+  ListTodo,
+} from "lucide-react";
 import { cn } from "@/lib/utils";
 import { EmptyState } from "./EmptyState";
 import { useRealtimeTable } from "@/lib/supabase/realtime";
@@ -10,6 +18,7 @@ import { useRegisterCommands } from "@/lib/use-register-commands";
 import { offlineFetch } from "@/lib/offline-fetch";
 import { CommentThread } from "./CommentThread";
 import { TaskComposer, type TaskComposerMember } from "./TaskComposer";
+import { SubtasksList, type Subtask } from "./SubtasksList";
 import {
   PriorityDots,
   StatusPill,
@@ -60,6 +69,53 @@ export function TasksPane({ ticker, projectId }: TasksPaneProps) {
   const [creating, setCreating] = useState(false);
   const [commentTaskId, setCommentTaskId] = useState<string | null>(null);
   const [mentionables, setMentionables] = useState<Mentionable[]>([]);
+
+  // Subtasks: lazily-loaded per parent. `null` = not yet fetched,
+  // `[]` = fetched and empty. The expand toggle drives both
+  // `expandedTaskIds` (visibility) and the first-fetch trigger.
+  const [expandedTaskIds, setExpandedTaskIds] = useState<Set<string>>(
+    () => new Set(),
+  );
+  const [subtasksByTaskId, setSubtasksByTaskId] = useState<
+    Record<string, Subtask[] | null>
+  >({});
+
+  async function loadSubtasks(taskId: string) {
+    setSubtasksByTaskId((prev) =>
+      taskId in prev ? prev : { ...prev, [taskId]: null },
+    );
+    try {
+      const r = await fetch(`/api/v1/tasks/${taskId}/subtasks`, {
+        credentials: "include",
+      });
+      const body = (await r.json().catch(() => ({}))) as {
+        data?: Subtask[];
+      };
+      setSubtasksByTaskId((prev) => ({
+        ...prev,
+        [taskId]: body.data ?? [],
+      }));
+    } catch {
+      setSubtasksByTaskId((prev) => ({ ...prev, [taskId]: [] }));
+    }
+  }
+
+  function toggleExpand(taskId: string) {
+    setExpandedTaskIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(taskId)) {
+        next.delete(taskId);
+      } else {
+        next.add(taskId);
+        // Fire the lazy fetch the first time the row expands. Re-opening
+        // a previously-loaded row reuses the cached array — no refetch.
+        if (!(taskId in subtasksByTaskId)) {
+          void loadSubtasks(taskId);
+        }
+      }
+      return next;
+    });
+  }
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -315,19 +371,39 @@ export function TasksPane({ ticker, projectId }: TasksPaneProps) {
           <Empty onCreate={() => setCreating(true)} />
         ) : (
           <ul className="divide-y divide-border">
-            {tasks.map((t, i) => (
-              <TaskRow
-                key={t.id}
-                task={t}
-                ticker={ticker}
-                selected={i === selectedIdx}
-                onClick={() => setSelectedIdx(i)}
-                onToggle={() => toggleComplete(t)}
-                onOpenComments={() =>
-                  setCommentTaskId((prev) => (prev === t.id ? null : t.id))
-                }
-              />
-            ))}
+            {tasks.map((t, i) => {
+              const expanded = expandedTaskIds.has(t.id);
+              return (
+                <li key={t.id}>
+                  <TaskRow
+                    task={t}
+                    ticker={ticker}
+                    selected={i === selectedIdx}
+                    expanded={expanded}
+                    onClick={() => setSelectedIdx(i)}
+                    onToggle={() => toggleComplete(t)}
+                    onOpenComments={() =>
+                      setCommentTaskId((prev) =>
+                        prev === t.id ? null : t.id,
+                      )
+                    }
+                    onToggleExpand={() => toggleExpand(t.id)}
+                  />
+                  {expanded ? (
+                    <SubtasksList
+                      taskId={t.id}
+                      subtasks={subtasksByTaskId[t.id] ?? null}
+                      onChange={(next) =>
+                        setSubtasksByTaskId((prev) => ({
+                          ...prev,
+                          [t.id]: next,
+                        }))
+                      }
+                    />
+                  ) : null}
+                </li>
+              );
+            })}
           </ul>
         )}
 
@@ -361,28 +437,48 @@ function TaskRow({
   task,
   ticker,
   selected,
+  expanded,
   onClick,
   onToggle,
   onOpenComments,
+  onToggleExpand,
 }: {
   task: Task;
   ticker: string;
   selected: boolean;
+  expanded: boolean;
   onClick: () => void;
   onToggle: () => void;
   onOpenComments: () => void;
+  onToggleExpand: () => void;
 }) {
   const done = task.status === "done";
 
   return (
-    <li
+    <div
       onClick={onClick}
       className={cn(
-        "group flex cursor-pointer items-center gap-3 px-4 py-2.5 transition-colors",
+        "group flex cursor-pointer items-center gap-2 px-2 py-2.5 transition-colors",
         selected ? "bg-bg-2" : "hover:bg-bg-2",
-        selected && "border-l-2 border-l-border-focus pl-[14px]",
+        selected && "border-l-2 border-l-border-focus pl-[6px]",
       )}
     >
+      <button
+        type="button"
+        onClick={(e) => {
+          e.stopPropagation();
+          onToggleExpand();
+        }}
+        aria-label={expanded ? "Collapse subtasks" : "Expand subtasks"}
+        aria-expanded={expanded}
+        className="flex h-4 w-4 flex-shrink-0 items-center justify-center rounded-sm text-text-3 hover:bg-bg-3 hover:text-text-0"
+      >
+        {expanded ? (
+          <ChevronDown className="h-3 w-3" aria-hidden="true" />
+        ) : (
+          <ChevronRight className="h-3 w-3" aria-hidden="true" />
+        )}
+      </button>
       <button
         onClick={(e) => {
           e.stopPropagation();
@@ -427,7 +523,7 @@ function TaskRow({
       {task.due_date ? <DueChip date={task.due_date} /> : null}
       <PriorityDots priority={task.priority} />
       <StatusPill status={task.status} />
-    </li>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary

Closes the gap between the subtasks API (`/api/v1/tasks/:id/subtasks` already supports GET/POST/PATCH/DELETE) and the UI, which had no way to interact with them outside the detail page.

Each task row in F3 now has a chevron on the left:

- Collapsed (default): just the parent row.
- Expanded: indented `SubtasksList` under it — checkbox per item, inline "+ Add subtask" composer, "{done}/{total}" roll-up chip.

Subtasks are lazy-fetched the first time a row expands. Re-collapsing keeps them cached. Toggle/add/delete are optimistic with rollback on error.

## Test plan

- [ ] /p/CSBLNC F3: click chevron on any row → "Loading subtasks…" briefly, then either an empty list or whatever's there.
- [ ] Type into "+ Add subtask" → Enter or click Add → row appears, count updates.
- [ ] Toggle the checkbox on an existing subtask → strikes through immediately, persists across page reloads.
- [ ] Hover a subtask → trash icon appears → click → row disappears, count updates.
- [ ] Re-collapse + re-expand: list comes back from cache instantly, no refetch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)