### PR TITLE
feat(messages): reminders channel (#11)

### DIFF
--- a/apps/web/src/app/api/v1/messages/threads/route.ts
+++ b/apps/web/src/app/api/v1/messages/threads/route.ts
@@ -31,7 +31,7 @@ export async function GET() {
     last_read_at: string | null;
     message_threads: {
       id: string;
-      kind: "dm" | "terminal" | "space" | "group";
+      kind: "dm" | "terminal" | "space" | "group" | "reminders";
       terminal_id: string | null;
       space_id: string | null;
       last_message_at: string;
@@ -49,7 +49,7 @@ export async function GET() {
     .in("kind", ["terminal", "space"]);
   type TT = {
     id: string;
-    kind: "dm" | "terminal" | "space" | "group";
+    kind: "dm" | "terminal" | "space" | "group" | "reminders";
     terminal_id: string | null;
     space_id: string | null;
     last_message_at: string;
@@ -158,6 +158,14 @@ export async function GET() {
         id: t.id,
         kind: t.kind,
         label: sp ? `#lobby · ${sp.name}` : "#lobby",
+        last_message_at: t.last_message_at,
+      };
+    }
+    if (t.kind === "reminders") {
+      return {
+        id: t.id,
+        kind: t.kind,
+        label: "Reminders",
         last_message_at: t.last_message_at,
       };
     }

--- a/apps/web/src/app/api/v1/reminders/refresh/route.ts
+++ b/apps/web/src/app/api/v1/reminders/refresh/route.ts
@@ -1,0 +1,185 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { createClient as createAdminClient } from "@supabase/supabase-js";
+import { createClient } from "@/lib/supabase/server";
+import { withObservability } from "@/lib/observability";
+import type { Database } from "@rokki/db";
+
+/**
+ * POST /api/v1/reminders/refresh
+ *
+ * Refreshes the caller's personal reminders thread.
+ *
+ *   1. Looks up (or lazily creates) a `kind='reminders'` thread that
+ *      has the caller as the sole participant.
+ *   2. Computes the user's "what's waiting on me today?" set:
+ *        - Overdue open tasks (due_date < today, status != 'done')
+ *        - Due-today open tasks
+ *      The horizon is intentionally tight — if we widen to 7d the
+ *      thread becomes a wall of stale dread instead of a triage
+ *      surface.
+ *   3. For each task in the set that doesn't already have a reminder
+ *      in the thread within the last 24h, inserts a message with
+ *      `pinging_task_id` so the inbox renders a deep-link chip.
+ *
+ * Idempotent: calling twice in rapid succession is a no-op (the 24h
+ * dedupe gate). Cron worker eventually owns the schedule; for now
+ * the UI button + manual API call cover the cycle.
+ *
+ * Response:
+ *   { data: { thread_id, posted: number, skipped: number } }
+ */
+async function handlePost(_req: NextRequest) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return unauth();
+
+  const admin = createAdminClient<Database>(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    { auth: { autoRefreshToken: false, persistSession: false } },
+  );
+
+  // 1. Find or create the user's reminders thread.
+  let threadId: string | null = null;
+  const { data: existingThreads } = await admin
+    .from("thread_participants")
+    .select(
+      "thread_id, message_threads!thread_participants_thread_id_fkey(id, kind)",
+    )
+    .eq("user_id", user.id);
+  type Row = {
+    thread_id: string;
+    message_threads: { id: string; kind: string } | null;
+  };
+  for (const r of (existingThreads ?? []) as unknown as Row[]) {
+    if (r.message_threads?.kind === "reminders") {
+      threadId = r.thread_id;
+      break;
+    }
+  }
+  if (!threadId) {
+    const { data: newThread, error: tErr } = await admin
+      .from("message_threads")
+      .insert({ kind: "reminders" } as never)
+      .select("id")
+      .single();
+    if (tErr || !newThread) {
+      return internal(tErr?.message ?? "thread create failed");
+    }
+    threadId = (newThread as { id: string }).id;
+    await admin
+      .from("thread_participants")
+      .insert({ thread_id: threadId, user_id: user.id } as never);
+  }
+
+  // 2. Compute the user's overdue + due-today open tasks. RLS via the
+  //    user's supabase client — admins of nothing are fine; the
+  //    join through task_assignees is what we filter on.
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const tomorrow = new Date(today);
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  const todayIso = today.toISOString().slice(0, 10);
+  const tomorrowIso = tomorrow.toISOString().slice(0, 10);
+
+  const { data: tasksRows } = await supabase
+    .from("task_assignees")
+    .select(
+      "tasks!task_assignees_task_id_fkey(id, title, status, due_date, terminal_id, ticker_seq)",
+    )
+    .eq("user_id", user.id);
+
+  type AssignedRow = {
+    tasks: {
+      id: string;
+      title: string;
+      status: string;
+      due_date: string | null;
+      terminal_id: string;
+      ticker_seq: number;
+    } | null;
+  };
+  const assigned = ((tasksRows ?? []) as unknown as AssignedRow[])
+    .map((r) => r.tasks)
+    .filter((t): t is NonNullable<AssignedRow["tasks"]> => !!t)
+    .filter((t) => t.status !== "done")
+    .filter(
+      (t) =>
+        t.due_date &&
+        t.due_date < tomorrowIso, // overdue OR due today
+    );
+
+  // 3. Look up the caller's recent reminder messages so we don't
+  //    spam the same task twice in 24h. `pinging_task_id` keys the
+  //    dedupe — the same row can be reminded again tomorrow once
+  //    the 24h window slides past.
+  const cutoff = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+  const { data: recentMsgs } = await admin
+    .from("messages")
+    .select("pinging_task_id, created_at")
+    .eq("thread_id", threadId)
+    .gte("created_at", cutoff);
+  type RecentRow = { pinging_task_id: string | null; created_at: string };
+  // @rokki/db types lag the latest migration — `pinging_task_id`
+  // exists in prod but the generated types haven't been regenerated.
+  // Round-trip through unknown to drop the synthesised SelectQueryError.
+  const recentTaskIds = new Set(
+    ((recentMsgs ?? []) as unknown as RecentRow[])
+      .map((r) => r.pinging_task_id)
+      .filter((x): x is string => !!x),
+  );
+
+  let posted = 0;
+  let skipped = 0;
+  for (const t of assigned) {
+    if (recentTaskIds.has(t.id)) {
+      skipped += 1;
+      continue;
+    }
+    const overdue = (t.due_date ?? "") < todayIso;
+    const body = overdue
+      ? `Overdue: "${t.title}" — was due ${t.due_date ?? "?"}`
+      : `Due today: "${t.title}"`;
+    await admin
+      .from("messages")
+      .insert({
+        thread_id: threadId,
+        author_id: user.id,
+        body,
+        pinging_task_id: t.id,
+      } as never);
+    posted += 1;
+  }
+
+  if (posted > 0) {
+    await admin
+      .from("message_threads")
+      .update({ last_message_at: new Date().toISOString() } as never)
+      .eq("id", threadId);
+  }
+
+  return NextResponse.json(
+    { data: { thread_id: threadId, posted, skipped } },
+    { status: 200 },
+  );
+}
+
+function unauth() {
+  return NextResponse.json(
+    { errors: [{ code: "unauthenticated", message: "Sign in required" }] },
+    { status: 401 },
+  );
+}
+function internal(msg: string) {
+  return NextResponse.json(
+    { errors: [{ code: "internal_error", message: msg }] },
+    { status: 500 },
+  );
+}
+
+export const POST = withObservability(
+  handlePost,
+  "POST /api/v1/reminders/refresh",
+);

--- a/apps/web/src/components/messages/MessagesInbox.tsx
+++ b/apps/web/src/components/messages/MessagesInbox.tsx
@@ -2,14 +2,14 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import Link from "next/link";
-import { Send, Hash, User as UserIcon, Pin } from "lucide-react";
+import { Send, Hash, User as UserIcon, Pin, Bell, RefreshCw } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useRealtimeTable } from "@/lib/supabase/realtime";
 import { createClient } from "@/lib/supabase/client";
 
 interface ThreadSummary {
   id: string;
-  kind: "dm" | "terminal" | "space" | "group";
+  kind: "dm" | "terminal" | "space" | "group" | "reminders";
   label: string;
   last_message_at: string;
   href_ticker?: string | null;
@@ -60,6 +60,7 @@ export function MessagesInbox() {
    */
   const [statusDrafts, setStatusDrafts] = useState<Record<string, string>>({});
   const [statusSending, setStatusSending] = useState<string | null>(null);
+  const [refreshingReminders, setRefreshingReminders] = useState(false);
   const scrollerRef = useRef<HTMLDivElement>(null);
 
   // Who am I?
@@ -150,6 +151,33 @@ export function MessagesInbox() {
   }
 
   /**
+   * Refresh the reminders thread — server scans the user's open
+   * tasks for overdue / due-today and posts new pinging messages.
+   * Idempotent (24h dedupe per task on the server). After refresh
+   * we reload the active thread and the thread list so any new
+   * messages + last_message_at bump show up immediately.
+   */
+  async function refreshReminders() {
+    if (refreshingReminders) return;
+    setRefreshingReminders(true);
+    try {
+      const r = await fetch("/api/v1/reminders/refresh", {
+        method: "POST",
+        credentials: "include",
+      });
+      if (r.ok) {
+        // Threads first so the new reminders thread (if first
+        // refresh) appears in the sidebar; then messages so the
+        // active thread refreshes if it was already selected.
+        await loadThreads();
+        if (activeId) await loadMessages(activeId);
+      }
+    } finally {
+      setRefreshingReminders(false);
+    }
+  }
+
+  /**
    * Submit a reply to a "request update" ping. Hits the task's
    * status-update endpoint, which both updates the latest_status_*
    * columns AND echoes the reply into this thread (with `Status update:`
@@ -189,6 +217,26 @@ export function MessagesInbox() {
             Conversations
           </span>
         </header>
+        {/* Reminders CTA — shows once until the user enables it; the
+            refresh endpoint creates the thread + posts pings for the
+            user's overdue / due-today tasks. After first run the
+            thread surfaces in the list below and this banner clears. */}
+        {!threads.some((t) => t.kind === "reminders") ? (
+          <button
+            type="button"
+            onClick={refreshReminders}
+            disabled={refreshingReminders}
+            className="flex w-full items-center gap-2 border-b border-border bg-bg-2 px-3 py-2 text-left text-xs text-text-1 hover:bg-bg-3 disabled:opacity-50"
+          >
+            <Bell className="h-3 w-3 flex-shrink-0 text-accent" />
+            <span className="flex-1">
+              {refreshingReminders
+                ? "Setting up reminders…"
+                : "Turn on Reminders"}
+            </span>
+            <span className="font-mono text-[10px] text-text-3">+</span>
+          </button>
+        ) : null}
         <ul className="overflow-y-auto">
           {threads.length === 0 ? (
             <li className="px-3 py-6 text-center text-xs text-text-3">
@@ -206,6 +254,8 @@ export function MessagesInbox() {
                 >
                   {t.kind === "terminal" ? (
                     <Hash className="h-3 w-3 flex-shrink-0 text-text-3" />
+                  ) : t.kind === "reminders" ? (
+                    <Bell className="h-3 w-3 flex-shrink-0 text-accent" />
                   ) : (
                     <UserIcon className="h-3 w-3 flex-shrink-0 text-text-3" />
                   )}
@@ -226,10 +276,29 @@ export function MessagesInbox() {
             <>
               {active.kind === "terminal" ? (
                 <Hash className="h-3 w-3 text-text-3" />
+              ) : active.kind === "reminders" ? (
+                <Bell className="h-3 w-3 text-accent" />
               ) : (
                 <UserIcon className="h-3 w-3 text-text-3" />
               )}
               <span className="text-xs text-text-1">{active.label}</span>
+              {active.kind === "reminders" ? (
+                <button
+                  type="button"
+                  onClick={refreshReminders}
+                  disabled={refreshingReminders}
+                  title="Scan for new overdue / due-today tasks"
+                  className="ml-auto flex items-center gap-1 rounded-sm border border-border px-2 py-0.5 text-[10px] uppercase tracking-wide text-text-2 hover:border-accent/40 hover:text-text-0 disabled:opacity-50"
+                >
+                  <RefreshCw
+                    className={cn(
+                      "h-2.5 w-2.5",
+                      refreshingReminders && "animate-spin",
+                    )}
+                  />
+                  {refreshingReminders ? "Refreshing…" : "Refresh"}
+                </button>
+              ) : null}
             </>
           ) : (
             <span className="text-xs text-text-3">Select a conversation</span>

--- a/supabase/migrations/20260507040000_reminders_channel.sql
+++ b/supabase/migrations/20260507040000_reminders_channel.sql
@@ -1,0 +1,37 @@
+-- Reminders message channel.
+--
+-- A new `kind = 'reminders'` for message_threads. Each user gets at
+-- most one reminders thread of their own — Rokki posts due-soon /
+-- overdue task pings into it so the messenger inbox carries the
+-- "what do I owe today?" workflow alongside the conversational
+-- threads. Eventually a cron worker pushes daily updates; for v0
+-- the user (or the API) triggers refresh on demand.
+--
+-- Why a thread rather than email or a separate "reminders" page:
+--   - Messenger is already the place users glance at for "what's
+--     waiting on me?" — adding email is a new product surface
+--     they'd have to build a habit around.
+--   - Pings carry `pinging_task_id` so each reminder is a one-click
+--     deep link back to the task.
+
+BEGIN;
+
+ALTER TABLE message_threads DROP CONSTRAINT IF EXISTS message_threads_kind_check;
+ALTER TABLE message_threads
+  ADD CONSTRAINT message_threads_kind_check
+  CHECK (kind IN ('dm', 'terminal', 'space', 'group', 'reminders'));
+
+-- Reminders threads are private to a single user (the only
+-- participant). They have no terminal_id or space_id (the cross-
+-- terminal "give me everything" shape is the whole point).
+ALTER TABLE message_threads DROP CONSTRAINT IF EXISTS message_threads_scope_ck;
+ALTER TABLE message_threads
+  ADD CONSTRAINT message_threads_scope_ck CHECK (
+    (kind = 'dm'        AND terminal_id IS NULL AND space_id IS NULL) OR
+    (kind = 'group'     AND terminal_id IS NULL AND space_id IS NULL) OR
+    (kind = 'reminders' AND terminal_id IS NULL AND space_id IS NULL) OR
+    (kind = 'terminal'  AND terminal_id IS NOT NULL) OR
+    (kind = 'space'     AND space_id IS NOT NULL)
+  );
+
+COMMIT;


### PR DESCRIPTION
## Summary

Each user gets a personal **Reminders** thread in the messenger. Rokki posts pings into it for tasks that are overdue or due today, with the 📌 chip + "Reply with status" affordance shipped in #114 wired up automatically.

- **DB**: new `kind='reminders'` thread type. Migration applied to prod.
- **API**: `POST /api/v1/reminders/refresh` — lazy-creates the thread, computes overdue + due-today open tasks, posts a message per task that hasn't been reminded in the past 24h. Idempotent; cron-safe.
- **UI**: "Turn on Reminders" CTA at the top of the conversation list when no thread exists. Once the thread is in place it shows up in the list with a Bell icon and the conversation header has a Refresh button.

A daily cron worker is the obvious follow-up — the endpoint is already shaped for it (24h per-task dedupe).

## Test plan
- [ ] Open /messages with at least one overdue or due-today task assigned to me → "Turn on Reminders" CTA visible
- [ ] Click → CTA disappears, "Reminders" thread appears in the list with a Bell, the bell-conversation has a "Refresh" button and a message per task with a 📌 chip
- [ ] Click the chip → deep-links to the task
- [ ] Hit Refresh again immediately → no duplicate messages (24h dedupe)

🤖 Generated with [Claude Code](https://claude.com/claude-code)