### PR TITLE
fix(calendar): AADSTS90023 + allow multiple Outlook accounts per user

### DIFF
--- a/apps/web/src/app/settings/calendars/ConnectButton.tsx
+++ b/apps/web/src/app/settings/calendars/ConnectButton.tsx
@@ -17,15 +17,27 @@ import { ProviderLogo } from "./ProviderLogo";
  *   3. We surface a "Redirecting…" pending state for slow networks,
  *      since browser tabs can show no progress between click and the
  *      provider redirect.
+ *
+ * `addAnother` switches the label from "Connect <Provider>" to
+ * "+ Add another" — used in the panel when at least one account is
+ * already linked. The schema (calendar_connections has
+ * UNIQUE(user_id, provider, account_email)) supports stacking, and
+ * the OAuth flow uses prompt=select_account so the IDP shows the
+ * account picker even if the user is already signed in elsewhere.
  */
 export function ConnectButton({
   provider,
   label,
+  addAnother = false,
 }: {
   provider: "google" | "microsoft";
   label: string;
+  addAnother?: boolean;
 }) {
   const [pending, setPending] = useState(false);
+  const restingLabel = addAnother
+    ? "+ Add another"
+    : `Connect ${label}`;
   return (
     <button
       type="button"
@@ -41,7 +53,7 @@ export function ConnectButton({
       ) : (
         <ProviderLogo provider={provider} size={12} />
       )}
-      {pending ? "Redirecting…" : `Connect ${label}`}
+      {pending ? "Redirecting…" : restingLabel}
     </button>
   );
 }

--- a/apps/web/src/app/settings/calendars/page.tsx
+++ b/apps/web/src/app/settings/calendars/page.tsx
@@ -183,15 +183,18 @@ export default async function CalendarsPage({ searchParams }: Props) {
           )}
         </AdminPanel>
 
-        {/* Add-calendar panel — only shown when there's at least one
-            provider not already connected, otherwise it's just noise. */}
-        {available.some((p) => !connectedProviders.has(p.id)) ||
-        unavailable.length > 0 ? (
+        {/* Add-calendar panel — always available because the schema
+            allows stacking multiple accounts per provider (e.g. work +
+            personal Outlook share one user but different
+            account_emails). The button reads "Connect" the first time
+            and "+ Add another" once at least one connection exists for
+            that provider. */}
+        {available.length > 0 || unavailable.length > 0 ? (
           <AdminPanel title="Add calendar" className="mb-4">
             <ul className="divide-y divide-border text-sm">
-              {available
-                .filter((p) => !connectedProviders.has(p.id))
-                .map((p) => (
+              {available.map((p) => {
+                const alreadyConnected = connectedProviders.has(p.id);
+                return (
                   <li
                     key={p.id}
                     className="flex items-center gap-3 px-4 py-2.5"
@@ -202,25 +205,14 @@ export default async function CalendarsPage({ searchParams }: Props) {
                       className="flex-shrink-0"
                     />
                     <span className="flex-1 text-text-1">{p.label}</span>
-                    <ConnectButton provider={p.id} label={p.label} />
-                  </li>
-                ))}
-              {available
-                .filter((p) => connectedProviders.has(p.id))
-                .map((p) => (
-                  <li
-                    key={p.id}
-                    className="flex items-center gap-3 px-4 py-2.5 text-text-3"
-                  >
-                    <ProviderLogo
+                    <ConnectButton
                       provider={p.id}
-                      size={18}
-                      className="flex-shrink-0 opacity-50"
+                      label={p.label}
+                      addAnother={alreadyConnected}
                     />
-                    <span className="flex-1">{p.label}</span>
-                    <AdminBadge variant="success">CONNECTED</AdminBadge>
                   </li>
-                ))}
+                );
+              })}
               {unavailable.map((p) => (
                 <li
                   key={p.id}

--- a/apps/web/src/lib/calendar-oauth.ts
+++ b/apps/web/src/lib/calendar-oauth.ts
@@ -68,13 +68,22 @@ export function providerConfig(p: Provider): ProviderConfig | null {
 /** Build the auth URL with a random state. Caller stores the state in a
  * short-lived cookie and verifies on callback.
  *
- * `prompt=select_account consent` — when a user is already signed into
- * a Microsoft/Google account in their browser, the IDP would otherwise
- * silently use that one. Forcing the account picker is critical for
- * the reconnect flow (users replacing a stale connection) and for the
- * second-account flow (e.g. work + personal Outlook). `consent` is
- * still requested so refresh_token is returned even if the user
- * previously consented and was about to skip the screen. */
+ * `prompt` handling differs per provider:
+ *   - Google supports space-separated multi-value prompts. We send
+ *     "select_account consent" so the account picker always renders
+ *     (critical for the reconnect / second-account flows) AND the
+ *     consent screen re-runs so a refresh_token is reissued.
+ *   - Microsoft Azure AD only accepts ONE prompt value at a time.
+ *     Sending multiple throws AADSTS90023 ("Unsupported 'prompt'
+ *     value"). We send only "select_account" — refresh tokens
+ *     come back automatically when `offline_access` is in the
+ *     requested scope (which it always is here).
+ *
+ * The Google `access_type=offline` is the equivalent of Microsoft's
+ * `offline_access` scope: both ask the IDP to return a refresh_token.
+ * Microsoft accepts the scope; Google requires the explicit query
+ * param.
+ */
 export function authorizeUrl(
   p: Provider,
   config: ProviderConfig,
@@ -85,10 +94,15 @@ export function authorizeUrl(
     redirect_uri: config.redirectUri,
     response_type: "code",
     scope: config.scopes.join(" "),
-    access_type: p === "google" ? "offline" : "",
-    prompt: "select_account consent",
     state,
   });
+  if (p === "google") {
+    params.set("access_type", "offline");
+    params.set("prompt", "select_account consent");
+  } else {
+    // Microsoft: single-value prompt only.
+    params.set("prompt", "select_account");
+  }
   return `${config.authorizeUrl}?${params.toString()}`;
 }
 


### PR DESCRIPTION
Two reported bugs in one PR.\n\n**1. AADSTS90023 'Unsupported prompt value' on Outlook sign-in.** Microsoft Azure AD only accepts a single value in the OAuth `prompt` parameter; we were sending `select_account consent` for both Google and Microsoft. Fix: branch on provider — Google keeps the multi-value (it supports it), Microsoft sends just `select_account`. Refresh tokens still come back via `offline_access`.\n\n**2. Can't connect a second Outlook account.** Schema already supports it (UNIQUE on user_id+provider+account_email); the UI was filtering the Connect button out as soon as any account was linked. Fix: always render the button + new `addAnother` prop that flips the label to `+ Add another` once a connection exists.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)