### PR TITLE
fix(layout): ResizeHandle uses mouse events, not pointer events

### DIFF
--- a/apps/web/src/components/ResizeHandle.tsx
+++ b/apps/web/src/components/ResizeHandle.tsx
@@ -71,10 +71,17 @@ export function useResizable({
    *
    * For vertical resizers (top/bottom panels) use `axis="y"`; the
    * deltas are read from clientY instead of clientX.
+   *
+   * Uses mouse events (not pointer events) on purpose. Some
+   * automated browser-control surfaces (Chrome's CDP, the in-app
+   * driver) dispatch only `mousedown/mousemove/mouseup` and skip
+   * the pointer-event family — every real user gets both, but
+   * standardising on mouse means the handle stays drivable from
+   * scripts and tests too.
    */
   const startDrag = useCallback(
     (
-      e: React.PointerEvent,
+      e: React.MouseEvent,
       opts: { side: "before" | "after"; axis?: "x" | "y" } = {
         side: "before",
         axis: "x",
@@ -85,7 +92,7 @@ export function useResizable({
       const startCoord = axis === "x" ? e.clientX : e.clientY;
       const startSize = size;
 
-      const onMove = (ev: PointerEvent) => {
+      const onMove = (ev: MouseEvent) => {
         const cur = axis === "x" ? ev.clientX : ev.clientY;
         const delta = cur - startCoord;
         const next =
@@ -93,15 +100,13 @@ export function useResizable({
         setSize(Math.min(max, Math.max(min, next)));
       };
       const onUp = () => {
-        window.removeEventListener("pointermove", onMove);
-        window.removeEventListener("pointerup", onUp);
-        window.removeEventListener("pointercancel", onUp);
+        window.removeEventListener("mousemove", onMove);
+        window.removeEventListener("mouseup", onUp);
         document.body.style.cursor = "";
         document.body.style.userSelect = "";
       };
-      window.addEventListener("pointermove", onMove);
-      window.addEventListener("pointerup", onUp);
-      window.addEventListener("pointercancel", onUp);
+      window.addEventListener("mousemove", onMove);
+      window.addEventListener("mouseup", onUp);
       // Dim everything else and lock the cursor while dragging so the
       // user gets unambiguous "I am resizing" feedback even if the
       // mouse leaves the handle.
@@ -123,8 +128,8 @@ interface ResizeHandleProps {
    *                     (drag vertically to resize)
    */
   orientation?: "vertical" | "horizontal";
-  /** Pointer-down handler. Wire to `useResizable().startDrag`. */
-  onPointerDown: (e: React.PointerEvent) => void;
+  /** Mouse-down handler. Wire to `useResizable().startDrag`. */
+  onMouseDown: (e: React.MouseEvent) => void;
   /** Optional aria-label override. */
   ariaLabel?: string;
   className?: string;
@@ -149,7 +154,7 @@ interface ResizeHandleProps {
  */
 export function ResizeHandle({
   orientation = "vertical",
-  onPointerDown,
+  onMouseDown,
   ariaLabel,
   className,
 }: ResizeHandleProps) {
@@ -158,7 +163,7 @@ export function ResizeHandle({
       role="separator"
       aria-orientation={orientation}
       aria-label={ariaLabel ?? "Resize"}
-      onPointerDown={onPointerDown}
+      onMouseDown={onMouseDown}
       className={cn(
         "group relative flex-shrink-0 transition-colors",
         orientation === "vertical"

--- a/apps/web/src/components/TerminalShell.tsx
+++ b/apps/web/src/components/TerminalShell.tsx
@@ -130,7 +130,7 @@ export function TerminalShell({
             <div className="hidden lg:block">
               <ResizeHandle
                 ariaLabel="Resize explorer"
-                onPointerDown={(e) =>
+                onMouseDown={(e) =>
                   explorerRail.startDrag(e, { side: "before" })
                 }
               />
@@ -148,7 +148,7 @@ export function TerminalShell({
             <div className="hidden lg:block">
               <ResizeHandle
                 ariaLabel="Resize context pane"
-                onPointerDown={(e) =>
+                onMouseDown={(e) =>
                   ctxPane.startDrag(e, { side: "before" })
                 }
               />
@@ -161,7 +161,7 @@ export function TerminalShell({
             <div className="hidden lg:block">
               <ResizeHandle
                 ariaLabel="Resize right pane"
-                onPointerDown={(e) =>
+                onMouseDown={(e) =>
                   rightSidePane.startDrag(e, { side: "after" })
                 }
               />

--- a/apps/web/src/components/dashboard/DashboardShell.tsx
+++ b/apps/web/src/components/dashboard/DashboardShell.tsx
@@ -81,7 +81,7 @@ export function DashboardShell({
         <div className="hidden lg:block">
           <ResizeHandle
             ariaLabel="Resize explorer"
-            onPointerDown={(e) =>
+            onMouseDown={(e) =>
               leftRail.startDrag(e, { side: "before" })
             }
           />
@@ -100,7 +100,7 @@ export function DashboardShell({
         <div className="hidden lg:block">
           <ResizeHandle
             ariaLabel="Resize messages"
-            onPointerDown={(e) =>
+            onMouseDown={(e) =>
               rightRail.startDrag(e, { side: "after" })
             }
           />


### PR DESCRIPTION
## Summary

Follow-up to #96. The handle responds correctly to hover/cursor styling but not to drag because synthetic CDP dispatchers (Chrome MCP, automation harnesses) emit `mousedown/mousemove/mouseup` and skip the pointer-event family. Real users get both families fired by the browser, so switching from `PointerEvent` → `MouseEvent` keeps real-user behaviour identical and makes the handle drivable from scripts/tests.

Caught while verifying the live drag in #96.

## Test plan

- [ ] Dashboard: drag the seam between Explorer and the center column → rail resizes live → release → `localStorage.getItem('rokki:dash-left-width')` matches the new size.
- [ ] /p/CSBLNC: drag any of three terminal seams.

🤖 Generated with [Claude Code](https://claude.com/claude-code)