### PR TITLE
feat(space): landing page at /s/[slug] with seven overview cards

### DIFF
--- a/apps/web/src/app/s/[slug]/page.tsx
+++ b/apps/web/src/app/s/[slug]/page.tsx
@@ -1,0 +1,178 @@
+import { notFound, redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { SpaceClient } from "@/components/space/SpaceClient";
+import {
+  loadDashSpaces,
+  loadDashTerminals,
+} from "@/lib/dashboard-queries";
+import {
+  loadSpaceActivity,
+  loadSpaceFiles,
+  loadSpaceLobby,
+  loadSpaceMembers,
+  loadSpaceTasks,
+  loadSpaceTerminals,
+  loadSpaceWeekItems,
+} from "@/lib/space-queries";
+
+interface Props {
+  params: Promise<{ slug: string }>;
+}
+
+type SpaceRole = "owner" | "admin" | "member";
+
+/**
+ * Space landing — `/s/<slug>`.
+ *
+ * Surfaces seven cards in a single round-trip: Terminals grid,
+ * cross-cutting Tasks roll-up, This Week, Members, Lobby messages,
+ * Recent files, plus a space-scoped activity ticker. The
+ * shell/topbar/explorer mirror the dashboard so navigating
+ * between the three feels seamless.
+ *
+ * Route guard: caller must be a member of the space (`space_members`).
+ * RLS would already filter most of the underlying queries, but
+ * the explicit check lets us return a clean 404 instead of a half-
+ * empty page when the slug doesn't resolve.
+ */
+export default async function SpaceLandingPage({ params }: Props) {
+  const { slug } = await params;
+  const lower = slug.toLowerCase();
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) redirect(`/login?redirect_to=${encodeURIComponent(`/s/${lower}`)}`);
+
+  const { data: space } = await supabase
+    .from("spaces")
+    .select("id, slug, name")
+    .eq("slug", lower)
+    .maybeSingle();
+  if (!space) notFound();
+  const s = space as { id: string; slug: string; name: string };
+
+  const { data: me } = await supabase
+    .from("space_members")
+    .select("role")
+    .eq("space_id", s.id)
+    .eq("user_id", user.id)
+    .maybeSingle();
+  const myRole = (me as { role?: SpaceRole } | null)?.role ?? null;
+  if (!myRole) notFound();
+
+  // All the heavy lifting in parallel — same pattern as the
+  // dashboard's loaders.
+  const [
+    terminals,
+    tasks,
+    members,
+    weekItems,
+    activity,
+    lobby,
+    files,
+    explorerSpaces,
+    explorerTerminals,
+    toolsResult,
+    profileResult,
+  ] = await Promise.all([
+    loadSpaceTerminals(supabase, s.id),
+    loadSpaceTasks(supabase, s.id),
+    loadSpaceMembers(supabase, s.id),
+    loadSpaceWeekItems(supabase, s.id),
+    loadSpaceActivity(supabase, s.id, 30),
+    loadSpaceLobby(supabase, s.id, 8),
+    loadSpaceFiles(supabase, s.id, 10),
+    loadDashSpaces(supabase, user.id),
+    loadDashTerminals(supabase),
+    supabase
+      .from("tools")
+      .select("id", { count: "exact", head: true })
+      .is("deleted_at", null),
+    supabase
+      .from("profiles")
+      .select("full_name, is_platform_admin, settings")
+      .eq("user_id", user.id)
+      .maybeSingle(),
+  ]);
+
+  const profile = profileResult.data as
+    | {
+        full_name: string | null;
+        is_platform_admin: boolean;
+        settings: Record<string, unknown> | null;
+      }
+    | null;
+  const userName = profile?.full_name ?? user.email?.split("@")[0] ?? "—";
+  const isPlatformAdmin = Boolean(profile?.is_platform_admin);
+  const initialDensity =
+    profile?.settings?.density === "compact" ? "compact" : "cozy";
+
+  // Build a tiny ticker label per activity row. Mirrors the
+  // dashboard's `summarizeActivity` so the ticker reads the same
+  // across surfaces.
+  const tickerItems = activity.map((a) => ({
+    id: a.id,
+    text: summarizeActivity(a.action, a.metadata ?? {}),
+    when: relativeTime(a.created_at),
+  }));
+
+  return (
+    <SpaceClient
+      space={s}
+      myRole={myRole}
+      spaces={explorerSpaces}
+      allTerminals={explorerTerminals}
+      toolCount={toolsResult.count ?? 0}
+      userName={userName}
+      userEmail={user.email ?? ""}
+      isPlatformAdmin={isPlatformAdmin}
+      initialDensity={initialDensity}
+      terminals={terminals}
+      tasks={tasks}
+      members={members}
+      weekItems={weekItems}
+      lobby={{ hasThread: lobby.threadId !== null, messages: lobby.messages }}
+      files={files}
+      tickerItems={tickerItems}
+    />
+  );
+}
+
+function summarizeActivity(
+  action: string,
+  metadata: Record<string, unknown>,
+): string {
+  const pick = (k: string): string | null => {
+    const v = metadata[k];
+    return typeof v === "string" ? v : null;
+  };
+  switch (action) {
+    case "terminal.create":
+      return `terminal created: ${pick("name") ?? ""}`;
+    case "task.create":
+      return `new task: ${pick("title") ?? ""}`;
+    case "task.complete":
+      return `task complete`;
+    case "file.upload":
+      return `uploaded ${pick("filename") ?? "a file"}`;
+    case "member.invite":
+      return `invited ${pick("email") ?? "a member"}`;
+    case "member.join":
+      return `${pick("name") ?? "someone"} joined`;
+    default:
+      return action.replace(/[._]/g, " ");
+  }
+}
+
+function relativeTime(iso: string): string {
+  const ms = Date.now() - new Date(iso).getTime();
+  const s = Math.floor(ms / 1000);
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h`;
+  return `${Math.floor(h / 24)}d`;
+}

--- a/apps/web/src/components/dashboard/ExplorerRail.tsx
+++ b/apps/web/src/components/dashboard/ExplorerRail.tsx
@@ -300,12 +300,13 @@ export function ExplorerRail({
                           <ChevronDown className="h-3 w-3" />
                         )}
                       </button>
-                      <span
-                        className="flex-1 truncate text-text-1"
-                        title={s.name}
+                      <Link
+                        href={`/s/${s.slug}`}
+                        className="flex-1 truncate text-text-1 hover:text-text-0"
+                        title={`Open ${s.name}`}
                       >
                         {s.name}
-                      </span>
+                      </Link>
                       {/* The "empty" italic hint that used to live here
                           for terminal-less spaces was dropped per UX
                           feedback — when a space has no terminals,

--- a/apps/web/src/components/space/SpaceClient.tsx
+++ b/apps/web/src/components/space/SpaceClient.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import Link from "next/link";
+import { Settings } from "lucide-react";
+import { DashboardShell } from "@/components/dashboard/DashboardShell";
+import { TopBar } from "@/components/TopBar";
+import { TickerTape } from "@/components/TickerTape";
+import { ExplorerRail } from "@/components/dashboard/ExplorerRail";
+import { DensityProvider, type Density } from "@/lib/density";
+import { TerminalsGrid } from "./TerminalsGrid";
+import { SpaceTasksCard } from "./SpaceTasksCard";
+import { SpaceWeekCard } from "./SpaceWeekCard";
+import { SpaceMembersCard } from "./SpaceMembersCard";
+import { SpaceLobbyCard } from "./SpaceLobbyCard";
+import { SpaceFilesCard } from "./SpaceFilesCard";
+import type {
+  DashSpace,
+  DashTerminal,
+} from "@/lib/dashboard-queries";
+import type {
+  SpaceTerminalCard,
+  SpaceTaskRow,
+  SpaceMemberRow,
+  SpaceLobbyMessage,
+  SpaceFileRow,
+  SpaceWeekItem,
+} from "@/lib/space-queries";
+
+interface SpaceClientProps {
+  space: { id: string; slug: string; name: string };
+  /** Caller's role in the space — used for owner/admin-gated UI. */
+  myRole: "owner" | "admin" | "member";
+  /** Spaces shown in the explorer rail. */
+  spaces: DashSpace[];
+  /** Terminals shown in the explorer rail (all visible to the user). */
+  allTerminals: DashTerminal[];
+  toolCount: number;
+  userName: string;
+  userEmail: string;
+  isPlatformAdmin: boolean;
+  initialDensity: Density;
+
+  // Space landing data
+  terminals: SpaceTerminalCard[];
+  tasks: {
+    assignedToMe: SpaceTaskRow[];
+    overdue: SpaceTaskRow[];
+    blocked: SpaceTaskRow[];
+    dueThisWeek: SpaceTaskRow[];
+  };
+  members: SpaceMemberRow[];
+  weekItems: SpaceWeekItem[];
+  lobby: { hasThread: boolean; messages: SpaceLobbyMessage[] };
+  files: SpaceFileRow[];
+  tickerItems: { id: string; text: string; when: string }[];
+}
+
+/**
+ * Composition root for the space landing (`/s/:slug`).
+ *
+ * Reuses the `DashboardShell` layout (topbar / ticker / explorer /
+ * center) so navigating between dashboard, space, and terminal
+ * feels like one continuous app rather than three different
+ * surfaces. The center column is a simple vertical stack — keep
+ * the overview easy to scan, click into a terminal for depth.
+ */
+export function SpaceClient({
+  space,
+  myRole,
+  spaces,
+  allTerminals,
+  toolCount,
+  userName,
+  userEmail,
+  isPlatformAdmin,
+  initialDensity,
+  terminals,
+  tasks,
+  members,
+  weekItems,
+  lobby,
+  files,
+  tickerItems,
+}: SpaceClientProps) {
+  const canManage = myRole === "owner" || myRole === "admin";
+  return (
+    <DensityProvider initial={initialDensity}>
+      <DashboardShell
+        topBar={
+          <TopBar>
+            <span className="text-text-3">/</span>
+            <Link href="/" className="text-text-1 hover:text-text-0">
+              Dashboard
+            </Link>
+            <span className="text-text-3">/</span>
+            <span className="text-text-0 font-medium">{space.name}</span>
+            {canManage ? (
+              <Link
+                href={`/s/${space.slug}/settings`}
+                aria-label={`${space.name} settings`}
+                title="Space settings"
+                className="rounded-sm p-1 text-text-3 hover:bg-bg-2 hover:text-text-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-focus"
+              >
+                <Settings className="h-3 w-3" aria-hidden="true" />
+              </Link>
+            ) : null}
+          </TopBar>
+        }
+        ticker={<TickerTape items={tickerItems} />}
+        left={
+          <ExplorerRail
+            spaces={spaces}
+            terminals={allTerminals}
+            toolCount={toolCount}
+            userName={userName}
+            userEmail={userEmail}
+            isPlatformAdmin={isPlatformAdmin}
+          />
+        }
+        center={
+          <div className="card-stack flex flex-col gap-3 p-2 sm:p-3">
+            {/* The grid is the lead — what does this space actually
+                have? — stretched full width. */}
+            <TerminalsGrid terminals={terminals} />
+
+            {/* Two side-by-side roll-ups: tasks + week. Both are
+                "look across the space" surfaces; pairing them keeps
+                the overview shape compact. Stacks on narrow viewports. */}
+            <div className="grid gap-3 lg:grid-cols-2">
+              <SpaceTasksCard
+                assignedToMe={tasks.assignedToMe}
+                overdue={tasks.overdue}
+                blocked={tasks.blocked}
+                dueThisWeek={tasks.dueThisWeek}
+              />
+              <SpaceWeekCard items={weekItems} />
+            </div>
+
+            {/* Members + Lobby — the social pair. */}
+            <div className="grid gap-3 lg:grid-cols-2">
+              <SpaceMembersCard members={members} />
+              <SpaceLobbyCard
+                spaceName={space.name}
+                messages={lobby.messages}
+                hasThread={lobby.hasThread}
+              />
+            </div>
+
+            <SpaceFilesCard files={files} />
+          </div>
+        }
+        right={
+          /* Right rail is empty on the space landing — the ticker
+             tape across the top already serves as "what's happening
+             across the space," and the center is dense enough that
+             a third column would just compete for attention. */
+          <div className="hidden" aria-hidden="true" />
+        }
+      />
+    </DensityProvider>
+  );
+}

--- a/apps/web/src/components/space/SpaceFilesCard.tsx
+++ b/apps/web/src/components/space/SpaceFilesCard.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import Link from "next/link";
+import { FileText } from "lucide-react";
+import { DashboardCard } from "@/components/dashboard/DashboardCard";
+import { TickerChip } from "@/components/primitives";
+import type { SpaceFileRow } from "@/lib/space-queries";
+
+interface SpaceFilesCardProps {
+  files: SpaceFileRow[];
+}
+
+/**
+ * Item #7 — most-recent file uploads across every terminal in
+ * the space. Files are still per-terminal in the schema; this is
+ * a simple cross-terminal "what got uploaded recently" view, the
+ * real "files vault" lands when the schema gets a space-level
+ * scope.
+ */
+export function SpaceFilesCard({ files }: SpaceFilesCardProps) {
+  return (
+    <DashboardCard
+      title="Recent files"
+      count={files.length}
+      expandHref={null}
+    >
+      {files.length === 0 ? (
+        <p className="px-3 py-4 text-center text-[11px] text-text-3">
+          No files uploaded yet in this space.
+        </p>
+      ) : (
+        <ul className="divide-y divide-border/40 text-xs">
+          {files.slice(0, 10).map((f) => (
+            <li key={f.id}>
+              <Link
+                href={
+                  f.terminal_ticker ? `/p/${f.terminal_ticker}` : "#"
+                }
+                className="flex items-center gap-2 px-3 py-1 hover:bg-bg-2"
+              >
+                <FileText
+                  className="h-3 w-3 flex-shrink-0 text-text-3"
+                  aria-hidden="true"
+                />
+                {f.terminal_ticker ? (
+                  <TickerChip>{f.terminal_ticker}</TickerChip>
+                ) : null}
+                <span className="flex-1 truncate text-text-0">
+                  {f.filename}
+                </span>
+                <span className="font-mono text-[10px] text-text-3">
+                  {formatRelative(f.uploaded_at)}
+                </span>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </DashboardCard>
+  );
+}
+
+function formatRelative(iso: string): string {
+  const ms = Date.now() - new Date(iso).getTime();
+  const s = Math.floor(ms / 1000);
+  if (s < 60) return "now";
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h`;
+  const d = Math.floor(h / 24);
+  if (d < 7) return `${d}d`;
+  return new Date(iso).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+  });
+}

