### PR TITLE
fix(theme): SSR-aware theme via cookie — kills white-then-dark flash + fixes space-page paint

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata, Viewport } from "next";
+import { cookies } from "next/headers";
 import { GeistSans } from "geist/font/sans";
 import { GeistMono } from "geist/font/mono";
 import { Newsreader } from "next/font/google";
@@ -70,26 +71,47 @@ export const viewport: Viewport = {
   viewportFit: "cover",
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  // Read theme + density from cookies at SSR time so the rendered HTML
+  // already carries the correct `data-theme` / `data-density` from the
+  // first byte. This is what kills the white-flash-then-dark on cold
+  // load: previously the server emitted no `data-theme`, the browser
+  // painted using the CSS-variable default, and the bootstrap script
+  // only set the attribute after parsing its own tag. For users with
+  // OS-level light preference + saved dark theme, the gap was
+  // perceptible — Zack reported it as "loads in white, then turns
+  // dark." Cookies are read at request time so navigation between
+  // routes also paints the correct theme without needing client JS.
+  //
+  // The bootstrap script below is kept as a fallback for users who
+  // don't yet have the cookie (first visit), and to reconcile against
+  // localStorage if the cookie was cleared but localStorage wasn't.
+  const cookieStore = await cookies();
+  const themeCookie = cookieStore.get("rokki_theme")?.value;
+  const densityCookie = cookieStore.get("rokki_density")?.value;
+  const resolvedTheme: "dark" | "light" =
+    themeCookie === "light" ? "light" : "dark";
+  const resolvedDensity: "cozy" | "compact" =
+    densityCookie === "compact" ? "compact" : "cozy";
+
   return (
-    // No `data-theme` on <html> here. The bootstrap script in <head>
-    // owns that attribute — it reads localStorage before first paint
-    // and assigns "light", "dark", or the resolved system preference.
-    // Putting `data-theme="dark"` in JSX caused React to silently
-    // overwrite the script's value back to dark on subsequent
-    // renders, which is what manifested as "the page keeps flipping
-    // back to dark even though I set light." Same pattern that
-    // `data-density` already follows (also script-managed, never in
-    // JSX). `suppressHydrationWarning` keeps React from warning when
-    // the SSR HTML and the script-mutated DOM differ on either
-    // attribute.
+    // `data-theme` and `data-density` are now seeded server-side from
+    // the cookies. The bootstrap script in <head> still runs on first
+    // visit (no cookie) and reconciles against localStorage; on
+    // subsequent visits the cookie path means the HTML is already
+    // correct before the script runs.
+    // `suppressHydrationWarning` keeps React quiet when the script
+    // mutates the attributes between SSR and CSR.
     <html
       lang="en"
       className={`${GeistSans.variable} ${GeistMono.variable} ${Newsreader_.variable}`}
+      data-theme={resolvedTheme}
+      data-density={resolvedDensity}
+      style={{ colorScheme: resolvedTheme }}
       suppressHydrationWarning
     >
       <head>
@@ -130,8 +152,11 @@ export default function RootLayout({
                  the same window. Real text colors land with the real
                  stylesheet a few ms later. */}
         <style>{`
-          html { color-scheme: dark; }
-          html, body { background: #000; color: #f5f5f5; }
+          html { color-scheme: ${resolvedTheme}; }
+          html, body {
+            background: ${resolvedTheme === "light" ? "#fafafa" : "#000"};
+            color: ${resolvedTheme === "light" ? "#0a0a0b" : "#f5f5f5"};
+          }
           :root {
             --font-sans: ${GeistSans.style.fontFamily};
             --font-mono: ${GeistMono.style.fontFamily};
@@ -159,13 +184,38 @@ export default function RootLayout({
                   document.documentElement.dataset.theme = resolved;
                   // Mirror the resolved theme onto color-scheme so the
                   // browser repaints native chrome (scrollbars, form
-                  // controls) the moment localStorage is read. The
-                  // inline <style> above defaults to dark; flip to light
-                  // here when needed before any further paint.
+                  // controls) the moment localStorage is read.
                   document.documentElement.style.colorScheme = resolved;
                   var d = localStorage.getItem("rokki_density");
                   if (d === "compact" || d === "cozy") {
                     document.documentElement.dataset.density = d;
+                  }
+                  // Mirror localStorage into cookies so the next
+                  // server-render (any navigation) paints the correct
+                  // theme from the first byte and we stop seeing the
+                  // white-then-dark flash. Set ONLY if the cookie isn't
+                  // already in sync — repeated writes are cheap but
+                  // adding a guard makes the network panel cleaner.
+                  function readCookie(name) {
+                    var m = document.cookie.match(
+                      new RegExp("(?:^|; )" + name + "=([^;]*)")
+                    );
+                    return m ? decodeURIComponent(m[1]) : null;
+                  }
+                  function setCookie(name, value) {
+                    // 1 year, root path, lax. Not HttpOnly because we
+                    // need to read it from JS as well; not Secure
+                    // because we want it on localhost too. The value
+                    // is non-sensitive (theme name), so plain is fine.
+                    document.cookie =
+                      name + "=" + encodeURIComponent(value) +
+                      "; max-age=31536000; path=/; samesite=lax";
+                  }
+                  if (readCookie("rokki_theme") !== resolved) {
+                    setCookie("rokki_theme", resolved);
+                  }
+                  if (d && readCookie("rokki_density") !== d) {
+                    setCookie("rokki_density", d);
                   }
                 } catch (e) {}
               })();

--- a/apps/web/src/app/settings/appearance/AppearanceForm.tsx
+++ b/apps/web/src/app/settings/appearance/AppearanceForm.tsx
@@ -33,6 +33,7 @@ export function AppearanceForm({
       try {
         localStorage.setItem("rokki_density", next);
       } catch {}
+      writeThemeCookie("rokki_density", next);
     }
     await save({ density: next });
   }
@@ -40,10 +41,17 @@ export function AppearanceForm({
   async function pickTheme(next: Theme) {
     if (next === theme || saving) return;
     setTheme(next);
-    applyTheme(next);
+    const resolved = applyTheme(next);
     try {
       localStorage.setItem("rokki_theme", next);
     } catch {}
+    // The cookie holds the RESOLVED concrete theme ("dark" / "light"),
+    // not the user's preference ("system"). The server-side layout
+    // only knows how to paint dark or light — it can't resolve
+    // `prefers-color-scheme` from the request. Saving the resolved
+    // value gives the next page-render the correct paint without
+    // having to re-resolve.
+    writeThemeCookie("rokki_theme", resolved);
     await save({ theme: next });
   }
 
@@ -143,11 +151,16 @@ export function AppearanceForm({
  * widgets (scrollbars, form chrome, the Edge UI) repaint
  * immediately. Without this the dataset attribute flips but the
  * native chrome stays at whatever the boot script set.
+ *
+ * Returns the resolved concrete theme ("dark" / "light") — the
+ * cookie path needs the resolved value, not the user-facing
+ * preference, since the server layout can't compute
+ * `prefers-color-scheme` from the request.
  */
-export function applyTheme(theme: Theme): void {
-  if (typeof document === "undefined") return;
+export function applyTheme(theme: Theme): "dark" | "light" {
+  if (typeof document === "undefined") return "dark";
   const html = document.documentElement;
-  const resolved =
+  const resolved: "dark" | "light" =
     theme === "system"
       ? window.matchMedia("(prefers-color-scheme: dark)").matches
         ? "dark"
@@ -155,6 +168,19 @@ export function applyTheme(theme: Theme): void {
       : theme;
   html.dataset.theme = resolved;
   html.style.colorScheme = resolved;
+  return resolved;
+}
+
+/**
+ * Write a theme/density cookie so the next server-side render paints
+ * with the right tokens before any client JS runs. Plain (non-Secure,
+ * non-HttpOnly) so JS can read/write it; values are non-sensitive.
+ */
+function writeThemeCookie(name: string, value: string): void {
+  if (typeof document === "undefined") return;
+  document.cookie =
+    `${name}=${encodeURIComponent(value)}` +
+    `; max-age=31536000; path=/; samesite=lax`;
 }
 
 function ThemeCard({


### PR DESCRIPTION
## Summary

Closes **fix #1** (dark-mode flash on cold load) and **fix #2** (space page turning white on nav). Same root cause for both.

The server used to emit HTML with no \`data-theme\`, leaving the bootstrap script to flip the attribute only after parsing its own tag. For users with OS-level light preference + dark saved in localStorage, the gap was perceptible — Zack reported it as "loads in white, then turns dark" and "the screen turns white when I go into a space."

Move source of truth to a cookie. Root layout reads \`rokki_theme\` server-side and bakes \`data-theme\` into the SSR HTML directly; inline \`<style>\` paints correctly from byte zero. Bootstrap script still runs for first-visit users (no cookie yet) and migrates existing localStorage users into the cookie path. AppearanceForm writes the cookie on every theme change.

## Test plan
- [ ] Cold load with dark theme set → no white frame
- [ ] Navigate into a space page → no white flash
- [ ] Toggle theme in Settings → cookie updates, next page-render paints right immediately
- [ ] First-visit user with no cookie → bootstrap script kicks in, no regression
- [ ] OS-system theme picker still works for users who chose "System"

🤖 Generated with [Claude Code](https://claude.com/claude-code)