### PR TITLE
feat(density): drop AccountBlock toggle + make compact actually scale

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -101,20 +101,34 @@
   --info-subtle: #ddf4ff;
 }
 
-/* Density — "cozy" is default; "compact" tightens list rows ~30% without
-   touching typography. Targets list items inside dashboard cards so the
-   rest of the UI keeps its rhythm. */
-[data-density="cozy"] {
+/* Density — "cozy" is the default; "compact" shrinks the entire UI
+   ~12.5% by reducing the root font-size, which scales every
+   rem-based Tailwind utility (padding, margin, gap, font-size,
+   line-height). One number, global effect — much more visible
+   than the old data-row-only padding tweak that didn't move
+   anything outside of dashboard list rows.
+   The previous bespoke variables (--row-padding-y, --card-gap)
+   are kept around for the few `data-row` / `.card-stack` markers
+   that already use them, but they're no longer the primary
+   driver — the font-size change is. */
+:root {
   --row-padding-y: 6px;
   --card-gap: 12px;
 }
-[data-density="compact"] {
+html[data-density="cozy"] {
+  font-size: 16px;
+  --row-padding-y: 6px;
+  --card-gap: 12px;
+}
+html[data-density="compact"] {
+  font-size: 14px;
   --row-padding-y: 3px;
   --card-gap: 8px;
 }
 /* Legacy names for any older markup: treat default=cozy, comfortable=cozy. */
-[data-density="default"],
-[data-density="comfortable"] {
+html[data-density="default"],
+html[data-density="comfortable"] {
+  font-size: 16px;
   --row-padding-y: 6px;
   --card-gap: 12px;
 }

--- a/apps/web/src/components/AccountBlock.tsx
+++ b/apps/web/src/components/AccountBlock.tsx
@@ -10,13 +10,10 @@ import {
   LogOut,
   Plus,
   RefreshCw,
-  Rows3,
-  Rows4,
   Settings,
   ShieldCheck,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { useDensity } from "@/lib/density";
 
 interface RingEntry {
   user_id: string;
@@ -49,7 +46,6 @@ export function AccountBlock({
   email: string;
   isPlatformAdmin: boolean;
 }) {
-  const { density, toggle: toggleDensity } = useDensity();
   const pathname = usePathname();
   const inAdmin = pathname?.startsWith("/admin") ?? false;
 
@@ -293,7 +289,9 @@ export function AccountBlock({
             </div>
           )}
 
-          {/* Preferences */}
+          {/* Preferences. Density toggle used to live here too;
+              moved to /settings/appearance per UX feedback ("there
+              is no point in having density in this side panel"). */}
           <div className="border-b border-border py-1">
             <Link
               href="/settings"
@@ -313,22 +311,6 @@ export function AccountBlock({
               <KeyRound className="h-3 w-3 flex-shrink-0 text-text-3" /> API
               tokens
             </Link>
-            <button
-              role="menuitem"
-              type="button"
-              onClick={() => {
-                toggleDensity();
-                setOpen(false);
-              }}
-              className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-text-1 hover:bg-bg-2"
-            >
-              {density === "cozy" ? (
-                <Rows3 className="h-3 w-3 flex-shrink-0 text-text-3" />
-              ) : (
-                <Rows4 className="h-3 w-3 flex-shrink-0 text-text-3" />
-              )}
-              Density: {density === "cozy" ? "Cozy" : "Compact"}
-            </button>
           </div>
 
           {/* Admin console toggle — only visible to platform admins. */}


### PR DESCRIPTION
Two related fixes from Zack's screenshot review of the AccountBlock dropdown.\n\n1. Density entry removed from AccountBlock — it's an appearance setting, not a per-tap action.\n2. Compact mode now scales the root font-size 16px → 14px so every rem-based Tailwind utility (padding, gap, font-size) shrinks proportionally. The previous bespoke padding-only override didn't move anything outside of dashboard list rows.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)