### PR TITLE
fix(ticker): undefined tip slot crashes dashboard at 10+ activity rows

### DIFF
--- a/apps/web/src/components/TickerTape.tsx
+++ b/apps/web/src/components/TickerTape.tsx
@@ -222,7 +222,16 @@ function withToolTips(items: TickerItem[]): TickerItem[] {
   const out: TickerItem[] = [];
   items.forEach((it, idx) => {
     out.push(it);
-    if ((idx + 1) % 10 === 0) out.push(tips[(idx / 10) % tips.length]);
+    // Every 10th item, sprinkle a tip. Use Math.floor so we land on
+    // an integer array index — `(idx / 10) % 3` evaluates to 0.9,
+    // 1.9, 2.9 at idx=9,19,29, and `tips[0.9]` is `undefined`. Once
+    // the activity stream crosses 10 rows, that undefined gets
+    // pushed into the ticker and the renderer trips on `item.id`,
+    // which is what the recent dashboard 500s were.
+    if ((idx + 1) % 10 === 0) {
+      const tip = tips[Math.floor(idx / 10) % tips.length];
+      if (tip) out.push(tip);
+    }
   });
   return out;
 }


### PR DESCRIPTION
## Summary

Fixes the production HTTP 500 on the dashboard — the cause Zack hit just now.

`withToolTips` in TickerTape was using a non-integer array index:

\`\`\`ts
out.push(tips[(idx / 10) % tips.length]);  // (9/10) % 3 === 0.9 → tips[0.9] === undefined
\`\`\`

At idx=9,19,29… we pushed \`undefined\` into the ticker stream. The renderer then read \`item.id\` on \`undefined\`, which threw a TypeError that escaped to the route error boundary and blanked the entire dashboard.

Latent since the tips array was first added — only manifested today because the activity stream finally crossed 10 rows.

## Fix

\`\`\`ts
const tip = tips[Math.floor(idx / 10) % tips.length];
if (tip) out.push(tip);
\`\`\`

`Math.floor` snaps to an integer index. The `if (tip)` guard makes the function defensive against any future shape change.

## Test plan
- [ ] Dashboard loads without 500 once deployed
- [ ] Tips still appear at every 10th slot in the ticker
- [ ] No regressions on the per-terminal ticker (`projectId` variant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)