--- a/apps/web/src/components/space/SpaceLobbyCard.tsx
+++ b/apps/web/src/components/space/SpaceLobbyCard.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import Link from "next/link";
+import { Hash } from "lucide-react";
+import { DashboardCard } from "@/components/dashboard/DashboardCard";
+import type { SpaceLobbyMessage } from "@/lib/space-queries";
+
+interface SpaceLobbyCardProps {
+  spaceName: string;
+  messages: SpaceLobbyMessage[];
+  /** Whether a thread exists yet — when null we render a hint, not an error. */
+  hasThread: boolean;
+}
+
+/**
+ * Item #6 — last-N messages from the space's lobby thread,
+ * scannable. Click anywhere in the card to open the full inbox.
+ *
+ * Author + body + relative timestamp; no rich rendering or
+ * mention-highlight v1 — that lives in the dedicated
+ * `MessagesInbox`.
+ */
+export function SpaceLobbyCard({
+  spaceName,
+  messages,
+  hasThread,
+}: SpaceLobbyCardProps) {
+  return (
+    <DashboardCard
+      title="Lobby"
+      count={hasThread ? messages.length : undefined}
+      expandHref="/messages"
+    >
+      {!hasThread ? (
+        <p className="px-3 py-4 text-center text-[11px] text-text-3">
+          No lobby thread yet for {spaceName}. Open the inbox to start
+          one.
+        </p>
+      ) : messages.length === 0 ? (
+        <p className="px-3 py-4 text-center text-[11px] text-text-3">
+          Quiet so far. Open the inbox to post the first message.
+        </p>
+      ) : (
+        <ul className="divide-y divide-border/40 text-xs">
+          {messages.slice(0, 8).map((m) => (
+            <li key={m.id}>
+              <Link
+                href="/messages"
+                className="flex items-start gap-2 px-3 py-1.5 hover:bg-bg-2"
+              >
+                <Hash
+                  className="mt-0.5 h-3 w-3 flex-shrink-0 text-text-3"
+                  aria-hidden="true"
+                />
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="truncate text-text-0">
+                      {m.author_name ?? "—"}
+                    </span>
+                    <span className="font-mono text-[10px] text-text-3">
+                      {formatRelative(m.created_at)}
+                    </span>
+                  </div>
+                  <div className="mt-0.5 truncate text-text-2">{m.body}</div>
+                </div>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </DashboardCard>
+  );
+}
+
+function formatRelative(iso: string): string {
+  const ms = Date.now() - new Date(iso).getTime();
+  const s = Math.floor(ms / 1000);
+  if (s < 60) return "now";
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h`;
+  const d = Math.floor(h / 24);
+  if (d < 7) return `${d}d`;
+  return new Date(iso).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+  });
+}

--- a/apps/web/src/components/space/SpaceMembersCard.tsx
+++ b/apps/web/src/components/space/SpaceMembersCard.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { ShieldCheck, Star } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { DashboardCard } from "@/components/dashboard/DashboardCard";
+import type { SpaceMemberRow } from "@/lib/space-queries";
+
+interface SpaceMembersCardProps {
+  members: SpaceMemberRow[];
+}
+
+const ROLE_BADGE: Record<SpaceMemberRow["role"], string> = {
+  owner: "Owner",
+  admin: "Admin",
+  member: "Member",
+};
+
+/**
+ * Item #4 — directory of every space member with role,
+ * terminal-membership count, and active-task count. Power version
+ * of "who's involved" plus enough signal to spot loaded vs.
+ * idle members.
+ *
+ * Owners get a star; admins get a shield. Both render before
+ * regular members. Initials avatar matches AccountBlock so the
+ * visual identity is consistent across the app.
+ */
+export function SpaceMembersCard({ members }: SpaceMembersCardProps) {
+  const sorted = [...members].sort((a, b) => {
+    const rank: Record<SpaceMemberRow["role"], number> = {
+      owner: 0,
+      admin: 1,
+      member: 2,
+    };
+    return rank[a.role] - rank[b.role];
+  });
+
+  return (
+    <DashboardCard
+      title="Members"
+      count={members.length}
+      expandHref={null}
+    >
+      {sorted.length === 0 ? (
+        <p className="px-3 py-4 text-center text-[11px] text-text-3">
+          No members yet.
+        </p>
+      ) : (
+        <ul className="divide-y divide-border/40">
+          {sorted.map((m) => (
+            <li
+              key={m.user_id}
+              className="flex items-center gap-2 px-3 py-1.5"
+            >
+              <Avatar name={m.full_name ?? m.email ?? "—"} />
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-1 text-xs text-text-0">
+                  <span className="truncate">
+                    {m.full_name ?? m.email ?? "—"}
+                  </span>
+                  {m.role === "owner" ? (
+                    <Star
+                      className="h-2.5 w-2.5 flex-shrink-0 text-accent"
+                      aria-label="owner"
+                    />
+                  ) : null}
+                  {m.role === "admin" ? (
+                    <ShieldCheck
+                      className="h-2.5 w-2.5 flex-shrink-0 text-accent"
+                      aria-label="admin"
+                    />
+                  ) : null}
+                </div>
+                <div className="truncate font-mono text-[10px] text-text-3">
+                  {ROLE_BADGE[m.role]}
+                  {" · "}
+                  {m.terminal_count} terminal
+                  {m.terminal_count === 1 ? "" : "s"}
+                </div>
+              </div>
+              <span
+                className={cn(
+                  "rounded-sm bg-bg-3 px-1 font-mono text-[10px]",
+                  m.active_task_count > 0 ? "text-text-1" : "text-text-3",
+                )}
+                title={`${m.active_task_count} active task${
+                  m.active_task_count === 1 ? "" : "s"
+                }`}
+              >
+                {m.active_task_count}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </DashboardCard>
+  );
+}
+
+function Avatar({ name }: { name: string }) {
+  const initials =
+    name
+      .split(/\s+/)
+      .map((s) => s[0])
+      .filter(Boolean)
+      .slice(0, 2)
+      .join("")
+      .toUpperCase() || "?";
+  return (
+    <span
+      className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full bg-bg-3 text-[10px] font-semibold text-text-0"
+      aria-hidden="true"
+    >
+      {initials}
+    </span>
+  );
+}

--- a/apps/web/src/components/space/SpaceTasksCard.tsx
+++ b/apps/web/src/components/space/SpaceTasksCard.tsx
@@ -1,0 +1,236 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+import { Check, AlertOctagon, Clock, User as UserIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { DashboardCard, CardSection } from "@/components/dashboard/DashboardCard";
+import {
+  PriorityDots,
+  TickerChip,
+  DueChip,
+} from "@/components/primitives";
+import type { SpaceTaskRow } from "@/lib/space-queries";
+
+interface SpaceTasksCardProps {
+  assignedToMe: SpaceTaskRow[];
+  overdue: SpaceTaskRow[];
+  blocked: SpaceTaskRow[];
+  dueThisWeek: SpaceTaskRow[];
+}
+
+type Tab = "mine" | "overdue" | "blocked" | "week";
+
+/**
+ * Item #2 — aggregate task roll-up across the whole space. Four
+ * tabs, never visible all at once: "Mine" (assigned to me),
+ * "Overdue", "Blocked", "Due this week". Empty tabs render a
+ * neutral message instead of a noisy zero state.
+ *
+ * Each row deep-links to its task detail. Counts on the tab
+ * labels make spotting hot spots easy without clicking through.
+ */
+export function SpaceTasksCard({
+  assignedToMe,
+  overdue,
+  blocked,
+  dueThisWeek,
+}: SpaceTasksCardProps) {
+  const [tab, setTab] = useState<Tab>(
+    overdue.length > 0
+      ? "overdue"
+      : assignedToMe.length > 0
+        ? "mine"
+        : blocked.length > 0
+          ? "blocked"
+          : "week",
+  );
+
+  const visible: SpaceTaskRow[] = (() => {
+    switch (tab) {
+      case "mine":
+        return assignedToMe;
+      case "overdue":
+        return overdue;
+      case "blocked":
+        return blocked;
+      case "week":
+        return dueThisWeek;
+    }
+  })();
+
+  return (
+    <DashboardCard
+      title="Tasks"
+      count={
+        assignedToMe.length +
+        overdue.length +
+        blocked.length +
+        dueThisWeek.length
+      }
+      expandHref={null}
+    >
+      <CardSection
+        title=""
+        action={
+          <div role="tablist" aria-label="Task filter">
+            <TabButton
+              active={tab === "mine"}
+              count={assignedToMe.length}
+              onClick={() => setTab("mine")}
+              icon={<UserIcon className="h-3 w-3" aria-hidden="true" />}
+              label="Mine"
+            />
+            <TabButton
+              active={tab === "overdue"}
+              count={overdue.length}
+              tone={overdue.length > 0 ? "danger" : "neutral"}
+              onClick={() => setTab("overdue")}
+              icon={<AlertOctagon className="h-3 w-3" aria-hidden="true" />}
+              label="Overdue"
+            />
+            <TabButton
+              active={tab === "blocked"}
+              count={blocked.length}
+              tone={blocked.length > 0 ? "warning" : "neutral"}
+              onClick={() => setTab("blocked")}
+              icon={<AlertOctagon className="h-3 w-3" aria-hidden="true" />}
+              label="Blocked"
+            />
+            <TabButton
+              active={tab === "week"}
+              count={dueThisWeek.length}
+              onClick={() => setTab("week")}
+              icon={<Clock className="h-3 w-3" aria-hidden="true" />}
+              label="Week"
+            />
+          </div>
+        }
+      >
+        {visible.length === 0 ? (
+          <p className="px-3 py-4 text-center text-[11px] text-text-3">
+            {emptyForTab(tab)}
+          </p>
+        ) : (
+          <ul className="divide-y divide-border/40">
+            {visible.slice(0, 12).map((t) => (
+              <TaskRow key={t.id} task={t} />
+            ))}
+          </ul>
+        )}
+      </CardSection>
+    </DashboardCard>
+  );
+}
+
+function TabButton({
+  active,
+  count,
+  onClick,
+  icon,
+  label,
+  tone = "neutral",
+}: {
+  active: boolean;
+  count: number;
+  onClick: () => void;
+  icon: React.ReactNode;
+  label: string;
+  tone?: "neutral" | "danger" | "warning";
+}) {
+  return (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={active}
+      onClick={onClick}
+      className={cn(
+        "ml-1 inline-flex items-center gap-1 rounded-sm border px-1.5 py-0.5 text-[10px] uppercase tracking-wide",
+        active
+          ? "border-accent/40 bg-bg-3 text-text-0"
+          : "border-border bg-bg-2 text-text-2 hover:bg-bg-3",
+      )}
+    >
+      {icon}
+      <span>{label}</span>
+      <span
+        className={cn(
+          "ml-0.5 font-mono text-[10px]",
+          active ? "text-text-1" : "text-text-3",
+          tone === "danger" && count > 0 && "text-danger",
+          tone === "warning" && count > 0 && "text-warning",
+        )}
+      >
+        {count}
+      </span>
+    </button>
+  );
+}
+
+function TaskRow({ task }: { task: SpaceTaskRow }) {
+  const href = task.ticker
+    ? `/p/${task.ticker}/task/${task.ticker_seq}`
+    : undefined;
+  const body = (
+    <div
+      data-row
+      className="flex items-center gap-2 px-3 py-1 text-xs hover:bg-bg-2"
+    >
+      {task.status === "done" ? (
+        <Check className="h-3 w-3 flex-shrink-0 text-success" />
+      ) : (
+        <span
+          className={cn(
+            "h-3 w-3 flex-shrink-0 rounded-full border",
+            task.status === "blocked"
+              ? "border-danger"
+              : task.status === "review"
+                ? "border-warning"
+                : task.status === "in_progress"
+                  ? "border-info"
+                  : "border-text-3",
+          )}
+          aria-hidden="true"
+        />
+      )}
+      {task.ticker ? <TickerChip>{task.ticker}</TickerChip> : null}
+      <span className="flex-1 truncate text-text-0">{task.title}</span>
+      {task.assignees.length > 0 ? (
+        <span
+          className="hidden truncate text-text-2 md:inline max-w-[12ch]"
+          title={task.assignees.map((a) => a.full_name ?? "—").join(", ")}
+        >
+          {task.assignees[0].full_name ??
+            (task.assignees.length === 1 ? "—" : "")}
+          {task.assignees.length > 1
+            ? ` +${task.assignees.length - 1}`
+            : ""}
+        </span>
+      ) : null}
+      <PriorityDots priority={task.priority} />
+      {task.due_date ? <DueChip date={task.due_date} /> : null}
+    </div>
+  );
+  return href ? (
+    <li>
+      <Link href={href} className="block">
+        {body}
+      </Link>
+    </li>
+  ) : (
+    <li>{body}</li>
+  );
+}
+
+function emptyForTab(tab: Tab): string {
+  switch (tab) {
+    case "mine":
+      return "Nothing assigned to you in this space.";
+    case "overdue":
+      return "Nothing overdue. Nice.";
+    case "blocked":
+      return "No blocked tasks.";
+    case "week":
+      return "Nothing due this week.";
+  }
+}

--- a/apps/web/src/components/space/SpaceWeekCard.tsx
+++ b/apps/web/src/components/space/SpaceWeekCard.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
+import { Diamond, Calendar as CalIcon } from "lucide-react";
+import { DashboardCard } from "@/components/dashboard/DashboardCard";
+import { TickerChip } from "@/components/primitives";
+import type { SpaceWeekItem } from "@/lib/space-queries";
+
+interface SpaceWeekCardProps {
+  items: SpaceWeekItem[];
+}
+
+/**
+ * Item #5 — space-wide "this week" calendar. Same shape as the
+ * dashboard's WeekCard but populated with every task + event
+ * across every terminal in the space, not just the personal slice.
+ *
+ * Defers rendering until mount (same trick as the dashboard
+ * WeekCard) because day-key generation uses `new Date()` and
+ * `toLocaleDateString`, both of which differ between Vercel UTC
+ * and the user's local TZ — that mismatch used to throw React
+ * #418.
+ */
+export function SpaceWeekCard({ items }: SpaceWeekCardProps) {
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const grouped = useMemo(() => {
+    if (!mounted) return [];
+    const days = new Map<string, SpaceWeekItem[]>();
+    for (const it of items) {
+      const key = it.when.slice(0, 10);
+      if (!days.has(key)) days.set(key, []);
+      days.get(key)!.push(it);
+    }
+    const start = new Date();
+    start.setHours(0, 0, 0, 0);
+    const out: { key: string; label: string; items: SpaceWeekItem[] }[] = [];
+    for (let i = 0; i < 7; i++) {
+      const d = new Date(start);
+      d.setDate(d.getDate() + i);
+      const key = d.toISOString().slice(0, 10);
+      out.push({
+        key,
+        label: formatDayLabel(d, i === 0),
+        items: (days.get(key) ?? []).sort((a, b) =>
+          a.when.localeCompare(b.when),
+        ),
+      });
+    }
+    return out;
+  }, [items, mounted]);
+
+  return (
+    <DashboardCard
+      title="This week"
+      count={items.length}
+      expandHref={null}
+    >
+      {items.length === 0 ? (
+        <p className="px-3 py-4 text-center text-[11px] text-text-3">
+          Nothing scheduled in the next 7 days.
+        </p>
+      ) : (
+        <ul className="divide-y divide-border/40 text-xs">
+          {grouped.map((day) => (
+            <li key={day.key}>
+              <div className="flex items-baseline gap-2 bg-bg-1 px-3 py-1">
+                <span className="text-[10px] font-semibold uppercase tracking-wide text-text-2">
+                  {day.label}
+                </span>
+                <span className="font-mono text-[10px] text-text-3">
+                  {day.items.length || ""}
+                </span>
+              </div>
+              {day.items.length === 0 ? (
+                <div className="px-3 py-1 text-[11px] text-text-3">—</div>
+              ) : (
+                <ul className="divide-y divide-border/40">
+                  {day.items.map((it) => (
+                    <WeekRow key={it.id} item={it} />
+                  ))}
+                </ul>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </DashboardCard>
+  );
+}
+
+function WeekRow({ item }: { item: SpaceWeekItem }) {
+  const href = item.terminal_ticker ? `/p/${item.terminal_ticker}` : undefined;
+  const content = (
+    <div className="flex items-center gap-2 px-3 py-1 hover:bg-bg-2">
+      <span className="flex h-4 w-12 flex-shrink-0 items-center justify-center font-mono text-[10px] text-text-3">
+        {item.kind === "event" ? formatTime(item.when) : "due"}
+      </span>
+      {item.kind === "due" ? (
+        <Diamond
+          className="h-3 w-3 flex-shrink-0 text-warning"
+          aria-hidden="true"
+        />
+      ) : (
+        <CalIcon
+          className="h-3 w-3 flex-shrink-0 text-info"
+          aria-hidden="true"
+        />
+      )}
+      <span className="flex-1 truncate text-text-0">{item.title}</span>
+      {item.terminal_ticker ? <TickerChip>{item.terminal_ticker}</TickerChip> : null}
+    </div>
+  );
+  return href ? (
+    <li>
+      <Link href={href} className="block">
+        {content}
+      </Link>
+    </li>
+  ) : (
+    <li>{content}</li>
+  );
+}
+
+function formatDayLabel(d: Date, isToday: boolean): string {
+  const fmt = d.toLocaleDateString(undefined, {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+  });
+  return isToday ? `Today · ${fmt}` : fmt;
+}
+
+function formatTime(iso: string): string {
+  if (!iso.includes("T")) return "";
+  const d = new Date(iso);
+  return d.toLocaleTimeString(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}

--- a/apps/web/src/components/space/TerminalsGrid.tsx
+++ b/apps/web/src/components/space/TerminalsGrid.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import Link from "next/link";
+import { ArrowRight } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { DashboardCard } from "@/components/dashboard/DashboardCard";
+import { StatusPill } from "@/components/primitives";
+import type { SpaceTerminalCard } from "@/lib/space-queries";
+
+interface TerminalsGridProps {
+  terminals: SpaceTerminalCard[];
+}
+
+/**
+ * Item #1 from the space-page list — every terminal in the space
+ * as a tile. Header shows the count; each tile is the ticker /
+ * name / status pill / member count / open-task count.
+ *
+ * Deliberately information-dense and grid-rather-than-list-style:
+ * this is the part of the page that says "what does this space
+ * actually do." Click a tile to enter the terminal.
+ */
+export function TerminalsGrid({ terminals }: TerminalsGridProps) {
+  return (
+    <DashboardCard
+      title="Terminals"
+      count={terminals.length}
+      expandHref={null}
+    >
+      {terminals.length === 0 ? (
+        <p className="px-3 py-6 text-center text-xs text-text-3">
+          No terminals in this space yet.
+        </p>
+      ) : (
+        <ul className="grid gap-2 p-3 sm:grid-cols-2 xl:grid-cols-3">
+          {terminals.map((t) => (
+            <li key={t.id}>
+              <Link
+                href={`/p/${t.ticker}`}
+                className="group flex h-full flex-col gap-2 rounded-sm border border-border bg-bg-2 p-3 transition-colors hover:border-accent/40 hover:bg-bg-3"
+              >
+                <div className="flex items-center gap-2">
+                  <span className="font-mono text-[11px] font-semibold text-accent">
+                    {t.ticker}
+                  </span>
+                  <span className="flex-1 truncate text-xs text-text-0">
+                    {t.name}
+                  </span>
+                  <ArrowRight
+                    className="h-3 w-3 flex-shrink-0 text-text-3 opacity-0 transition-opacity group-hover:opacity-100"
+                    aria-hidden="true"
+                  />
+                </div>
+                <div className="flex items-center gap-2 text-[10px] text-text-3">
+                  <StatusPill status={t.status} />
+                  <span>·</span>
+                  <span title={`${t.member_count} member${t.member_count === 1 ? "" : "s"}`}>
+                    {t.member_count} member{t.member_count === 1 ? "" : "s"}
+                  </span>
+                </div>
+                <div
+                  className={cn(
+                    "font-mono text-[10px]",
+                    t.open_task_count > 0 ? "text-text-1" : "text-text-3",
+                  )}
+                >
+                  {t.open_task_count > 0
+                    ? `${t.open_task_count} open task${t.open_task_count === 1 ? "" : "s"}`
+                    : "no open tasks"}
+                  {t.done_task_count > 0 ? (
+                    <span className="text-text-3">
+                      {" "}· {t.done_task_count} done
+                    </span>
+                  ) : null}
+                </div>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </DashboardCard>
+  );
+}

--- a/apps/web/src/lib/space-queries.ts
+++ b/apps/web/src/lib/space-queries.ts
@@ -1,0 +1,715 @@
+/**
+ * Server-side data loaders for the space landing page (`/s/:slug`).
+ *
+ * Each loader is scoped to a single space by id. The page calls
+ * them in parallel and renders one combined client tree, mirroring
+ * the dashboard's "all cards in a single round-trip" pattern from
+ * `dashboard-queries.ts`.
+ *
+ * RLS does the access enforcement; these loaders assume the caller
+ * has already verified the user is a member of the space (so we
+ * can return rich aggregates without leaking).
+ */
+import { traceSpan } from "./observability";
+
+type AnySupabaseClient = any;
+
+export interface SpaceTerminalCard {
+  id: string;
+  ticker: string;
+  name: string;
+  status: string;
+  created_at: string;
+  updated_at: string;
+  member_count: number;
+  open_task_count: number;
+  done_task_count: number;
+}
+
+export interface SpaceTaskRow {
+  id: string;
+  ticker_seq: number;
+  title: string;
+  status: string;
+  priority: number;
+  due_date: string | null;
+  terminal_id: string;
+  ticker: string | null;
+  assignees: { user_id: string; full_name: string | null }[];
+}
+
+export interface SpaceMemberRow {
+  user_id: string;
+  role: "owner" | "admin" | "member";
+  joined_at: string;
+  full_name: string | null;
+  email: string | null;
+  /**
+   * Count of terminals in *this space* the member is currently a
+   * member of. `0` is a valid signal — they're in the space but
+   * haven't been added to a working context yet.
+   */
+  terminal_count: number;
+  /** Active assigned tasks across this space (status != done). */
+  active_task_count: number;
+}
+
+export interface SpaceActivityRow {
+  id: string;
+  action: string;
+  actor_id: string | null;
+  terminal_id: string | null;
+  metadata: Record<string, unknown> | null;
+  created_at: string;
+}
+
+export interface SpaceWeekItem {
+  id: string;
+  kind: "due" | "event";
+  title: string;
+  when: string;
+  terminal_id: string | null;
+  terminal_ticker: string | null;
+}
+
+export interface SpaceLobbyMessage {
+  id: string;
+  body: string;
+  author_id: string;
+  author_name: string | null;
+  created_at: string;
+}
+
+export interface SpaceFileRow {
+  id: string;
+  filename: string;
+  mime_type: string;
+  uploaded_at: string;
+  terminal_id: string;
+  terminal_ticker: string | null;
+}
+
+/**
+ * Load every terminal in the space + its aggregate counts. Three
+ * round-trips (terminals, members, tasks) joined client-side
+ * because the supabase generic select can't express the aggregate
+ * in one call cleanly.
+ */
+export async function loadSpaceTerminals(
+  supabase: AnySupabaseClient,
+  spaceId: string,
+): Promise<SpaceTerminalCard[]> {
+  return traceSpan(
+    {
+      name: "db.space.terminals",
+      op: "db.query",
+      attributes: { table: "terminals" },
+    },
+    async () => {
+      const { data: terminalRows } = await supabase
+        .from("terminals")
+        .select("id, ticker, name, status, created_at, updated_at")
+        .eq("space_id", spaceId)
+        .is("archived_at", null)
+        .order("updated_at", { ascending: false });
+      type TRow = {
+        id: string;
+        ticker: string;
+        name: string;
+        status: string;
+        created_at: string;
+        updated_at: string;
+      };
+      const terminals = (terminalRows ?? []) as TRow[];
+      if (terminals.length === 0) return [];
+
+      const ids = terminals.map((t) => t.id);
+
+      const [membersResult, openTasksResult, doneTasksResult] =
+        await Promise.all([
+          supabase
+            .from("terminal_members")
+            .select("terminal_id")
+            .in("terminal_id", ids),
+          supabase
+            .from("tasks")
+            .select("terminal_id")
+            .in("terminal_id", ids)
+            .neq("status", "done")
+            .is("deleted_at", null),
+          supabase
+            .from("tasks")
+            .select("terminal_id")
+            .in("terminal_id", ids)
+            .eq("status", "done")
+            .is("deleted_at", null),
+        ]);
+
+      const memberCounts = new Map<string, number>();
+      for (const r of (membersResult.data ?? []) as {
+        terminal_id: string;
+      }[]) {
+        memberCounts.set(r.terminal_id, (memberCounts.get(r.terminal_id) ?? 0) + 1);
+      }
+      const openCounts = new Map<string, number>();
+      for (const r of (openTasksResult.data ?? []) as {
+        terminal_id: string;
+      }[]) {
+        openCounts.set(r.terminal_id, (openCounts.get(r.terminal_id) ?? 0) + 1);
+      }
+      const doneCounts = new Map<string, number>();
+      for (const r of (doneTasksResult.data ?? []) as {
+        terminal_id: string;
+      }[]) {
+        doneCounts.set(r.terminal_id, (doneCounts.get(r.terminal_id) ?? 0) + 1);
+      }
+
+      return terminals.map((t) => ({
+        ...t,
+        member_count: memberCounts.get(t.id) ?? 0,
+        open_task_count: openCounts.get(t.id) ?? 0,
+        done_task_count: doneCounts.get(t.id) ?? 0,
+      }));
+    },
+  );
+}
+
+/**
+ * Load aggregate task signals for the space — the cross-cutting
+ * roll-up the dashboard's TasksCard can't show because it's
+ * personal-only.
+ */
+export async function loadSpaceTasks(
+  supabase: AnySupabaseClient,
+  spaceId: string,
+): Promise<{
+  assignedToMe: SpaceTaskRow[];
+  overdue: SpaceTaskRow[];
+  blocked: SpaceTaskRow[];
+  dueThisWeek: SpaceTaskRow[];
+}> {
+  return traceSpan(
+    {
+      name: "db.space.tasks",
+      op: "db.query",
+      attributes: { table: "tasks" },
+    },
+    async () => {
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+      if (!user) {
+        return {
+          assignedToMe: [],
+          overdue: [],
+          blocked: [],
+          dueThisWeek: [],
+        };
+      }
+
+      // Resolve terminals in this space first so every task query
+      // can stay in a single `.in("terminal_id", ids)` filter — RLS
+      // handles the per-row read check.
+      const { data: terminals } = await supabase
+        .from("terminals")
+        .select("id, ticker")
+        .eq("space_id", spaceId)
+        .is("archived_at", null);
+      type TRow = { id: string; ticker: string };
+      const tList = (terminals ?? []) as TRow[];
+      const tickerById = new Map(tList.map((t) => [t.id, t.ticker]));
+      const ids = tList.map((t) => t.id);
+      if (ids.length === 0) {
+        return {
+          assignedToMe: [],
+          overdue: [],
+          blocked: [],
+          dueThisWeek: [],
+        };
+      }
+
+      const todayIso = new Date().toISOString().slice(0, 10);
+      const weekFromNow = new Date();
+      weekFromNow.setDate(weekFromNow.getDate() + 7);
+      const weekIso = weekFromNow.toISOString().slice(0, 10);
+
+      const [
+        { data: assignedTaskIds },
+        { data: openTasks },
+        { data: blockedTasks },
+      ] = await Promise.all([
+        supabase
+          .from("task_assignees")
+          .select("task_id")
+          .eq("user_id", user.id),
+        supabase
+          .from("tasks")
+          .select(
+            "id, ticker_seq, title, status, priority, due_date, terminal_id",
+          )
+          .in("terminal_id", ids)
+          .neq("status", "done")
+          .is("deleted_at", null),
+        supabase
+          .from("tasks")
+          .select(
+            "id, ticker_seq, title, status, priority, due_date, terminal_id",
+          )
+          .in("terminal_id", ids)
+          .eq("status", "blocked")
+          .is("deleted_at", null),
+      ]);
+
+      type TaskCore = {
+        id: string;
+        ticker_seq: number;
+        title: string;
+        status: string;
+        priority: number;
+        due_date: string | null;
+        terminal_id: string;
+      };
+
+      const myAssignedIds = new Set(
+        ((assignedTaskIds ?? []) as { task_id: string }[]).map(
+          (r) => r.task_id,
+        ),
+      );
+      const open = (openTasks ?? []) as TaskCore[];
+      const blocked = (blockedTasks ?? []) as TaskCore[];
+
+      // Pull assignees for the visible task ids in one round-trip.
+      const visibleIds = Array.from(
+        new Set([
+          ...open.map((t) => t.id),
+          ...blocked.map((t) => t.id),
+        ]),
+      );
+      const { data: assigneeRows } = visibleIds.length
+        ? await supabase
+            .from("task_assignees")
+            .select("task_id, user_id")
+            .in("task_id", visibleIds)
+        : { data: [] };
+      type ARow = { task_id: string; user_id: string };
+      const userIds = Array.from(
+        new Set(
+          ((assigneeRows ?? []) as ARow[]).map((r) => r.user_id),
+        ),
+      );
+      const { data: profiles } = userIds.length
+        ? await supabase
+            .from("profiles")
+            .select("user_id, full_name")
+            .in("user_id", userIds)
+        : { data: [] };
+      type PRow = { user_id: string; full_name: string | null };
+      const nameById = new Map(
+        ((profiles ?? []) as PRow[]).map((p) => [p.user_id, p.full_name]),
+      );
+      const assigneesByTask = new Map<
+        string,
+        SpaceTaskRow["assignees"]
+      >();
+      for (const r of (assigneeRows ?? []) as ARow[]) {
+        const list = assigneesByTask.get(r.task_id) ?? [];
+        list.push({
+          user_id: r.user_id,
+          full_name: nameById.get(r.user_id) ?? null,
+        });
+        assigneesByTask.set(r.task_id, list);
+      }
+
+      function decorate(t: TaskCore): SpaceTaskRow {
+        return {
+          id: t.id,
+          ticker_seq: t.ticker_seq,
+          title: t.title,
+          status: t.status,
+          priority: t.priority,
+          due_date: t.due_date,
+          terminal_id: t.terminal_id,
+          ticker: tickerById.get(t.terminal_id) ?? null,
+          assignees: assigneesByTask.get(t.id) ?? [],
+        };
+      }
+
+      const assignedToMe = open
+        .filter((t) => myAssignedIds.has(t.id))
+        .map(decorate);
+      const overdue = open
+        .filter((t) => t.due_date && t.due_date < todayIso)
+        .map(decorate);
+      const dueThisWeek = open
+        .filter(
+          (t) =>
+            t.due_date && t.due_date >= todayIso && t.due_date <= weekIso,
+        )
+        .map(decorate);
+      const blockedDecorated = blocked.map(decorate);
+
+      return {
+        assignedToMe,
+        overdue,
+        blocked: blockedDecorated,
+        dueThisWeek,
+      };
+    },
+  );
+}
+
+/**
+ * Load every member of the space with their roll-up counts so the
+ * directory card can show "who's involved + how busy."
+ */
+export async function loadSpaceMembers(
+  supabase: AnySupabaseClient,
+  spaceId: string,
+): Promise<SpaceMemberRow[]> {
+  return traceSpan(
+    {
+      name: "db.space.members",
+      op: "db.query",
+      attributes: { table: "space_members" },
+    },
+    async () => {
+      const { data: rawMembers } = await supabase
+        .from("space_members")
+        .select("user_id, role, joined_at")
+        .eq("space_id", spaceId)
+        .order("joined_at", { ascending: true });
+      type MRow = {
+        user_id: string;
+        role: "owner" | "admin" | "member";
+        joined_at: string;
+      };
+      const members = (rawMembers ?? []) as MRow[];
+      if (members.length === 0) return [];
+
+      const userIds = members.map((m) => m.user_id);
+
+      const [
+        { data: profiles },
+        { data: terminalsInSpace },
+      ] = await Promise.all([
+        supabase
+          .from("profiles")
+          .select("user_id, full_name, email")
+          .in("user_id", userIds),
+        supabase
+          .from("terminals")
+          .select("id")
+          .eq("space_id", spaceId)
+          .is("archived_at", null),
+      ]);
+
+      type PRow = {
+        user_id: string;
+        full_name: string | null;
+        email: string | null;
+      };
+      const profileById = new Map(
+        ((profiles ?? []) as PRow[]).map((p) => [p.user_id, p]),
+      );
+
+      const terminalIds = ((terminalsInSpace ?? []) as { id: string }[]).map(
+        (t) => t.id,
+      );
+
+      // Per-member terminal count = how many terminals in this space
+      // they're a member of. Plus their open assigned-task count.
+      const [
+        { data: termMemberRows },
+        { data: assigneeRows },
+      ] = terminalIds.length
+        ? await Promise.all([
+            supabase
+              .from("terminal_members")
+              .select("terminal_id, user_id")
+              .in("terminal_id", terminalIds)
+              .in("user_id", userIds),
+            supabase
+              .from("task_assignees")
+              .select(
+                "user_id, tasks!task_assignees_task_id_fkey(status, terminal_id, deleted_at)",
+              )
+              .in("user_id", userIds),
+          ])
+        : [{ data: [] }, { data: [] }];
+
+      const terminalCountByUser = new Map<string, number>();
+      for (const r of (termMemberRows ?? []) as {
+        user_id: string;
+      }[]) {
+        terminalCountByUser.set(
+          r.user_id,
+          (terminalCountByUser.get(r.user_id) ?? 0) + 1,
+        );
+      }
+
+      type ARow = {
+        user_id: string;
+        tasks: {
+          status: string;
+          terminal_id: string;
+          deleted_at: string | null;
+        } | null;
+      };
+      const terminalIdSet = new Set(terminalIds);
+      const activeTaskCountByUser = new Map<string, number>();
+      for (const r of (assigneeRows ?? []) as unknown as ARow[]) {
+        if (!r.tasks) continue;
+        if (r.tasks.deleted_at) continue;
+        if (r.tasks.status === "done") continue;
+        if (!terminalIdSet.has(r.tasks.terminal_id)) continue;
+        activeTaskCountByUser.set(
+          r.user_id,
+          (activeTaskCountByUser.get(r.user_id) ?? 0) + 1,
+        );
+      }
+
+      return members.map((m) => {
+        const p = profileById.get(m.user_id);
+        return {
+          user_id: m.user_id,
+          role: m.role,
+          joined_at: m.joined_at,
+          full_name: p?.full_name ?? null,
+          email: p?.email ?? null,
+          terminal_count: terminalCountByUser.get(m.user_id) ?? 0,
+          active_task_count: activeTaskCountByUser.get(m.user_id) ?? 0,
+        };
+      });
+    },
+  );
+}
+
+/**
+ * Load the most recent activity rows scoped to terminals in this
+ * space — feeds the space-wide ticker tape (item #3).
+ */
+export async function loadSpaceActivity(
+  supabase: AnySupabaseClient,
+  spaceId: string,
+  limit: number = 30,
+): Promise<SpaceActivityRow[]> {
+  return traceSpan(
+    {
+      name: "db.space.activity",
+      op: "db.query",
+      attributes: { table: "activity" },
+    },
+    async () => {
+      const { data: terminals } = await supabase
+        .from("terminals")
+        .select("id")
+        .eq("space_id", spaceId)
+        .is("archived_at", null);
+      const ids = ((terminals ?? []) as { id: string }[]).map((t) => t.id);
+      if (ids.length === 0) return [];
+
+      const { data } = await supabase
+        .from("activity")
+        .select("id, action, actor_id, terminal_id, metadata, created_at")
+        .in("terminal_id", ids)
+        .order("created_at", { ascending: false })
+        .limit(limit);
+      return (data ?? []) as SpaceActivityRow[];
+    },
+  );
+}
+
+/**
+ * Load this week's items (tasks + calendar events) scoped to the
+ * space. Mirror of the dashboard `loadWeekItems` but with
+ * everything in the space, not just "tasks I touch."
+ */
+export async function loadSpaceWeekItems(
+  supabase: AnySupabaseClient,
+  spaceId: string,
+): Promise<SpaceWeekItem[]> {
+  return traceSpan(
+    { name: "db.space.week_items", op: "db.query" },
+    async () => {
+      const start = new Date();
+      start.setHours(0, 0, 0, 0);
+      const end = new Date(start);
+      end.setDate(end.getDate() + 7);
+
+      const { data: terminals } = await supabase
+        .from("terminals")
+        .select("id, ticker")
+        .eq("space_id", spaceId)
+        .is("archived_at", null);
+      type TRow = { id: string; ticker: string };
+      const tList = (terminals ?? []) as TRow[];
+      const ids = tList.map((t) => t.id);
+      const tickerById = new Map(tList.map((t) => [t.id, t.ticker]));
+      if (ids.length === 0) return [];
+
+      const [{ data: tasks }, { data: events }] = await Promise.all([
+        supabase
+          .from("tasks")
+          .select("id, title, due_date, terminal_id")
+          .in("terminal_id", ids)
+          .gte("due_date", start.toISOString().slice(0, 10))
+          .lte("due_date", end.toISOString().slice(0, 10))
+          .neq("status", "done")
+          .is("deleted_at", null),
+        supabase
+          .from("calendar_events")
+          .select("id, title, starts_at, terminal_id")
+          .in("terminal_id", ids)
+          .gte("starts_at", start.toISOString())
+          .lte("starts_at", end.toISOString())
+          .is("deleted_at", null),
+      ]);
+
+      type TT = {
+        id: string;
+        title: string;
+        due_date: string | null;
+        terminal_id: string;
+      };
+      type EE = {
+        id: string;
+        title: string;
+        starts_at: string;
+        terminal_id: string | null;
+      };
+
+      const dueRows = ((tasks ?? []) as TT[]).map<SpaceWeekItem>((t) => ({
+        id: `task:${t.id}`,
+        kind: "due",
+        title: t.title,
+        when: t.due_date ?? "",
+        terminal_id: t.terminal_id,
+        terminal_ticker: tickerById.get(t.terminal_id) ?? null,
+      }));
+      const eventRows = ((events ?? []) as EE[]).map<SpaceWeekItem>((e) => ({
+        id: `event:${e.id}`,
+        kind: "event",
+        title: e.title,
+        when: e.starts_at,
+        terminal_id: e.terminal_id,
+        terminal_ticker: e.terminal_id
+          ? tickerById.get(e.terminal_id) ?? null
+          : null,
+      }));
+      return [...dueRows, ...eventRows];
+    },
+  );
+}
+
+/**
+ * Load the most recent messages from the space's lobby thread (the
+ * single `kind = 'space'` thread for this space, auto-provisioned
+ * elsewhere). Returns up to `limit` newest-first.
+ */
+export async function loadSpaceLobby(
+  supabase: AnySupabaseClient,
+  spaceId: string,
+  limit: number = 8,
+): Promise<{ threadId: string | null; messages: SpaceLobbyMessage[] }> {
+  return traceSpan(
+    {
+      name: "db.space.lobby",
+      op: "db.query",
+      attributes: { table: "messages" },
+    },
+    async () => {
+      const { data: thread } = await supabase
+        .from("message_threads")
+        .select("id")
+        .eq("kind", "space")
+        .eq("space_id", spaceId)
+        .maybeSingle();
+      const threadId = (thread as { id: string } | null)?.id ?? null;
+      if (!threadId) return { threadId: null, messages: [] };
+
+      const { data: rows } = await supabase
+        .from("messages")
+        .select("id, body, author_id, created_at")
+        .eq("thread_id", threadId)
+        .is("deleted_at", null)
+        .order("created_at", { ascending: false })
+        .limit(limit);
+      type MRow = {
+        id: string;
+        body: string;
+        author_id: string;
+        created_at: string;
+      };
+      const messages = (rows ?? []) as MRow[];
+
+      const userIds = Array.from(new Set(messages.map((m) => m.author_id)));
+      const { data: profiles } = userIds.length
+        ? await supabase
+            .from("profiles")
+            .select("user_id, full_name")
+            .in("user_id", userIds)
+        : { data: [] };
+      type PRow = { user_id: string; full_name: string | null };
+      const nameById = new Map(
+        ((profiles ?? []) as PRow[]).map((p) => [p.user_id, p.full_name]),
+      );
+
+      return {
+        threadId,
+        messages: messages.map((m) => ({
+          id: m.id,
+          body: m.body,
+          author_id: m.author_id,
+          author_name: nameById.get(m.author_id) ?? null,
+          created_at: m.created_at,
+        })),
+      };
+    },
+  );
+}
+
+/**
+ * Load the most-recently-uploaded files across all terminals in
+ * the space. Files are still per-terminal in the schema; this is
+ * a simple cross-terminal recents view.
+ */
+export async function loadSpaceFiles(
+  supabase: AnySupabaseClient,
+  spaceId: string,
+  limit: number = 10,
+): Promise<SpaceFileRow[]> {
+  return traceSpan(
+    { name: "db.space.files", op: "db.query", attributes: { table: "files" } },
+    async () => {
+      const { data: terminals } = await supabase
+        .from("terminals")
+        .select("id, ticker")
+        .eq("space_id", spaceId)
+        .is("archived_at", null);
+      type TRow = { id: string; ticker: string };
+      const tList = (terminals ?? []) as TRow[];
+      const ids = tList.map((t) => t.id);
+      const tickerById = new Map(tList.map((t) => [t.id, t.ticker]));
+      if (ids.length === 0) return [];
+
+      const { data: rows } = await supabase
+        .from("files")
+        .select("id, filename, mime_type, uploaded_at, terminal_id")
+        .in("terminal_id", ids)
+        .is("deleted_at", null)
+        .order("uploaded_at", { ascending: false })
+        .limit(limit);
+      type FRow = {
+        id: string;
+        filename: string;
+        mime_type: string;
+        uploaded_at: string;
+        terminal_id: string;
+      };
+      return ((rows ?? []) as FRow[]).map((f) => ({
+        ...f,
+        terminal_ticker: tickerById.get(f.terminal_id) ?? null,
+      }));
+    },
+  );
+}


### PR DESCRIPTION
Clicking a space in the explorer used to do nothing — now it opens a proper space-level landing.\n\nReuses DashboardShell so dashboard / space / terminal feel like one app. Seven cards: terminals grid, cross-cutting tasks roll-up, space-scoped activity ticker, members directory, week calendar, lobby messages, recent files. Settings cog for owners/admins.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)