### PR TITLE
fix(ci): visual baseline glob matches Playwright's per-spec layout

### DIFF
--- a/.github/workflows/update-visual-baselines.yml
+++ b/.github/workflows/update-visual-baselines.yml
@@ -123,5 +123,10 @@ jobs:
             close this PR and either revert the underlying UI change
             or amend the visual spec.
           delete-branch: true
+          # Playwright writes baselines to `<spec>-snapshots/` per
+          # spec file (apps/web/tests/visual/public-pages.spec.ts
+          # → public-pages.spec.ts-snapshots/), NOT a single
+          # `__snapshots__/` dir. Match the actual layout or
+          # peter-evans finds nothing to commit.
           add-paths: |
-            apps/web/tests/visual/__snapshots__/**
+            apps/web/tests/visual/**/*-snapshots/**


### PR DESCRIPTION
Workflow ran cleanly but didn't open a PR because the `add-paths` glob was `__snapshots__/**` while Playwright actually writes to `<spec>-snapshots/`. Fix the glob.

🤖 Generated with [Claude Code](https://claude.com/claude-code)