### PR TITLE
feat(layout): drag-to-resize columns in dashboard + terminal shells

### DIFF
--- a/apps/web/src/components/ResizeHandle.tsx
+++ b/apps/web/src/components/ResizeHandle.tsx
@@ -1,0 +1,184 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { cn } from "@/lib/utils";
+
+interface UseResizableConfig {
+  /** Stable localStorage key — persists size across reloads. */
+  storageKey: string;
+  /** Initial size in pixels. */
+  defaultSize: number;
+  /** Minimum width / height. */
+  min: number;
+  /** Maximum width / height. */
+  max: number;
+}
+
+/**
+ * Hook for the column-width state behind a `<ResizeHandle />`.
+ *
+ * Tracks one number (the width or height of the adjacent panel),
+ * hydrates it from `localStorage` on mount, and exposes a
+ * `startDrag` callback that callers wire up to the handle's
+ * `onPointerDown`. The handle itself is a presentational thumb;
+ * this hook owns the drag math.
+ */
+export function useResizable({
+  storageKey,
+  defaultSize,
+  min,
+  max,
+}: UseResizableConfig) {
+  const [size, setSize] = useState(defaultSize);
+  const [hydrated, setHydrated] = useState(false);
+
+  // Hydrate from localStorage after mount. Doing it before would race
+  // SSR — server has no localStorage and would render `defaultSize`,
+  // then a client-side rehydrate would shift the layout. The first
+  // render uses defaultSize on both sides; one tick later we apply the
+  // saved value.
+  useEffect(() => {
+    try {
+      const saved = window.localStorage.getItem(storageKey);
+      if (saved) {
+        const n = Number(saved);
+        if (Number.isFinite(n)) {
+          setSize(Math.min(max, Math.max(min, n)));
+        }
+      }
+    } catch {
+      /* localStorage unavailable — stick with defaultSize */
+    }
+    setHydrated(true);
+  }, [storageKey, min, max]);
+
+  useEffect(() => {
+    if (!hydrated) return;
+    try {
+      window.localStorage.setItem(storageKey, String(size));
+    } catch {
+      /* ignore */
+    }
+  }, [storageKey, size, hydrated]);
+
+  /**
+   * Begin a drag. `side` describes which side of the handle the
+   * resizable panel sits on:
+   *   - "before"  — panel is to the LEFT of the handle. Drag right
+   *                  grows it, drag left shrinks it.
+   *   - "after"   — panel is to the RIGHT of the handle. Drag left
+   *                  grows it, drag right shrinks it.
+   *
+   * For vertical resizers (top/bottom panels) use `axis="y"`; the
+   * deltas are read from clientY instead of clientX.
+   */
+  const startDrag = useCallback(
+    (
+      e: React.PointerEvent,
+      opts: { side: "before" | "after"; axis?: "x" | "y" } = {
+        side: "before",
+        axis: "x",
+      },
+    ) => {
+      e.preventDefault();
+      const axis = opts.axis ?? "x";
+      const startCoord = axis === "x" ? e.clientX : e.clientY;
+      const startSize = size;
+
+      const onMove = (ev: PointerEvent) => {
+        const cur = axis === "x" ? ev.clientX : ev.clientY;
+        const delta = cur - startCoord;
+        const next =
+          opts.side === "before" ? startSize + delta : startSize - delta;
+        setSize(Math.min(max, Math.max(min, next)));
+      };
+      const onUp = () => {
+        window.removeEventListener("pointermove", onMove);
+        window.removeEventListener("pointerup", onUp);
+        window.removeEventListener("pointercancel", onUp);
+        document.body.style.cursor = "";
+        document.body.style.userSelect = "";
+      };
+      window.addEventListener("pointermove", onMove);
+      window.addEventListener("pointerup", onUp);
+      window.addEventListener("pointercancel", onUp);
+      // Dim everything else and lock the cursor while dragging so the
+      // user gets unambiguous "I am resizing" feedback even if the
+      // mouse leaves the handle.
+      document.body.style.cursor = axis === "x" ? "col-resize" : "row-resize";
+      document.body.style.userSelect = "none";
+    },
+    [size, min, max],
+  );
+
+  return { size, setSize, startDrag };
+}
+
+interface ResizeHandleProps {
+  /**
+   * Direction the handle is rendered:
+   *   - "vertical"   — a vertical bar between two side-by-side panels
+   *                     (drag horizontally to resize)
+   *   - "horizontal" — a horizontal bar between stacked panels
+   *                     (drag vertically to resize)
+   */
+  orientation?: "vertical" | "horizontal";
+  /** Pointer-down handler. Wire to `useResizable().startDrag`. */
+  onPointerDown: (e: React.PointerEvent) => void;
+  /** Optional aria-label override. */
+  ariaLabel?: string;
+  className?: string;
+}
+
+/**
+ * Thin draggable thumb that sits between two panels and resizes
+ * the one wired to it via `useResizable`.
+ *
+ * Visuals:
+ *   - 4px wide / tall, transparent by default
+ *   - hover and active states subtly tint it accent so the user
+ *     can see they've grabbed the right edge
+ *   - cursor flips to col-resize / row-resize on hover
+ *
+ * Accessibility:
+ *   - role="separator" with `aria-orientation` so screen readers
+ *     announce it as a resizer
+ *   - keyboard adjustment is not wired here — the localStorage
+ *     state and pointer drag are the v1; arrow-key bumps will
+ *     come later
+ */
+export function ResizeHandle({
+  orientation = "vertical",
+  onPointerDown,
+  ariaLabel,
+  className,
+}: ResizeHandleProps) {
+  return (
+    <div
+      role="separator"
+      aria-orientation={orientation}
+      aria-label={ariaLabel ?? "Resize"}
+      onPointerDown={onPointerDown}
+      className={cn(
+        "group relative flex-shrink-0 transition-colors",
+        orientation === "vertical"
+          ? "w-1 cursor-col-resize hover:bg-border-focus active:bg-accent"
+          : "h-1 cursor-row-resize hover:bg-border-focus active:bg-accent",
+        className,
+      )}
+    >
+      {/* Wider hit area than the visible 4px — clicking *exactly* a
+          4px target is hard. The pseudo-element extends the
+          interactive zone without changing visual width. */}
+      <span
+        aria-hidden="true"
+        className={cn(
+          "absolute",
+          orientation === "vertical"
+            ? "inset-y-0 -left-1 -right-1"
+            : "inset-x-0 -top-1 -bottom-1",
+        )}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/TerminalShell.tsx
+++ b/apps/web/src/components/TerminalShell.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState, type ReactNode } from "react";
 import { FunctionKeys, type FunctionKey } from "./FunctionKeys";
 import { TickerTape } from "./TickerTape";
 import { CommandBar } from "./CommandBar";
+import { ResizeHandle, useResizable } from "./ResizeHandle";
 import { isEditableTarget } from "@/lib/shortcuts";
 
 interface TerminalShellProps {
@@ -63,6 +64,29 @@ export function TerminalShell({
   const [leftOpen, setLeftOpen] = useState(true);
   const [rightOpen, setRightOpen] = useState(true);
 
+  // Resizable column widths. Sizes persist per-user across all
+  // terminals — the ratio of "explorer / context / main / right"
+  // is a personal preference, not a per-terminal concern. Add a
+  // per-project override later if a use case shows up.
+  const explorerRail = useResizable({
+    storageKey: "rokki:term-explorer-width",
+    defaultSize: 260,
+    min: 200,
+    max: 480,
+  });
+  const ctxPane = useResizable({
+    storageKey: "rokki:term-leftpane-width",
+    defaultSize: 360,
+    min: 240,
+    max: 560,
+  });
+  const rightSidePane = useResizable({
+    storageKey: "rokki:term-rightpane-width",
+    defaultSize: 360,
+    min: 280,
+    max: 560,
+  });
+
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       if (!(e.metaKey || e.ctrlKey)) return;
@@ -95,23 +119,60 @@ export function TerminalShell({
       </div>
       <div className="flex flex-1 flex-col overflow-hidden sm:flex-row">
         {leftOpen && leftRail ? (
-          <aside
-            aria-label="Explorer"
-            className="hidden flex-shrink-0 overflow-y-auto border-r border-border bg-bg-0 lg:flex lg:w-[260px] lg:flex-col"
-          >
-            {leftRail}
-          </aside>
+          <>
+            <aside
+              aria-label="Explorer"
+              style={{ width: explorerRail.size }}
+              className="hidden flex-shrink-0 overflow-y-auto border-r border-border bg-bg-0 lg:flex lg:flex-col"
+            >
+              {leftRail}
+            </aside>
+            <div className="hidden lg:block">
+              <ResizeHandle
+                ariaLabel="Resize explorer"
+                onPointerDown={(e) =>
+                  explorerRail.startDrag(e, { side: "before" })
+                }
+              />
+            </div>
+          </>
         ) : null}
         {leftOpen && leftPane ? (
-          <div className="hidden overflow-y-auto border-r border-border bg-bg-0 lg:block lg:w-[28%] lg:min-w-[240px]">
-            {leftPane}
-          </div>
+          <>
+            <div
+              style={{ width: ctxPane.size }}
+              className="hidden flex-shrink-0 overflow-y-auto border-r border-border bg-bg-0 lg:block"
+            >
+              {leftPane}
+            </div>
+            <div className="hidden lg:block">
+              <ResizeHandle
+                ariaLabel="Resize context pane"
+                onPointerDown={(e) =>
+                  ctxPane.startDrag(e, { side: "before" })
+                }
+              />
+            </div>
+          </>
         ) : null}
         <div className="flex-1 overflow-y-auto bg-bg-0">{mainPane}</div>
         {rightPane && rightOpen ? (
-          <div className="hidden overflow-y-auto border-t border-border bg-bg-0 sm:block sm:border-l sm:border-t-0 lg:w-[28%] lg:min-w-[280px]">
-            {rightPane}
-          </div>
+          <>
+            <div className="hidden lg:block">
+              <ResizeHandle
+                ariaLabel="Resize right pane"
+                onPointerDown={(e) =>
+                  rightSidePane.startDrag(e, { side: "after" })
+                }
+              />
+            </div>
+            <div
+              style={{ width: rightSidePane.size }}
+              className="hidden flex-shrink-0 overflow-y-auto border-t border-border bg-bg-0 sm:block sm:border-l sm:border-t-0"
+            >
+              {rightPane}
+            </div>
+          </>
         ) : null}
       </div>
       <div className="sm:hidden">

--- a/apps/web/src/components/dashboard/DashboardShell.tsx
+++ b/apps/web/src/components/dashboard/DashboardShell.tsx
@@ -2,6 +2,7 @@
 
 import type { ReactNode } from "react";
 import { MobileTabBar } from "./MobileTabBar";
+import { ResizeHandle, useResizable } from "@/components/ResizeHandle";
 
 /**
  * Three-rail dashboard shell, responsive.
@@ -33,6 +34,10 @@ import { MobileTabBar } from "./MobileTabBar";
  * tree, tools, account) are reachable through the tab bar and command
  * palette. The right rail (messages) is appended under the center on
  * mobile so nothing is lost.
+ *
+ * Both rails are user-resizable on desktop via the thin `ResizeHandle`
+ * thumbs that flank the center column. Sizes persist in localStorage
+ * so a user's preferred ratio sticks across reloads.
  */
 export function DashboardShell({
   topBar,
@@ -47,6 +52,18 @@ export function DashboardShell({
   center: ReactNode;
   right: ReactNode;
 }) {
+  const leftRail = useResizable({
+    storageKey: "rokki:dash-left-width",
+    defaultSize: 260,
+    min: 200,
+    max: 480,
+  });
+  const rightRail = useResizable({
+    storageKey: "rokki:dash-right-width",
+    defaultSize: 320,
+    min: 240,
+    max: 560,
+  });
   return (
     <div className="flex h-[100dvh] flex-col overflow-hidden bg-bg-0">
       {/* Skip link is now in the root layout (app/layout.tsx) so every page
@@ -56,10 +73,19 @@ export function DashboardShell({
       <div className="flex flex-1 min-h-0 flex-col overflow-hidden lg:flex-row">
         <aside
           aria-label="Explorer"
-          className="hidden flex-shrink-0 border-r border-border lg:flex lg:w-[260px] lg:flex-col"
+          style={{ width: leftRail.size }}
+          className="hidden flex-shrink-0 border-r border-border lg:flex lg:flex-col"
         >
           {left}
         </aside>
+        <div className="hidden lg:block">
+          <ResizeHandle
+            ariaLabel="Resize explorer"
+            onPointerDown={(e) =>
+              leftRail.startDrag(e, { side: "before" })
+            }
+          />
+        </div>
         <main
           id="main-content"
           tabIndex={-1}
@@ -71,9 +97,18 @@ export function DashboardShell({
             {right}
           </div>
         </main>
+        <div className="hidden lg:block">
+          <ResizeHandle
+            ariaLabel="Resize messages"
+            onPointerDown={(e) =>
+              rightRail.startDrag(e, { side: "after" })
+            }
+          />
+        </div>
         <aside
           aria-label="Messages"
-          className="hidden flex-shrink-0 border-l border-border lg:flex lg:w-[320px] lg:flex-col"
+          style={{ width: rightRail.size }}
+          className="hidden flex-shrink-0 border-l border-border lg:flex lg:flex-col"
         >
           {right}
         </aside>


### PR DESCRIPTION
## Summary

Adds a thin draggable thumb between every shell column on desktop. Drag to resize the adjacent panel; sizes persist per-user in localStorage so the chosen ratio sticks across reloads.

- New `ResizeHandle` (4px bar, wider invisible hit area, hover/active accent tint, role="separator").
- New `useResizable({ storageKey, defaultSize, min, max })` hook owning the size + drag math.

## Wired into

- **DashboardShell** — left rail (200–480px, default 260) and right Messages rail (240–560px, default 320).
- **TerminalShell** — explorer rail (200–480px, default 260), contextual left pane (240–560px, default 360), and right pane (280–560px, default 360).

## Storage

- `rokki:dash-left-width`, `rokki:dash-right-width`
- `rokki:term-explorer-width`, `rokki:term-leftpane-width`, `rokki:term-rightpane-width`

Terminal sizes are user-global, not per-terminal — the ratio is a personal preference, not a per-terminal concern. Add a per-project override later if a use case shows up.

## Test plan

- [ ] Dashboard: hover the seam between Explorer and the center column → cursor flips to col-resize → drag → rail resizes live → release → reload → size sticks.
- [ ] Same for the Messages rail seam on the right.
- [ ] Terminal `/p/CSBLNC` Overview tab: three seams (explorer | context | main | right). Each one drags independently.
- [ ] Push a rail past the configured min — it stops at the min, not 0.
- [ ] Mobile (<lg breakpoint): handles are hidden, layout stacks as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)