### PR TITLE
perf: preconnect Supabase + lazy-load CommentThread

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -93,6 +93,24 @@ export default function RootLayout({
       suppressHydrationWarning
     >
       <head>
+        {/* Cut latency on the first API roundtrip. Browsers open a TCP
+            handshake + TLS session against Supabase the moment the
+            HTML lands, so by the time React hydrates and dispatches
+            its first `supabase.from(...)` the connection is already
+            warm. ~100-300ms saved on cold visits. */}
+        {process.env.NEXT_PUBLIC_SUPABASE_URL ? (
+          <>
+            <link
+              rel="preconnect"
+              href={process.env.NEXT_PUBLIC_SUPABASE_URL}
+              crossOrigin="anonymous"
+            />
+            <link
+              rel="dns-prefetch"
+              href={process.env.NEXT_PUBLIC_SUPABASE_URL}
+            />
+          </>
+        ) : null}
         {/* Paint pure black before the CSS file even arrives. Without
             this the browser shows a flash of default white on cold
             loads — especially noticeable on cross-page navigations

--- a/apps/web/src/components/TasksPane.tsx
+++ b/apps/web/src/components/TasksPane.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
+import dynamic from "next/dynamic";
 import Link from "next/link";
 import {
   ChevronDown,
@@ -17,7 +18,13 @@ import { EmptyState } from "./EmptyState";
 import { useRealtimeTable } from "@/lib/supabase/realtime";
 import { useRegisterCommands } from "@/lib/use-register-commands";
 import { offlineFetch } from "@/lib/offline-fetch";
-import { CommentThread } from "./CommentThread";
+// CommentThread is opened on demand (the user clicks the comment icon
+// or hits `;`). Code-splitting it out trims the TasksPane bundle so
+// the list renders sooner on first paint.
+const CommentThread = dynamic(
+  () => import("./CommentThread").then((m) => ({ default: m.CommentThread })),
+  { ssr: false },
+);
 import { TaskComposer, type TaskComposerMember } from "./TaskComposer";
 import { SubtasksList, type Subtask } from "./SubtasksList";
 import {


### PR DESCRIPTION
## Summary

Two no-architectural-change perf wins.

1. **Preconnect Supabase** — emits `<link rel=preconnect>` and `<link rel=dns-prefetch>` for the Supabase URL in the layout `<head>`, so browsers open the TCP/TLS handshake against the API domain the moment the HTML lands. The first user-triggered API call then lands on a warm connection — saves ~100-300ms on cold visits, especially over hotel/mobile networks.

2. **Lazy-load CommentThread** — `CommentThread` only renders after the user clicks the comment icon (or hits `;`). Code-splitting it out of `TasksPane` via `next/dynamic` removes its bundle from the initial JS download. Compounds with all the other features that landed in `TasksPane` this week (group-by, status pin, request-update, etc.).

## Test plan
- [ ] Open DevTools → Network → reload dashboard → confirm preconnect to Supabase URL fires before any XHR
- [ ] Open a terminal → confirm initial bundle is smaller (Network → JS column)
- [ ] Click the comment icon on a task → CommentThread loads dynamically; works the same
- [ ] No regressions on offline / SW behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)