### PR TITLE
fix(ci): visual baseline refresh tolerates flaky tests

### DIFF
--- a/.github/workflows/update-visual-baselines.yml
+++ b/.github/workflows/update-visual-baselines.yml
@@ -80,6 +80,16 @@ jobs:
         # `--update-snapshots` writes any failing baseline rather
         # than diffing against it. With CI's deterministic env this
         # produces stable PNGs we can commit.
+        #
+        # `continue-on-error: true` is intentional. In refresh mode
+        # we WANT every successful capture to land regardless of
+        # whether one or two tests are flaky (e.g. a synthetic 500
+        # route that times out waiting for fonts). The next step
+        # commits whatever snapshots Playwright managed to write —
+        # baselines for the flaky tests stay at their old values
+        # until they stabilize. Without this, a single flaky test
+        # aborts the whole refresh and Zack ends up with nothing.
+        continue-on-error: true
         run: pnpm -C apps/web test:e2e --project=visual --update-snapshots
         env:
           CI: "true"


### PR DESCRIPTION
First run of the visual-baseline workflow died on a single flaky test (timeout waiting for fonts), aborting the whole refresh and discarding the snapshots Playwright *did* capture.

Add \`continue-on-error: true\` so refresh mode keeps every successful capture and lets the auto-PR's diff make obvious which baselines refreshed vs which stayed put.

🤖 Generated with [Claude Code](https://claude.com/claude-code)