### PR TITLE
chore(observability): wrap top 8 user-facing API routes

### DIFF
--- a/apps/web/src/app/api/v1/briefing/route.ts
+++ b/apps/web/src/app/api/v1/briefing/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
+import { withObservability } from "@/lib/observability";
 
 /**
  * GET /api/v1/briefing
@@ -8,7 +9,7 @@ import { createClient } from "@/lib/supabase/server";
  * LLM calls. The dashboard card renders this with a "Good morning, X …"
  * intro line. Keep the computation cheap: 4 small queries, ~50 ms total.
  */
-export async function GET() {
+async function handleGet() {
   const supabase = await createClient();
   const {
     data: { user },
@@ -131,3 +132,5 @@ export async function GET() {
     },
   });
 }
+
+export const GET = withObservability(handleGet, "GET /api/v1/briefing");

--- a/apps/web/src/app/api/v1/comments/[id]/route.ts
+++ b/apps/web/src/app/api/v1/comments/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { mentionedUserIds } from "@/lib/mentions";
+import { withObservability } from "@/lib/observability";
 
 interface Props {
   params: Promise<{ id: string }>;
@@ -10,7 +11,7 @@ interface Props {
  * PATCH /api/v1/comments/:id  { body }   — edit your own comment
  * DELETE /api/v1/comments/:id            — soft delete (sets deleted_at)
  */
-export async function PATCH(request: NextRequest, { params }: Props) {
+async function handlePatch(request: NextRequest, { params }: Props) {
   const { id } = await params;
   const supabase = await createClient();
   const {
@@ -85,7 +86,7 @@ export async function PATCH(request: NextRequest, { params }: Props) {
   return NextResponse.json({ data });
 }
 
-export async function DELETE(_req: NextRequest, { params }: Props) {
+async function handleDelete(_req: NextRequest, { params }: Props) {
   const { id } = await params;
   const supabase = await createClient();
   const {
@@ -127,3 +128,12 @@ function internal(msg: string) {
     { status: 500 },
   );
 }
+
+export const PATCH = withObservability<Props>(
+  handlePatch,
+  "PATCH /api/v1/comments/:id",
+);
+export const DELETE = withObservability<Props>(
+  handleDelete,
+  "DELETE /api/v1/comments/:id",
+);

--- a/apps/web/src/app/api/v1/comments/route.ts
+++ b/apps/web/src/app/api/v1/comments/route.ts
@@ -3,6 +3,7 @@ import { createClient as createAdminClient } from "@supabase/supabase-js";
 import { createClient } from "@/lib/supabase/server";
 import { mentionedUserIds, renderMentionsAsText } from "@/lib/mentions";
 import { sendEmail } from "@/lib/email";
+import { withObservability } from "@/lib/observability";
 import type { Database } from "@rokki/db";
 
 /**
@@ -29,7 +30,7 @@ interface CommentRow {
   created_by: string;
 }
 
-export async function GET(request: NextRequest) {
+async function handleGet(request: NextRequest) {
   const supabase = await createClient();
   const {
     data: { user },
@@ -77,7 +78,7 @@ export async function GET(request: NextRequest) {
   return NextResponse.json({ data: decorated });
 }
 
-export async function POST(request: NextRequest) {
+async function handlePost(request: NextRequest) {
   const supabase = await createClient();
   const {
     data: { user },
@@ -238,3 +239,6 @@ function internal(msg: string) {
     { status: 500 },
   );
 }
+
+export const GET = withObservability(handleGet, "GET /api/v1/comments");
+export const POST = withObservability(handlePost, "POST /api/v1/comments");

--- a/apps/web/src/app/api/v1/cron/calendar-sync/route.ts
+++ b/apps/web/src/app/api/v1/cron/calendar-sync/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { runCalendarSyncTick } from "@/lib/calendar-sync";
+import { withObservability } from "@/lib/observability";
 
 /**
  * POST /api/v1/cron/calendar-sync
@@ -20,7 +21,7 @@ import { runCalendarSyncTick } from "@/lib/calendar-sync";
 export const dynamic = "force-dynamic";
 export const maxDuration = 60;
 
-export async function POST(request: NextRequest) {
+async function handlePost(request: NextRequest) {
   if (!authorize(request)) return unauthorized();
 
   const result = await runCalendarSyncTick();
@@ -29,11 +30,20 @@ export async function POST(request: NextRequest) {
 
 // Also accept GET so a curl smoke test works without a body. The
 // secret check still gates it.
-export async function GET(request: NextRequest) {
+async function handleGet(request: NextRequest) {
   if (!authorize(request)) return unauthorized();
   const result = await runCalendarSyncTick();
   return NextResponse.json({ data: result });
 }
+
+export const POST = withObservability(
+  handlePost,
+  "POST /api/v1/cron/calendar-sync",
+);
+export const GET = withObservability(
+  handleGet,
+  "GET /api/v1/cron/calendar-sync",
+);
 
 function authorize(request: NextRequest): boolean {
   const expected = process.env.CRON_SECRET;

--- a/apps/web/src/app/api/v1/cron/reminders/route.ts
+++ b/apps/web/src/app/api/v1/cron/reminders/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { createClient as createAdminClient } from "@supabase/supabase-js";
+import { withObservability } from "@/lib/observability";
 import type { Database } from "@rokki/db";
 
 /**
@@ -39,18 +40,21 @@ interface TickResult {
   errors: number;
 }
 
-export async function POST(request: NextRequest) {
+async function handlePost(request: NextRequest) {
   if (!authorize(request)) return unauthorized();
   const result = await runRemindersTick();
   return NextResponse.json({ data: result });
 }
 
 // GET for smoke-test convenience. Same auth gate.
-export async function GET(request: NextRequest) {
+async function handleGet(request: NextRequest) {
   if (!authorize(request)) return unauthorized();
   const result = await runRemindersTick();
   return NextResponse.json({ data: result });
 }
+
+export const POST = withObservability(handlePost, "POST /api/v1/cron/reminders");
+export const GET = withObservability(handleGet, "GET /api/v1/cron/reminders");
 
 async function runRemindersTick(): Promise<TickResult> {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;

--- a/apps/web/src/app/api/v1/me/route.ts
+++ b/apps/web/src/app/api/v1/me/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { validateBearer } from "@/lib/api-auth";
+import { withObservability } from "@/lib/observability";
 
 /**
  * GET   /api/v1/me                 — my profile + preferences
@@ -10,7 +11,7 @@ import { validateBearer } from "@/lib/api-auth";
  * so partial updates don't clobber unrelated keys.
  */
 
-export async function GET(request: NextRequest) {
+async function handleGet(request: NextRequest) {
   // Accept cookie OR bearer so the CLI can call /me. Bearer uses admin
   // client but we still filter by user_id.
   const bearer = await validateBearer(request);
@@ -57,7 +58,7 @@ export async function GET(request: NextRequest) {
   });
 }
 
-export async function PATCH(request: NextRequest) {
+async function handlePatch(request: NextRequest) {
   const supabase = await createClient();
   const {
     data: { user },
@@ -157,3 +158,6 @@ function internal(msg: string) {
     { status: 500 },
   );
 }
+
+export const GET = withObservability(handleGet, "GET /api/v1/me");
+export const PATCH = withObservability(handlePatch, "PATCH /api/v1/me");

--- a/apps/web/src/app/api/v1/messages/threads/[id]/route.ts
+++ b/apps/web/src/app/api/v1/messages/threads/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { createClient } from "@/lib/supabase/server";
+import { withObservability } from "@/lib/observability";
 
 interface Props {
   params: Promise<{ id: string }>;
@@ -10,7 +11,7 @@ interface Props {
  * POST /api/v1/messages/threads/:id  { body }  — post a new message
  */
 
-export async function GET(_req: NextRequest, { params }: Props) {
+async function handleGet(_req: NextRequest, { params }: Props) {
   const { id } = await params;
   const supabase = await createClient();
   const {
@@ -99,7 +100,7 @@ export async function GET(_req: NextRequest, { params }: Props) {
   return NextResponse.json({ data: decorated });
 }
 
-export async function POST(request: NextRequest, { params }: Props) {
+async function handlePost(request: NextRequest, { params }: Props) {
   const { id } = await params;
   const supabase = await createClient();
   const {
@@ -140,3 +141,12 @@ function internal(msg: string) {
     { status: 500 },
   );
 }
+
+export const GET = withObservability<Props>(
+  handleGet,
+  "GET /api/v1/messages/threads/:id",
+);
+export const POST = withObservability<Props>(
+  handlePost,
+  "POST /api/v1/messages/threads/:id",
+);

--- a/apps/web/src/app/api/v1/messages/threads/route.ts
+++ b/apps/web/src/app/api/v1/messages/threads/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { createClient } from "@/lib/supabase/server";
+import { withObservability } from "@/lib/observability";
 
 /**
  * GET  /api/v1/messages/threads    — threads I can see, newest first
@@ -8,7 +9,7 @@ import { createClient } from "@/lib/supabase/server";
  *   { kind: "terminal", terminal_id }             → create or reuse the terminal's single thread
  */
 
-export async function GET() {
+async function handleGet() {
   const supabase = await createClient();
   const {
     data: { user },
@@ -198,7 +199,7 @@ export async function GET() {
   return NextResponse.json({ data: decorated });
 }
 
-export async function POST(request: NextRequest) {
+async function handlePost(request: NextRequest) {
   const supabase = await createClient();
   const {
     data: { user },
@@ -299,3 +300,12 @@ function internal(msg: string) {
     { status: 500 },
   );
 }
+
+export const GET = withObservability(
+  handleGet,
+  "GET /api/v1/messages/threads",
+);
+export const POST = withObservability(
+  handlePost,
+  "POST /api/v1/messages/threads",
+);

--- a/apps/web/src/app/api/v1/notifications/route.ts
+++ b/apps/web/src/app/api/v1/notifications/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { createClient } from "@/lib/supabase/server";
+import { withObservability } from "@/lib/observability";
 
 /**
  * GET  /api/v1/notifications?unread=1&limit=50  — your notifications feed
@@ -8,7 +9,7 @@ import { createClient } from "@/lib/supabase/server";
  *     their own rows (RLS enforced).
  */
 
-export async function GET(request: NextRequest) {
+async function handleGet(request: NextRequest) {
   const supabase = await createClient();
   const {
     data: { user },
@@ -85,7 +86,7 @@ export async function GET(request: NextRequest) {
   });
 }
 
-export async function PATCH(request: NextRequest) {
+async function handlePatch(request: NextRequest) {
   const supabase = await createClient();
   const {
     data: { user },
@@ -134,3 +135,9 @@ function internal(msg: string) {
     { status: 500 },
   );
 }
+
+export const GET = withObservability(handleGet, "GET /api/v1/notifications");
+export const PATCH = withObservability(
+  handlePatch,
+  "PATCH /api/v1/notifications",
+);


### PR DESCRIPTION
Closes #2 from tonight's list. Wraps the highest-traffic routes (notifications, comments, me, messages, both crons, briefing) in `withObservability` so the next mystery prod error has route + duration context in Sentry/Axiom.

Remaining 50+ admin / lower-traffic routes still need the same treatment — follow-up. The pattern's mechanical at this point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)