### PR TITLE
fix(ci): persist-credentials:false on checkout for baseline workflows

### DIFF
--- a/.github/workflows/update-bundle-baseline.yml
+++ b/.github/workflows/update-bundle-baseline.yml
@@ -35,6 +35,12 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v6
+        # peter-evans/create-pull-request does its own auth via the
+        # GITHUB_TOKEN we pass it explicitly. If checkout also
+        # persists credentials, the two stack and git fails with
+        # "Duplicate header: Authorization" → HTTP 400 on push.
+        with:
+          persist-credentials: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6

--- a/.github/workflows/update-visual-baselines.yml
+++ b/.github/workflows/update-visual-baselines.yml
@@ -33,6 +33,12 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v6
+        # peter-evans/create-pull-request does its own auth via the
+        # GITHUB_TOKEN we pass it explicitly. If checkout also
+        # persists credentials, the two stack and git fails with
+        # "Duplicate header: Authorization" → HTTP 400 on push.
+        with:
+          persist-credentials: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6


### PR DESCRIPTION
## Summary

The bundle-baseline workflow failed on its first run with \`Duplicate header: Authorization\` because \`actions/checkout\` and \`peter-evans/create-pull-request\` both set git auth headers.

Fix is one line per workflow: \`persist-credentials: false\` on the checkout step. Applied to both new baseline workflows since they share the pattern.

## Test plan
- [ ] Trigger "Update bundle-size baseline" → reaches the create-pull-request step without 400 → opens an auto-PR
- [ ] Same for "Update visual snapshot baselines"

🤖 Generated with [Claude Code](https://claude.com/claude-code)