### PR TITLE
feat(spaces): owner can delete their own space

### DIFF
--- a/apps/web/src/app/api/v1/orgs/[slug]/route.ts
+++ b/apps/web/src/app/api/v1/orgs/[slug]/route.ts
@@ -1,23 +1,33 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { emitEvent } from "@/lib/events";
+import { withObservability } from "@/lib/observability";
 
 interface Props {
   params: Promise<{ slug: string }>;
 }
 
 /**
- * GET   /api/v1/orgs/:slug
- * PATCH /api/v1/orgs/:slug  { name?, slug? }
+ * GET    /api/v1/orgs/:slug
+ * PATCH  /api/v1/orgs/:slug  { name?, slug? }
+ * DELETE /api/v1/orgs/:slug
  *
- * Only space owners/admins (or platform admins) can edit. Slug renames are
- * allowed — existing URLs break, but that's the user's call. DELETE is not
- * exposed: spaces are not routinely deleted, and doing so through the UI
- * would require a destructive-confirm flow we haven't built yet.
+ * Only space owners/admins (or platform admins) can edit. Slug renames
+ * are allowed — existing URLs break, but that's the user's call.
+ *
+ * DELETE is owner-only (stricter than the PATCH gate, which allows
+ * admins). It's a SOFT delete via `archived_at` — the
+ * `cascade_space_archive` trigger fans the archive down to every
+ * terminal / task / file in the space, and `purge_expired_trash()`
+ * hard-deletes them after the TTL. Restorable via the admin console
+ * within the retention window.
+ *
+ * Two-step confirmation lives on the client (settings page) — the
+ * server trusts the request once auth + role pass.
  */
 const SLUG = /^[a-z][a-z0-9-]{1,38}[a-z0-9]$/;
 
