### PR TITLE
feat(space): visible '+ New terminal' button + rich activity ticker

### DIFF
--- a/apps/web/src/app/s/[slug]/page.tsx
+++ b/apps/web/src/app/s/[slug]/page.tsx
@@ -12,6 +12,7 @@ import {
   loadSpaceTasks,
   loadSpaceTerminals,
 } from "@/lib/space-queries";
+import { summarizeActivity } from "@/lib/activity-summary";
 
 interface Props {
   params: Promise<{ slug: string }>;
@@ -105,12 +106,17 @@ export default async function SpaceLandingPage({ params }: Props) {
   const initialDensity =
     profile?.settings?.density === "compact" ? "compact" : "cozy";
 
-  // Build a tiny ticker label per activity row. Mirrors the
-  // dashboard's `summarizeActivity` so the ticker reads the same
-  // across surfaces.
+  // Tiny ticker label per activity row. Uses the shared
+  // `summarizeActivity` helper so dashboard / space / terminal
+  // tickers all read the same way.
   const tickerItems = activity.map((a) => ({
     id: a.id,
-    text: summarizeActivity(a.action, a.metadata ?? {}),
+    text: summarizeActivity({
+      action: a.action,
+      metadata: a.metadata,
+      before_json: a.before_json,
+      after_json: a.after_json,
+    }),
     when: relativeTime(a.created_at),
   }));
 
@@ -132,62 +138,6 @@ export default async function SpaceLandingPage({ params }: Props) {
       tickerItems={tickerItems}
     />
   );
-}
-
-function summarizeActivity(
-  action: string,
-  metadata: Record<string, unknown>,
-): string {
-  // Mirror of the dashboard's summarizeActivity (apps/web/src/app/page.tsx)
-  // — kept local for the space ticker so we don't have to plumb
-  // it through props. Both should be edited together.
-  const pick = (k: string): string | null => {
-    const v = metadata[k];
-    return typeof v === "string" ? v : null;
-  };
-  switch (action) {
-    case "task.create":
-      return `task created: ${pick("title") ?? "(untitled)"}`;
-    case "task.complete":
-      return `task completed: ${pick("title") ?? "(untitled)"}`;
-    case "task.update":
-    case "task_updated":
-      return `task updated: ${pick("title") ?? "(untitled)"}`;
-    case "task.delete":
-      return `task deleted: ${pick("title") ?? "(untitled)"}`;
-    case "task.assigned":
-      return `assigned: ${pick("title") ?? "(untitled)"}`;
-    case "terminal.create":
-      return `new terminal: ${pick("name") ?? "(unnamed)"}`;
-    case "terminal.update":
-    case "terminal_updated":
-      return `terminal updated: ${pick("name") ?? ""}`.trim();
-    case "terminal.archive":
-      return `archived ${pick("name") ?? "a terminal"}`;
-    case "file.upload":
-      return `uploaded ${pick("filename") ?? "a file"}`;
-    case "file.delete":
-      return `deleted ${pick("filename") ?? "a file"}`;
-    case "file.update":
-    case "file_updated":
-      return `file updated: ${pick("filename") ?? ""}`.trim();
-    case "comment.create":
-      return `commented on ${pick("entity_kind") ?? "a task"}`;
-    case "comment.update":
-    case "comment_updated":
-      return `comment edited`;
-    case "member.invite":
-      return `invited ${pick("email") ?? "a member"}`;
-    case "member.join":
-      return `${pick("name") ?? "someone"} joined`;
-    case "member.remove":
-      return `removed ${pick("name") ?? "a member"}`;
-    case "space_updated":
-    case "space.update":
-      return `space updated: ${pick("name") ?? ""}`.trim();
-    default:
-      return action.replace(/[._]/g, " ");
-  }
 }
 
 function relativeTime(iso: string): string {

--- a/apps/web/src/components/space/SpaceClient.tsx
+++ b/apps/web/src/components/space/SpaceClient.tsx
@@ -1,10 +1,12 @@
 "use client";
 
 import Link from "next/link";
+import { useState } from "react";
 import { DashboardShell } from "@/components/dashboard/DashboardShell";
 import { TopBar } from "@/components/TopBar";
 import { TickerTape } from "@/components/TickerTape";
 import { ExplorerRail } from "@/components/dashboard/ExplorerRail";
+import { CreateProjectDialog } from "@/components/CreateProjectDialog";
 import { DensityProvider, type Density } from "@/lib/density";
 import { TerminalsGrid } from "./TerminalsGrid";
 import { SpaceTasksCard } from "./SpaceTasksCard";
@@ -76,6 +78,7 @@ export function SpaceClient({
   // myRole is consumed by the parent route's auth gate (member-only
   // landing); we don't render any role-gated chrome on this page.
   void myRole;
+  const [createTerminalOpen, setCreateTerminalOpen] = useState(false);
   return (
     <DensityProvider initial={initialDensity}>
       <DashboardShell
@@ -108,8 +111,16 @@ export function SpaceClient({
         center={
           <div className="card-stack flex flex-col gap-3 p-2 sm:p-3">
             {/* The grid is the lead — what does this space actually
-                have? — stretched full width. */}
-            <TerminalsGrid terminals={terminals} />
+                have? — stretched full width. The "+ Terminal" button
+                lives in the card header AND as a tile in the grid
+                (or a CTA in the empty state) so the affordance is
+                impossible to miss. Permission to create is handled
+                by RLS on the API side; the button just opens the
+                dialog and lets the server enforce. */}
+            <TerminalsGrid
+              terminals={terminals}
+              onCreateTerminal={() => setCreateTerminalOpen(true)}
+            />
 
             {/* Tasks roll-up sits below — the cross-cutting "what's
                 actually moving" view. Members live next to it on
@@ -138,6 +149,12 @@ export function SpaceClient({
             />
           </div>
         }
+      />
+      <CreateProjectDialog
+        open={createTerminalOpen}
+        onClose={() => setCreateTerminalOpen(false)}
+        orgs={spaces}
+        preferredSlug={space.slug}
       />
     </DensityProvider>
   );

--- a/apps/web/src/components/space/TerminalsGrid.tsx
+++ b/apps/web/src/components/space/TerminalsGrid.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { ArrowRight } from "lucide-react";
+import { ArrowRight, Plus } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { DashboardCard } from "@/components/dashboard/DashboardCard";
 import { StatusPill } from "@/components/primitives";
@@ -9,6 +9,14 @@ import type { SpaceTerminalCard } from "@/lib/space-queries";
 
 interface TerminalsGridProps {
   terminals: SpaceTerminalCard[];
+  /**
+   * Optional click handler for the "+ Terminal" affordance. When
+   * supplied the card sprouts a button in its header AND a tile in
+   * the grid (or a prominent CTA in the empty state) so the user can
+   * spin up a new terminal without bouncing through the command
+   * palette. Wired up by SpaceClient → CreateProjectDialog.
+   */
+  onCreateTerminal?: () => void;
 }
 
 /**
@@ -20,17 +28,42 @@ interface TerminalsGridProps {
  * this is the part of the page that says "what does this space
  * actually do." Click a tile to enter the terminal.
  */
-export function TerminalsGrid({ terminals }: TerminalsGridProps) {
+export function TerminalsGrid({ terminals, onCreateTerminal }: TerminalsGridProps) {
   return (
     <DashboardCard
       title="Terminals"
       count={terminals.length}
       expandHref={null}
+      headerRight={
+        onCreateTerminal ? (
+          <button
+            type="button"
+            onClick={onCreateTerminal}
+            title="Create a new terminal in this space"
+            className="flex items-center gap-1 rounded-sm border border-border bg-bg-2 px-2 py-0.5 text-[10px] uppercase tracking-wide text-text-1 hover:border-accent/40 hover:bg-bg-3"
+          >
+            <Plus className="h-3 w-3" aria-hidden="true" />
+            <span>New terminal</span>
+          </button>
+        ) : null
+      }
     >
       {terminals.length === 0 ? (
-        <p className="px-3 py-6 text-center text-xs text-text-3">
-          No terminals in this space yet.
-        </p>
+        <div className="flex flex-col items-center justify-center gap-3 px-3 py-10 text-center">
+          <p className="text-xs text-text-3">
+            No terminals in this space yet.
+          </p>
+          {onCreateTerminal ? (
+            <button
+              type="button"
+              onClick={onCreateTerminal}
+              className="inline-flex items-center gap-1.5 rounded-sm border border-accent bg-accent-subtle px-3 py-1.5 text-xs font-semibold uppercase tracking-wide text-accent hover:bg-accent/20"
+            >
+              <Plus className="h-3 w-3" aria-hidden="true" />
+              Create the first terminal
+            </button>
+          ) : null}
+        </div>
       ) : (
         <ul className="grid gap-2 p-3 sm:grid-cols-2 xl:grid-cols-3">
           {terminals.map((t) => (
@@ -76,6 +109,20 @@ export function TerminalsGrid({ terminals }: TerminalsGridProps) {
               </Link>
             </li>
           ))}
+          {onCreateTerminal ? (
+            <li>
+              <button
+                type="button"
+                onClick={onCreateTerminal}
+                className="flex h-full w-full flex-col items-center justify-center gap-2 rounded-sm border border-dashed border-border bg-bg-1 p-3 text-text-3 transition-colors hover:border-accent/40 hover:bg-bg-2 hover:text-accent"
+              >
+                <Plus className="h-4 w-4" aria-hidden="true" />
+                <span className="text-[11px] font-semibold uppercase tracking-wide">
+                  New terminal
+                </span>
+              </button>
+            </li>
+          ) : null}
         </ul>
       )}
     </DashboardCard>

--- a/apps/web/src/lib/space-queries.ts
+++ b/apps/web/src/lib/space-queries.ts
@@ -60,6 +60,8 @@ export interface SpaceActivityRow {
   actor_id: string | null;
   terminal_id: string | null;
   metadata: Record<string, unknown> | null;
+  before_json: Record<string, unknown> | null;
+  after_json: Record<string, unknown> | null;
   created_at: string;
 }
 
@@ -492,7 +494,9 @@ export async function loadSpaceActivity(
 
       const { data } = await supabase
         .from("activity")
-        .select("id, action, actor_id, terminal_id, metadata, created_at")
+        .select(
+          "id, action, actor_id, terminal_id, metadata, before_json, after_json, created_at",
+        )
         .in("terminal_id", ids)
         .order("created_at", { ascending: false })
         .limit(limit);


### PR DESCRIPTION
## Summary

Closes **fix #4**: terminal-creation in a space wasn't straightforward. Now there are three obvious affordances on the same card:

- **Header chip** — \`+ New terminal\` always visible at the top of the Terminals card
- **Empty state CTA** — accent button that says "Create the first terminal", replaces the bare "No terminals yet" placeholder
- **Last tile in the grid** — dashed-border tile that reads "click here to add another"

All three open the existing \`CreateProjectDialog\` with this space pre-selected via \`preferredSlug\`. Permissions stay server-side.

Also rolls in a small cleanup: the space page had a third copy of the activity-summarizer switch (alongside dashboard + per-terminal). Switched it to the shared \`lib/activity-summary\` helper from PR #122 so all three surfaces render the same way and pick up field-level diff rendering.

## Test plan
- [ ] Navigate to /s/{slug} → "+ New terminal" chip in card header
- [ ] Empty space → big accent CTA front and center
- [ ] Populated space → dashed tile at end of grid
- [ ] Click any → CreateProjectDialog opens with this space selected
- [ ] Edit a task in this space → ticker shows the field-level diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)