### PR TITLE
feat(tasks): request-update + status pin (#20)

### DIFF
--- a/apps/web/src/app/api/v1/messages/threads/[id]/route.ts
+++ b/apps/web/src/app/api/v1/messages/threads/[id]/route.ts
@@ -20,7 +20,9 @@ export async function GET(_req: NextRequest, { params }: Props) {
 
   const { data } = await supabase
     .from("messages")
-    .select("id, author_id, body, created_at, edited_at, deleted_at")
+    .select(
+      "id, author_id, body, created_at, edited_at, deleted_at, pinging_task_id",
+    )
     .eq("thread_id", id)
     .is("deleted_at", null)
     .order("created_at", { ascending: true });
@@ -32,6 +34,7 @@ export async function GET(_req: NextRequest, { params }: Props) {
     created_at: string;
     edited_at: string | null;
     deleted_at: string | null;
+    pinging_task_id: string | null;
   };
   const rows = (data ?? []) as Row[];
   const authorIds = Array.from(new Set(rows.map((r) => r.author_id)));
@@ -45,9 +48,44 @@ export async function GET(_req: NextRequest, { params }: Props) {
   const nameById = new Map(
     ((profiles ?? []) as ProfileRow[]).map((p) => [p.user_id, p.full_name]),
   );
+
+  // Decorate any "request update" pings (pinging_task_id != null) with the
+  // referenced task's title + ticker so the inbox can render a chip and
+  // a deep-link to the task. One follow-up query, batched by task_id.
+  const taskIds = Array.from(
+    new Set(rows.map((r) => r.pinging_task_id).filter((x): x is string => !!x)),
+  );
+  type TaskRef = {
+    id: string;
+    ticker_seq: number;
+    title: string;
+    terminal_id: string;
+    terminals: { ticker: string } | { ticker: string }[] | null;
+  };
+  let taskById = new Map<
+    string,
+    { id: string; ticker_seq: number; title: string; ticker: string }
+  >();
+  if (taskIds.length > 0) {
+    const { data: taskRows } = await supabase
+      .from("tasks")
+      .select("id, ticker_seq, title, terminal_id, terminals(ticker)")
+      .in("id", taskIds);
+    for (const row of (taskRows ?? []) as TaskRef[]) {
+      const term = Array.isArray(row.terminals) ? row.terminals[0] : row.terminals;
+      taskById.set(row.id, {
+        id: row.id,
+        ticker_seq: row.ticker_seq,
+        title: row.title,
+        ticker: term?.ticker ?? "",
+      });
+    }
+  }
+
   const decorated = rows.map((r) => ({
     ...r,
     author_name: nameById.get(r.author_id) ?? "someone",
+    pinging_task: r.pinging_task_id ? taskById.get(r.pinging_task_id) ?? null : null,
   }));
 
   // Best effort: mark my last_read_at to "now" so unread counts drop.

--- a/apps/web/src/app/api/v1/messages/threads/route.ts
+++ b/apps/web/src/app/api/v1/messages/threads/route.ts
@@ -31,7 +31,7 @@ export async function GET() {
     last_read_at: string | null;
     message_threads: {
       id: string;
-      kind: "dm" | "terminal" | "space";
+      kind: "dm" | "terminal" | "space" | "group";
       terminal_id: string | null;
       space_id: string | null;
       last_message_at: string;
@@ -49,7 +49,7 @@ export async function GET() {
     .in("kind", ["terminal", "space"]);
   type TT = {
     id: string;
-    kind: "dm" | "terminal" | "space";
+    kind: "dm" | "terminal" | "space" | "group";
     terminal_id: string | null;
     space_id: string | null;
     last_message_at: string;
@@ -86,12 +86,16 @@ export async function GET() {
     ((terms ?? []) as TermRow[]).map((t) => [t.id, t]),
   );
 
-  const dmIds = all.filter((t) => t.kind === "dm").map((t) => t.id);
-  const { data: dmParticipants } = dmIds.length
+  // DMs and group threads both label by participants — fetch them
+  // together. (terminal/space threads label by the terminal/space row.)
+  const peopleIds = all
+    .filter((t) => t.kind === "dm" || t.kind === "group")
+    .map((t) => t.id);
+  const { data: dmParticipants } = peopleIds.length
     ? await supabase
         .from("thread_participants")
         .select("thread_id, user_id")
-        .in("thread_id", dmIds)
+        .in("thread_id", peopleIds)
     : { data: [] };
   type PP = { thread_id: string; user_id: string };
   const partsByThread = new Map<string, string[]>();
@@ -101,7 +105,7 @@ export async function GET() {
   }
   const otherUserIds = Array.from(
     new Set(
-      dmIds.flatMap(
+      peopleIds.flatMap(
         (id) => partsByThread.get(id)?.filter((u) => u !== user.id) ?? [],
       ),
     ),
@@ -157,18 +161,20 @@ export async function GET() {
         last_message_at: t.last_message_at,
       };
     }
-    if (t.kind === "dm") {
+    if (t.kind === "dm" || t.kind === "group") {
       const others = (partsByThread.get(t.id) ?? []).filter(
         (u) => u !== user.id,
       );
       const label =
         others
           .map((u) => nameById.get(u) ?? "someone")
-          .join(", ") || "Direct message";
+          .join(", ") || (t.kind === "group" ? "Group chat" : "Direct message");
       return {
         id: t.id,
         kind: t.kind,
         label,
+        // Group threads have multiple "others"; expose only the first
+        // for callers that care (most consumers just use `label`).
         other_user_id: others[0] ?? null,
         last_message_at: t.last_message_at,
       };

--- a/apps/web/src/app/api/v1/projects/[ticker]/tasks/route.ts
+++ b/apps/web/src/app/api/v1/projects/[ticker]/tasks/route.ts
@@ -45,7 +45,7 @@ async function handleGet(request: NextRequest, { params }: Props) {
   let query = supabase
     .from("tasks")
     .select(
-      "id, ticker_seq, title, description, status, priority, due_date, labels, position, created_at, updated_at, completed_at",
+      "id, ticker_seq, title, description, status, priority, due_date, labels, position, latest_status_text, latest_status_author_id, latest_status_at, status_thread_id, created_at, updated_at, completed_at",
     )
     .eq("terminal_id", project.id);
 

--- a/apps/web/src/app/api/v1/tasks/[id]/request-update/route.ts
+++ b/apps/web/src/app/api/v1/tasks/[id]/request-update/route.ts
@@ -1,0 +1,258 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { createClient as createAdminClient } from "@supabase/supabase-js";
+import { createClient } from "@/lib/supabase/server";
+import { withObservability } from "@/lib/observability";
+import type { Database } from "@rokki/db";
+
+interface Props {
+  params: Promise<{ id: string }>;
+}
+
+const TEMPLATE_BODY = "What is the status of this task?";
+
+/**
+ * POST /api/v1/tasks/:id/request-update
+ *
+ * Sends a "what's the status?" ping to the task's assignee(s) via
+ * the messenger. Single assignee → DM thread (kind='dm'). Multiple
+ * assignees → group chat (kind='group'). The requester is always
+ * a participant so they can see replies.
+ *
+ * The status thread is persistent: subsequent calls reuse the
+ * existing `tasks.status_thread_id` and only sync participants if
+ * the assignee set has changed (e.g. task was reassigned).
+ *
+ * Each ping inserts a message with `pinging_task_id = task.id` so
+ * the messenger inbox can render the "📌 task" chip + the "Reply
+ * with status" button on the message.
+ *
+ * Response:
+ *   { data: { thread_id, message_id, recipients: string[] } }
+ */
+async function handlePost(_req: NextRequest, { params }: Props) {
+  const { id: taskId } = await params;
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return unauth();
+
+  // Load the task + verify visibility (RLS does the actual filter,
+  // we just check the row resolved).
+  const { data: taskRow } = await supabase
+    .from("tasks")
+    .select("id, terminal_id, title, status_thread_id")
+    .eq("id", taskId)
+    .maybeSingle();
+  if (!taskRow) return notFound();
+  const task = taskRow as {
+    id: string;
+    terminal_id: string;
+    title: string;
+    status_thread_id: string | null;
+  };
+
+  // Caller must be a member of the parent terminal — this matches
+  // the existing comment + assignee mutation policies.
+  const { data: callerMembership } = await supabase
+    .from("terminal_members")
+    .select("user_id")
+    .eq("terminal_id", task.terminal_id)
+    .eq("user_id", user.id)
+    .maybeSingle();
+  if (!callerMembership) {
+    return forbidden("not a member of this terminal");
+  }
+
+  const { data: assigneeRows } = await supabase
+    .from("task_assignees")
+    .select("user_id")
+    .eq("task_id", taskId);
+  const assigneeIds = ((assigneeRows ?? []) as { user_id: string }[]).map(
+    (r) => r.user_id,
+  );
+  if (assigneeIds.length === 0) {
+    return bad("task has no assignees to ping");
+  }
+  if (
+    assigneeIds.length === 1 &&
+    assigneeIds[0] === user.id
+  ) {
+    return bad("you are the only assignee — nobody to ping");
+  }
+
+  // The thread participants are: requester ∪ assignees. Self-pings
+  // collapse onto the assignee set (no duplication).
+  const participantIds = Array.from(new Set([user.id, ...assigneeIds]));
+
+  // Decide thread kind. 2 participants → DM. 3+ → group.
+  const kind: "dm" | "group" = participantIds.length === 2 ? "dm" : "group";
+
+  // Service-role client for the thread / participant inserts —
+  // bypasses RLS on threads (which is intentionally restrictive
+  // for non-channel kinds). Auditing happens via `actor_id` on
+  // the message itself.
+  const admin = createAdminClient<Database>(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    { auth: { autoRefreshToken: false, persistSession: false } },
+  );
+
+  // Resolve (or lazily create) the persistent status thread for this
+  // task. We compute `threadId` as a non-null string so the closure
+  // captures below don't have to worry about narrowing through `let`.
+  let threadId: string;
+  if (task.status_thread_id) {
+    threadId = task.status_thread_id;
+    // Reuse existing thread; sync participants if the assignee set
+    // changed since last ping (reassignment is the common case).
+    const { data: currentParticipants } = await admin
+      .from("thread_participants")
+      .select("user_id")
+      .eq("thread_id", threadId);
+    const currentIds = new Set(
+      ((currentParticipants ?? []) as { user_id: string }[]).map(
+        (r) => r.user_id,
+      ),
+    );
+    const desiredIds = new Set(participantIds);
+    const toAdd = participantIds.filter((id) => !currentIds.has(id));
+    const toRemove = [...currentIds].filter((id) => !desiredIds.has(id));
+    if (toAdd.length > 0) {
+      const tid = threadId;
+      await admin
+        .from("thread_participants")
+        .insert(
+          toAdd.map((uid) => ({ thread_id: tid, user_id: uid })) as never,
+        );
+    }
+    if (toRemove.length > 0) {
+      await admin
+        .from("thread_participants")
+        .delete()
+        .eq("thread_id", threadId)
+        .in("user_id", toRemove);
+    }
+  } else {
+    // Create new thread + seed participants.
+    const { data: newThread, error: threadErr } = await admin
+      .from("message_threads")
+      .insert({ kind } as never)
+      .select("id")
+      .single();
+    if (threadErr || !newThread) {
+      return internal(threadErr?.message ?? "thread create failed");
+    }
+    threadId = (newThread as { id: string }).id;
+    const tid = threadId;
+    await admin
+      .from("thread_participants")
+      .insert(
+        participantIds.map((uid) => ({
+          thread_id: tid,
+          user_id: uid,
+        })) as never,
+      );
+    // Pin the thread back to the task so future calls reuse it.
+    await admin
+      .from("tasks")
+      .update({ status_thread_id: threadId } as never)
+      .eq("id", taskId);
+  }
+
+  // Insert the ping message itself with pinging_task_id set.
+  const { data: msg, error: msgErr } = await admin
+    .from("messages")
+    .insert({
+      thread_id: threadId,
+      author_id: user.id,
+      body: TEMPLATE_BODY,
+      pinging_task_id: taskId,
+    } as never)
+    .select("id")
+    .single();
+  if (msgErr || !msg) {
+    return internal(msgErr?.message ?? "message insert failed");
+  }
+  // Bump last_message_at so the thread surfaces in the inbox sort.
+  await admin
+    .from("message_threads")
+    .update({ last_message_at: new Date().toISOString() } as never)
+    .eq("id", threadId);
+
+  // Notify each non-self participant (the assignees + anyone else
+  // pinned on the thread) so the bell badges appropriately.
+  const recipients = participantIds.filter((id) => id !== user.id);
+  if (recipients.length > 0) {
+    const { data: callerProfile } = await supabase
+      .from("profiles")
+      .select("full_name")
+      .eq("user_id", user.id)
+      .maybeSingle();
+    const callerName =
+      (callerProfile as { full_name?: string | null } | null)?.full_name ??
+      "Someone";
+    await admin
+      .from("notifications")
+      .insert(
+        recipients.map((uid) => ({
+          user_id: uid,
+          kind: "mention" as const,
+          title: `${callerName} requested a status update`,
+          body: `"${task.title}" — ${TEMPLATE_BODY}`,
+          entity_type: "task",
+          entity_id: taskId,
+          terminal_id: task.terminal_id,
+          actor_id: user.id,
+          url: "/messages",
+        })) as never,
+      );
+  }
+
+  return NextResponse.json(
+    {
+      data: {
+        thread_id: threadId,
+        message_id: (msg as { id: string }).id,
+        recipients,
+      },
+    },
+    { status: 201 },
+  );
+}
+
+function unauth() {
+  return NextResponse.json(
+    { errors: [{ code: "unauthenticated", message: "Sign in required" }] },
+    { status: 401 },
+  );
+}
+function forbidden(msg: string) {
+  return NextResponse.json(
+    { errors: [{ code: "forbidden", message: msg }] },
+    { status: 403 },
+  );
+}
+function bad(msg: string) {
+  return NextResponse.json(
+    { errors: [{ code: "invalid_request", message: msg }] },
+    { status: 400 },
+  );
+}
+function notFound() {
+  return NextResponse.json(
+    { errors: [{ code: "not_found", message: "Task not found" }] },
+    { status: 404 },
+  );
+}
+function internal(msg: string) {
+  return NextResponse.json(
+    { errors: [{ code: "internal_error", message: msg }] },
+    { status: 500 },
+  );
+}
+
+export const POST = withObservability<Props>(
+  handlePost,
+  "POST /api/v1/tasks/:id/request-update",
+);

--- a/apps/web/src/app/api/v1/tasks/[id]/status-update/route.ts
+++ b/apps/web/src/app/api/v1/tasks/[id]/status-update/route.ts
@@ -1,0 +1,182 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { createClient as createAdminClient } from "@supabase/supabase-js";
+import { createClient } from "@/lib/supabase/server";
+import { withObservability } from "@/lib/observability";
+import type { Database } from "@rokki/db";
+
+interface Props {
+  params: Promise<{ id: string }>;
+}
+
+/**
+ * POST /api/v1/tasks/:id/status-update
+ *
+ * Records a status update on the task — sets `latest_status_*`
+ * and (optionally) posts a paired message into the task's status
+ * thread so the conversation history is honest.
+ *
+ * Authorization: caller must be an assignee on the task OR a
+ * member of the parent terminal. Per Zack's spec the chip can be
+ * edited inline by the requester or the assignee; this endpoint
+ * is the single write path for both.
+ *
+ * Body:
+ *   { text: string, post_to_thread?: boolean (default true) }
+ *
+ * Response:
+ *   { data: { latest_status_text, latest_status_author_id, latest_status_at } }
+ */
+async function handlePost(request: NextRequest, { params }: Props) {
+  const { id: taskId } = await params;
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return unauth();
+
+  const body = (await request.json().catch(() => ({}))) as {
+    text?: string;
+    post_to_thread?: boolean;
+  };
+  const text = (body.text ?? "").trim();
+  if (!text) return bad("text is required");
+  if (text.length > 2000) return bad("text must be ≤ 2000 characters");
+  const postToThread = body.post_to_thread !== false;
+
+  const { data: taskRow } = await supabase
+    .from("tasks")
+    .select("id, terminal_id, title, status_thread_id")
+    .eq("id", taskId)
+    .maybeSingle();
+  if (!taskRow) return notFound();
+  const task = taskRow as {
+    id: string;
+    terminal_id: string;
+    title: string;
+    status_thread_id: string | null;
+  };
+
+  const { data: callerMembership } = await supabase
+    .from("terminal_members")
+    .select("user_id")
+    .eq("terminal_id", task.terminal_id)
+    .eq("user_id", user.id)
+    .maybeSingle();
+  if (!callerMembership) {
+    return forbidden("not a member of this terminal");
+  }
+
+  const admin = createAdminClient<Database>(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    { auth: { autoRefreshToken: false, persistSession: false } },
+  );
+
+  const now = new Date().toISOString();
+  const { data: updated, error: updateErr } = await admin
+    .from("tasks")
+    .update({
+      latest_status_text: text,
+      latest_status_author_id: user.id,
+      latest_status_at: now,
+    } as never)
+    .eq("id", taskId)
+    .select("latest_status_text, latest_status_author_id, latest_status_at")
+    .single();
+  if (updateErr || !updated) {
+    return internal(updateErr?.message ?? "task update failed");
+  }
+
+  // Echo the status into the thread as a normal message so the
+  // conversation reads naturally — and so the requester's
+  // "Reply with status" button can be wired to call this endpoint
+  // without leaving the messenger.
+  if (postToThread && task.status_thread_id) {
+    await admin
+      .from("messages")
+      .insert({
+        thread_id: task.status_thread_id,
+        author_id: user.id,
+        body: `Status update: ${text}`,
+        pinging_task_id: taskId,
+      } as never);
+    await admin
+      .from("message_threads")
+      .update({ last_message_at: now } as never)
+      .eq("id", task.status_thread_id);
+
+    // Notify everyone in the thread except the author so the
+    // requester (and anyone else watching) gets a "status came
+    // back" ping.
+    const { data: participants } = await admin
+      .from("thread_participants")
+      .select("user_id")
+      .eq("thread_id", task.status_thread_id);
+    const recipients = ((participants ?? []) as { user_id: string }[])
+      .map((r) => r.user_id)
+      .filter((uid) => uid !== user.id);
+    if (recipients.length > 0) {
+      const { data: callerProfile } = await supabase
+        .from("profiles")
+        .select("full_name")
+        .eq("user_id", user.id)
+        .maybeSingle();
+      const callerName =
+        (callerProfile as { full_name?: string | null } | null)?.full_name ??
+        "Someone";
+      await admin
+        .from("notifications")
+        .insert(
+          recipients.map((uid) => ({
+            user_id: uid,
+            kind: "mention" as const,
+            title: `${callerName} replied with a status update`,
+            body: `"${task.title}" — ${text.slice(0, 280)}`,
+            entity_type: "task",
+            entity_id: taskId,
+            terminal_id: task.terminal_id,
+            actor_id: user.id,
+            url: "/messages",
+          })) as never,
+        );
+    }
+  }
+
+  return NextResponse.json({ data: updated }, { status: 200 });
+}
+
+function unauth() {
+  return NextResponse.json(
+    { errors: [{ code: "unauthenticated", message: "Sign in required" }] },
+    { status: 401 },
+  );
+}
+function forbidden(msg: string) {
+  return NextResponse.json(
+    { errors: [{ code: "forbidden", message: msg }] },
+    { status: 403 },
+  );
+}
+function bad(msg: string) {
+  return NextResponse.json(
+    { errors: [{ code: "invalid_request", message: msg }] },
+    { status: 400 },
+  );
+}
+function notFound() {
+  return NextResponse.json(
+    { errors: [{ code: "not_found", message: "Task not found" }] },
+    { status: 404 },
+  );
+}
+function internal(msg: string) {
+  return NextResponse.json(
+    { errors: [{ code: "internal_error", message: msg }] },
+    { status: 500 },
+  );
+}
+
+export const POST = withObservability<Props>(
+  handlePost,
+  "POST /api/v1/tasks/:id/status-update",
+);

--- a/apps/web/src/components/TasksPane.tsx
+++ b/apps/web/src/components/TasksPane.tsx
@@ -10,6 +10,7 @@ import {
   MessageSquare,
   Maximize2,
   ListTodo,
+  Send,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { EmptyState } from "./EmptyState";
@@ -36,6 +37,9 @@ interface Task {
   priority: number | null;
   due_date: string | null;
   labels: string[];
+  latest_status_text?: string | null;
+  latest_status_author_id?: string | null;
+  latest_status_at?: string | null;
   /**
    * Sparse-integer manual-sort position. May be null for legacy rows
    * created before the column existed; the GET endpoint coerces NULLs
@@ -88,6 +92,7 @@ export function TasksPane({ ticker, projectId, currentUserId }: TasksPaneProps) 
   const [tasks, setTasks] = useState<Task[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [statusNotice, setStatusNotice] = useState<string | null>(null);
   const [selectedIdx, setSelectedIdx] = useState(0);
   const [creating, setCreating] = useState(false);
   const [commentTaskId, setCommentTaskId] = useState<string | null>(null);
@@ -405,6 +410,38 @@ export function TasksPane({ ticker, projectId, currentUserId }: TasksPaneProps) 
     }
   }
 
+  /**
+   * Ping the task's assignees with a "what's the status?" message
+   * via the messenger. Backend creates/reuses a `status_thread` and
+   * delivers a notification to each assignee. UX is intentionally
+   * quiet: the requester sees the row stay put, the assignee sees
+   * a notification + DM/group thread. We pop a tiny inline notice
+   * so the requester knows the ping fired.
+   */
+  async function requestUpdate(task: Task) {
+    try {
+      const r = await fetch(`/api/v1/tasks/${task.id}/request-update`, {
+        method: "POST",
+        credentials: "include",
+      });
+      if (!r.ok) {
+        const body = (await r.json().catch(() => ({}))) as {
+          errors?: { message: string }[];
+        };
+        setError(
+          body.errors?.[0]?.message ??
+            `Failed to request update (HTTP ${r.status})`,
+        );
+        return;
+      }
+      setError(null);
+      setStatusNotice(`Ping sent for "${task.title}"`);
+      window.setTimeout(() => setStatusNotice(null), 2500);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Network error");
+    }
+  }
+
   async function toggleComplete(task: Task) {
     const nextStatus: TaskStatus = task.status === "done" ? "todo" : "done";
     // Optimistic update
@@ -540,6 +577,12 @@ export function TasksPane({ ticker, projectId, currentUserId }: TasksPaneProps) 
         </div>
       ) : null}
 
+      {statusNotice ? (
+        <div className="border-b border-border bg-accent-subtle px-4 py-2 text-xs text-accent">
+          {statusNotice}
+        </div>
+      ) : null}
+
       <div className="flex-1 overflow-y-auto">
         {loading ? (
           <SkeletonList />
@@ -622,6 +665,7 @@ export function TasksPane({ ticker, projectId, currentUserId }: TasksPaneProps) 
                       )
                     }
                     onToggleExpand={() => toggleExpand(t.id)}
+                    onRequestUpdate={() => requestUpdate(t)}
                   />
                   {expanded ? (
                     <SubtasksList
@@ -678,6 +722,7 @@ function TaskRow({
   onToggle,
   onOpenComments,
   onToggleExpand,
+  onRequestUpdate,
 }: {
   task: Task;
   ticker: string;
@@ -688,10 +733,12 @@ function TaskRow({
   onToggle: () => void;
   onOpenComments: () => void;
   onToggleExpand: () => void;
+  onRequestUpdate: () => void;
 }) {
   const done = task.status === "done";
   const subtaskTotal = task.subtask_total ?? 0;
   const subtaskDone = task.subtask_done ?? 0;
+  const status = task.latest_status_text?.trim() ?? "";
 
   return (
     <div
@@ -752,14 +799,27 @@ function TaskRow({
       >
         {done ? <Check className="h-3 w-3" aria-hidden="true" /> : null}
       </button>
-      <span
-        className={cn(
-          "flex-1 truncate text-sm",
-          done ? "text-text-3 line-through" : "text-text-0",
-        )}
-      >
-        {task.title}
-      </span>
+      <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+        <span
+          className={cn(
+            "truncate text-sm",
+            done ? "text-text-3 line-through" : "text-text-0",
+          )}
+        >
+          {task.title}
+        </span>
+        {status ? (
+          <span
+            className="flex items-center gap-1 truncate text-[11px] leading-tight text-text-2"
+            title={status}
+          >
+            <span className="font-mono text-[9px] uppercase tracking-wide text-text-3">
+              Status
+            </span>
+            <span className="truncate">{status}</span>
+          </span>
+        ) : null}
+      </div>
       {/* Subtask roll-up — surfaces the count without expanding. The
           list endpoint already returns subtask_total/subtask_done
           aggregates, so this is free. */}
@@ -788,6 +848,17 @@ function TaskRow({
         className="rounded-sm p-1 text-text-3 opacity-0 transition-opacity hover:bg-bg-3 hover:text-text-0 group-hover:opacity-100"
       >
         <MessageSquare className="h-3 w-3" />
+      </button>
+      <button
+        onClick={(e) => {
+          e.stopPropagation();
+          onRequestUpdate();
+        }}
+        aria-label="Request status update"
+        title="Request status update"
+        className="rounded-sm p-1 text-text-3 opacity-0 transition-opacity hover:bg-bg-3 hover:text-accent group-hover:opacity-100"
+      >
+        <Send className="h-3 w-3" />
       </button>
       {task.due_date ? <DueChip date={task.due_date} /> : null}
       <PriorityDots priority={task.priority} />

--- a/apps/web/src/components/messages/MessagesInbox.tsx
+++ b/apps/web/src/components/messages/MessagesInbox.tsx
@@ -1,18 +1,26 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Send, Hash, User as UserIcon } from "lucide-react";
+import Link from "next/link";
+import { Send, Hash, User as UserIcon, Pin } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useRealtimeTable } from "@/lib/supabase/realtime";
 import { createClient } from "@/lib/supabase/client";
 
 interface ThreadSummary {
   id: string;
-  kind: "dm" | "terminal" | "space";
+  kind: "dm" | "terminal" | "space" | "group";
   label: string;
   last_message_at: string;
   href_ticker?: string | null;
   other_user_id?: string | null;
+}
+
+interface PingingTask {
+  id: string;
+  ticker_seq: number;
+  title: string;
+  ticker: string;
 }
 
 interface Message {
@@ -23,6 +31,8 @@ interface Message {
   created_at: string;
   edited_at: string | null;
   deleted_at: string | null;
+  pinging_task_id: string | null;
+  pinging_task: PingingTask | null;
 }
 
 /**
@@ -42,6 +52,14 @@ export function MessagesInbox() {
   const [draft, setDraft] = useState("");
   const [sending, setSending] = useState(false);
   const [meId, setMeId] = useState<string | null>(null);
+  /**
+   * Maps message_id → in-progress draft for the "Reply with status"
+   * inline composer attached to a `pinging_task_id` ping. Storing the
+   * open state alongside the draft text lets the user keep typing while
+   * other thread events stream in without losing what they wrote.
+   */
+  const [statusDrafts, setStatusDrafts] = useState<Record<string, string>>({});
+  const [statusSending, setStatusSending] = useState<string | null>(null);
   const scrollerRef = useRef<HTMLDivElement>(null);
 
   // Who am I?
@@ -131,6 +149,36 @@ export function MessagesInbox() {
     }
   }
 
+  /**
+   * Submit a reply to a "request update" ping. Hits the task's
+   * status-update endpoint, which both updates the latest_status_*
+   * columns AND echoes the reply into this thread (with `Status update:`
+   * prefix). Closes the inline composer on success.
+   */
+  async function submitStatusReply(messageId: string, taskId: string) {
+    const text = (statusDrafts[messageId] ?? "").trim();
+    if (!text || statusSending) return;
+    setStatusSending(messageId);
+    try {
+      const r = await fetch(`/api/v1/tasks/${taskId}/status-update`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({ text, post_to_thread: true }),
+      });
+      if (r.ok) {
+        setStatusDrafts((prev) => {
+          const next = { ...prev };
+          delete next[messageId];
+          return next;
+        });
+        if (activeId) await loadMessages(activeId);
+      }
+    } finally {
+      setStatusSending(null);
+    }
+  }
+
   const active = threads.find((t) => t.id === activeId) ?? null;
 
   return (
@@ -201,6 +249,9 @@ export function MessagesInbox() {
             <ul className="flex flex-col gap-2">
               {messages.map((m) => {
                 const mine = m.author_id === meId;
+                const ping = m.pinging_task;
+                const composerOpen = m.id in statusDrafts;
+                const isStatusEcho = m.body.startsWith("Status update:");
                 return (
                   <li
                     key={m.id}
@@ -209,10 +260,25 @@ export function MessagesInbox() {
                       mine ? "items-end" : "items-start",
                     )}
                   >
+                    {/* "📌 task" chip — shown for both the original ping
+                        AND the status echo so the connection stays
+                        legible as the thread grows. */}
+                    {ping ? (
+                      <Link
+                        href={`/p/${ping.ticker}/task/${ping.ticker_seq}`}
+                        className="mb-1 inline-flex max-w-[75%] items-center gap-1 truncate rounded-sm bg-bg-3 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wide text-text-2 hover:text-text-0"
+                      >
+                        <Pin className="h-2.5 w-2.5 flex-shrink-0" />
+                        <span className="truncate">
+                          {ping.ticker}-{ping.ticker_seq} · {ping.title}
+                        </span>
+                      </Link>
+                    ) : null}
                     <div
                       className={cn(
                         "max-w-[75%] rounded px-2 py-1 text-xs",
                         mine ? "bg-accent text-bg-0" : "bg-bg-2 text-text-0",
+                        isStatusEcho && !mine && "border border-accent/40",
                       )}
                     >
                       {m.body}
@@ -221,7 +287,82 @@ export function MessagesInbox() {
                       <span>{mine ? "you" : m.author_name}</span>
                       <span>·</span>
                       <span>{formatRelative(m.created_at)}</span>
+                      {/* "Reply with status" — only on the original ping
+                          (the status-update echo isn't itself replyable),
+                          and only when the viewer is NOT the requester
+                          (the requester sent the ping; replies come from
+                          assignees). */}
+                      {ping && !mine && !isStatusEcho ? (
+                        <>
+                          <span>·</span>
+                          <button
+                            type="button"
+                            onClick={() =>
+                              setStatusDrafts((prev) =>
+                                m.id in prev
+                                  ? (() => {
+                                      const next = { ...prev };
+                                      delete next[m.id];
+                                      return next;
+                                    })()
+                                  : { ...prev, [m.id]: "" },
+                              )
+                            }
+                            className="rounded-sm px-1 py-0.5 text-text-2 hover:bg-bg-3 hover:text-text-0"
+                          >
+                            {composerOpen ? "Cancel" : "Reply with status"}
+                          </button>
+                        </>
+                      ) : null}
                     </div>
+                    {ping && composerOpen ? (
+                      <form
+                        onSubmit={(e) => {
+                          e.preventDefault();
+                          void submitStatusReply(m.id, ping.id);
+                        }}
+                        className="mt-1 flex w-full max-w-[75%] flex-col gap-1 rounded border border-border bg-bg-1 p-1.5"
+                      >
+                        <textarea
+                          value={statusDrafts[m.id] ?? ""}
+                          onChange={(e) =>
+                            setStatusDrafts((prev) => ({
+                              ...prev,
+                              [m.id]: e.target.value,
+                            }))
+                          }
+                          onKeyDown={(e) => {
+                            if (
+                              e.key === "Enter" &&
+                              (e.metaKey || e.ctrlKey)
+                            ) {
+                              e.preventDefault();
+                              void submitStatusReply(m.id, ping.id);
+                            }
+                          }}
+                          rows={2}
+                          autoFocus
+                          placeholder={`Status of "${ping.title}"…`}
+                          className="resize-none rounded-sm border border-border bg-bg-0 px-2 py-1 text-xs text-text-0 outline-none focus:border-border-focus"
+                          disabled={statusSending === m.id}
+                        />
+                        <div className="flex justify-end gap-2">
+                          <span className="font-mono text-[10px] text-text-3">
+                            ⌘↵ to send
+                          </span>
+                          <button
+                            type="submit"
+                            disabled={
+                              !(statusDrafts[m.id] ?? "").trim() ||
+                              statusSending === m.id
+                            }
+                            className="flex items-center gap-1 rounded-sm bg-accent px-2 py-0.5 text-[11px] text-bg-0 disabled:opacity-40"
+                          >
+                            <Send className="h-2.5 w-2.5" /> Send status
+                          </button>
+                        </div>
+                      </form>
+                    ) : null}
                   </li>
                 );
               })}

--- a/supabase/migrations/20260507020000_task_status_updates_and_group_threads.sql
+++ b/supabase/migrations/20260507020000_task_status_updates_and_group_threads.sql
@@ -1,0 +1,70 @@
+-- Task "Request update" feature wiring.
+--
+-- Two coupled additions:
+--
+--   1. tasks gain a "latest status" pin — separate from comments.
+--      It's the most recent answer to "where are we on this?" and
+--      surfaces as a chip on the task row + in detail. Editable
+--      inline; preserved as a record (not cleared on `done`).
+--
+--   2. message_threads gains a `group` kind for multi-assignee
+--      pings. The schema already had `dm | terminal | space`; we
+--      add `group` so the request-update flow can create a thread
+--      with 3+ participants when a task has multiple assignees.
+--
+-- Plus: messages.pinging_task_id so the messenger UI can render a
+-- "📌 task" chip + "Reply with status" button on the ping, and so
+-- replies can be linked back to the task they're updating.
+--
+-- The thread re-uses across the task lifetime; on assignee change,
+-- the calling code syncs `thread_participants` to the new set of
+-- assignees + the requester.
+
+BEGIN;
+
+-- 1. Latest-status pin on tasks ---------------------------------------------
+
+ALTER TABLE tasks
+  ADD COLUMN IF NOT EXISTS latest_status_text TEXT,
+  ADD COLUMN IF NOT EXISTS latest_status_author_id UUID
+    REFERENCES auth.users(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS latest_status_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS status_thread_id UUID
+    REFERENCES message_threads(id) ON DELETE SET NULL;
+
+COMMENT ON COLUMN tasks.latest_status_text IS
+  'Most recent status update on the task — the answer to "what''s the latest?". Set via /api/v1/tasks/:id/status-update or inline edit. Preserved as a record across status transitions including done.';
+COMMENT ON COLUMN tasks.status_thread_id IS
+  'Persistent message_threads row for status pings/replies on this task. Created lazily on first request-update; participants are synced to assignees + requester whenever assignees change.';
+
+-- 2. message_threads kind: add 'group' ----------------------------------
+
+ALTER TABLE message_threads DROP CONSTRAINT IF EXISTS message_threads_kind_check;
+ALTER TABLE message_threads
+  ADD CONSTRAINT message_threads_kind_check
+  CHECK (kind IN ('dm', 'terminal', 'space', 'group'));
+
+-- The scope-check needs to allow group threads (no terminal_id, no
+-- space_id; participation is tracked in thread_participants only).
+ALTER TABLE message_threads DROP CONSTRAINT IF EXISTS message_threads_scope_ck;
+ALTER TABLE message_threads
+  ADD CONSTRAINT message_threads_scope_ck CHECK (
+    (kind = 'dm'       AND terminal_id IS NULL AND space_id IS NULL) OR
+    (kind = 'group'    AND terminal_id IS NULL AND space_id IS NULL) OR
+    (kind = 'terminal' AND terminal_id IS NOT NULL) OR
+    (kind = 'space'    AND space_id IS NOT NULL)
+  );
+
+-- 3. messages.pinging_task_id ----------------------------------
+
+ALTER TABLE messages
+  ADD COLUMN IF NOT EXISTS pinging_task_id UUID
+    REFERENCES tasks(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_messages_pinging_task
+  ON messages(pinging_task_id) WHERE pinging_task_id IS NOT NULL;
+
+COMMENT ON COLUMN messages.pinging_task_id IS
+  'When non-null, this message is a "request update" ping referencing the named task. Renders a 📌 chip + "Reply with status" button in the inbox.';
+
+COMMIT;


### PR DESCRIPTION
## Summary

Ships the "ping the assignee, get a status, pin it on the task" flow end-to-end.

- **TaskRow** gets a Send button to request a status update; the request creates/reuses a status thread (DM if 1 assignee, group if 2+) and notifies the assignees.
- **Latest status** is pinned on the task as an inline chip beneath the title — preserved across status transitions, including done.
- **MessagesInbox** renders a 📌 task chip on ping messages and a "Reply with status" inline composer (⌘↵ to send). Status echoes are visually distinguished with an accent border.
- **Group threads** (3+ participants) are now first-class in the inbox.

## Schema

`20260507020000_task_status_updates_and_group_threads` — already applied to prod:
- `tasks.latest_status_text` / `latest_status_author_id` / `latest_status_at` / `status_thread_id`
- `message_threads.kind` accepts `group`
- `messages.pinging_task_id` (FK + index)

## API

- `POST /api/v1/tasks/:id/request-update` — fans out the ping
- `POST /api/v1/tasks/:id/status-update` — updates latest_status_*, optionally echoes to thread

## Test plan
- [ ] Create a task, click the Send icon → assignee receives notification + DM (or group thread if multi-assignee)
- [ ] Assignee opens the DM, sees the 📌 chip linking to the task, clicks "Reply with status", types, sends
- [ ] Requester sees the reply in the thread (with accent border) and the chip on the task row updates
- [ ] Reassign task → next ping reuses the thread and syncs participants

🤖 Generated with [Claude Code](https://claude.com/claude-code)