### PR TITLE
feat(notifications): rich activity descriptions with field-level diffs

### DIFF
--- a/apps/web/src/app/p/[ticker]/page.tsx
+++ b/apps/web/src/app/p/[ticker]/page.tsx
@@ -13,6 +13,7 @@ import {
   loadDashSpaces,
   loadDashTerminals,
 } from "@/lib/dashboard-queries";
+import { summarizeActivity } from "@/lib/activity-summary";
 import { CORE_MODULE_CARDS, SPACE_TAGLINE } from "@/lib/project-templates";
 import type { ProjectStatus } from "@rokki/db";
 
@@ -97,6 +98,8 @@ interface ActivityRow {
   id: string;
   action: string;
   metadata: Record<string, unknown>;
+  before_json: Record<string, unknown> | null;
+  after_json: Record<string, unknown> | null;
   created_at: string;
 }
 
@@ -139,7 +142,7 @@ export default async function ProjectTerminalPage({ params }: Props) {
   ] = await Promise.all([
     supabase
       .from("activity")
-      .select("id, action, metadata, created_at")
+      .select("id, action, metadata, before_json, after_json, created_at")
       .eq("terminal_id", p.id)
       .order("created_at", { ascending: false })
       .limit(10),
@@ -205,7 +208,12 @@ export default async function ProjectTerminalPage({ params }: Props) {
 
   const tickerItems = activities.map((a) => ({
     id: a.id,
-    text: humanizeAction(a.action, a.metadata),
+    text: summarizeActivity({
+      action: a.action,
+      metadata: a.metadata,
+      before_json: a.before_json,
+      after_json: a.after_json,
+    }),
     when: relativeTime(a.created_at),
   }));
 
@@ -400,57 +408,3 @@ function relativeTime(iso: string): string {
   return `${Math.floor(h / 24)}d ago`;
 }
 
-function humanizeAction(
-  action: string,
-  metadata: Record<string, unknown>,
-): string {
-  // Same source-of-truth as the dashboard's `summarizeActivity` —
-  // dotted-versus-underscored variants both supported because the
-  // diff trigger emits `task_updated` while API code emits
-  // `task.update`. Rich phrasing replaces the old terse default
-  // (`action.replace(/\./g, " ")`) which produced unhelpful
-  // strings like "task update" or "tasks updated".
-  const m = metadata as Record<string, unknown>;
-  const s = (k: string): string | null =>
-    typeof m?.[k] === "string" ? (m[k] as string) : null;
-  switch (action) {
-    case "task.create":
-      return `Task "${s("title") ?? "(untitled)"}" created`;
-    case "task.complete":
-      return `Task "${s("title") ?? "(untitled)"}" completed`;
-    case "task.update":
-    case "task_updated":
-      return `Task "${s("title") ?? ""}" updated`.trim();
-    case "task.delete":
-      return `Task "${s("title") ?? "(untitled)"}" deleted`;
-    case "task.assigned":
-      return `Task "${s("title") ?? ""}" assigned`.trim();
-    case "terminal.create":
-      return `Terminal created`;
-    case "terminal.update":
-    case "terminal_updated":
-      return `Terminal updated`;
-    case "terminal.archive":
-      return `Terminal archived`;
-    case "file.upload":
-      return `${s("filename") ?? "File"} uploaded`;
-    case "file.delete":
-      return `${s("filename") ?? "File"} deleted`;
-    case "file.update":
-    case "file_updated":
-      return `File ${s("filename") ?? ""} updated`.trim();
-    case "comment.create":
-      return `New comment on ${s("entity_kind") ?? "a task"}`;
-    case "comment.update":
-    case "comment_updated":
-      return `Comment edited`;
-    case "member.invite":
-      return `${s("email") ?? "Someone"} invited`;
-    case "member.join":
-      return `${s("name") ?? "Someone"} joined`;
-    case "member.remove":
-      return `${s("name") ?? "Member"} removed`;
-    default:
-      return action.replace(/[._]/g, " ");
-  }
-}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -8,6 +8,7 @@ import {
   loadDelegatedTasks,
   loadWeekItems,
 } from "@/lib/dashboard-queries";
+import { summarizeActivity } from "@/lib/activity-summary";
 
 export default async function DashboardPage() {
   const supabase = await createClient();
@@ -60,7 +61,9 @@ export default async function DashboardPage() {
       .is("deleted_at", null),
     supabase
       .from("activity")
-      .select("id, action, actor_id, metadata, created_at")
+      .select(
+        "id, action, actor_id, metadata, before_json, after_json, created_at",
+      )
       .order("created_at", { ascending: false })
       .limit(30),
     supabase
@@ -93,12 +96,19 @@ export default async function DashboardPage() {
     action: string;
     actor_id: string | null;
     metadata: Record<string, unknown> | null;
+    before_json: Record<string, unknown> | null;
+    after_json: Record<string, unknown> | null;
     created_at: string;
   };
   const tickerItems = ((activityResult.data ?? []) as ActivityRow[]).map(
     (a) => ({
       id: a.id,
-      text: summarizeActivity(a.action, a.metadata),
+      text: summarizeActivity({
+        action: a.action,
+        metadata: a.metadata,
+        before_json: a.before_json,
+        after_json: a.after_json,
+      }),
       when: relativeTime(a.created_at),
     }),
   );
@@ -121,63 +131,6 @@ export default async function DashboardPage() {
       briefingDismissedOn={briefingDismissedOn}
     />
   );
-}
-
-function summarizeActivity(
-  action: string,
-  metadata: Record<string, unknown> | null,
-): string {
-  const pick = (k: string): string | null => {
-    const v = metadata?.[k];
-    return typeof v === "string" ? v : null;
-  };
-  // Rich, specific phrasing per action — used to be a generic
-  // ".replace(/[._]/g, ' ')" fallback that produced garbage like
-  // "tasks updated", which is what Zack flagged as "I want more
-  // detail than 'task updated'." Cases are sorted by frequency.
-  switch (action) {
-    case "task.create":
-      return `task created: ${pick("title") ?? "(untitled)"}`;
-    case "task.complete":
-      return `task completed: ${pick("title") ?? "(untitled)"}`;
-    case "task.update":
-    case "task_updated":
-      return `task updated: ${pick("title") ?? "(untitled)"}`;
-    case "task.delete":
-      return `task deleted: ${pick("title") ?? "(untitled)"}`;
-    case "task.assigned":
-      return `assigned: ${pick("title") ?? "(untitled)"}`;
-    case "terminal.create":
-      return `new terminal: ${pick("name") ?? "(unnamed)"}`;
-    case "terminal.update":
-    case "terminal_updated":
-      return `terminal updated: ${pick("name") ?? ""}`.trim();
-    case "terminal.archive":
-      return `archived ${pick("name") ?? "a terminal"}`;
-    case "file.upload":
-      return `uploaded ${pick("filename") ?? "a file"}`;
-    case "file.delete":
-      return `deleted ${pick("filename") ?? "a file"}`;
-    case "file.update":
-    case "file_updated":
-      return `file updated: ${pick("filename") ?? ""}`.trim();
-    case "comment.create":
-      return `commented on ${pick("entity_kind") ?? "a task"}`;
-    case "comment.update":
-    case "comment_updated":
-      return `comment edited`;
-    case "member.invite":
-      return `invited ${pick("email") ?? "a member"}`;
-    case "member.join":
-      return `${pick("name") ?? "someone"} joined`;
-    case "member.remove":
-      return `removed ${pick("name") ?? "a member"}`;
-    case "space_updated":
-    case "space.update":
-      return `space updated: ${pick("name") ?? ""}`.trim();
-    default:
-      return action.replace(/[._]/g, " ");
-  }
 }
 
 function relativeTime(iso: string): string {

--- a/apps/web/src/components/TickerTape.tsx
+++ b/apps/web/src/components/TickerTape.tsx
@@ -6,6 +6,7 @@ import { Activity, Sparkles } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { createClient } from "@/lib/supabase/client";
 import { useRealtimeTable } from "@/lib/supabase/realtime";
+import { summarizeActivity } from "@/lib/activity-summary";
 
 interface TickerItem {
   id: string;
@@ -24,6 +25,8 @@ interface ActivityRow {
   entity_type: string | null;
   entity_id: string | null;
   metadata: Record<string, unknown> | null;
+  before_json?: Record<string, unknown> | null;
+  after_json?: Record<string, unknown> | null;
   created_at: string;
 }
 
@@ -238,9 +241,18 @@ function withToolTips(items: TickerItem[]): TickerItem[] {
 
 /**
  * Convert a raw activity row into a ticker item with a sensible deep link.
+ *
+ * Uses the shared `summarizeActivity` helper so the dashboard ticker,
+ * per-terminal ticker, and notification descriptions all read the same
+ * way and pick up new action types in one place.
  */
 function toTickerItem(row: ActivityRow): TickerItem | null {
-  const text = describeActivity(row);
+  const text = summarizeActivity({
+    action: row.action,
+    metadata: row.metadata,
+    before_json: row.before_json ?? null,
+    after_json: row.after_json ?? null,
+  });
   if (!text) return null;
   return {
     id: row.id,
@@ -257,58 +269,6 @@ function hrefForActivity(row: ActivityRow): string | undefined {
   if (row.entity_type === "file" || row.action.startsWith("file."))
     return ticker ? `/p/${ticker}` : undefined;
   return undefined;
-}
-
-function describeActivity(row: ActivityRow): string | null {
-  const m = (row.metadata ?? {}) as Record<string, unknown>;
-  const pick = (key: string): string | null => {
-    const v = m[key];
-    return typeof v === "string" ? v : null;
-  };
-  switch (row.action) {
-    case "terminal.create":
-      return `terminal created: ${pick("name") ?? ""}`;
-    case "terminal.update":
-      return `terminal updated`;
-    case "terminal.archive":
-      return `terminal archived`;
-    case "member.invite":
-      return `invited ${pick("email") ?? "a member"}`;
-    case "member.join":
-      return `joined the terminal`;
-    case "task.create":
-      return `task: "${pick("title") ?? ""}"`;
-    case "task.complete":
-      return `task complete`;
-    case "task.delete":
-      return `task deleted${pick("title") ? `: "${pick("title")}"` : ""}`;
-    case "task.update":
-      return `task updated`;
-    case "file.upload": {
-      const op = pick("op");
-      if (op === "folder.create") return `folder: ${pick("path") ?? ""}`;
-      if (op === "file.duplicate") return `duplicated ${pick("filename") ?? "file"}`;
-      return `uploaded ${pick("filename") ?? "a file"}`;
-    }
-    case "file.update": {
-      const op = pick("op");
-      if (op === "file.rename")
-        return `renamed ${pick("from") ?? ""} → ${pick("to") ?? ""}`;
-      if (op === "folder.rename")
-        return `renamed ${pick("from") ?? ""} → ${pick("to") ?? ""}`;
-      if (op === "file.move")
-        return `moved file ${pick("from") ?? ""} → ${pick("to") ?? ""}`;
-      return `file updated`;
-    }
-    case "file.delete":
-      return `deleted ${pick("filename") ?? pick("path") ?? "item"}`;
-    case "file.download":
-      return `read ${pick("filename") ?? "a file"}`;
-    case "tool.invoke":
-      return `called tool ${pick("slug") ? `"${pick("slug")}"` : ""}`.trim();
-    default:
-      return row.action.replace(/[._]/g, " ");
-  }
 }
 
 function relativeTime(iso: string): string {

--- a/apps/web/src/lib/activity-summary.ts
+++ b/apps/web/src/lib/activity-summary.ts
@@ -1,0 +1,272 @@
+/**
+ * Single source of truth for turning an `activity` row into the human
+ * sentence that surfaces in:
+ *
+ *   - the dashboard ticker tape ("Recent activity" feed)
+ *   - the per-terminal ticker ("$TICKER · activity")
+ *   - the notifications bell (when it eventually swaps to driving off
+ *     activity rather than a duplicate notifications table)
+ *
+ * Rules of engagement:
+ *
+ *   1. The `_updated` plural action variants emitted by the audit
+ *      trigger (`tasks_updated`, `terminals_updated`, etc.) are
+ *      first-class citizens — Zack flagged "I just want more detail
+ *      than 'task updated'", which used to fall through to the
+ *      `replace(/[._]/g, ' ')` default and produce that exact garbage.
+ *
+ *   2. For UPDATE rows with `before_json` + `after_json` set, render
+ *      the diff as "field: from → to" for the columns the user
+ *      actually cares about (title, status, priority, due_date,
+ *      assignees, name). Bag everything else into "+N more changes"
+ *      so the chip stays scannable.
+ *
+ *   3. Fall back to the dotted app-emitted action names where the
+ *      caller still uses them (task.create, file.upload, etc.).
+ */
+
+export type ActivityMetadata = Record<string, unknown> | null | undefined;
+export type ActivityJson = Record<string, unknown> | null | undefined;
+
+export interface ActivityRow {
+  action: string;
+  metadata?: ActivityMetadata;
+  before_json?: ActivityJson;
+  after_json?: ActivityJson;
+}
+
+/**
+ * Maps 1=High, 2=Medium, 3=Low, null=No priority — matches the
+ * 2026-05-07 priority redesign.
+ */
+const PRIORITY_LABEL: Record<number, string> = {
+  1: "High",
+  2: "Medium",
+  3: "Low",
+};
+
+const STATUS_LABEL: Record<string, string> = {
+  todo: "To do",
+  in_progress: "In progress",
+  review: "Review",
+  blocked: "Blocked",
+  done: "Done",
+};
+
+/**
+ * Columns that produce a useful, short human delta on update. Any
+ * other diffed column rolls up into the "+N more" tail.
+ */
+const TASK_DIFF_FIELDS: Array<{
+  key: string;
+  label: string;
+  format: (v: unknown) => string;
+}> = [
+  { key: "title", label: "title", format: (v) => fmtString(v) ?? "—" },
+  { key: "status", label: "status", format: (v) => fmtStatus(v) },
+  { key: "priority", label: "priority", format: (v) => fmtPriority(v) },
+  { key: "due_date", label: "due", format: (v) => fmtString(v) ?? "—" },
+  { key: "completed_at", label: "completed", format: (v) => (v ? "yes" : "no") },
+  { key: "description", label: "description", format: () => "(text)" },
+];
+
+const TERMINAL_DIFF_FIELDS: Array<{
+  key: string;
+  label: string;
+  format: (v: unknown) => string;
+}> = [
+  { key: "name", label: "name", format: (v) => fmtString(v) ?? "—" },
+  { key: "status", label: "status", format: (v) => fmtString(v) ?? "—" },
+  {
+    key: "description",
+    label: "description",
+    format: () => "(text)",
+  },
+];
+
+/**
+ * Single entry point. Returns the sentence to render in a chip-sized
+ * UI slot — keep it under ~80 chars so we don't overflow the ticker.
+ */
+export function summarizeActivity(row: ActivityRow): string {
+  const action = row.action;
+  const m = row.metadata ?? {};
+  const pick = (k: string): string | null => {
+    const v = m?.[k];
+    return typeof v === "string" ? v : null;
+  };
+
+  switch (action) {
+    case "task.create":
+      return `task created: ${pick("title") ?? "(untitled)"}`;
+    case "task.complete":
+      return `completed: ${pick("title") ?? "(untitled)"}`;
+    case "task.delete":
+      return `task deleted: ${pick("title") ?? "(untitled)"}`;
+    case "task.assigned":
+      return `assigned: ${pick("title") ?? "(untitled)"}`;
+
+    case "task.update":
+    case "task_updated":
+    case "tasks_updated": {
+      const after = (row.after_json ?? {}) as Record<string, unknown>;
+      const title =
+        fmtString(after.title) ?? pick("title") ?? "(untitled)";
+      const diffs = describeDiff(
+        row.before_json ?? null,
+        row.after_json ?? null,
+        TASK_DIFF_FIELDS,
+      );
+      if (!diffs) return `task updated: ${title}`;
+      return `${title}: ${diffs}`;
+    }
+
+    case "terminal.create":
+      return `new terminal: ${pick("name") ?? "(unnamed)"}`;
+    case "terminal.archive":
+      return `archived ${pick("name") ?? "a terminal"}`;
+
+    case "terminal.update":
+    case "terminal_updated":
+    case "terminals_updated": {
+      const after = (row.after_json ?? {}) as Record<string, unknown>;
+      const name = fmtString(after.name) ?? pick("name") ?? "terminal";
+      const diffs = describeDiff(
+        row.before_json ?? null,
+        row.after_json ?? null,
+        TERMINAL_DIFF_FIELDS,
+      );
+      if (!diffs) return `${name} updated`;
+      return `${name}: ${diffs}`;
+    }
+
+    case "file.upload": {
+      const op = pick("op");
+      if (op === "folder.create") return `folder: ${pick("path") ?? ""}`;
+      if (op === "file.duplicate")
+        return `duplicated ${pick("filename") ?? "file"}`;
+      return `uploaded ${pick("filename") ?? "a file"}`;
+    }
+    case "file.update":
+    case "file_updated":
+    case "files_updated":
+      return `file updated: ${pick("filename") ?? ""}`.trim();
+    case "file.delete":
+      return `deleted ${pick("filename") ?? pick("path") ?? "item"}`;
+    case "file.download":
+      return `read ${pick("filename") ?? "a file"}`;
+
+    case "comment.create":
+      return `commented on ${pick("entity_kind") ?? "a task"}`;
+    case "comment.update":
+    case "comment_updated":
+    case "comments_updated":
+      return `comment edited`;
+
+    case "member.invite":
+      return `invited ${pick("email") ?? "a member"}`;
+    case "member.join":
+      return `${pick("name") ?? "someone"} joined`;
+    case "member.remove":
+      return `removed ${pick("name") ?? "a member"}`;
+
+    case "space.update":
+    case "space_updated":
+    case "spaces_updated":
+      return `space updated: ${pick("name") ?? ""}`.trim();
+
+    case "tool.invoke":
+      return `called tool ${pick("slug") ? `"${pick("slug")}"` : ""}`.trim();
+
+    default:
+      // Last-resort fallback. NOT seen in practice for any action we
+      // emit today, but keeps the ticker from rendering nothing if a
+      // future action lands without a case here.
+      return action.replace(/[._]/g, " ");
+  }
+}
+
+/**
+ * Format a JSON diff into "field: from → to" segments for the
+ * provided field set. Returns `null` when nothing in the field set
+ * actually changed.
+ *
+ * Anything that changed but isn't in the field set gets bundled into
+ * a "+N more" tail so the chip stays a one-liner. We deliberately
+ * skip boring columns (updated_at, position) so they don't dominate
+ * the display.
+ */
+function describeDiff(
+  before: ActivityJson,
+  after: ActivityJson,
+  fields: Array<{
+    key: string;
+    label: string;
+    format: (v: unknown) => string;
+  }>,
+): string | null {
+  if (!before || !after) return null;
+  const segments: string[] = [];
+  let extras = 0;
+  const trackedKeys = new Set(fields.map((f) => f.key));
+  const noiseKeys = new Set([
+    "updated_at",
+    "created_at",
+    "position",
+    "ticker_seq",
+    "id",
+    "metadata",
+    "labels", // arrays format poorly in a chip; skip for now
+  ]);
+
+  for (const f of fields) {
+    const a = (before as Record<string, unknown>)[f.key];
+    const b = (after as Record<string, unknown>)[f.key];
+    if (jsonEqual(a, b)) continue;
+    const from = f.format(a);
+    const to = f.format(b);
+    segments.push(`${f.label}: ${from} → ${to}`);
+  }
+
+  // Tally fields that DID change but aren't in our curated list.
+  const allKeys = new Set<string>([
+    ...Object.keys(before as object),
+    ...Object.keys(after as object),
+  ]);
+  for (const k of allKeys) {
+    if (trackedKeys.has(k) || noiseKeys.has(k)) continue;
+    const a = (before as Record<string, unknown>)[k];
+    const b = (after as Record<string, unknown>)[k];
+    if (!jsonEqual(a, b)) extras += 1;
+  }
+  if (segments.length === 0 && extras === 0) return null;
+  if (extras > 0)
+    segments.push(`+${extras} more change${extras === 1 ? "" : "s"}`);
+  return segments.join(" · ");
+}
+
+function jsonEqual(a: unknown, b: unknown): boolean {
+  // Cheap deep equality for the diff use case. The before/after blobs
+  // are small (one row), so JSON.stringify is fine; key-order
+  // differences are rare since both come from the same `to_jsonb`.
+  if (a === b) return true;
+  if (a == null && b == null) return true;
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+function fmtString(v: unknown): string | null {
+  if (typeof v === "string") return v.length > 60 ? `${v.slice(0, 57)}…` : v;
+  return null;
+}
+
+function fmtPriority(v: unknown): string {
+  if (v == null) return "None";
+  if (typeof v === "number" && PRIORITY_LABEL[v]) return PRIORITY_LABEL[v];
+  return String(v);
+}
+
+function fmtStatus(v: unknown): string {
+  if (typeof v === "string" && STATUS_LABEL[v]) return STATUS_LABEL[v];
+  if (v == null) return "—";
+  return String(v);
+}


### PR DESCRIPTION
## Summary

Closes **fix #3**: notifications/ticker still saying "task updated" instead of detail on what changed.

Two coupled bugs:

1. The audit trigger emits \`tasks_updated\` / \`terminals_updated\` (plural, underscored), but the summarizer only matched \`task.update\` and \`task_updated\`. Every trigger event fell through to \`replace(/[._]/g, " ")\` → "tasks updated".
2. We were capturing \`before_json\` + \`after_json\` on every update but never rendering them anywhere.

This PR:
- Consolidates three duplicated activity-text functions (dashboard, ticker tape, per-terminal page) into \`lib/activity-summary.ts\`.
- Handles all three action-name shapes in one switch.
- Renders field-level deltas: "priority: Medium → High", "status: Todo → Done", "due: 2026-05-15 → 2026-05-22", with a "+N more" tail for less-interesting fields.

## Test plan
- [ ] Edit a task's priority → ticker reads "<title>: priority: Medium → High"
- [ ] Edit a task's title → ticker reads "<old>: title: <old> → <new>"
- [ ] Rename a terminal → "Old name: name: Old → New"
- [ ] Existing dotted events (task.create, file.upload, etc.) still phrase the same way

🤖 Generated with [Claude Code](https://claude.com/claude-code)