### PR TITLE
feat(reminders): cron worker for daily fan-out

### DIFF
--- a/.github/workflows/reminders.yml
+++ b/.github/workflows/reminders.yml
@@ -1,0 +1,55 @@
+name: Reminders fan-out
+
+# Daily reminders tick — for every user with a reminders thread,
+# scan their open tasks and post a fresh ping for any overdue or
+# due-today task that hasn't been reminded in the past 24h.
+#
+# The endpoint is per-task 24h-deduped, so over-firing the cron is
+# harmless. We run once a day at 8:00 UTC (~3am Eastern, 8pm Pacific
+# the previous day) — early enough to be in someone's inbox by
+# breakfast, late enough that timezone-shifted users don't miss the
+# day's reminders.
+#
+# Secrets required:
+#   ROKKI_CRON_SECRET — must match the CRON_SECRET env var on Vercel.
+#
+# Manual run: Actions tab → "Reminders fan-out" → Run workflow.
+on:
+  schedule:
+    - cron: "0 8 * * *"
+  workflow_dispatch:
+
+# Belt-and-suspenders concurrency guard. The 24h dedupe already
+# protects against duplicate posts, but skipping a stacked second
+# run also keeps the action log readable.
+concurrency:
+  group: reminders-fanout
+  cancel-in-progress: false
+
+jobs:
+  tick:
+    name: POST /api/v1/cron/reminders
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Trigger reminders fan-out
+        env:
+          CRON_SECRET: ${{ secrets.ROKKI_CRON_SECRET }}
+        run: |
+          if [ -z "$CRON_SECRET" ]; then
+            echo "::warning::ROKKI_CRON_SECRET not set; skipping tick"
+            exit 0
+          fi
+          STATUS=$(curl -sS -o /tmp/body -w "%{http_code}" \
+            -X POST \
+            -H "x-cron-secret: $CRON_SECRET" \
+            -H "content-type: application/json" \
+            --max-time 290 \
+            https://rokki.ai/api/v1/cron/reminders)
+          BODY=$(cat /tmp/body)
+          echo "HTTP $STATUS"
+          echo "$BODY"
+          if [ "$STATUS" != "200" ]; then
+            echo "::error::reminders tick failed with HTTP $STATUS: $BODY"
+            exit 1
+          fi

--- a/apps/web/src/app/api/v1/cron/reminders/route.ts
+++ b/apps/web/src/app/api/v1/cron/reminders/route.ts
@@ -1,0 +1,210 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { createClient as createAdminClient } from "@supabase/supabase-js";
+import type { Database } from "@rokki/db";
+
+/**
+ * POST /api/v1/cron/reminders
+ *
+ * Daily reminders fan-out. For every user who already has a
+ * `kind='reminders'` thread (i.e. who's hit "Turn on Reminders"
+ * once), recompute their overdue + due-today open tasks and post a
+ * fresh ping for any task that hasn't been reminded in the past 24h.
+ *
+ * Mirrors `/api/v1/reminders/refresh` per-user but runs as a single
+ * service-role pass so a cron caller doesn't need to impersonate
+ * each user.
+ *
+ * Auth: same `x-cron-secret` / Bearer pattern as the calendar-sync
+ * cron. The /api/v1/cron/* prefix is allowlisted in the auth
+ * middleware so this handler runs without a user session — the
+ * secret is the only gate.
+ *
+ * Idempotent: per-task 24h dedupe means re-running the same hour
+ * is a no-op. We also tolerate transient errors (network, RLS
+ * surprises) and continue with the next user — the daily run can
+ * tolerate missing one user once if their next run picks them up.
+ *
+ * Response:
+ *   { data: { users_processed, posted, skipped, errors } }
+ */
+export const dynamic = "force-dynamic";
+// Generous timeout — large user bases mean a single tick can fan
+// out to hundreds of refreshes, each two or three round-trips.
+export const maxDuration = 300;
+
+interface TickResult {
+  users_processed: number;
+  posted: number;
+  skipped: number;
+  errors: number;
+}
+
+export async function POST(request: NextRequest) {
+  if (!authorize(request)) return unauthorized();
+  const result = await runRemindersTick();
+  return NextResponse.json({ data: result });
+}
+
+// GET for smoke-test convenience. Same auth gate.
+export async function GET(request: NextRequest) {
+  if (!authorize(request)) return unauthorized();
+  const result = await runRemindersTick();
+  return NextResponse.json({ data: result });
+}
+
+async function runRemindersTick(): Promise<TickResult> {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    return { users_processed: 0, posted: 0, skipped: 0, errors: 0 };
+  }
+  const admin = createAdminClient<Database>(url, key, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+
+  // Gather every reminders thread + its single participant. The
+  // user_id IS the audience for that thread; one round-trip lets us
+  // drive the whole fan-out without per-user thread lookups.
+  const { data: threads } = await admin
+    .from("message_threads")
+    .select(
+      "id, thread_participants!thread_participants_thread_id_fkey(user_id)",
+    )
+    .eq("kind", "reminders" as never);
+
+  type ThreadRow = {
+    id: string;
+    thread_participants: { user_id: string } | { user_id: string }[] | null;
+  };
+  const result: TickResult = {
+    users_processed: 0,
+    posted: 0,
+    skipped: 0,
+    errors: 0,
+  };
+  for (const row of ((threads ?? []) as unknown) as ThreadRow[]) {
+    const part = Array.isArray(row.thread_participants)
+      ? row.thread_participants[0]
+      : row.thread_participants;
+    if (!part?.user_id) continue;
+    try {
+      const r = await refreshOne(admin, row.id, part.user_id);
+      result.users_processed += 1;
+      result.posted += r.posted;
+      result.skipped += r.skipped;
+    } catch {
+      result.errors += 1;
+    }
+  }
+  return result;
+}
+
+/**
+ * Per-user refresh — mirror of /api/v1/reminders/refresh's compute
+ * step, but driven by the service-role admin client so we don't need
+ * a user session. RLS doesn't apply here; the trade-off is that the
+ * caller (cron) must already know the user_id this thread belongs to.
+ */
+async function refreshOne(
+  admin: ReturnType<typeof createAdminClient<Database>>,
+  threadId: string,
+  userId: string,
+): Promise<{ posted: number; skipped: number }> {
+  // Find the user's overdue + due-today open assigned tasks.
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const tomorrow = new Date(today);
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  const todayIso = today.toISOString().slice(0, 10);
+  const tomorrowIso = tomorrow.toISOString().slice(0, 10);
+
+  const { data: rows } = await admin
+    .from("task_assignees")
+    .select(
+      "tasks!task_assignees_task_id_fkey(id, title, status, due_date)",
+    )
+    .eq("user_id", userId);
+
+  type AssignedRow = {
+    tasks: {
+      id: string;
+      title: string;
+      status: string;
+      due_date: string | null;
+    } | null;
+  };
+  const open = (((rows ?? []) as unknown) as AssignedRow[])
+    .map((r) => r.tasks)
+    .filter((t): t is NonNullable<AssignedRow["tasks"]> => !!t)
+    .filter((t) => t.status !== "done")
+    .filter((t) => t.due_date && t.due_date < tomorrowIso);
+
+  // Per-task 24h dedupe — don't double-post.
+  const cutoff = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+  const { data: recent } = await admin
+    .from("messages")
+    .select("pinging_task_id, created_at")
+    .eq("thread_id", threadId)
+    .gte("created_at", cutoff);
+  type RecentRow = { pinging_task_id: string | null; created_at: string };
+  const recentTaskIds = new Set(
+    (((recent ?? []) as unknown) as RecentRow[])
+      .map((r) => r.pinging_task_id)
+      .filter((x): x is string => !!x),
+  );
+
+  let posted = 0;
+  let skipped = 0;
+  for (const t of open) {
+    if (recentTaskIds.has(t.id)) {
+      skipped += 1;
+      continue;
+    }
+    const overdue = (t.due_date ?? "") < todayIso;
+    const body = overdue
+      ? `Overdue: "${t.title}" — was due ${t.due_date ?? "?"}`
+      : `Due today: "${t.title}"`;
+    await admin
+      .from("messages")
+      .insert({
+        thread_id: threadId,
+        author_id: userId,
+        body,
+        pinging_task_id: t.id,
+      } as never);
+    posted += 1;
+  }
+
+  if (posted > 0) {
+    await admin
+      .from("message_threads")
+      .update({ last_message_at: new Date().toISOString() } as never)
+      .eq("id", threadId);
+  }
+  return { posted, skipped };
+}
+
+function authorize(request: NextRequest): boolean {
+  const expected = process.env.CRON_SECRET;
+  if (!expected) return false; // no secret configured = endpoint disabled
+  const cronHeader = request.headers.get("x-cron-secret");
+  if (cronHeader === expected) return true;
+  const auth = request.headers.get("authorization") ?? "";
+  if (auth === `Bearer ${expected}`) return true;
+  return false;
+}
+
+function unauthorized(): NextResponse {
+  return NextResponse.json(
+    {
+      errors: [
+        {
+          code: "unauthorized",
+          message:
+            "Cron endpoint requires `x-cron-secret` or Bearer token",
+        },
+      ],
+    },
+    { status: 401 },
+  );
+}


### PR DESCRIPTION
## Summary

Closes the cron follow-up from PR #118. Daily reminders now fan out automatically — users no longer need to hit "Refresh" manually.

- New \`/api/v1/cron/reminders\` route — service-role pass over every \`kind='reminders'\` thread, posts pings for overdue / due-today tasks, 24h-deduped per task.
- New \`.github/workflows/reminders.yml\` — runs at 08:00 UTC daily. Uses the existing \`ROKKI_CRON_SECRET\` GH secret already wired up for calendar sync.
- Idempotent: stacking runs is safe.

No new env vars, no new migrations. The GH workflow won't run until the secret is configured (it already is, for calendar sync).

## Test plan
- [ ] Manual smoke: \`curl -X POST -H "x-cron-secret: …" https://rokki.ai/api/v1/cron/reminders\` → 200 with \`{ users_processed, posted, skipped, errors }\`
- [ ] Repeat within 24h → \`posted: 0\` (dedupe holds)
- [ ] GH Actions tab shows the workflow on schedule

🤖 Generated with [Claude Code](https://claude.com/claude-code)