### PR TITLE
test: cover today's shipments + extract pure logic to libs (45 cases)

### DIFF
--- a/apps/web/src/app/api/v1/projects/[ticker]/tasks/route.ts
+++ b/apps/web/src/app/api/v1/projects/[ticker]/tasks/route.ts
@@ -3,6 +3,7 @@ import { createClient } from "@/lib/supabase/server";
 import { emitEvent } from "@/lib/events";
 import { withObservability } from "@/lib/observability";
 import { validateRecurrenceRule } from "@/lib/task-recurrence";
+import { normalizeEmails } from "@/lib/normalize-emails";
 import type { TaskRecurrenceRule, TaskStatus } from "@rokki/db";
 
 interface Props {
@@ -292,32 +293,6 @@ async function handlePost(request: NextRequest, { params }: Props) {
   });
 
   return NextResponse.json({ data }, { status: 201 });
-}
-
-/**
- * Normalize a caller-provided list of email addresses. Trims,
- * lower-cases, dedupes, and validates the shape. Returns the
- * canonical list, or the literal string "invalid" if any entry
- * fails the basic shape check (which the API surfaces as a 400).
- *
- * Empty / whitespace-only entries are silently dropped so a UI
- * with a stale chip can't accidentally poison the row.
- */
-function normalizeEmails(input: unknown): string[] | "invalid" {
-  if (!Array.isArray(input)) return "invalid";
-  const out = new Set<string>();
-  // Permissive: anything with `<local>@<domain>.<tld>` and no spaces.
-  // The deeper validation (existence, deliverability) belongs in
-  // the invite email step, not here.
-  const re = /^[^@\s]+@[^@\s]+\.[^@\s]+$/;
-  for (const raw of input) {
-    if (typeof raw !== "string") continue;
-    const v = raw.trim().toLowerCase();
-    if (!v) continue;
-    if (!re.test(v)) return "invalid";
-    out.add(v);
-  }
-  return Array.from(out);
 }
 
 async function resolveProject(

--- a/apps/web/src/app/api/v1/tasks/[id]/route.ts
+++ b/apps/web/src/app/api/v1/tasks/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextResponse, type NextRequest } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { withObservability } from "@/lib/observability";
 import { validateRecurrenceRule } from "@/lib/task-recurrence";