-export async function GET(_req: NextRequest, { params }: Props) {
+async function handleGet(_req: NextRequest, { params }: Props) {
   const { slug } = await params;
   const supabase = await createClient();
   const {
@@ -35,7 +45,7 @@ export async function GET(_req: NextRequest, { params }: Props) {
   return NextResponse.json({ data });
 }
 
-export async function PATCH(request: NextRequest, { params }: Props) {
+async function handlePatch(request: NextRequest, { params }: Props) {
   const { slug } = await params;
   const supabase = await createClient();
   const {
@@ -93,6 +103,67 @@ export async function PATCH(request: NextRequest, { params }: Props) {
   });
 
   return NextResponse.json({ data });
+}
+
+async function handleDelete(_req: NextRequest, { params }: Props) {
+  const { slug } = await params;
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return unauth();
+
+  const space = await resolveSpace(supabase, slug);
+  if (!space) return notFound();
+
+  // Owners-only — admins can rename/manage members but archiving a
+  // whole space (with cascade-archive on every terminal/task/file
+  // inside) is irreversible from the owner's seat once the TTL
+  // expires. Platform admins still have a separate path in
+  // /api/v1/admin/spaces/:slug for cross-space ops.
+  const { data: membership } = await supabase
+    .from("space_members")
+    .select("role")
+    .eq("space_id", space.id)
+    .eq("user_id", user.id)
+    .maybeSingle();
+  const role = (membership as { role?: string } | null)?.role;
+  if (role !== "owner") {
+    return forbidden("only the space owner can delete this space");
+  }
+
+  // Idempotent: if already archived, no-op + return success so a
+  // refresh-after-network-blip doesn't error out.
+  const { data: current } = await supabase
+    .from("spaces")
+    .select("archived_at")
+    .eq("id", space.id)
+    .maybeSingle();
+  const already = (current as { archived_at: string | null } | null)
+    ?.archived_at;
+  if (already) {
+    return NextResponse.json({ data: { archived: true, archived_at: already } });
+  }
+
+  const now = new Date().toISOString();
+  const { error } = await supabase
+    .from("spaces")
+    // @ts-expect-error Phase 0 — Database<generic> inference collapses to never
+    .update({ archived_at: now })
+    .eq("id", space.id);
+  // The `cascade_space_archive` AFTER UPDATE trigger fans this out
+  // to terminals/tasks/files — no manual cleanup needed here.
+  if (error) return internal(error.message);
+
+  void emitEvent("space.archived", {
+    actor_id: user.id,
+    space_id: space.id,
+    entity_type: "space",
+    entity_id: space.id,
+    payload: { slug: space.slug, name: space.name },
+  });
+
+  return NextResponse.json({ data: { archived: true, archived_at: now } });
 }
 
 async function resolveSpace(
@@ -168,3 +239,16 @@ function internal(msg: string) {
     { status: 500 },
   );
 }
+
+export const GET = withObservability<Props>(
+  handleGet,
+  "GET /api/v1/orgs/:slug",
+);
+export const PATCH = withObservability<Props>(
+  handlePatch,
+  "PATCH /api/v1/orgs/:slug",
+);
+export const DELETE = withObservability<Props>(
+  handleDelete,
+  "DELETE /api/v1/orgs/:slug",
+);

--- a/apps/web/src/app/s/[slug]/settings/SpaceSettingsForm.tsx
+++ b/apps/web/src/app/s/[slug]/settings/SpaceSettingsForm.tsx
@@ -2,7 +2,7 @@
 
 import { useState, type FormEvent } from "react";
 import { useRouter } from "next/navigation";
-import { Check, UserMinus, UserPlus, Mail } from "lucide-react";
+import { AlertTriangle, Check, UserMinus, UserPlus, Mail } from "lucide-react";
 import { Avatar } from "@/components/primitives";
 import { cn } from "@/lib/utils";
 
@@ -78,6 +78,9 @@ export function SpaceSettingsForm({
         canManage={canManage}
         onAdd={(invite) => setInvites((prev) => [invite, ...prev])}
       />
+      {myRole === "owner" ? (
+        <DangerZoneCard slug={slug} spaceName={initial.name} />
+      ) : null}
     </div>
   );
 }
@@ -564,4 +567,139 @@ async function messageOf(r: Response): Promise<string> {
   } catch {
     return `HTTP ${r.status}`;
   }
+}
+
+// ---------------------------------------------------------------------------
+
+/**
+ * Owner-only "Danger zone" card. Soft-deletes the space (sets
+ * spaces.archived_at = now()) and lets the DB cascade trigger fan
+ * the archive down to every terminal / task / file in the space.
+ *
+ * Two-step confirmation: the primary "Delete space" button reveals
+ * a typed-confirmation prompt. The user has to type the exact
+ * space name to enable the final action — same pattern GitHub /
+ * Vercel / Linear use for destructive ops, and the right ratio of
+ * friction for a side-effect this wide.
+ *
+ * On success, navigates to "/" — the deleted space won't show up
+ * in the explorer rail any longer (queries filter
+ * `archived_at IS NULL`), so leaving the user on the now-stale
+ * settings URL would be jarring.
+ */
+function DangerZoneCard({
+  slug,
+  spaceName,
+}: {
+  slug: string;
+  spaceName: string;
+}) {
+  const [armed, setArmed] = useState(false);
+  const [typed, setTyped] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const confirmed = typed.trim() === spaceName;
+
+  async function submit() {
+    if (!confirmed || submitting) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const r = await fetch(`/api/v1/orgs/${slug}`, {
+        method: "DELETE",
+        credentials: "include",
+      });
+      if (!r.ok) {
+        setError(await messageOf(r));
+        setSubmitting(false);
+        return;
+      }
+      // Hard browser navigation to "/" — the soft-archived space
+      // would still be cached by the App Router's RSC layer for a
+      // moment, and we want to be on a fresh dashboard.
+      window.location.assign("/");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Network error");
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <section className="overflow-hidden rounded border border-danger/40 bg-danger-subtle/30">
+      <header className="flex items-center gap-2 border-b border-danger/40 bg-bg-2 px-4 py-2 text-[10px] font-semibold uppercase tracking-wide text-danger">
+        <AlertTriangle className="h-3 w-3" />
+        Danger zone
+      </header>
+      <div className="flex flex-col gap-3 p-4">
+        <div>
+          <h3 className="text-sm font-semibold text-text-0">Delete this space</h3>
+          <p className="mt-1 text-xs text-text-2">
+            Archives <span className="font-mono text-text-1">{spaceName}</span>{" "}
+            and every terminal, task, file, and message inside it. Members
+            lose access immediately. A platform admin can restore within
+            the retention window; after that it&apos;s purged permanently.
+          </p>
+        </div>
+        {!armed ? (
+          <div>
+            <button
+              type="button"
+              onClick={() => setArmed(true)}
+              className="rounded-sm border border-danger bg-bg-2 px-3 py-1.5 text-xs font-semibold uppercase tracking-wide text-danger hover:bg-danger/10"
+            >
+              Delete space
+            </button>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-2 rounded-sm border border-danger/60 bg-bg-1 p-3">
+            <label className="text-xs text-text-2" htmlFor="space-delete-confirm">
+              Type{" "}
+              <span className="font-mono text-text-0">{spaceName}</span>{" "}
+              to confirm:
+            </label>
+            <input
+              id="space-delete-confirm"
+              type="text"
+              value={typed}
+              onChange={(e) => setTyped(e.target.value)}
+              autoFocus
+              autoComplete="off"
+              spellCheck={false}
+              disabled={submitting}
+              className="rounded-sm border border-border bg-bg-0 px-2 py-1 font-mono text-sm text-text-0 outline-none focus:border-border-focus disabled:opacity-50"
+            />
+            {error ? (
+              <p className="text-xs text-danger">{error}</p>
+            ) : null}
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={() => void submit()}
+                disabled={!confirmed || submitting}
+                className={cn(
+                  "rounded-sm bg-danger px-3 py-1.5 text-xs font-semibold uppercase tracking-wide text-bg-0",
+                  (!confirmed || submitting) &&
+                    "cursor-not-allowed opacity-40",
+                )}
+              >
+                {submitting ? "Deleting…" : "Delete permanently"}
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  setArmed(false);
+                  setTyped("");
+                  setError(null);
+                }}
+                disabled={submitting}
+                className="rounded-sm border border-border bg-bg-2 px-3 py-1.5 text-xs uppercase tracking-wide text-text-1 hover:bg-bg-3"
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </section>
+  );
 }


### PR DESCRIPTION
## Summary

Adds the owner-side space deletion flow Zack flagged. Previously only platform admins could archive a space (via \`/api/v1/admin/spaces/:slug\`); the user-side \`/api/v1/orgs/:slug\` route's header comment even said \"DELETE is not exposed: destructive-confirm flow we haven't built yet.\" Building it now.

## Changes

**Backend** — new \`DELETE /api/v1/orgs/:slug\`:
- Owner-only (admins of the space can't archive it — too destructive for that role)
- Soft delete via \`archived_at\`; the existing \`cascade_space_archive\` trigger fans it down to terminals / tasks / files
- Idempotent (already-archived returns 200 with the existing timestamp)
- Emits \`space.archived\` event
- Wrapped in \`withObservability\` along with the existing GET/PATCH

**UI** — \`DangerZoneCard\` in \`SpaceSettingsForm\`:
- Only renders for \`myRole === "owner"\`
- Two-step typed-confirmation pattern (matches GitHub/Vercel/Linear destructive-action UX)
- On success: hard browser nav to \`/\` so the App Router RSC layer can't serve the half-stale archived shell

## Test plan

- [ ] Owner sees the Danger zone card on \`/s/{slug}/settings\`
- [ ] Admin/member don't see it
- [ ] Clicking the primary button arms the confirm prompt
- [ ] Typing the wrong name keeps the final button disabled
- [ ] Typing the exact name enables it; clicking soft-archives the space
- [ ] After: the space is gone from the explorer rail; \`/s/{slug}\` 404s
- [ ] Calling DELETE a second time returns the same \`archived_at\` (idempotent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)