### PR TITLE
fix(layout): resize handle had height: 0 — make it actually fill the column

### DIFF
--- a/apps/web/src/components/TerminalShell.tsx
+++ b/apps/web/src/components/TerminalShell.tsx
@@ -127,7 +127,7 @@ export function TerminalShell({
             >
               {leftRail}
             </aside>
-            <div className="hidden flex-shrink-0 lg:block">
+            <div className="hidden flex-shrink-0 self-stretch lg:flex">
               <ResizeHandle
                 ariaLabel="Resize explorer"
                 onMouseDown={(e) =>
@@ -145,7 +145,7 @@ export function TerminalShell({
             >
               {leftPane}
             </div>
-            <div className="hidden flex-shrink-0 lg:block">
+            <div className="hidden flex-shrink-0 self-stretch lg:flex">
               <ResizeHandle
                 ariaLabel="Resize context pane"
                 onMouseDown={(e) =>
@@ -158,7 +158,7 @@ export function TerminalShell({
         <div className="flex-1 overflow-y-auto bg-bg-0">{mainPane}</div>
         {rightPane && rightOpen ? (
           <>
-            <div className="hidden flex-shrink-0 lg:block">
+            <div className="hidden flex-shrink-0 self-stretch lg:flex">
               <ResizeHandle
                 ariaLabel="Resize right pane"
                 onMouseDown={(e) =>

--- a/apps/web/src/components/dashboard/DashboardShell.tsx
+++ b/apps/web/src/components/dashboard/DashboardShell.tsx
@@ -78,7 +78,7 @@ export function DashboardShell({
         >
           {left}
         </aside>
-        <div className="hidden flex-shrink-0 lg:block">
+        <div className="hidden flex-shrink-0 self-stretch lg:flex">
           <ResizeHandle
             ariaLabel="Resize explorer"
             onMouseDown={(e) =>
@@ -97,7 +97,7 @@ export function DashboardShell({
             {right}
           </div>
         </main>
-        <div className="hidden flex-shrink-0 lg:block">
+        <div className="hidden flex-shrink-0 self-stretch lg:flex">
           <ResizeHandle
             ariaLabel="Resize messages"
             onMouseDown={(e) =>


### PR DESCRIPTION
**The bug**: live diagnosis in Zack's browser showed the handle's bounding rect was `{ x: 480, y: 61, w: 4, h: 0 }`. The 4px-wide bar from PR #101 was correct horizontally but invisibly short vertically, so nobody could see or grab it.\n\n**Why**: the wrapping `<div className='hidden lg:block'>` was a flex item inside the row layout. The wrapper got stretched vertically by default `align-items: stretch`, but its display was `block` — and the handle inside, also block-with-no-height, didn't inherit any height.\n\n**Fix**: change the wrapper to `lg:flex` so the handle becomes a flex item with default `align-items: stretch`, plus `self-stretch` on the wrapper itself for belt-and-suspenders. Same change applied to TerminalShell.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)