### PR TITLE
feat(tasks): external (email) assignees (#12)

### DIFF
--- a/apps/web/src/app/api/v1/projects/[ticker]/tasks/route.ts
+++ b/apps/web/src/app/api/v1/projects/[ticker]/tasks/route.ts
@@ -45,7 +45,7 @@ async function handleGet(request: NextRequest, { params }: Props) {
   let query = supabase
     .from("tasks")
     .select(
-      "id, ticker_seq, title, description, status, priority, due_date, labels, position, latest_status_text, latest_status_author_id, latest_status_at, status_thread_id, created_at, updated_at, completed_at",
+      "id, ticker_seq, title, description, status, priority, due_date, labels, position, latest_status_text, latest_status_author_id, latest_status_at, status_thread_id, external_assignee_emails, created_at, updated_at, completed_at",
     )
     .eq("terminal_id", project.id);
 
@@ -77,6 +77,7 @@ async function handleGet(request: NextRequest, { params }: Props) {
     due_date: string | null;
     labels: string[] | null;
     position: number | null;
+    external_assignee_emails: string[] | null;
     created_at: string;
     updated_at: string;
     completed_at: string | null;
@@ -139,6 +140,7 @@ async function handleGet(request: NextRequest, { params }: Props) {
     subtask_total: subtaskTotals.get(t.id)?.total ?? 0,
     subtask_done: subtaskTotals.get(t.id)?.done ?? 0,
     assignees: assigneesByTask.get(t.id) ?? [],
+    external_assignee_emails: t.external_assignee_emails ?? [],
   }));
 
   return NextResponse.json({ data });
@@ -172,6 +174,12 @@ async function handlePost(request: NextRequest, { params }: Props) {
      * trg_tasks_default_assignee trigger.
      */
     assignee_ids?: string[];
+    /**
+     * External (not-yet-platform-user) email assignees. Stored on
+     * tasks.external_assignee_emails as a normalized text[]. The
+     * email-invite + reconcile flow runs server-side later.
+     */
+    external_assignee_emails?: string[];
   };
 
   if (!body.title?.trim()) return bad("title is required");
@@ -192,6 +200,14 @@ async function handlePost(request: NextRequest, { params }: Props) {
     rule = parsed;
   }
 
+  // Normalize external assignee emails: trim, lower-case, dedupe,
+  // reject anything obviously not an email. The DB column is
+  // NOT NULL DEFAULT '{}', so an empty list becomes the default.
+  const externalEmails = normalizeEmails(body.external_assignee_emails ?? []);
+  if (externalEmails === "invalid") {
+    return bad("external_assignee_emails contains an invalid address");
+  }
+
   const result = await supabase
     .from("tasks")
     // @ts-expect-error Phase 0 — Database<generic> inference collapses to never
@@ -206,6 +222,7 @@ async function handlePost(request: NextRequest, { params }: Props) {
       labels: body.tags ?? body.labels ?? [],
       status: body.status ?? "todo",
       recurrence_rule: rule,
+      external_assignee_emails: externalEmails,
       created_by: user.id,
     })
     .select(
@@ -275,6 +292,32 @@ async function handlePost(request: NextRequest, { params }: Props) {
   });
 
   return NextResponse.json({ data }, { status: 201 });
