### PR TITLE
perf(nav): pipeline auth + admin checks into main Promise.all

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -17,29 +17,19 @@ export default async function DashboardPage() {
   } = await supabase.auth.getUser();
   if (!user) redirect("/login");
 
-  // Pure-admin shortcut: a user who is platform admin AND has zero space
-  // memberships has nothing to do on the user dashboard. Send them
-  // straight to /admin so the operator console is their landing.
-  const adminCheck = await supabase
-    .from("profiles")
-    .select("is_platform_admin")
-    .eq("user_id", user.id)
-    .maybeSingle();
-  const isAdmin = Boolean(
-    (adminCheck.data as { is_platform_admin?: boolean } | null)
-      ?.is_platform_admin,
-  );
-  if (isAdmin) {
-    const { count: spaceCount } = await supabase
-      .from("space_members")
-      .select("space_id", { count: "exact", head: true })
-      .eq("user_id", user.id);
-    if ((spaceCount ?? 0) === 0) {
-      redirect("/admin");
-    }
-  }
-
-  // Parallelise: every card fetches independently against RLS.
+  // ONE round-trip for everything we need to render the dashboard
+  // shell + cards + admin-shortcut decision. Previously we did three
+  // sequential queries (profile admin check → space_members count →
+  // big Promise.all), which serialized 2-3 RTTs onto the cold-load
+  // critical path. Profile was also queried twice (once for the
+  // admin check, once in the parallel block).
+  //
+  // Now: kick off everything in parallel and decide on the admin
+  // redirect after the results land. For non-admin users (the common
+  // case) we save the two extra RTTs. For pure-admin-zero-spaces
+  // we waste the eight other fetches but immediately redirect, so
+  // the user never sees the wasted work. Net: faster dashboard for
+  // everyone who lands on it.
   const [
     spaces,
     terminals,
@@ -81,6 +71,15 @@ export default async function DashboardPage() {
         timezone: string | null;
       }
     | null;
+
+  // Pure-admin shortcut: a user who is platform admin AND has zero
+  // space memberships has nothing to do on the user dashboard. Send
+  // them to /admin so the operator console is their landing.
+  // `spaces.length` already came back from the parallel fetch above,
+  // saving a dedicated count() round-trip.
+  if ((profile?.is_platform_admin ?? false) && spaces.length === 0) {
+    redirect("/admin");
+  }
   const userName =
     profile?.full_name ?? user.email?.split("@")[0] ?? "there";
   const savedDensity =

--- a/apps/web/src/app/s/[slug]/page.tsx
+++ b/apps/web/src/app/s/[slug]/page.tsx
@@ -52,15 +52,13 @@ export default async function SpaceLandingPage({ params }: Props) {
   if (!space) notFound();
   const s = space as { id: string; slug: string; name: string };
 
-  const { data: me } = await supabase
-    .from("space_members")
-    .select("role")
-    .eq("space_id", s.id)
-    .eq("user_id", user.id)
-    .maybeSingle();
-  const myRole = (me as { role?: SpaceRole } | null)?.role ?? null;
-  if (!myRole) notFound();
-
+  // The membership check used to gate the Promise.all on a separate
+  // RTT. Now it runs ALONGSIDE the data fetches. Non-members never
+  // reach the render (notFound() short-circuits after the parallel
+  // resolves), so the only "wasted" case is someone hitting a space
+  // URL they don't belong to — which should be rare and is cheap to
+  // throw away. RLS already filters the actual data rows.
+  //
   // All the heavy lifting in parallel — same pattern as the
   // dashboard's loaders. The week-calendar / files-vault loaders
   // were dropped after the v1 ship per UX feedback ("remove the
@@ -75,6 +73,7 @@ export default async function SpaceLandingPage({ params }: Props) {
     explorerTerminals,
     toolsResult,
     profileResult,
+    membershipResult,
   ] = await Promise.all([
     loadSpaceTerminals(supabase, s.id),
     loadSpaceTasks(supabase, s.id),
@@ -92,7 +91,17 @@ export default async function SpaceLandingPage({ params }: Props) {
       .select("full_name, is_platform_admin, settings")
       .eq("user_id", user.id)
       .maybeSingle(),
+    supabase
+      .from("space_members")
+      .select("role")
+      .eq("space_id", s.id)
+      .eq("user_id", user.id)
+      .maybeSingle(),
   ]);
+
+  const myRole =
+    (membershipResult.data as { role?: SpaceRole } | null)?.role ?? null;
+  if (!myRole) notFound();
 
   const profile = profileResult.data as
     | {


### PR DESCRIPTION
## Summary

Continuing the navigation-perf work from PR #138. Cuts the cold-load critical path on \`/\` and \`/s/[slug]\` by 1-2 round-trips.

Both routes were doing this sequentially:
\`\`\`
getUser → admin-or-membership check → Promise.all of data fetches
\`\`\`

Now:
\`\`\`
getUser → Promise.all that ALSO includes the admin/membership check
\`\`\`

The redirect/notFound decision happens after the parallel resolves. Common cases (non-admin user landing on /, member visiting their space) save the 1-2 RTTs. Edge cases (admin-with-zero-spaces, non-member visiting space URL) waste a few fetches but immediately redirect/404, so no user-visible cost.

Also dropped a duplicate \`profiles\` fetch on the dashboard — admin check reads from the single combined fetch, and the space-count check uses \`spaces.length === 0\` instead of a dedicated \`count()\` query.

## Expected impact
- ~50-150 ms off cold dashboard / space cold-load TTFB depending on DB latency
- No change to render output — purely a data-loader rearrangement

## Test plan
- [ ] Dashboard cold-load → renders correctly
- [ ] Admin-with-zero-spaces user → redirects to /admin
- [ ] Non-member hitting /s/some-slug → 404
- [ ] Member hitting /s/their-space → renders normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)