### PR TITLE
feat(tasks): priority redesign (High/Med/Low/None + dropdown)

### DIFF
--- a/apps/web/src/app/api/v1/projects/[ticker]/tasks/route.ts
+++ b/apps/web/src/app/api/v1/projects/[ticker]/tasks/route.ts
@@ -176,8 +176,14 @@ async function handlePost(request: NextRequest, { params }: Props) {
 
   if (!body.title?.trim()) return bad("title is required");
   if (body.title.length > 300) return bad("title must be ≤ 300 characters");
-  if (body.priority !== undefined && (body.priority < 1 || body.priority > 4))
-    return bad("priority must be 1–4");
+  // priority: nullable + 1..3 (1=High, 2=Medium, 3=Low, NULL=No
+  // priority). Was 1..4 before the 2026-05-07 redesign.
+  if (
+    body.priority !== undefined &&
+    body.priority !== null &&
+    (body.priority < 1 || body.priority > 3)
+  )
+    return bad("priority must be 1 (High), 2 (Medium), 3 (Low), or null");
 
   let rule: TaskRecurrenceRule | null = null;
   if (body.recurrence_rule !== undefined) {
@@ -193,7 +199,9 @@ async function handlePost(request: NextRequest, { params }: Props) {
       terminal_id: project.id,
       title: body.title.trim(),
       description: body.description ?? null,
-      priority: body.priority ?? 3,
+      // Default = NULL (no priority) per the 2026-05-07 redesign.
+      // Was `?? 3` (Medium / "Normal" in the old 1-4 scheme).
+      priority: body.priority ?? null,
       due_date: body.due_date ?? null,
       labels: body.tags ?? body.labels ?? [],
       status: body.status ?? "todo",

--- a/apps/web/src/app/api/v1/tasks/[id]/route.ts
+++ b/apps/web/src/app/api/v1/tasks/[id]/route.ts
@@ -48,7 +48,8 @@ async function handlePatch(request: NextRequest, { params }: Props) {
     title?: string;
     description?: string | null;
     status?: TaskStatus;
-    priority?: number;
+    /** 1=High, 2=Medium, 3=Low, null=No priority. Pass null to clear. */
+    priority?: number | null;
     due_date?: string | null;
     labels?: string[];
     /** Spec also calls these "tags"; we accept either name and map to labels. */
@@ -80,7 +81,12 @@ async function handlePatch(request: NextRequest, { params }: Props) {
   }
   if (body.description !== undefined) patch.description = body.description;
   if (body.priority !== undefined) {
-    if (body.priority < 1 || body.priority > 4) return bad("priority must be 1–4");
+    // null is allowed (= "no priority"). 1..3 otherwise.
+    if (
+      body.priority !== null &&
+      (body.priority < 1 || body.priority > 3)
+    )
+      return bad("priority must be 1 (High), 2 (Medium), 3 (Low), or null");
     patch.priority = body.priority;
   }
   if (body.due_date !== undefined) patch.due_date = body.due_date;

--- a/apps/web/src/app/api/v1/tasks/bulk/route.ts
+++ b/apps/web/src/app/api/v1/tasks/bulk/route.ts
@@ -12,7 +12,7 @@ import type { TaskStatus } from "@rokki/db";
  *
  * Supported actions:
  *   - status        { status: TaskStatus }                 — set status (and completed_at if done)
- *   - priority      { priority: 1..4 }                     — set priority
+ *   - priority      { priority: 1..3 | null }              — set priority (null = no priority)
  *   - delete        — remove the rows
  *   - assign        { user_ids: string[], replace: bool }  — add (or replace) assignees
  *
@@ -28,7 +28,7 @@ type BulkBody =
   | {
       task_ids: string[];
       action: "priority";
-      priority: number;
+      priority: number | null;
     }
   | {
       task_ids: string[];
@@ -81,12 +81,16 @@ async function handlePost(request: NextRequest) {
       break;
     }
     case "priority": {
+      // null is allowed (= "no priority"). 1..3 otherwise.
       if (
-        typeof body.priority !== "number" ||
-        body.priority < 1 ||
-        body.priority > 4
+        body.priority !== null &&
+        (typeof body.priority !== "number" ||
+          body.priority < 1 ||
+          body.priority > 3)
       )
-        return bad("priority must be 1..4");
+        return bad(
+          "priority must be 1 (High), 2 (Medium), 3 (Low), or null",
+        );
       const { data, error } = await supabase
         .from("tasks")
         // @ts-expect-error generic update collapses to never

--- a/apps/web/src/components/QuickTaskDialog.tsx
+++ b/apps/web/src/components/QuickTaskDialog.tsx
@@ -107,7 +107,7 @@ export function QuickTaskDialog({
 
   async function handleSubmit(input: {
     title: string;
-    priority: number;
+    priority: number | null;
     due_date: string | null;
     labels: string[];
     assignee_ids: string[];

--- a/apps/web/src/components/TaskComposer.tsx
+++ b/apps/web/src/components/TaskComposer.tsx
@@ -31,7 +31,8 @@ export interface TaskComposerMember {
 
 export interface TaskComposerSubmit {
   title: string;
-  priority: number;
+  /** 1=High, 2=Medium, 3=Low, null=No priority. */
+  priority: number | null;
   due_date: string | null;
   labels: string[];
   assignee_ids: string[];
@@ -40,8 +41,11 @@ export interface TaskComposerSubmit {
 interface TaskComposerProps {
   /** Members available for assignee selection. Empty = no picker. */
   members?: TaskComposerMember[];
-  /** Pre-fill the priority chip. Defaults to 3 (the API default). */
-  initialPriority?: number;
+  /**
+   * Pre-fill the priority chip. Defaults to null = "No priority".
+   * Use 1/2/3 for High/Medium/Low.
+   */
+  initialPriority?: number | null;
   /** Pre-fill assignees. */
   initialAssigneeIds?: string[];
   /**
@@ -102,7 +106,7 @@ interface TaskComposerProps {
  */
 export function TaskComposer({
   members = [],
-  initialPriority = 3,
+  initialPriority = null,
   initialAssigneeIds = [],
   currentUserId,
   initialLabels = [],
@@ -116,7 +120,7 @@ export function TaskComposer({
   submitLabel = "Create",
 }: TaskComposerProps) {
   const [title, setTitle] = useState("");
-  const [priority, setPriority] = useState(initialPriority);
+  const [priority, setPriority] = useState<number | null>(initialPriority);
   const [dueIso, setDueIso] = useState<string | null>(null);
   // If the parent gave us a currentUserId AND no explicit pre-fill,
   // default the assignee to the viewer. Matches "I made this, so
@@ -292,11 +296,18 @@ export function TaskComposer({
 /* Chip primitives                                                  */
 /* --------------------------------------------------------------- */
 
+// 1=High, 2=Medium, 3=Low, null=No priority. Was a 1..4 scale
+// before the 2026-05-07 redesign — see the priority migration for
+// the value remap.
 const PRIORITY_LABEL: Record<number, string> = {
-  1: "P1 · Critical",
-  2: "P2 · High",
-  3: "P3 · Normal",
-  4: "P4 · Low",
+  1: "High",
+  2: "Medium",
+  3: "Low",
+};
+const PRIORITY_DOT_TONE: Record<number, string> = {
+  1: "bg-danger",
+  2: "bg-warning",
+  3: "bg-text-3",
 };
 
 function PriorityChip({
@@ -304,23 +315,100 @@ function PriorityChip({
   onChange,
   disabled,
 }: {
-  priority: number;
-  onChange: (p: number) => void;
+  priority: number | null;
+  onChange: (p: number | null) => void;
   disabled: boolean;
 }) {
-  const cycle = () => onChange(priority === 4 ? 1 : priority + 1);
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Click-outside to close.
+  useEffect(() => {
+    if (!open) return;
+    function onDoc(e: MouseEvent) {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(e.target as Node)
+      ) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", onDoc);
+    return () => document.removeEventListener("mousedown", onDoc);
+  }, [open]);
+
+  const label =
+    priority == null ? "Priority" : PRIORITY_LABEL[priority] ?? "Priority";
   return (
-    <button
-      type="button"
-      onClick={cycle}
-      disabled={disabled}
-      title={`${PRIORITY_LABEL[priority]} (click to cycle)`}
-      aria-label={`Priority ${priority} of 4 — click to change`}
-      className="flex items-center gap-1 rounded-sm border border-border bg-bg-2 px-2 py-1 text-[11px] text-text-1 hover:bg-bg-3"
-    >
-      <Flag className="h-3 w-3 text-text-3" aria-hidden="true" />
-      <span className="font-mono">P{priority}</span>
-    </button>
+    <div ref={containerRef} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        disabled={disabled}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        title={priority == null ? "No priority — click to set" : `Priority: ${label}`}
+        className={cn(
+          "flex items-center gap-1 rounded-sm border bg-bg-2 px-2 py-1 text-[11px]",
+          priority == null
+            ? "border-border text-text-1 hover:bg-bg-3"
+            : "border-accent/40 text-text-0",
+        )}
+      >
+        {priority == null ? (
+          <Flag className="h-3 w-3 text-text-3" aria-hidden="true" />
+        ) : (
+          <span
+            aria-hidden="true"
+            className={cn(
+              "h-2 w-2 rounded-full",
+              PRIORITY_DOT_TONE[priority] ?? "bg-text-3",
+            )}
+          />
+        )}
+        <span>{label}</span>
+      </button>
+      {open ? (
+        <div
+          role="menu"
+          className="absolute left-0 top-full z-50 mt-1 w-36 overflow-hidden rounded-sm border border-border bg-bg-1 py-1 shadow-lg"
+        >
+          {[
+            { val: 1, label: "High", tone: PRIORITY_DOT_TONE[1] },
+            { val: 2, label: "Medium", tone: PRIORITY_DOT_TONE[2] },
+            { val: 3, label: "Low", tone: PRIORITY_DOT_TONE[3] },
+            { val: null, label: "No priority", tone: null },
+          ].map((opt) => (
+            <button
+              key={String(opt.val)}
+              type="button"
+              role="menuitem"
+              onClick={() => {
+                onChange(opt.val);
+                setOpen(false);
+              }}
+              className={cn(
+                "flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs hover:bg-bg-2",
+                priority === opt.val && "bg-bg-2 text-text-0",
+              )}
+            >
+              {opt.tone ? (
+                <span
+                  aria-hidden="true"
+                  className={cn("h-2 w-2 rounded-full", opt.tone)}
+                />
+              ) : (
+                <span
+                  aria-hidden="true"
+                  className="h-2 w-2 rounded-full border border-text-3"
+                />
+              )}
+              <span className="flex-1 text-text-1">{opt.label}</span>
+            </button>
+          ))}
+        </div>
+      ) : null}
+    </div>
   );
 }
 

--- a/apps/web/src/components/TasksPane.tsx
+++ b/apps/web/src/components/TasksPane.tsx
@@ -32,7 +32,8 @@ interface Task {
   title: string;
   description: string | null;
   status: TaskStatus;
-  priority: number;
+  /** 1=High, 2=Medium, 3=Low, null=No priority. */
+  priority: number | null;
   due_date: string | null;
   labels: string[];
   /**
@@ -442,7 +443,7 @@ export function TasksPane({ ticker, projectId, currentUserId }: TasksPaneProps) 
    */
   async function createTask(input: {
     title: string;
-    priority: number;
+    priority: number | null;
     due_date: string | null;
     labels: string[];
     assignee_ids: string[];
@@ -852,10 +853,13 @@ function sortTasks(tasks: Task[], mode: SortMode = "auto"): Task[] {
     blocked: 3,
     done: 4,
   };
+  // null priority sorts after 1..3 (matches the server ORDER BY).
+  const pkey = (p: number | null | undefined): number =>
+    p == null ? Number.POSITIVE_INFINITY : p;
   return [...tasks].sort((a, b) => {
     const s = rank[a.status] - rank[b.status];
     if (s !== 0) return s;
-    const p = a.priority - b.priority;
+    const p = pkey(a.priority) - pkey(b.priority);
     if (p !== 0) return p;
     const da = a.due_date ? new Date(a.due_date).getTime() : Number.POSITIVE_INFINITY;
     const db = b.due_date ? new Date(b.due_date).getTime() : Number.POSITIVE_INFINITY;

--- a/apps/web/src/components/primitives.tsx
+++ b/apps/web/src/components/primitives.tsx
@@ -16,30 +16,54 @@ import { cn } from "@/lib/utils";
 /* -------------------------------------------------------------------- */
 /* PriorityDots                                                           */
 /* -------------------------------------------------------------------- */
+/**
+ * Shows the task's priority as a small colored dot + label.
+ *   1 = High   (danger color)
+ *   2 = Medium (warning color)
+ *   3 = Low    (text-3, subtle)
+ *   null = no chip (renders nothing)
+ *
+ * Replaces the old four-dot "P1/P2/P3/P4" rendering. Component
+ * name stayed the same to avoid touching every call site —
+ * "Dots" is a slight misnomer now (one dot + label).
+ */
+const PRIORITY_DOT: Record<number, string> = {
+  1: "bg-danger",
+  2: "bg-warning",
+  3: "bg-text-3",
+};
+const PRIORITY_LABEL_PRIMITIVE: Record<number, string> = {
+  1: "High",
+  2: "Med",
+  3: "Low",
+};
 
 export function PriorityDots({
   priority,
   className,
 }: {
-  priority: number;
+  /** 1..3 or null. null/undefined = no chip rendered. */
+  priority: number | null | undefined;
   className?: string;
 }) {
+  if (priority == null || !PRIORITY_LABEL_PRIMITIVE[priority]) return null;
   return (
     <span
       role="img"
-      aria-label={`Priority ${priority}`}
-      className={cn("flex items-center gap-0.5", className)}
+      aria-label={`Priority ${PRIORITY_LABEL_PRIMITIVE[priority]}`}
+      className={cn(
+        "inline-flex flex-shrink-0 items-center gap-1 font-mono text-[10px] uppercase tracking-wide text-text-2",
+        className,
+      )}
     >
-      {[1, 2, 3, 4].map((n) => (
-        <span
-          key={n}
-          aria-hidden="true"
-          className={cn(
-            "h-1 w-1 rounded-full",
-            n <= priority ? "bg-text-2" : "bg-bg-3",
-          )}
-        />
-      ))}
+      <span
+        aria-hidden="true"
+        className={cn(
+          "h-1.5 w-1.5 rounded-full",
+          PRIORITY_DOT[priority] ?? "bg-text-3",
+        )}
+      />
+      {PRIORITY_LABEL_PRIMITIVE[priority]}
     </span>
   );
 }

--- a/apps/web/src/components/task-detail/TaskDetail.tsx
+++ b/apps/web/src/components/task-detail/TaskDetail.tsx
@@ -41,7 +41,8 @@ interface Task {
   title: string;
   description: string | null;
   status: string;
-  priority: number;
+  /** 1=High, 2=Medium, 3=Low, null=No priority. */
+  priority: number | null;
   due_date: string | null;
   labels: string[] | null;
   recurrence_rule?: TaskRecurrenceRule | null;
@@ -596,16 +597,19 @@ export function TaskDetail({
             label="Priority"
             right={
               <select
-                value={task.priority}
+                value={task.priority == null ? "" : String(task.priority)}
                 onChange={(e) =>
-                  patchTask({ priority: Number(e.target.value) })
+                  patchTask({
+                    priority:
+                      e.target.value === "" ? null : Number(e.target.value),
+                  })
                 }
                 className="rounded-sm border border-border bg-bg-2 px-1.5 py-0.5 text-[11px] text-text-0 outline-none focus:border-border-focus"
               >
-                <option value={1}>Urgent</option>
-                <option value={2}>High</option>
-                <option value={3}>Medium</option>
-                <option value={4}>Low</option>
+                <option value="">No priority</option>
+                <option value={1}>High</option>
+                <option value={2}>Medium</option>
+                <option value={3}>Low</option>
               </select>
             }
           >
@@ -1055,15 +1059,17 @@ function LabelBlock({
 /* PriorityChip — color-coded chip per spec (gray/blue/orange/red)      */
 /* ------------------------------------------------------------------- */
 
+// 1=High, 2=Medium, 3=Low, null=No priority chip rendered.
 const PRIORITY_TONE: Record<number, { tone: string; label: string }> = {
-  1: { tone: "bg-danger-subtle text-danger", label: "Urgent" },
-  2: { tone: "bg-warning-subtle text-warning", label: "High" },
-  3: { tone: "bg-info-subtle text-info", label: "Medium" },
-  4: { tone: "bg-bg-3 text-text-2", label: "Low" },
+  1: { tone: "bg-danger-subtle text-danger", label: "High" },
+  2: { tone: "bg-warning-subtle text-warning", label: "Medium" },
+  3: { tone: "bg-bg-3 text-text-2", label: "Low" },
 };
 
-function PriorityChip({ priority }: { priority: number }) {
-  const meta = PRIORITY_TONE[priority] ?? PRIORITY_TONE[3];
+function PriorityChip({ priority }: { priority: number | null }) {
+  if (priority == null) return null;
+  const meta = PRIORITY_TONE[priority];
+  if (!meta) return null;
   return (
     <span
       className={cn(

--- a/apps/web/src/lib/dashboard-queries.ts
+++ b/apps/web/src/lib/dashboard-queries.ts
@@ -35,7 +35,8 @@ export interface AssignedTask {
   id: string;
   title: string;
   status: string;
-  priority: number;
+  /** 1=High, 2=Medium, 3=Low, null=No priority. */
+  priority: number | null;
   due_date: string | null;
   terminal_id: string;
   ticker_seq: number;
@@ -118,7 +119,7 @@ export async function loadAssignedTasks(
           id: string;
           title: string;
           status: string;
-          priority: number;
+          priority: number | null;
           due_date: string | null;
           terminal_id: string;
           ticker_seq: number;
@@ -128,9 +129,14 @@ export async function loadAssignedTasks(
         .map((r) => r.tasks)
         .filter((t): t is NonNullable<Row["tasks"]> => !!t)
         .filter((t) => t.status !== "done");
+      // Sort: priority asc with NULL = "no priority" sinking to the
+      // bottom, then due_date asc. Matches the server ORDER BY
+      // semantics with NULLS LAST.
+      const pkey = (p: number | null): number =>
+        p == null ? Number.POSITIVE_INFINITY : p;
       return rows.sort(
         (a, b) =>
-          a.priority - b.priority ||
+          pkey(a.priority) - pkey(b.priority) ||
           (a.due_date ? new Date(a.due_date).getTime() : Infinity) -
             (b.due_date ? new Date(b.due_date).getTime() : Infinity),
       );
@@ -157,7 +163,7 @@ export async function loadDelegatedTasks(
         id: string;
         title: string;
         status: string;
-        priority: number;
+        priority: number | null;
         due_date: string | null;
         terminal_id: string;
         ticker_seq: number;

--- a/apps/web/src/lib/tasks-sort.test.ts
+++ b/apps/web/src/lib/tasks-sort.test.ts
@@ -4,7 +4,8 @@ import { applyTaskSort } from "./tasks-sort";
 interface T {
   id: string;
   status: string;
-  priority: number;
+  /** 1=High, 2=Medium, 3=Low, null=No priority. */
+  priority: number | null;
   due_date: string | null;
   position: number | null;
   created_at: string;
@@ -14,7 +15,7 @@ interface T {
 
 const t = (over: Partial<T> & { id: string }): T => ({
   status: "todo",
-  priority: 3,
+  priority: null,
   due_date: null,
   position: null,
   created_at: "2026-04-20T00:00:00Z",
@@ -34,16 +35,18 @@ describe("applyTaskSort", () => {
     expect(sorted).toEqual(["c", "b", "a"]);
   });
 
-  it("priority sort: urgent (1) first", () => {
+  it("priority sort: high (1) first, no-priority (null) last", () => {
     const tasks: T[] = [
-      t({ id: "lo", priority: 4 }),
+      t({ id: "lo", priority: 3 }),
+      t({ id: "none", priority: null }),
       t({ id: "hi", priority: 1 }),
-      t({ id: "med", priority: 3 }),
+      t({ id: "med", priority: 2 }),
     ];
     expect(applyTaskSort(tasks, "priority").map((x) => x.id)).toEqual([
       "hi",
       "med",
       "lo",
+      "none",
     ]);
   });
 

--- a/apps/web/src/lib/tasks-sort.ts
+++ b/apps/web/src/lib/tasks-sort.ts
@@ -3,7 +3,7 @@
  *
  * - `default`  → priority then due-date (matches the server ORDER BY).
  * - `due`      → due_date ascending; nulls last.
- * - `priority` → 1 (urgent) → 4 (low).
+ * - `priority` → 1 (High) → 2 (Medium) → 3 (Low) → null (No priority).
  * - `assignee` → alphabetical by first assignee's full_name.
  * - `status`   → todo → in_progress → blocked → review → done.
  * - `created`  → newest first.
@@ -74,13 +74,18 @@ export function saveTaskSort(key: TaskSortKey): void {
 interface SortableTask {
   id: string;
   status: string;
-  priority: number;
+  /** 1=High, 2=Medium, 3=Low, null=No priority. */
+  priority: number | null;
   due_date: string | null;
   position: number | null;
   created_at: string;
   updated_at: string;
   assignees: { user_id: string; full_name: string | null }[];
 }
+
+/** Treat NULL priority as "infinity" — drops to the bottom of priority sorts. */
+const priorityKey = (p: number | null | undefined): number =>
+  p == null ? Number.POSITIVE_INFINITY : p;
 
 /**
  * Stable sort. We pre-derive each comparison key and fall back to
@@ -105,7 +110,7 @@ export function applyTaskSort<T extends SortableTask>(
         return ad - bd;
       }
       case "priority":
-        return a.priority - b.priority;
+        return priorityKey(a.priority) - priorityKey(b.priority);
       case "assignee": {
         const an = (a.assignees[0]?.full_name ?? "").toLowerCase();
         const bn = (b.assignees[0]?.full_name ?? "").toLowerCase();
@@ -133,7 +138,7 @@ export function applyTaskSort<T extends SortableTask>(
       }
       case "default":
       default: {
-        const p = a.priority - b.priority;
+        const p = priorityKey(a.priority) - priorityKey(b.priority);
         if (p !== 0) return p;
         const ad = a.due_date ? new Date(a.due_date).getTime() : Infinity;
         const bd = b.due_date ? new Date(b.due_date).getTime() : Infinity;

--- a/supabase/migrations/20260507010000_priority_three_tier_plus_none.sql
+++ b/supabase/migrations/20260507010000_priority_three_tier_plus_none.sql
@@ -1,0 +1,48 @@
+-- Priority redesign per Zack: three named tiers + "no priority"
+-- (was a 1–4 scale).
+--
+--   Old:                      New:
+--     1 = P1 critical           1 = High
+--     2 = P2 high               2 = Medium
+--     3 = P3 normal (default)   3 = Low
+--     4 = P4 low                NULL = no priority
+--
+-- Mapping for the existing rows:
+--   1 (critical), 2 (high)        →  1 (High)
+--   3 (normal, the most common)   →  2 (Medium)
+--   4 (low)                       →  3 (Low)
+--
+-- The column was NOT NULL with default=3. New default is NULL.
+-- The check constraint changes from `BETWEEN 1 AND 4` to
+-- `IS NULL OR BETWEEN 1 AND 3`.
+
+BEGIN;
+
+-- 1. Drop the existing CHECK constraint so we can rewrite values
+--    that fall outside the new range.
+ALTER TABLE tasks DROP CONSTRAINT IF EXISTS tasks_priority_check;
+
+-- 2. Remap existing values.
+UPDATE tasks
+SET priority = CASE priority
+  WHEN 1 THEN 1   -- was critical → High
+  WHEN 2 THEN 1   -- was high → High
+  WHEN 3 THEN 2   -- was normal → Medium
+  WHEN 4 THEN 3   -- was low → Low
+  ELSE priority   -- defensive: leave anything else alone
+END
+WHERE priority IS NOT NULL;
+
+-- 3. Drop NOT NULL + default so rows can land at "no priority".
+ALTER TABLE tasks ALTER COLUMN priority DROP NOT NULL;
+ALTER TABLE tasks ALTER COLUMN priority DROP DEFAULT;
+
+-- 4. New CHECK: null or 1..3.
+ALTER TABLE tasks
+  ADD CONSTRAINT tasks_priority_check
+  CHECK (priority IS NULL OR (priority BETWEEN 1 AND 3));
+
+COMMENT ON COLUMN tasks.priority IS
+  'Task priority. NULL = no priority (default). 1 = High, 2 = Medium, 3 = Low. Old 1–4 scale was remapped on 2026-05-07.';
+
+COMMIT;


### PR DESCRIPTION
Schema + UI redesign of task priority. 1=High, 2=Medium, 3=Low, NULL=No priority. Dropdown selector replaces click-to-cycle. Migration already applied to prod. See commit message for full surface area.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)