+import { normalizeEmails } from "@/lib/normalize-emails";
 import type { TaskRecurrenceRule, TaskStatus } from "@rokki/db";
 
 interface Props {
@@ -231,25 +232,6 @@ async function handleDelete(_request: NextRequest, { params }: Props) {
   return new NextResponse(null, { status: 204 });
 }
 
-/**
- * Normalize email assignee list — duplicate of the helper in the
- * project tasks POST route. Keeping the duplication local rather
- * than building a shared lib for a 12-line function until a third
- * call site shows up.
- */
-function normalizeEmails(input: unknown): string[] | "invalid" {
-  if (!Array.isArray(input)) return "invalid";
-  const out = new Set<string>();
-  const re = /^[^@\s]+@[^@\s]+\.[^@\s]+$/;
-  for (const raw of input) {
-    if (typeof raw !== "string") continue;
-    const v = raw.trim().toLowerCase();
-    if (!v) continue;
-    if (!re.test(v)) return "invalid";
-    out.add(v);
-  }
-  return Array.from(out);
-}
 
 function unauth() {
   return NextResponse.json(

--- a/apps/web/src/components/TasksPane.tsx
+++ b/apps/web/src/components/TasksPane.tsx
@@ -32,6 +32,7 @@ import {
   StatusPill,
   DueChip,
 } from "./primitives";
+import { groupTasks, type TaskGroupMode } from "@/lib/task-grouping";
 import type { TaskStatus } from "@rokki/db";
 
 interface TaskAssignee {
@@ -71,9 +72,11 @@ type SortMode = "auto" | "manual";
 /**
  * Group-by modes for the task list. "None" keeps the flat list. The
  * other modes bucket tasks visually with section headers; sorting
- * within a bucket still respects the active SortMode.
+ * within a bucket still respects the active SortMode. Re-exported
+ * from `lib/task-grouping` so the bucket logic + tests share one
+ * source of truth.
  */
-type GroupMode = "none" | "assignee" | "due" | "priority" | "status";
+type GroupMode = TaskGroupMode;
 
 function sortStorageKey(projectId: string): string {
   return `rokki_tasks_sort:${projectId}`;
@@ -1057,128 +1060,4 @@ function sortTasks(tasks: Task[], mode: SortMode = "auto"): Task[] {
   });
 }
 
-/**
- * Bucket tasks for the group-by view. Returns an ordered list of
- * `{ key, label, tasks }` so the renderer can emit a section header
- * per bucket. Empty buckets are dropped — the layout shouldn't waste
- * vertical space on "0 tasks" headers.
- *
- * Ordering rationale:
- *   - assignee: name A→Z; "Unassigned" last
- *   - due: Overdue → Today → This week → Later → No due date
- *           (matches the urgency-first triage order)
- *   - priority: High → Medium → Low → No priority
- *   - status: todo → in_progress → review → blocked → done
- */
-function groupTasks(
-  tasks: Task[],
-  mode: GroupMode,
-): { key: string; label: string; tasks: Task[] }[] {
-  if (mode === "none" || tasks.length === 0) {
-    return [{ key: "all", label: "", tasks }];
-  }
-  if (mode === "assignee") {
-    const buckets = new Map<string, { label: string; tasks: Task[] }>();
-    for (const t of tasks) {
-      const list = t.assignees ?? [];
-      if (list.length === 0) {
-        const acc = buckets.get("__none__") ?? {
-          label: "Unassigned",
-          tasks: [],
-        };
-        acc.tasks.push(t);
-        buckets.set("__none__", acc);
-        continue;
-      }
-      // Tasks with multiple assignees show up under each one — the
-      // user expectation when grouping by assignee is "show me what
-      // each person owes me", not "pick one canonical owner".
-      for (const a of list) {
-        const key = a.user_id;
-        const acc = buckets.get(key) ?? {
-          label: a.full_name?.trim() || "Someone",
-          tasks: [],
-        };
-        acc.tasks.push(t);
-        buckets.set(key, acc);
-      }
-    }
-    return Array.from(buckets.entries())
-      .map(([key, v]) => ({ key, label: v.label, tasks: v.tasks }))
-      .sort((a, b) => {
-        if (a.key === "__none__") return 1;
-        if (b.key === "__none__") return -1;
-        return a.label.localeCompare(b.label);
-      });
-  }
-  if (mode === "due") {
-    const now = new Date();
-    const startOfDay = new Date(now);
-    startOfDay.setHours(0, 0, 0, 0);
-    const endOfDay = new Date(startOfDay);
-    endOfDay.setDate(endOfDay.getDate() + 1);
-    const endOfWeek = new Date(startOfDay);
-    endOfWeek.setDate(endOfWeek.getDate() + 7);
-    const buckets = new Map<string, Task[]>();
-    const order = ["overdue", "today", "week", "later", "none"];
-    for (const k of order) buckets.set(k, []);
-    for (const t of tasks) {
-      let key: string;
-      if (!t.due_date) key = "none";
-      else {
-        const d = new Date(t.due_date).getTime();
-        if (d < startOfDay.getTime()) key = "overdue";
-        else if (d < endOfDay.getTime()) key = "today";
-        else if (d < endOfWeek.getTime()) key = "week";
-        else key = "later";
-      }
-      buckets.get(key)!.push(t);
-    }
-    const labels: Record<string, string> = {
-      overdue: "Overdue",
-      today: "Today",
-      week: "This week",
-      later: "Later",
-      none: "No due date",
-    };
-    return order
-      .map((k) => ({ key: k, label: labels[k], tasks: buckets.get(k) ?? [] }))
-      .filter((g) => g.tasks.length > 0);
-  }
-  if (mode === "priority") {
-    const buckets: Record<string, Task[]> = { high: [], med: [], low: [], none: [] };
-    for (const t of tasks) {
-      const k =
-        t.priority === 1
-          ? "high"
-          : t.priority === 2
-            ? "med"
-            : t.priority === 3
-              ? "low"
-              : "none";
-      buckets[k].push(t);
-    }
-    return [
-      { key: "high", label: "High", tasks: buckets.high },
-      { key: "med", label: "Medium", tasks: buckets.med },
-      { key: "low", label: "Low", tasks: buckets.low },
-      { key: "none", label: "No priority", tasks: buckets.none },
-    ].filter((g) => g.tasks.length > 0);
-  }
-  // status
-  const order: TaskStatus[] = ["todo", "in_progress", "review", "blocked", "done"];
-  const labels: Record<TaskStatus, string> = {
-    todo: "To do",
-    in_progress: "In progress",
-    review: "Review",
-    blocked: "Blocked",
-    done: "Done",
-  };
-  const buckets = new Map<TaskStatus, Task[]>();
-  for (const s of order) buckets.set(s, []);
-  for (const t of tasks) buckets.get(t.status)?.push(t);
-  return order
-    .map((s) => ({ key: s, label: labels[s], tasks: buckets.get(s) ?? [] }))
-    .filter((g) => g.tasks.length > 0);
-}
 

--- a/apps/web/src/components/TickerTape.tsx
+++ b/apps/web/src/components/TickerTape.tsx
@@ -7,6 +7,7 @@ import { cn } from "@/lib/utils";
 import { createClient } from "@/lib/supabase/client";
 import { useRealtimeTable } from "@/lib/supabase/realtime";
 import { summarizeActivity } from "@/lib/activity-summary";
+import { withToolTips } from "@/lib/ticker-tips";
 
 interface TickerItem {
   id: string;
@@ -191,52 +192,6 @@ function TickerRow({ item }: { item: TickerItem }) {
       {content}
     </Link>
   );
-}
-
-/**
- * Sprinkle a tool tip in roughly every 10th slot so power users keep
- * discovering what they can do via MCP without a dedicated toolbox card.
- */
-function withToolTips(items: TickerItem[]): TickerItem[] {
-  if (items.length < 5) return items;
-  const tips: TickerItem[] = [
-    {
-      id: "tip:ask",
-      text: `Try: "ask rokki what's in the permit folder" — ⌘K "ask"`,
-      when: "",
-      href: "/tools",
-      tip: true,
-    },
-    {
-      id: "tip:search",
-      text: `Try: "search across all my files" — ⌘K "search"`,
-      when: "",
-      href: "/tools",
-      tip: true,
-    },
-    {
-      id: "tip:tool",
-      text: `💡 Your tools are one keystroke away — ⌘K`,
-      when: "",
-      href: "/tools",
-      tip: true,
-    },
-  ];
-  const out: TickerItem[] = [];
-  items.forEach((it, idx) => {
-    out.push(it);
-    // Every 10th item, sprinkle a tip. Use Math.floor so we land on
-    // an integer array index — `(idx / 10) % 3` evaluates to 0.9,
-    // 1.9, 2.9 at idx=9,19,29, and `tips[0.9]` is `undefined`. Once
-    // the activity stream crosses 10 rows, that undefined gets
-    // pushed into the ticker and the renderer trips on `item.id`,
-    // which is what the recent dashboard 500s were.
-    if ((idx + 1) % 10 === 0) {
-      const tip = tips[Math.floor(idx / 10) % tips.length];
-      if (tip) out.push(tip);
-    }
-  });
-  return out;
 }
 
 /**

--- a/apps/web/src/components/dashboard/TasksCard.tsx
+++ b/apps/web/src/components/dashboard/TasksCard.tsx
@@ -20,6 +20,7 @@ import {
   TickerChip,
 } from "@/components/primitives";
 import { useRealtimeTable } from "@/lib/supabase/realtime";
+import { bucketDashTasks } from "@/lib/task-grouping";
 import type { AssignedTask, DelegatedTask } from "@/lib/dashboard-queries";
 
 interface TasksCardProps {
@@ -352,134 +353,6 @@ function FilterChip({
       </span>
     </button>
   );
-}
-
-/**
- * Bucket dashboard tasks for the group-by view.
- *
- *   terminal:  one bucket per terminal, label = "TICKER · Name"
- *   priority:  High → Medium → Low → No priority
- *   due:       Overdue → Today → This week → Later → No due date
- *   assignee:  one bucket per assignee (delegated tab only); falls
- *              back to a single "All" bucket if assignees aren't on
- *              the row (Mine / Overdue / etc. don't include them).
- */
-function bucketDashTasks(
-  tasks: AssignedTask[],
-  by: "terminal" | "priority" | "due" | "assignee",
-  tickerById: Record<string, string>,
-  terminalNameById?: Record<string, string>,
-): { key: string; label: string; tasks: AssignedTask[] }[] {
-  if (by === "terminal") {
-    const buckets = new Map<string, AssignedTask[]>();
-    for (const t of tasks) {
-      const key = t.terminal_id;
-      if (!buckets.has(key)) buckets.set(key, []);
-      buckets.get(key)!.push(t);
-    }
-    return Array.from(buckets.entries())
-      .map(([key, list]) => {
-        const ticker = tickerById[key] ?? "";
-        const name = terminalNameById?.[key] ?? "";
-        const label = ticker
-          ? name
-            ? `${ticker} · ${name}`
-            : ticker
-          : name || "Terminal";
-        return { key, label, tasks: list };
-      })
-      .sort((a, b) => a.label.localeCompare(b.label));
-  }
-  if (by === "priority") {
-    const buckets: Record<string, AssignedTask[]> = {
-      high: [],
-      med: [],
-      low: [],
-      none: [],
-    };
-    for (const t of tasks) {
-      const k =
-        t.priority === 1
-          ? "high"
-          : t.priority === 2
-            ? "med"
-            : t.priority === 3
-              ? "low"
-              : "none";
-      buckets[k].push(t);
-    }
-    return [
-      { key: "high", label: "High", tasks: buckets.high },
-      { key: "med", label: "Medium", tasks: buckets.med },
-      { key: "low", label: "Low", tasks: buckets.low },
-      { key: "none", label: "No priority", tasks: buckets.none },
-    ].filter((g) => g.tasks.length > 0);
-  }
-  if (by === "due") {
-    const now = new Date();
-    const startOfDay = new Date(now);
-    startOfDay.setHours(0, 0, 0, 0);
-    const endOfDay = new Date(startOfDay);
-    endOfDay.setDate(endOfDay.getDate() + 1);
-    const endOfWeek = new Date(startOfDay);
-    endOfWeek.setDate(endOfWeek.getDate() + 7);
-    const buckets: Record<string, AssignedTask[]> = {
-      overdue: [],
-      today: [],
-      week: [],
-      later: [],
-      none: [],
-    };
-    for (const t of tasks) {
-      let key: string;
-      if (!t.due_date) key = "none";
-      else {
-        const d = new Date(t.due_date).getTime();
-        if (d < startOfDay.getTime()) key = "overdue";
-        else if (d < endOfDay.getTime()) key = "today";
-        else if (d < endOfWeek.getTime()) key = "week";
-        else key = "later";
-      }
-      buckets[key].push(t);
-    }
-    return [
-      { key: "overdue", label: "Overdue", tasks: buckets.overdue },
-      { key: "today", label: "Today", tasks: buckets.today },
-      { key: "week", label: "This week", tasks: buckets.week },
-      { key: "later", label: "Later", tasks: buckets.later },
-      { key: "none", label: "No due date", tasks: buckets.none },
-    ].filter((g) => g.tasks.length > 0);
-  }
-  // assignee — only delegated rows carry the list
-  const buckets = new Map<string, { label: string; tasks: AssignedTask[] }>();
-  for (const t of tasks) {
-    const list = (t as DelegatedTask).assignees ?? [];
-    if (list.length === 0) {
-      const acc = buckets.get("__none__") ?? {
-        label: "Unassigned",
-        tasks: [],
-      };
-      acc.tasks.push(t);
-      buckets.set("__none__", acc);
-      continue;
-    }
-    for (const a of list) {
-      const key = a.user_id;
-      const acc = buckets.get(key) ?? {
-        label: a.full_name?.trim() || "Someone",
-        tasks: [],
-      };
-      acc.tasks.push(t);
-      buckets.set(key, acc);
-    }
-  }
-  return Array.from(buckets.entries())
-    .map(([key, v]) => ({ key, label: v.label, tasks: v.tasks }))
-    .sort((a, b) => {
-      if (a.key === "__none__") return 1;
-      if (b.key === "__none__") return -1;
-      return a.label.localeCompare(b.label);
-    });
 }
 
 function emptyForTab(tab: "mine" | "delegated" | "overdue" | "week" | "all"): string {

--- a/apps/web/src/lib/activity-summary.test.ts
+++ b/apps/web/src/lib/activity-summary.test.ts
@@ -1,0 +1,258 @@
+import { describe, expect, it } from "vitest";
+import { summarizeActivity } from "./activity-summary";
+
+describe("summarizeActivity", () => {
+  describe("dotted app-emitted actions", () => {
+    it("renders task.create with the title", () => {
+      expect(
+        summarizeActivity({
+          action: "task.create",
+          metadata: { title: "Pour the slab" },
+        }),
+      ).toBe("task created: Pour the slab");
+    });
+
+    it("falls back to (untitled) when title missing", () => {
+      expect(summarizeActivity({ action: "task.create", metadata: {} })).toBe(
+        "task created: (untitled)",
+      );
+    });
+
+    it("renders terminal.create with the name", () => {
+      expect(
+        summarizeActivity({
+          action: "terminal.create",
+          metadata: { name: "HELIOS" },
+        }),
+      ).toBe("new terminal: HELIOS");
+    });
+
+    it("renders task.complete + task.delete + task.assigned", () => {
+      expect(
+        summarizeActivity({
+          action: "task.complete",
+          metadata: { title: "Build deck" },
+        }),
+      ).toBe("completed: Build deck");
+      expect(
+        summarizeActivity({
+          action: "task.delete",
+          metadata: { title: "Old plan" },
+        }),
+      ).toBe("task deleted: Old plan");
+      expect(
+        summarizeActivity({
+          action: "task.assigned",
+          metadata: { title: "Site visit" },
+        }),
+      ).toBe("assigned: Site visit");
+    });
+  });
+
+  describe("plural underscored trigger actions (the original bug)", () => {
+    it("handles tasks_updated without a diff", () => {
+      // Pre-fix: this fell through `replace(/[._]/g, " ")` →
+      // "tasks updated", which is exactly what Zack reported.
+      expect(
+        summarizeActivity({
+          action: "tasks_updated",
+          metadata: { title: "Pour slab" },
+        }),
+      ).toBe("task updated: Pour slab");
+    });
+
+    it("handles terminals_updated", () => {
+      expect(
+        summarizeActivity({
+          action: "terminals_updated",
+          metadata: { name: "HELIOS" },
+        }),
+      ).toBe("HELIOS updated");
+    });
+
+    it("handles spaces_updated, files_updated, comments_updated", () => {
+      expect(
+        summarizeActivity({ action: "spaces_updated", metadata: {} }),
+      ).toBe("space updated:");
+      expect(
+        summarizeActivity({
+          action: "files_updated",
+          metadata: { filename: "spec.pdf" },
+        }),
+      ).toBe("file updated: spec.pdf");
+      expect(
+        summarizeActivity({ action: "comments_updated", metadata: {} }),
+      ).toBe("comment edited");
+    });
+  });
+
+  describe("field-level diffs from before/after", () => {
+    it("renders priority change (Medium → High)", () => {
+      const text = summarizeActivity({
+        action: "tasks_updated",
+        before_json: { title: "Pour slab", priority: 2, status: "todo" },
+        after_json: { title: "Pour slab", priority: 1, status: "todo" },
+      });
+      expect(text).toBe("Pour slab: priority: Medium → High");
+    });
+
+    it("renders status change (Todo → Done)", () => {
+      const text = summarizeActivity({
+        action: "tasks_updated",
+        before_json: { title: "Pour slab", status: "todo", priority: 2 },
+        after_json: { title: "Pour slab", status: "done", priority: 2 },
+      });
+      expect(text).toBe("Pour slab: status: To do → Done");
+    });
+
+    it("renders multi-field diff with separator", () => {
+      const text = summarizeActivity({
+        action: "tasks_updated",
+        before_json: {
+          title: "Old",
+          status: "todo",
+          priority: 3,
+          due_date: null,
+        },
+        after_json: {
+          title: "New",
+          status: "in_progress",
+          priority: 1,
+          due_date: "2026-05-15",
+        },
+      });
+      expect(text).toContain("title: Old → New");
+      expect(text).toContain("status: To do → In progress");
+      expect(text).toContain("priority: Low → High");
+      expect(text).toContain("due: — → 2026-05-15");
+      expect(text).toContain(" · ");
+    });
+
+    it("renders + N more when off-list fields also changed", () => {
+      const text = summarizeActivity({
+        action: "tasks_updated",
+        before_json: {
+          title: "X",
+          priority: 2,
+          recurrence_rule: { freq: "daily" },
+        },
+        after_json: {
+          title: "X",
+          priority: 1,
+          recurrence_rule: { freq: "weekly" },
+        },
+      });
+      expect(text).toMatch(/priority: Medium → High/);
+      expect(text).toMatch(/\+1 more change/);
+    });
+
+    it("ignores noise columns (updated_at, position, ticker_seq)", () => {
+      // These shouldn't fire the diff — if they did the chip would
+      // light up on every save with no real user-facing change.
+      const text = summarizeActivity({
+        action: "tasks_updated",
+        before_json: {
+          title: "Stable",
+          priority: 1,
+          updated_at: "2026-05-01T00:00:00Z",
+          position: 1000,
+          ticker_seq: 5,
+        },
+        after_json: {
+          title: "Stable",
+          priority: 1,
+          updated_at: "2026-05-02T00:00:00Z",
+          position: 2000,
+          ticker_seq: 5,
+        },
+      });
+      expect(text).toBe("task updated: Stable");
+    });
+
+    it("falls back to plain 'task updated' when before/after match", () => {
+      const text = summarizeActivity({
+        action: "tasks_updated",
+        before_json: { title: "Same", priority: 1 },
+        after_json: { title: "Same", priority: 1 },
+      });
+      expect(text).toBe("task updated: Same");
+    });
+
+    it("handles null priority (no priority sentinel)", () => {
+      const text = summarizeActivity({
+        action: "tasks_updated",
+        before_json: { title: "X", priority: null },
+        after_json: { title: "X", priority: 1 },
+      });
+      expect(text).toBe("X: priority: None → High");
+    });
+  });
+
+  describe("file actions", () => {
+    it("renders file.upload", () => {
+      expect(
+        summarizeActivity({
+          action: "file.upload",
+          metadata: { filename: "plans.pdf" },
+        }),
+      ).toBe("uploaded plans.pdf");
+    });
+
+    it("renders folder.create via op metadata", () => {
+      expect(
+        summarizeActivity({
+          action: "file.upload",
+          metadata: { op: "folder.create", path: "drawings/" },
+        }),
+      ).toBe("folder: drawings/");
+    });
+
+    it("renders file_updated singular", () => {
+      expect(
+        summarizeActivity({
+          action: "file_updated",
+          metadata: { filename: "spec.pdf" },
+        }),
+      ).toBe("file updated: spec.pdf");
+    });
+  });
+
+  describe("members + comments", () => {
+    it("renders member.invite + member.join", () => {
+      expect(
+        summarizeActivity({
+          action: "member.invite",
+          metadata: { email: "ann@example.com" },
+        }),
+      ).toBe("invited ann@example.com");
+      expect(
+        summarizeActivity({
+          action: "member.join",
+          metadata: { name: "Ann" },
+        }),
+      ).toBe("Ann joined");
+    });
+
+    it("renders comment.create with entity_kind", () => {
+      expect(
+        summarizeActivity({
+          action: "comment.create",
+          metadata: { entity_kind: "task" },
+        }),
+      ).toBe("commented on task");
+    });
+  });
+
+  describe("unknown actions", () => {
+    it("falls back to humanized action name", () => {
+      // An action we never see in practice but might emit in the
+      // future. The fallback should still produce a readable chip.
+      expect(
+        summarizeActivity({
+          action: "shiny_new_kind",
+          metadata: {},
+        }),
+      ).toBe("shiny new kind");
+    });
+  });
+});

--- a/apps/web/src/lib/normalize-emails.test.ts
+++ b/apps/web/src/lib/normalize-emails.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { normalizeEmails } from "./normalize-emails";
+
+describe("normalizeEmails", () => {
+  it("trims whitespace and lower-cases", () => {
+    expect(normalizeEmails(["  ZackM@trumpgroup.com  "])).toEqual([
+      "zackm@trumpgroup.com",
+    ]);
+  });
+
+  it("dedupes case-insensitively", () => {
+    expect(
+      normalizeEmails(["a@b.com", "A@B.COM", "  a@b.com"]),
+    ).toEqual(["a@b.com"]);
+  });
+
+  it("drops empty / whitespace-only entries silently", () => {
+    expect(
+      normalizeEmails(["a@b.com", "", "   ", "\t"]),
+    ).toEqual(["a@b.com"]);
+  });
+
+  it("returns 'invalid' on a garbage entry", () => {
+    expect(normalizeEmails(["not-an-email"])).toBe("invalid");
+    expect(normalizeEmails(["a@b.com", "@@@"])).toBe("invalid");
+    expect(normalizeEmails(["a @b.com"])).toBe("invalid"); // space in local
+  });
+
+  it("returns 'invalid' when input isn't an array", () => {
+    expect(normalizeEmails("a@b.com")).toBe("invalid");
+    expect(normalizeEmails(null)).toBe("invalid");
+    expect(normalizeEmails(undefined)).toBe("invalid");
+    expect(normalizeEmails({ 0: "a@b.com" })).toBe("invalid");
+  });
+
+  it("ignores non-string array entries (skips silently)", () => {
+    expect(
+      normalizeEmails(["a@b.com", null, 42, undefined, "c@d.com"]),
+    ).toEqual(["a@b.com", "c@d.com"]);
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(normalizeEmails([])).toEqual([]);
+  });
+
+  it("accepts subdomains, plus addressing, dashes", () => {
+    expect(
+      normalizeEmails([
+        "ann+filter@helios.co",
+        "first.last@sub.example.com",
+        "user-name@x.io",
+      ]),
+    ).toEqual([
+      "ann+filter@helios.co",
+      "first.last@sub.example.com",
+      "user-name@x.io",
+    ]);
+  });
+});

--- a/apps/web/src/lib/normalize-emails.ts
+++ b/apps/web/src/lib/normalize-emails.ts
@@ -1,0 +1,30 @@
+/**
+ * Normalize a caller-provided list of email addresses for storage on
+ * `tasks.external_assignee_emails`.
+ *
+ * Trims, lower-cases, dedupes, and shape-validates each entry.
+ * Returns the canonical list, or the literal string `"invalid"` when
+ * any entry fails the basic regex (which the API surfaces as a 400).
+ *
+ * Empty / whitespace-only entries are silently dropped so a stale UI
+ * chip can't accidentally poison the row.
+ *
+ * Validation is intentionally permissive — anything with a local
+ * part, an `@`, and a TLD-shaped domain. Deeper validation
+ * (existence, deliverability) belongs in the invite-email step, not
+ * here. We only care that what lands on the row is at least the
+ * shape of an email.
+ */
+export function normalizeEmails(input: unknown): string[] | "invalid" {
+  if (!Array.isArray(input)) return "invalid";
+  const out = new Set<string>();
+  const re = /^[^@\s]+@[^@\s]+\.[^@\s]+$/;
+  for (const raw of input) {
+    if (typeof raw !== "string") continue;
+    const v = raw.trim().toLowerCase();
+    if (!v) continue;
+    if (!re.test(v)) return "invalid";
+    out.add(v);
+  }
+  return Array.from(out);
+}

--- a/apps/web/src/lib/task-grouping.test.ts
+++ b/apps/web/src/lib/task-grouping.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from "vitest";
+import {
+  bucketDashTasks,
+  groupTasks,
+  type GroupableTask,
+} from "./task-grouping";
+
+const t = (
+  over: Partial<GroupableTask> & { id: string },
+): GroupableTask => ({
+  status: "todo",
+  priority: null,
+  due_date: null,
+  ...over,
+});
+
+describe("groupTasks", () => {
+  it("none mode returns one group with everything", () => {
+    const tasks = [t({ id: "a" }), t({ id: "b" })];
+    const out = groupTasks(tasks, "none");
+    expect(out).toHaveLength(1);
+    expect(out[0].key).toBe("all");
+    expect(out[0].label).toBe("");
+    expect(out[0].tasks).toHaveLength(2);
+  });
+
+  it("priority groups: orders High → Medium → Low → No priority and drops empties", () => {
+    const tasks = [
+      t({ id: "a", priority: 3 }),
+      t({ id: "b", priority: 1 }),
+      t({ id: "c", priority: null }),
+      t({ id: "d", priority: 1 }),
+    ];
+    const out = groupTasks(tasks, "priority");
+    expect(out.map((g) => g.key)).toEqual(["high", "low", "none"]);
+    expect(out[0].tasks.map((x) => x.id).sort()).toEqual(["b", "d"]);
+  });
+
+  it("status groups: Todo → In progress → Review → Blocked → Done", () => {
+    const tasks = [
+      t({ id: "a", status: "done" }),
+      t({ id: "b", status: "todo" }),
+      t({ id: "c", status: "in_progress" }),
+    ];
+    const out = groupTasks(tasks, "status");
+    expect(out.map((g) => g.key)).toEqual([
+      "todo",
+      "in_progress",
+      "done",
+    ]);
+  });
+
+  it("assignee groups: alphabetical, Unassigned last", () => {
+    const tasks = [
+      t({
+        id: "a",
+        assignees: [{ user_id: "u1", full_name: "Zack" }],
+      }),
+      t({
+        id: "b",
+        assignees: [{ user_id: "u2", full_name: "Ann" }],
+      }),
+      t({ id: "c", assignees: [] }),
+    ];
+    const out = groupTasks(tasks, "assignee");
+    expect(out.map((g) => g.label)).toEqual([
+      "Ann",
+      "Zack",
+      "Unassigned",
+    ]);
+  });
+
+  it("assignee groups: a task with two assignees lands in BOTH buckets", () => {
+    const tasks = [
+      t({
+        id: "shared",
+        assignees: [
+          { user_id: "u1", full_name: "Ann" },
+          { user_id: "u2", full_name: "Bob" },
+        ],
+      }),
+    ];
+    const out = groupTasks(tasks, "assignee");
+    expect(out).toHaveLength(2);
+    expect(out[0].tasks).toHaveLength(1);
+    expect(out[1].tasks).toHaveLength(1);
+    expect(out[0].tasks[0].id).toBe("shared");
+    expect(out[1].tasks[0].id).toBe("shared");
+  });
+
+  it("due groups: Overdue → Today → This week → Later → No due date", () => {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    const yesterday = new Date(today);
+    yesterday.setDate(yesterday.getDate() - 1);
+    const twoDays = new Date(today);
+    twoDays.setDate(twoDays.getDate() + 2);
+    const month = new Date(today);
+    month.setMonth(month.getMonth() + 1);
+
+    const fmt = (d: Date) => d.toISOString().slice(0, 10);
+    const tasks = [
+      t({ id: "old", due_date: fmt(yesterday) }),
+      t({ id: "today", due_date: fmt(today) }),
+      t({ id: "soon", due_date: fmt(twoDays) }),
+      t({ id: "later", due_date: fmt(month) }),
+      t({ id: "none" }),
+    ];
+    const out = groupTasks(tasks, "due");
+    expect(out.map((g) => g.key)).toEqual([
+      "overdue",
+      "today",
+      "week",
+      "later",
+      "none",
+    ]);
+    expect(out[0].tasks[0].id).toBe("old");
+    expect(out[1].tasks[0].id).toBe("today");
+    expect(out[2].tasks[0].id).toBe("soon");
+    expect(out[3].tasks[0].id).toBe("later");
+    expect(out[4].tasks[0].id).toBe("none");
+  });
+
+  it("empty list returns one empty group regardless of mode", () => {
+    expect(groupTasks([], "priority")).toEqual([
+      { key: "all", label: "", tasks: [] },
+    ]);
+  });
+});
+
+describe("bucketDashTasks", () => {
+  const tickerById = { t1: "HELIOS", t2: "CASA" };
+  const nameById = { t1: "Helios", t2: "Casablanca" };
+
+  const dt = (
+    over: Partial<GroupableTask> & { id: string; terminal_id: string },
+  ) => ({
+    status: "todo",
+    priority: null as number | null,
+    due_date: null as string | null,
+    ...over,
+  });
+
+  it("terminal mode buckets per terminal_id with TICKER · Name labels", () => {
+    const out = bucketDashTasks(
+      [
+        dt({ id: "a", terminal_id: "t1" }),
+        dt({ id: "b", terminal_id: "t2" }),
+        dt({ id: "c", terminal_id: "t1" }),
+      ],
+      "terminal",
+      tickerById,
+      nameById,
+    );
+    expect(out).toHaveLength(2);
+    const labels = out.map((g) => g.label);
+    expect(labels).toContain("HELIOS · Helios");
+    expect(labels).toContain("CASA · Casablanca");
+  });
+
+  it("terminal mode falls back to ticker-only when name missing", () => {
+    const out = bucketDashTasks(
+      [dt({ id: "a", terminal_id: "t1" })],
+      "terminal",
+      tickerById,
+      undefined,
+    );
+    expect(out[0].label).toBe("HELIOS");
+  });
+
+  it("delegates to groupTasks for shared modes", () => {
+    const out = bucketDashTasks(
+      [
+        dt({ id: "a", terminal_id: "t1", priority: 1 }),
+        dt({ id: "b", terminal_id: "t2", priority: null }),
+      ],
+      "priority",
+      tickerById,
+      nameById,
+    );
+    expect(out.map((g) => g.key)).toEqual(["high", "none"]);
+  });
+
+  it("none mode returns flat single group", () => {
+    const out = bucketDashTasks(
+      [dt({ id: "a", terminal_id: "t1" })],
+      "none",
+      tickerById,
+      nameById,
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0].label).toBe("");
+  });
+});

--- a/apps/web/src/lib/task-grouping.ts
+++ b/apps/web/src/lib/task-grouping.ts
@@ -1,0 +1,246 @@
+/**
+ * Bucket helpers for the task list group-by view.
+ *
+ * Two consumers:
+ *
+ *   - In-terminal `TasksPane` — groups by assignee / due / priority /
+ *     status (terminal context already pins the space + project).
+ *   - Dashboard `TasksCard` — groups by terminal / priority / due /
+ *     assignee (cross-cutting view, terminal-grouping is the headline
+ *     value here since the dashboard list spans terminals).
+ *
+ * Both surfaces render the result as section headers + a count chip.
+ * Empty buckets are dropped so the layout doesn't waste vertical
+ * space on "0 tasks" headers.
+ */
+
+export type TaskGroupMode =
+  | "none"
+  | "assignee"
+  | "due"
+  | "priority"
+  | "status";
+
+/**
+ * Minimal shape needed to bucket. Both `TasksPane.Task` and
+ * `dashboard.AssignedTask` satisfy it (with the assignees field
+ * optional — the dashboard's "Mine" tab doesn't carry one).
+ */
+export interface GroupableTask {
+  id: string;
+  status: string;
+  priority: number | null;
+  due_date: string | null;
+  assignees?: { user_id: string; full_name: string | null }[];
+}
+
+export interface TaskGroup<T> {
+  key: string;
+  label: string;
+  tasks: T[];
+}
+
+/**
+ * Group an in-terminal task list. The "none" mode returns a single
+ * unlabeled group containing every task — matches the flat list
+ * rendering and avoids special-casing in the renderer.
+ */
+export function groupTasks<T extends GroupableTask>(
+  tasks: T[],
+  mode: TaskGroupMode,
+): TaskGroup<T>[] {
+  if (mode === "none" || tasks.length === 0) {
+    return [{ key: "all", label: "", tasks }];
+  }
+
+  if (mode === "assignee") return bucketByAssignee(tasks);
+  if (mode === "due") return bucketByDue(tasks);
+  if (mode === "priority") return bucketByPriority(tasks);
+  return bucketByStatus(tasks);
+}
+
+/**
+ * Group dashboard tasks. Terminal-grouping is the headline value
+ * here; the rest mirror the in-terminal pane's modes.
+ *
+ * Falls through to `groupTasks` for the shared modes so the bucket
+ * logic only lives in one place.
+ */
+export type DashGroupMode =
+  | "none"
+  | "terminal"
+  | "priority"
+  | "due"
+  | "assignee";
+
+export interface DashGroupableTask extends GroupableTask {
+  terminal_id: string;
+}
+
+export function bucketDashTasks<T extends DashGroupableTask>(
+  tasks: T[],
+  by: DashGroupMode,
+  tickerById: Record<string, string>,
+  terminalNameById?: Record<string, string>,
+): TaskGroup<T>[] {
+  if (by === "none" || tasks.length === 0) {
+    return [{ key: "all", label: "", tasks }];
+  }
+  if (by === "terminal") {
+    const buckets = new Map<string, T[]>();
+    for (const t of tasks) {
+      const key = t.terminal_id;
+      if (!buckets.has(key)) buckets.set(key, []);
+      buckets.get(key)!.push(t);
+    }
+    return Array.from(buckets.entries())
+      .map(([key, list]) => {
+        const ticker = tickerById[key] ?? "";
+        const name = terminalNameById?.[key] ?? "";
+        const label = ticker
+          ? name
+            ? `${ticker} · ${name}`
+            : ticker
+          : name || "Terminal";
+        return { key, label, tasks: list };
+      })
+      .sort((a, b) => a.label.localeCompare(b.label));
+  }
+  // Reuse the in-terminal helpers for shared modes.
+  return groupTasks(tasks, by);
+}
+
+/* ------------------------------------------------------------------ */
+/* Bucket implementations                                               */
+/* ------------------------------------------------------------------ */
+
+function bucketByAssignee<T extends GroupableTask>(tasks: T[]): TaskGroup<T>[] {
+  const buckets = new Map<string, { label: string; tasks: T[] }>();
+  for (const t of tasks) {
+    const list = t.assignees ?? [];
+    if (list.length === 0) {
+      const acc = buckets.get("__none__") ?? {
+        label: "Unassigned",
+        tasks: [],
+      };
+      acc.tasks.push(t);
+      buckets.set("__none__", acc);
+      continue;
+    }
+    // Tasks with multiple assignees show up under each one — when
+    // grouping by assignee the user expects "show me what each
+    // person owes me", not "pick one canonical owner."
+    for (const a of list) {
+      const acc = buckets.get(a.user_id) ?? {
+        label: a.full_name?.trim() || "Someone",
+        tasks: [],
+      };
+      acc.tasks.push(t);
+      buckets.set(a.user_id, acc);
+    }
+  }
+  return Array.from(buckets.entries())
+    .map(([key, v]) => ({ key, label: v.label, tasks: v.tasks }))
+    .sort((a, b) => {
+      if (a.key === "__none__") return 1;
+      if (b.key === "__none__") return -1;
+      return a.label.localeCompare(b.label);
+    });
+}
+
+function bucketByDue<T extends GroupableTask>(tasks: T[]): TaskGroup<T>[] {
+  const now = new Date();
+  const startOfDay = new Date(now);
+  startOfDay.setHours(0, 0, 0, 0);
+  const endOfDay = new Date(startOfDay);
+  endOfDay.setDate(endOfDay.getDate() + 1);
+  const endOfWeek = new Date(startOfDay);
+  endOfWeek.setDate(endOfWeek.getDate() + 7);
+
+  const order = ["overdue", "today", "week", "later", "none"] as const;
+  const buckets: Record<(typeof order)[number], T[]> = {
+    overdue: [],
+    today: [],
+    week: [],
+    later: [],
+    none: [],
+  };
+  for (const t of tasks) {
+    let key: (typeof order)[number];
+    if (!t.due_date) key = "none";
+    else {
+      // Parse YYYY-MM-DD as a local-midnight Date — `new Date(iso)`
+      // treats bare date strings as UTC, which puts a "today" task
+      // in the previous day's bucket for users east of UTC. The
+      // explicit constructor pins it to the user's local calendar.
+      const [y, mo, d] = t.due_date.split("-").map(Number);
+      const due = new Date(y, (mo ?? 1) - 1, d ?? 1).getTime();
+      if (due < startOfDay.getTime()) key = "overdue";
+      else if (due < endOfDay.getTime()) key = "today";
+      else if (due < endOfWeek.getTime()) key = "week";
+      else key = "later";
+    }
+    buckets[key].push(t);
+  }
+  const labels: Record<string, string> = {
+    overdue: "Overdue",
+    today: "Today",
+    week: "This week",
+    later: "Later",
+    none: "No due date",
+  };
+  return order
+    .map((k) => ({ key: k, label: labels[k], tasks: buckets[k] }))
+    .filter((g) => g.tasks.length > 0);
+}
+
+function bucketByPriority<T extends GroupableTask>(tasks: T[]): TaskGroup<T>[] {
+  const buckets: Record<string, T[]> = {
+    high: [],
+    med: [],
+    low: [],
+    none: [],
+  };
+  for (const t of tasks) {
+    const k =
+      t.priority === 1
+        ? "high"
+        : t.priority === 2
+          ? "med"
+          : t.priority === 3
+            ? "low"
+            : "none";
+    buckets[k].push(t);
+  }
+  return [
+    { key: "high", label: "High", tasks: buckets.high },
+    { key: "med", label: "Medium", tasks: buckets.med },
+    { key: "low", label: "Low", tasks: buckets.low },
+    { key: "none", label: "No priority", tasks: buckets.none },
+  ].filter((g) => g.tasks.length > 0);
+}
+
+function bucketByStatus<T extends GroupableTask>(tasks: T[]): TaskGroup<T>[] {
+  const order = ["todo", "in_progress", "review", "blocked", "done"] as const;
+  const labels: Record<string, string> = {
+    todo: "To do",
+    in_progress: "In progress",
+    review: "Review",
+    blocked: "Blocked",
+    done: "Done",
+  };
+  const buckets = new Map<string, T[]>();
+  for (const s of order) buckets.set(s, []);
+  for (const t of tasks) {
+    if (buckets.has(t.status)) buckets.get(t.status)!.push(t);
+    else {
+      // Unknown status — bucket under "todo" so the row still shows.
+      // (Shouldn't happen — status is enum'd in the DB — but the
+      // group logic stays defensive against schema drift.)
+      buckets.get("todo")!.push(t);
+    }
+  }
+  return order
+    .map((s) => ({ key: s, label: labels[s], tasks: buckets.get(s) ?? [] }))
+    .filter((g) => g.tasks.length > 0);
+}

--- a/apps/web/src/lib/ticker-tips.test.ts
+++ b/apps/web/src/lib/ticker-tips.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { withToolTips, type TickerTip } from "./ticker-tips";
+
+const item = (id: string) => ({ id, text: `e-${id}`, when: "1m" });
+
+describe("withToolTips — the bug that crashed the dashboard at 10+ rows", () => {
+  it("does not push undefined into the stream at idx 9, 19, 29", () => {
+    // Pre-fix: `tips[(idx / 10) % tips.length]` evaluated to
+    // `tips[0.9]`, `tips[1.9]`, `tips[2.9]` — all undefined. The
+    // renderer then read `.id` on undefined and threw.
+    const items = Array.from({ length: 30 }, (_, i) => item(`a-${i}`));
+    const out = withToolTips(items);
+    for (const row of out) {
+      expect(row).toBeDefined();
+      expect((row as { id: string }).id).toBeTruthy();
+    }
+  });
+
+  it("inserts a tip exactly every 10th slot", () => {
+    const items = Array.from({ length: 30 }, (_, i) => item(`x-${i}`));
+    const out = withToolTips(items);
+    // Tips are pushed AFTER each multiple of 10, so there are 3:
+    // after item idx=9, idx=19, idx=29.
+    const tips = out.filter((r) => "tip" in r && r.tip);
+    expect(tips).toHaveLength(3);
+  });
+
+  it("rotates through the tip list", () => {
+    const tips: TickerTip[] = [
+      { id: "t1", text: "1", when: "", tip: true },
+      { id: "t2", text: "2", when: "", tip: true },
+      { id: "t3", text: "3", when: "", tip: true },
+    ];
+    const items = Array.from({ length: 50 }, (_, i) => item(`x-${i}`));
+    const out = withToolTips(items, tips);
+    const tipIds = out
+      .filter((r) => "tip" in r && r.tip)
+      .map((r) => (r as TickerTip).id);
+    // 50 items → tips after idx 9, 19, 29, 39, 49 → 5 tips
+    expect(tipIds).toEqual(["t1", "t2", "t3", "t1", "t2"]);
+  });
+
+  it("no-ops for short streams (< 5 items)", () => {
+    const items = [item("a"), item("b"), item("c")];
+    const out = withToolTips(items);
+    expect(out).toEqual(items);
+    expect(out.some((r) => "tip" in r && r.tip)).toBe(false);
+  });
+
+  it("no-ops when tips array is empty", () => {
+    const items = Array.from({ length: 30 }, (_, i) => item(`x-${i}`));
+    const out = withToolTips(items, []);
+    expect(out).toHaveLength(30);
+    expect(out.some((r) => "tip" in r && r.tip)).toBe(false);
+  });
+
+  it("custom interval respects `every` arg", () => {
+    const items = Array.from({ length: 20 }, (_, i) => item(`x-${i}`));
+    const out = withToolTips(items, undefined, 5);
+    // Tips after idx 4, 9, 14, 19 → 4 tips.
+    const tips = out.filter((r) => "tip" in r && r.tip);
+    expect(tips).toHaveLength(4);
+  });
+});

--- a/apps/web/src/lib/ticker-tips.ts
+++ b/apps/web/src/lib/ticker-tips.ts
@@ -1,0 +1,82 @@
+/**
+ * Tip-injection logic for the activity ticker.
+ *
+ * Sprinkles a "💡 Try: …" pseudo-row into the stream every 10th
+ * slot so power users keep discovering MCP / shortcut features
+ * without a dedicated card eating dashboard real estate.
+ *
+ * History:
+ *   The original `(idx / 10) % tips.length` returned non-integer
+ *   indices (0.9, 1.9, 2.9 at idx=9,19,29). `tips[0.9]` is
+ *   `undefined`, which got pushed into the stream and crashed the
+ *   renderer with `Cannot read properties of undefined (reading
+ *   'id')` — see PR #119. The bug only manifested once a user's
+ *   activity stream crossed 10 rows for the first time.
+ *
+ * Extracted from `TickerTape.tsx` so the index-rounding bug class
+ * can be locked down by tests in isolation.
+ */
+
+export interface TickerTip {
+  id: string;
+  text: string;
+  when: string;
+  href?: string;
+  /** Marks the row as a tip (vs. a real activity event). */
+  tip?: boolean;
+}
+
+/**
+ * Default tip list. The exported variable lets the caller swap in a
+ * custom set (e.g. tests, alternate tip rotations) without forking
+ * the injection logic.
+ */
+export const DEFAULT_TIPS: TickerTip[] = [
+  {
+    id: "tip:ask",
+    text: `Try: "ask rokki what's in the permit folder" — ⌘K "ask"`,
+    when: "",
+    href: "/tools",
+    tip: true,
+  },
+  {
+    id: "tip:search",
+    text: `Try: "search across all my files" — ⌘K "search"`,
+    when: "",
+    href: "/tools",
+    tip: true,
+  },
+  {
+    id: "tip:tool",
+    text: `💡 Your tools are one keystroke away — ⌘K`,
+    when: "",
+    href: "/tools",
+    tip: true,
+  },
+];
+
+/**
+ * Inject a tip every Nth row (default 10). Rotates through the
+ * provided tip list. No-ops for short streams (< 5 items) so a quiet
+ * user doesn't see tips outweigh real events.
+ *
+ * Defensive: integer-rounded index + falsy-skip means a malformed
+ * tips list (or a future shape change) can't push undefined into
+ * the stream.
+ */
+export function withToolTips<T extends { id: string }>(
+  items: T[],
+  tips: TickerTip[] = DEFAULT_TIPS,
+  every: number = 10,
+): (T | TickerTip)[] {
+  if (items.length < 5 || tips.length === 0) return items;
+  const out: (T | TickerTip)[] = [];
+  items.forEach((it, idx) => {
+    out.push(it);
+    if ((idx + 1) % every === 0) {
+      const tip = tips[Math.floor(idx / every) % tips.length];
+      if (tip) out.push(tip);
+    }
+  });
+  return out;
+}


### PR DESCRIPTION
## Summary

Adds 45 vitest cases pinning down the bug classes that bit prod today plus the new feature surfaces from PRs #110-#123.

To make pure logic testable, three small extractions:
- \`lib/task-grouping.ts\` — \`groupTasks\` + \`bucketDashTasks\` (was duplicated across TasksPane and TasksCard)
- \`lib/ticker-tips.ts\` — \`withToolTips\` (the function whose non-integer index 500'd the dashboard tonight; tests pin the bug class)
- \`lib/normalize-emails.ts\` — was duplicated in two route files

Plus one real correctness fix found while writing the due-bucket test: \`new Date("YYYY-MM-DD")\` parses as UTC, which puts a "due today" task in yesterday's bucket for users east of UTC. Switched to the local-calendar constructor.

## Coverage

- \`activity-summary.test.ts\` (20) — dotted, plural-underscored, and diff-rendering paths; the plural \`tasks_updated\` regression that PR #122 fixed
- \`task-grouping.test.ts\` (11) — all 5 grouping modes, alphabetical/recency ordering, multi-assignee bucketing, dashboard terminal-grouping
- \`ticker-tips.test.ts\` (6) — explicit assertion that no \`undefined\` row gets pushed into a 30-item stream
- \`normalize-emails.test.ts\` (8) — trim, lowercase, dedupe, garbage-rejection, non-array input, plus-addressing

## Test plan
- [ ] CI green (`Lint, Typecheck, Test`)
- [ ] Affected components still build (TasksPane, TasksCard, TickerTape)

🤖 Generated with [Claude Code](https://claude.com/claude-code)