+}
+
+/**
+ * Normalize a caller-provided list of email addresses. Trims,
+ * lower-cases, dedupes, and validates the shape. Returns the
+ * canonical list, or the literal string "invalid" if any entry
+ * fails the basic shape check (which the API surfaces as a 400).
+ *
+ * Empty / whitespace-only entries are silently dropped so a UI
+ * with a stale chip can't accidentally poison the row.
+ */
+function normalizeEmails(input: unknown): string[] | "invalid" {
+  if (!Array.isArray(input)) return "invalid";
+  const out = new Set<string>();
+  // Permissive: anything with `<local>@<domain>.<tld>` and no spaces.
+  // The deeper validation (existence, deliverability) belongs in
+  // the invite email step, not here.
+  const re = /^[^@\s]+@[^@\s]+\.[^@\s]+$/;
+  for (const raw of input) {
+    if (typeof raw !== "string") continue;
+    const v = raw.trim().toLowerCase();
+    if (!v) continue;
+    if (!re.test(v)) return "invalid";
+    out.add(v);
+  }
+  return Array.from(out);
 }
 
 async function resolveProject(

--- a/apps/web/src/app/api/v1/tasks/[id]/route.ts
+++ b/apps/web/src/app/api/v1/tasks/[id]/route.ts
@@ -63,6 +63,13 @@ async function handlePatch(request: NextRequest, { params }: Props) {
     position?: number;
     recurrence_rule?: TaskRecurrenceRule | null;
     /**
+     * External (not-yet-platform-user) email assignees. Pass the
+     * full canonical list — server replaces the column wholesale,
+     * matching the way the user thinks of "set these emails" rather
+     * than "add/remove". Pass `[]` to clear.
+     */
+    external_assignee_emails?: string[];
+    /**
      * Optimistic-concurrency token. If supplied (either via this field or
      * the `If-Match` header) we 409 when the row's current `updated_at`
      * doesn't match what the client thought it was editing.
@@ -104,6 +111,13 @@ async function handlePatch(request: NextRequest, { params }: Props) {
   if (body.status !== undefined) {
     patch.status = body.status;
     patch.completed_at = body.status === "done" ? new Date().toISOString() : null;
+  }
+  if (body.external_assignee_emails !== undefined) {
+    const normalized = normalizeEmails(body.external_assignee_emails);
+    if (normalized === "invalid") {
+      return bad("external_assignee_emails contains an invalid address");
+    }
+    patch.external_assignee_emails = normalized;
   }
 
   if (Object.keys(patch).length === 0) return bad("no fields to update");
@@ -215,6 +229,26 @@ async function handleDelete(_request: NextRequest, { params }: Props) {
     });
 
   return new NextResponse(null, { status: 204 });
+}
+
+/**
+ * Normalize email assignee list — duplicate of the helper in the
+ * project tasks POST route. Keeping the duplication local rather
+ * than building a shared lib for a 12-line function until a third
+ * call site shows up.
+ */
+function normalizeEmails(input: unknown): string[] | "invalid" {
+  if (!Array.isArray(input)) return "invalid";
+  const out = new Set<string>();
+  const re = /^[^@\s]+@[^@\s]+\.[^@\s]+$/;
+  for (const raw of input) {
+    if (typeof raw !== "string") continue;
+    const v = raw.trim().toLowerCase();
+    if (!v) continue;
+    if (!re.test(v)) return "invalid";
+    out.add(v);
+  }
+  return Array.from(out);
 }
 
 function unauth() {

--- a/apps/web/src/components/QuickTaskDialog.tsx
+++ b/apps/web/src/components/QuickTaskDialog.tsx
@@ -111,6 +111,7 @@ export function QuickTaskDialog({
     due_date: string | null;
     labels: string[];
     assignee_ids: string[];
+    external_assignee_emails: string[];
   }) {
     if (!selectedTerminal) {
       throw new Error("Pick a terminal first");
@@ -128,6 +129,10 @@ export function QuickTaskDialog({
           labels: input.labels,
           assignee_ids:
             input.assignee_ids.length > 0 ? input.assignee_ids : undefined,
+          external_assignee_emails:
+            input.external_assignee_emails.length > 0
+              ? input.external_assignee_emails
+              : undefined,
         }),
       },
     );

--- a/apps/web/src/components/TaskComposer.tsx
+++ b/apps/web/src/components/TaskComposer.tsx
@@ -36,6 +36,11 @@ export interface TaskComposerSubmit {
   due_date: string | null;
   labels: string[];
   assignee_ids: string[];
+  /**
+   * Email-based assignees for people not (yet) on the platform.
+   * Server side these land on `tasks.external_assignee_emails`.
+   */
+  external_assignee_emails: string[];
 }
 
 interface TaskComposerProps {
@@ -48,6 +53,8 @@ interface TaskComposerProps {
   initialPriority?: number | null;
   /** Pre-fill assignees. */
   initialAssigneeIds?: string[];
+  /** Pre-fill external (email) assignees. */
+  initialExternalEmails?: string[];
   /**
    * Current viewer's user_id. When provided AND `initialAssigneeIds`
    * is empty, the composer auto-pre-populates the assignee chip
@@ -108,6 +115,7 @@ export function TaskComposer({
   members = [],
   initialPriority = null,
   initialAssigneeIds = [],
+  initialExternalEmails = [],
   currentUserId,
   initialLabels = [],
   variant = "inline",
@@ -132,6 +140,9 @@ export function TaskComposer({
     }
     return [];
   });
+  const [externalEmails, setExternalEmails] = useState<string[]>(
+    initialExternalEmails,
+  );
   const [labels, setLabels] = useState<string[]>(initialLabels);
   const [labelDraft, setLabelDraft] = useState("");
   const [showAssignees, setShowAssignees] = useState(false);
@@ -175,6 +186,7 @@ export function TaskComposer({
         due_date: dueIso,
         labels: labelsFinal,
         assignee_ids: assigneeIds,
+        external_assignee_emails: externalEmails,
       });
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to create");
@@ -234,16 +246,16 @@ export function TaskComposer({
           onChange={setDueIso}
           disabled={submitting}
         />
-        {members.length > 0 ? (
-          <AssigneeChip
-            members={members}
-            selected={assigneeIds}
-            open={showAssignees}
-            onToggleOpen={() => setShowAssignees((v) => !v)}
-            onChange={setAssigneeIds}
-            disabled={submitting}
-          />
-        ) : null}
+        <AssigneeChip
+          members={members}
+          selected={assigneeIds}
+          externalEmails={externalEmails}
+          open={showAssignees}
+          onToggleOpen={() => setShowAssignees((v) => !v)}
+          onChange={setAssigneeIds}
+          onChangeExternal={setExternalEmails}
+          disabled={submitting}
+        />
         <LabelsChip
           labels={labels}
           draft={labelDraft}
@@ -617,19 +629,25 @@ function DueChipPopover({
 function AssigneeChip({
   members,
   selected,
+  externalEmails,
   open,
   onToggleOpen,
   onChange,
+  onChangeExternal,
   disabled,
 }: {
   members: TaskComposerMember[];
   selected: string[];
+  externalEmails: string[];
   open: boolean;
   onToggleOpen: () => void;
   onChange: (ids: string[]) => void;
+  onChangeExternal: (emails: string[]) => void;
   disabled: boolean;
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
+  const [emailDraft, setEmailDraft] = useState("");
+  const [emailError, setEmailError] = useState<string | null>(null);
 
   // Click outside to close.
   useEffect(() => {
@@ -661,12 +679,31 @@ function AssigneeChip({
     );
   }
 
+  function commitEmail() {
+    const v = emailDraft.trim().toLowerCase();
+    if (!v) return;
+    const re = /^[^@\s]+@[^@\s]+\.[^@\s]+$/;
+    if (!re.test(v)) {
+      setEmailError("Not a valid email");
+      return;
+    }
+    if (externalEmails.includes(v)) {
+      setEmailDraft("");
+      setEmailError(null);
+      return;
+    }
+    onChangeExternal([...externalEmails, v]);
+    setEmailDraft("");
+    setEmailError(null);
+  }
+
+  const totalCount = selected.length + externalEmails.length;
   const label =
-    selected.length === 0
+    totalCount === 0
       ? "Assign"
-      : selected.length === 1
-        ? (selectedNames[0] ?? "1 assigned")
-        : `${selected.length} assigned`;
+      : totalCount === 1
+        ? (selectedNames[0] ?? externalEmails[0] ?? "1 assigned")
+        : `${totalCount} assigned`;
 
   return (
     <div ref={containerRef} className="relative">
@@ -679,49 +716,118 @@ function AssigneeChip({
         aria-expanded={open}
         className={cn(
           "flex items-center gap-1 rounded-sm border bg-bg-2 px-2 py-1 text-[11px] text-text-1 hover:bg-bg-3",
-          selected.length > 0 ? "border-accent/40" : "border-border",
+          totalCount > 0 ? "border-accent/40" : "border-border",
         )}
       >
         <UserPlus className="h-3 w-3 text-text-3" aria-hidden="true" />
-        <span className="max-w-[120px] truncate">{label}</span>
+        <span className="max-w-[140px] truncate">{label}</span>
       </button>
       {open ? (
         <div
           role="menu"
-          className="absolute left-0 top-full z-50 mt-1 max-h-60 w-56 overflow-y-auto rounded-sm border border-border bg-bg-1 py-1 shadow-lg"
+          className="absolute left-0 top-full z-50 mt-1 w-64 overflow-hidden rounded-sm border border-border bg-bg-1 py-1 shadow-lg"
         >
-          {members.length === 0 ? (
-            <p className="px-3 py-2 text-xs text-text-3">No members yet.</p>
-          ) : (
-            members.map((m) => {
-              const checked = selected.includes(m.user_id);
-              return (
-                <button
-                  key={m.user_id}
-                  role="menuitem"
-                  type="button"
-                  onClick={() => toggle(m.user_id)}
-                  className={cn(
-                    "flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs hover:bg-bg-2",
-                    checked && "bg-bg-2 text-text-0",
-                  )}
-                >
-                  <span
+          <div className="max-h-44 overflow-y-auto">
+            {members.length === 0 ? (
+              <p className="px-3 py-2 text-xs text-text-3">No members yet.</p>
+            ) : (
+              members.map((m) => {
+                const checked = selected.includes(m.user_id);
+                return (
+                  <button
+                    key={m.user_id}
+                    role="menuitem"
+                    type="button"
+                    onClick={() => toggle(m.user_id)}
                     className={cn(
-                      "h-3 w-3 flex-shrink-0 rounded-sm border",
-                      checked
-                        ? "border-accent bg-accent"
-                        : "border-border bg-bg-0",
+                      "flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs hover:bg-bg-2",
+                      checked && "bg-bg-2 text-text-0",
                     )}
-                    aria-hidden="true"
-                  />
-                  <span className="flex-1 truncate text-text-1">
-                    {m.full_name ?? "—"}
-                  </span>
-                </button>
-              );
-            })
-          )}
+                  >
+                    <span
+                      className={cn(
+                        "h-3 w-3 flex-shrink-0 rounded-sm border",
+                        checked
+                          ? "border-accent bg-accent"
+                          : "border-border bg-bg-0",
+                      )}
+                      aria-hidden="true"
+                    />
+                    <span className="flex-1 truncate text-text-1">
+                      {m.full_name ?? "—"}
+                    </span>
+                  </button>
+                );
+              })
+            )}
+          </div>
+          {externalEmails.length > 0 ? (
+            <div className="border-t border-border px-2 py-1.5">
+              <p className="mb-1 text-[10px] font-semibold uppercase tracking-wide text-text-3">
+                External (by email)
+              </p>
+              <ul className="flex flex-wrap gap-1">
+                {externalEmails.map((email) => (
+                  <li
+                    key={email}
+                    className="flex items-center gap-1 rounded-sm bg-bg-3 px-1.5 py-0.5 font-mono text-[10px] text-text-1"
+                  >
+                    <span className="truncate max-w-[160px]">{email}</span>
+                    <button
+                      type="button"
+                      onClick={() =>
+                        onChangeExternal(
+                          externalEmails.filter((x) => x !== email),
+                        )
+                      }
+                      aria-label={`Remove ${email}`}
+                      className="text-text-3 hover:text-text-0"
+                    >
+                      <X className="h-2.5 w-2.5" aria-hidden="true" />
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+          <div className="border-t border-border px-2 py-1.5">
+            <label
+              htmlFor="ext-email-input"
+              className="mb-1 block text-[10px] font-semibold uppercase tracking-wide text-text-3"
+            >
+              Add by email
+            </label>
+            <input
+              id="ext-email-input"
+              type="email"
+              autoComplete="off"
+              spellCheck={false}
+              value={emailDraft}
+              onChange={(e) => {
+                setEmailDraft(e.target.value);
+                if (emailError) setEmailError(null);
+              }}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === ",") {
+                  e.preventDefault();
+                  commitEmail();
+                }
+              }}
+              onBlur={() => {
+                if (emailDraft.trim()) commitEmail();
+              }}
+              placeholder="vendor@example.com"
+              aria-label="External assignee email"
+              className="h-7 w-full rounded-sm border border-border bg-bg-0 px-2 text-[11px] text-text-0 placeholder:text-text-3 focus:border-border-focus focus:outline-none"
+            />
+            {emailError ? (
+              <p className="mt-1 text-[10px] text-danger">{emailError}</p>
+            ) : (
+              <p className="mt-1 text-[10px] text-text-3">
+                They&rsquo;ll be invited when they sign up.
+              </p>
+            )}
+          </div>
         </div>
       ) : null}
     </div>

--- a/apps/web/src/components/TasksPane.tsx
+++ b/apps/web/src/components/TasksPane.tsx
@@ -46,6 +46,7 @@ interface Task {
   latest_status_author_id?: string | null;
   latest_status_at?: string | null;
   assignees?: TaskAssignee[];
+  external_assignee_emails?: string[];
   /**
    * Sparse-integer manual-sort position. May be null for legacy rows
    * created before the column existed; the GET endpoint coerces NULLs
@@ -526,6 +527,7 @@ export function TasksPane({ ticker, projectId, currentUserId }: TasksPaneProps) 
     due_date: string | null;
     labels: string[];
     assignee_ids: string[];
+    external_assignee_emails: string[];
   }) {
     const r = await offlineFetch(`/api/v1/projects/${ticker}/tasks`, {
       method: "POST",
@@ -537,6 +539,10 @@ export function TasksPane({ ticker, projectId, currentUserId }: TasksPaneProps) 
         labels: input.labels,
         assignee_ids:
           input.assignee_ids.length > 0 ? input.assignee_ids : undefined,
+        external_assignee_emails:
+          input.external_assignee_emails.length > 0
+            ? input.external_assignee_emails
+            : undefined,
       }),
       label: `Create task: ${input.title}`,
     });
@@ -831,6 +837,11 @@ function TaskRow({
   const subtaskTotal = task.subtask_total ?? 0;
   const subtaskDone = task.subtask_done ?? 0;
   const status = task.latest_status_text?.trim() ?? "";
+  const externalCount = task.external_assignee_emails?.length ?? 0;
+  const externalEmailsTitle =
+    externalCount > 0
+      ? `External assignees: ${task.external_assignee_emails!.join(", ")}`
+      : "";
 
   return (
     <div
@@ -921,6 +932,14 @@ function TaskRow({
           title={`${subtaskDone} of ${subtaskTotal} subtasks done`}
         >
           {subtaskDone}/{subtaskTotal}
+        </span>
+      ) : null}
+      {externalCount > 0 ? (
+        <span
+          className="flex-shrink-0 rounded-sm border border-border bg-bg-2 px-1 font-mono text-[10px] uppercase tracking-wide text-text-2"
+          title={externalEmailsTitle}
+        >
+          @+{externalCount}
         </span>
       ) : null}
       <Link

--- a/supabase/migrations/20260507030000_external_assignees.sql
+++ b/supabase/migrations/20260507030000_external_assignees.sql
@@ -1,0 +1,34 @@
+-- External assignees for tasks.
+--
+-- Until now task_assignees has only handled platform users (FK to
+-- auth.users). Real-life delegation is messier — Zack often delegates
+-- to vendors, lawyers, contractors who aren't in the workspace yet.
+-- We model them as plain email addresses on the task itself; once
+-- they sign up and get matched against the email, the row migrates
+-- to a real task_assignees entry.
+--
+-- v0 trade-off: we use a `text[]` column on tasks rather than a new
+-- table. Pros: no new RLS policies, no new indexes, "show me a
+-- task's assignees" is one row read. Cons: querying "tasks
+-- assigned to email X" requires an array-contains scan (acceptable
+-- at our scale; future-proof with a GIN if we ever go big).
+
+BEGIN;
+
+ALTER TABLE tasks
+  ADD COLUMN IF NOT EXISTS external_assignee_emails TEXT[]
+    NOT NULL DEFAULT ARRAY[]::TEXT[];
+
+COMMENT ON COLUMN tasks.external_assignee_emails IS
+  'Email addresses the task is delegated to that don''t (yet) belong to a platform user. When a matching user signs up, server-side reconciliation moves them into task_assignees and clears the email from this list.';
+
+-- Email shape validation lives at the API layer (lower-cased,
+-- duplicated entries collapsed, basic regex). A DB CHECK with a
+-- subquery is not portable; we trust the gate above the row write.
+
+-- GIN index makes "find tasks for this email" cheap once we wire up
+-- the reconcile job. Free for the array-contains lookups we'd run.
+CREATE INDEX IF NOT EXISTS idx_tasks_external_assignee_emails
+  ON tasks USING gin (external_assignee_emails);
+
+COMMIT;


### PR DESCRIPTION
## Summary

Lets users delegate tasks to people who aren't on the platform yet. Vendors, contractors, lawyers — get a slot on the task without going through a formal invite first.

- **DB**: `tasks.external_assignee_emails text[]` (GIN-indexed). Migration applied to prod.
- **API**: Both create + PATCH accept `external_assignee_emails`. Server normalizes (trim, lowercase, dedupe) + validates shape.
- **UI**: TaskComposer's Assignee chip gets an "Add by email" input. TaskRow renders an `@+N` badge with the email list as a tooltip.

The actual email-invite + reconcile flow (when a matching user signs up, move them into `task_assignees` and clear the email) lands in a follow-up PR — unblocked by this one.

## Test plan
- [ ] Open a task composer → Assign chip → type a vendor email → Enter → email appears as a chip in the popover
- [ ] Submit → API accepts → row appears in the list with the `@+1` badge
- [ ] Hover the badge → tooltip shows the email
- [ ] PATCH a task to add/remove emails → list updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)