### PR TITLE
feat: PR A — terminal-creation by any member + richer notifications + dashboard realtime + filter cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,10 @@ older docs using the old names are wrong, treat this section as authoritative.
 **Permissions model:**
 
 - Only **platform administrators** (`profiles.is_platform_admin`) can create spaces.
-- Only **owners / admins of a space** can create terminals inside that space.
+- **Any member of a space** can create terminals inside that space. The
+  `trg_terminal_init_members` trigger seeds `terminal_members` with the
+  creator (role='owner') AND every space owner (role='owner') so both have
+  admin control of the new terminal.
 - Any **member of a terminal** can create tasks, upload files, post comments.
 
 Old docs sometimes say "project" or "organization" — read those as "terminal"

--- a/apps/web/src/app/api/v1/projects/route.ts
+++ b/apps/web/src/app/api/v1/projects/route.ts
@@ -54,7 +54,12 @@ export async function POST(request: NextRequest) {
   // No longer gates UI behavior — every space gets the same universal core.
   const type = body.type ?? "space";
 
-  // Only owners or admins of the parent space may create terminals.
+  // Any member of the parent space can create terminals. The
+  // `trg_terminal_init_members` DB trigger seeds terminal_members
+  // with the creator (role='owner') AND every space owner
+  // (role='owner') so both have admin control of the new terminal.
+  // Old rule was owner/admin-only; relaxed per Zack — regular space
+  // members are who actually need to start working contexts.
   const { data: membership } = await supabase
     .from("space_members")
     .select("role")
@@ -62,12 +67,8 @@ export async function POST(request: NextRequest) {
     .eq("user_id", user.id)
     .maybeSingle();
 
-  const role = (membership as { role?: string } | null)?.role;
-  if (!role) return forbidden("you are not a member of this space");
-  if (role !== "owner" && role !== "admin")
-    return forbidden(
-      "Only owners and admins of a space can create terminals. Ask a space admin to create it or promote you.",
-    );
+  if (!membership)
+    return forbidden("you are not a member of this space");
 
   // Resolve ticker: use provided, or auto-suggest + dedupe against existing
   let ticker = body.ticker?.toUpperCase();

--- a/apps/web/src/app/p/[ticker]/page.tsx
+++ b/apps/web/src/app/p/[ticker]/page.tsx
@@ -400,23 +400,57 @@ function relativeTime(iso: string): string {
   return `${Math.floor(h / 24)}d ago`;
 }
 
-function humanizeAction(action: string, metadata: Record<string, unknown>): string {
+function humanizeAction(
+  action: string,
+  metadata: Record<string, unknown>,
+): string {
+  // Same source-of-truth as the dashboard's `summarizeActivity` —
+  // dotted-versus-underscored variants both supported because the
+  // diff trigger emits `task_updated` while API code emits
+  // `task.update`. Rich phrasing replaces the old terse default
+  // (`action.replace(/\./g, " ")`) which produced unhelpful
+  // strings like "task update" or "tasks updated".
+  const m = metadata as Record<string, unknown>;
+  const s = (k: string): string | null =>
+    typeof m?.[k] === "string" ? (m[k] as string) : null;
   switch (action) {
-    case "terminal.create":
-      return `Space created`;
-    case "terminal.update":
-      return `Space updated`;
     case "task.create":
-      return `Task "${metadata.title ?? ""}" created`;
+      return `Task "${s("title") ?? "(untitled)"}" created`;
     case "task.complete":
-      return `Task completed`;
+      return `Task "${s("title") ?? "(untitled)"}" completed`;
+    case "task.update":
+    case "task_updated":
+      return `Task "${s("title") ?? ""}" updated`.trim();
+    case "task.delete":
+      return `Task "${s("title") ?? "(untitled)"}" deleted`;
+    case "task.assigned":
+      return `Task "${s("title") ?? ""}" assigned`.trim();
+    case "terminal.create":
+      return `Terminal created`;
+    case "terminal.update":
+    case "terminal_updated":
+      return `Terminal updated`;
+    case "terminal.archive":
+      return `Terminal archived`;
     case "file.upload":
-      return `${metadata.filename ?? "File"} uploaded`;
+      return `${s("filename") ?? "File"} uploaded`;
+    case "file.delete":
+      return `${s("filename") ?? "File"} deleted`;
+    case "file.update":
+    case "file_updated":
+      return `File ${s("filename") ?? ""} updated`.trim();
+    case "comment.create":
+      return `New comment on ${s("entity_kind") ?? "a task"}`;
+    case "comment.update":
+    case "comment_updated":
+      return `Comment edited`;
     case "member.invite":
-      return `${metadata.email ?? "Someone"} invited`;
+      return `${s("email") ?? "Someone"} invited`;
     case "member.join":
-      return `${metadata.name ?? "Someone"} joined`;
+      return `${s("name") ?? "Someone"} joined`;
+    case "member.remove":
+      return `${s("name") ?? "Member"} removed`;
     default:
-      return action.replace(/\./g, " ");
+      return action.replace(/[._]/g, " ");
   }
 }

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -131,15 +131,50 @@ function summarizeActivity(
     const v = metadata?.[k];
     return typeof v === "string" ? v : null;
   };
+  // Rich, specific phrasing per action — used to be a generic
+  // ".replace(/[._]/g, ' ')" fallback that produced garbage like
+  // "tasks updated", which is what Zack flagged as "I want more
+  // detail than 'task updated'." Cases are sorted by frequency.
   switch (action) {
-    case "terminal.create":
-      return `terminal created: ${pick("name") ?? ""}`;
     case "task.create":
-      return `new task: ${pick("title") ?? ""}`;
+      return `task created: ${pick("title") ?? "(untitled)"}`;
     case "task.complete":
-      return `task complete`;
+      return `task completed: ${pick("title") ?? "(untitled)"}`;
+    case "task.update":
+    case "task_updated":
+      return `task updated: ${pick("title") ?? "(untitled)"}`;
+    case "task.delete":
+      return `task deleted: ${pick("title") ?? "(untitled)"}`;
+    case "task.assigned":
+      return `assigned: ${pick("title") ?? "(untitled)"}`;
+    case "terminal.create":
+      return `new terminal: ${pick("name") ?? "(unnamed)"}`;
+    case "terminal.update":
+    case "terminal_updated":
+      return `terminal updated: ${pick("name") ?? ""}`.trim();
+    case "terminal.archive":
+      return `archived ${pick("name") ?? "a terminal"}`;
     case "file.upload":
       return `uploaded ${pick("filename") ?? "a file"}`;
+    case "file.delete":
+      return `deleted ${pick("filename") ?? "a file"}`;
+    case "file.update":
+    case "file_updated":
+      return `file updated: ${pick("filename") ?? ""}`.trim();
+    case "comment.create":
+      return `commented on ${pick("entity_kind") ?? "a task"}`;
+    case "comment.update":
+    case "comment_updated":
+      return `comment edited`;
+    case "member.invite":
+      return `invited ${pick("email") ?? "a member"}`;
+    case "member.join":
+      return `${pick("name") ?? "someone"} joined`;
+    case "member.remove":
+      return `removed ${pick("name") ?? "a member"}`;
+    case "space_updated":
+    case "space.update":
+      return `space updated: ${pick("name") ?? ""}`.trim();
     default:
       return action.replace(/[._]/g, " ");
   }

--- a/apps/web/src/app/s/[slug]/page.tsx
+++ b/apps/web/src/app/s/[slug]/page.tsx
@@ -138,23 +138,53 @@ function summarizeActivity(
   action: string,
   metadata: Record<string, unknown>,
 ): string {
+  // Mirror of the dashboard's summarizeActivity (apps/web/src/app/page.tsx)
+  // — kept local for the space ticker so we don't have to plumb
+  // it through props. Both should be edited together.
   const pick = (k: string): string | null => {
     const v = metadata[k];
     return typeof v === "string" ? v : null;
   };
   switch (action) {
-    case "terminal.create":
-      return `terminal created: ${pick("name") ?? ""}`;
     case "task.create":
-      return `new task: ${pick("title") ?? ""}`;
+      return `task created: ${pick("title") ?? "(untitled)"}`;
     case "task.complete":
-      return `task complete`;
+      return `task completed: ${pick("title") ?? "(untitled)"}`;
+    case "task.update":
+    case "task_updated":
+      return `task updated: ${pick("title") ?? "(untitled)"}`;
+    case "task.delete":
+      return `task deleted: ${pick("title") ?? "(untitled)"}`;
+    case "task.assigned":
+      return `assigned: ${pick("title") ?? "(untitled)"}`;
+    case "terminal.create":
+      return `new terminal: ${pick("name") ?? "(unnamed)"}`;
+    case "terminal.update":
+    case "terminal_updated":
+      return `terminal updated: ${pick("name") ?? ""}`.trim();
+    case "terminal.archive":
+      return `archived ${pick("name") ?? "a terminal"}`;
     case "file.upload":
       return `uploaded ${pick("filename") ?? "a file"}`;
+    case "file.delete":
+      return `deleted ${pick("filename") ?? "a file"}`;
+    case "file.update":
+    case "file_updated":
+      return `file updated: ${pick("filename") ?? ""}`.trim();
+    case "comment.create":
+      return `commented on ${pick("entity_kind") ?? "a task"}`;
+    case "comment.update":
+    case "comment_updated":
+      return `comment edited`;
     case "member.invite":
       return `invited ${pick("email") ?? "a member"}`;
     case "member.join":
       return `${pick("name") ?? "someone"} joined`;
+    case "member.remove":
+      return `removed ${pick("name") ?? "a member"}`;
+    case "space_updated":
+    case "space.update":
+      return `space updated: ${pick("name") ?? ""}`.trim();
     default:
       return action.replace(/[._]/g, " ");
   }

--- a/apps/web/src/components/dashboard/ExplorerRail.tsx
+++ b/apps/web/src/components/dashboard/ExplorerRail.tsx
@@ -6,7 +6,6 @@ import {
   ChevronDown,
   ChevronRight,
   Clock,
-  Search,
   Settings,
   Sparkles,
   X,
@@ -203,24 +202,23 @@ export function ExplorerRail({
         {spaces.length > 0 ? (
           <div className="sticky top-0 z-10 flex-shrink-0 border-b border-border bg-bg-0 px-2 py-1.5">
             <div className="relative">
-              <Search
-                className="pointer-events-none absolute left-2 top-1/2 h-3 w-3 -translate-y-1/2 text-text-3"
-                aria-hidden="true"
-              />
+              {/* The leading magnifying-glass icon was dropped per
+                  Zack's report ("there is still a + in the filter").
+                  At 12px the lucide-search circle + stroke combined
+                  with the text cursor on focus visually read as a
+                  "+" — so there's nothing inside the input now but
+                  the placeholder, the value, and the clear button
+                  on the right when there's a value. */}
               <input
                 ref={filterRef}
                 type="text"
                 value={filter}
                 onChange={(e) => setFilter(e.target.value)}
-                placeholder="Filter…"
+                placeholder="Search…"
                 aria-label="Filter explorer"
                 title="Press / to focus"
-                className="h-7 w-full rounded-sm border border-border bg-bg-1 pl-7 pr-2 text-xs text-text-0 placeholder:text-text-3 focus:border-border-focus focus:outline-none focus-visible:ring-2 focus-visible:ring-border-focus"
+                className="h-7 w-full rounded-sm border border-border bg-bg-1 px-2 text-xs text-text-0 placeholder:text-text-3 focus:border-border-focus focus:outline-none focus-visible:ring-2 focus-visible:ring-border-focus"
               />
-              {/* The "/" kbd hint that used to render here was dropped
-                  per UX feedback — it doubled up with the placeholder
-                  inside an already-narrow input and crowded the
-                  visible characters of what the user was typing. */}
               {filter ? (
                 <button
                   type="button"

--- a/apps/web/src/components/dashboard/TasksCard.tsx
+++ b/apps/web/src/components/dashboard/TasksCard.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import Link from "next/link";
-import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
 import { Check, ArrowRight, Plus } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { DashboardCard, CardSection } from "./DashboardCard";
@@ -10,6 +11,7 @@ import {
   DueChip,
   TickerChip,
 } from "@/components/primitives";
+import { useRealtimeTable } from "@/lib/supabase/realtime";
 import type { AssignedTask, DelegatedTask } from "@/lib/dashboard-queries";
 
 interface TasksCardProps {
@@ -54,6 +56,26 @@ export function TasksCard({
   // Show ~10 rows per the spec; users with more get a "see all" link to a
   // dedicated full-list page.
   const ROW_LIMIT = 10;
+
+  // Subscribe to global task INSERT/UPDATE/DELETE events so the
+  // dashboard reflects new work without a refresh — Zack's report:
+  // "When i make a new task it doesn't automatically add it to the
+  // page. I have to refresh the browser to see it." Filter is
+  // intentionally absent (RLS scopes the events to tasks the user
+  // can see); we just `router.refresh()` on any of them rather than
+  // mutating the props locally, since the card owns view-derived
+  // counts and per-row decoration that are easier to recompute
+  // server-side.
+  const router = useRouter();
+  useRealtimeTable<{ id: string }>(
+    { table: "tasks", channelKey: "dash:tasks" },
+    {
+      onInsert: () => router.refresh(),
+      onUpdate: () => router.refresh(),
+      onDelete: () => router.refresh(),
+    },
+  );
+
   return (
     <DashboardCard
       title="Tasks"

--- a/apps/web/src/components/dashboard/TasksCard.tsx
+++ b/apps/web/src/components/dashboard/TasksCard.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Check, ArrowRight, Plus } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { DashboardCard, CardSection } from "./DashboardCard";

--- a/supabase/migrations/20260506010000_terminal_creation_loosen.sql
+++ b/supabase/migrations/20260506010000_terminal_creation_loosen.sql
@@ -1,0 +1,72 @@
+-- Any space member can create terminals.
+--
+-- Old rule: only owners/admins of a space could create terminals
+-- inside it. New rule per Zack: any member of the space can — and
+-- when they do, both the creator AND every space owner are
+-- auto-added as terminal owners (the creator gets admin control of
+-- the new terminal, the space owner stays in the loop without
+-- having to be invited).
+--
+-- Two coordinated changes:
+--   1. Replace the `terminals_insert` RLS policy so the membership
+--      gate uses `is_space_member` instead of `is_space_admin`.
+--   2. New AFTER-INSERT trigger on `terminals` that seeds
+--      `terminal_members` with the creator + every space owner,
+--      both with role='owner'. The trigger runs SECURITY DEFINER
+--      so it bypasses the (still RLS-protected) terminal_members
+--      insert policy — we don't want a regular member to be able
+--      to forge terminal_members rows on their own.
+--
+-- The CLAUDE.md permissions section is updated in the same PR to
+-- reflect the new model.
+
+BEGIN;
+
+DROP POLICY IF EXISTS "terminals_insert" ON terminals;
+
+CREATE POLICY "terminals_insert" ON terminals FOR INSERT TO authenticated
+WITH CHECK (
+  created_by = auth.uid()
+  AND is_space_member(space_id)
+);
+
+COMMENT ON POLICY "terminals_insert" ON terminals IS
+  'Any member of the parent space may create terminals inside it. The trg_terminal_init_members trigger auto-adds the creator and every space owner as terminal owners on insert.';
+
+CREATE OR REPLACE FUNCTION add_terminal_creator_and_space_owner()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  -- Creator → terminal owner. ON CONFLICT guards against a future
+  -- code path that already inserts the creator manually.
+  INSERT INTO terminal_members (terminal_id, user_id, role, added_by)
+  VALUES (NEW.id, NEW.created_by, 'owner', NEW.created_by)
+  ON CONFLICT (terminal_id, user_id) DO NOTHING;
+
+  -- Every space owner → terminal owner too. The space owner needs
+  -- visibility into work happening under their tenant; before this
+  -- they relied on the is_space_admin fallback in is_terminal_member
+  -- which gave them read access but no actual membership row, so
+  -- features keyed on terminal_members (presence, assignment
+  -- pickers) skipped them.
+  INSERT INTO terminal_members (terminal_id, user_id, role, added_by)
+  SELECT NEW.id, sm.user_id, 'owner', NEW.created_by
+  FROM space_members sm
+  WHERE sm.space_id = NEW.space_id
+    AND sm.role = 'owner'
+    AND sm.user_id <> NEW.created_by
+  ON CONFLICT (terminal_id, user_id) DO NOTHING;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_terminal_init_members ON terminals;
+CREATE TRIGGER trg_terminal_init_members
+  AFTER INSERT ON terminals
+  FOR EACH ROW EXECUTE FUNCTION add_terminal_creator_and_space_owner();
+
+COMMIT;


### PR DESCRIPTION
Four coherent changes from the batch queue.\n\n- **#16** Any space member can create terminals; trigger auto-adds creator + space owners as terminal owners.\n- **#15** Richer notification copy across dashboard / terminal / space tickers (no more terse 'task updated').\n- **#9** Dashboard TasksCard subscribes to realtime → new tasks auto-show without refresh.\n- Filter affordance: dropped the search icon inside the explorer Filter input (was visually conflating with the text caret as a '+' at small font sizes).\n\n**Includes a SQL migration** `20260506010000_terminal_creation_loosen.sql` that loosens the `terminals_insert` RLS policy and adds `trg_terminal_init_members`. Apply via `scripts/apply_pending_migrations.py` after merge.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)