### PR TITLE
feat(tasks): wire recurring tasks UI to existing schema

### DIFF
--- a/apps/web/src/app/api/v1/projects/[ticker]/tasks/route.ts
+++ b/apps/web/src/app/api/v1/projects/[ticker]/tasks/route.ts
@@ -46,7 +46,7 @@ async function handleGet(request: NextRequest, { params }: Props) {
   let query = supabase
     .from("tasks")
     .select(
-      "id, ticker_seq, title, description, status, priority, due_date, labels, position, latest_status_text, latest_status_author_id, latest_status_at, status_thread_id, external_assignee_emails, created_at, updated_at, completed_at",
+      "id, ticker_seq, title, description, status, priority, due_date, labels, position, latest_status_text, latest_status_author_id, latest_status_at, status_thread_id, external_assignee_emails, recurrence_rule, created_at, updated_at, completed_at",
     )
     .eq("terminal_id", project.id);
 

--- a/apps/web/src/components/QuickTaskDialog.tsx
+++ b/apps/web/src/components/QuickTaskDialog.tsx
@@ -4,7 +4,11 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { ChevronDown, Search } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Dialog } from "./Dialog";
-import { TaskComposer, type TaskComposerMember } from "./TaskComposer";
+import {
+  TaskComposer,
+  type TaskComposerMember,
+  type TaskComposerSubmit,
+} from "./TaskComposer";
 import type { DashSpace, DashTerminal } from "@/lib/dashboard-queries";
 
 interface QuickTaskDialogProps {
@@ -105,14 +109,7 @@ export function QuickTaskDialog({
     [terminalId, terminals],
   );
 
-  async function handleSubmit(input: {
-    title: string;
-    priority: number | null;
-    due_date: string | null;
-    labels: string[];
-    assignee_ids: string[];
-    external_assignee_emails: string[];
-  }) {
+  async function handleSubmit(input: TaskComposerSubmit) {
     if (!selectedTerminal) {
       throw new Error("Pick a terminal first");
     }
@@ -133,6 +130,7 @@ export function QuickTaskDialog({
             input.external_assignee_emails.length > 0
               ? input.external_assignee_emails
               : undefined,
+          recurrence_rule: input.recurrence_rule,
         }),
       },
     );

--- a/apps/web/src/components/TaskComposer.tsx
+++ b/apps/web/src/components/TaskComposer.tsx
@@ -14,6 +14,7 @@ import {
   ChevronDown,
   Circle,
   Flag,
+  Repeat,
   Tag,
   UserPlus,
   X,
@@ -23,6 +24,7 @@ import {
   formatDueLabel,
   parseDueDate,
 } from "@/lib/parse-due-date";
+import type { TaskRecurrenceRule } from "@rokki/db";
 
 export interface TaskComposerMember {
   user_id: string;
@@ -41,6 +43,13 @@ export interface TaskComposerSubmit {
    * Server side these land on `tasks.external_assignee_emails`.
    */
   external_assignee_emails: string[];
+  /**
+   * Recurrence pattern. Null means one-shot task. Composer only
+   * surfaces the four canonical patterns (None/Daily/Weekly/Monthly,
+   * interval=1); the more elaborate weekdays/end_date variants are
+   * served from the task detail page when we build that out.
+   */
+  recurrence_rule: TaskRecurrenceRule | null;
 }
 
 interface TaskComposerProps {
@@ -65,6 +74,8 @@ interface TaskComposerProps {
   currentUserId?: string;
   /** Pre-fill labels. */
   initialLabels?: string[];
+  /** Pre-fill the recurrence chip. Default null (one-shot). */
+  initialRecurrence?: TaskRecurrenceRule | null;
   /**
    * Render variant. `inline` uses a tight horizontal layout suited to
    * the task list itself; `dialog` uses a roomier vertical layout.
@@ -118,6 +129,7 @@ export function TaskComposer({
   initialExternalEmails = [],
   currentUserId,
   initialLabels = [],
+  initialRecurrence = null,
   variant = "inline",
   autoFocus = true,
   placeholder = "New task… Enter to save, Esc to cancel",
@@ -145,6 +157,8 @@ export function TaskComposer({
   );
   const [labels, setLabels] = useState<string[]>(initialLabels);
   const [labelDraft, setLabelDraft] = useState("");
+  const [recurrence, setRecurrence] =
+    useState<TaskRecurrenceRule | null>(initialRecurrence);
   const [showAssignees, setShowAssignees] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -187,6 +201,7 @@ export function TaskComposer({
         labels: labelsFinal,
         assignee_ids: assigneeIds,
         external_assignee_emails: externalEmails,
+        recurrence_rule: recurrence,
       });
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to create");
@@ -264,6 +279,11 @@ export function TaskComposer({
           onRemove={(l) =>
             setLabels((prev) => prev.filter((x) => x !== l))
           }
+          disabled={submitting}
+        />
+        <RecurrenceChip
+          rule={recurrence}
+          onChange={setRecurrence}
           disabled={submitting}
         />
 
@@ -898,5 +918,121 @@ function LabelsChip({
         disabled={disabled}
       />
     </span>
+  );
+}
+
+/* --------------------------------------------------------------- */
+/* RecurrenceChip — None / Daily / Weekly / Monthly                  */
+/* --------------------------------------------------------------- */
+
+const RECURRENCE_LABEL: Record<"daily" | "weekly" | "monthly", string> = {
+  daily: "Daily",
+  weekly: "Weekly",
+  monthly: "Monthly",
+};
+
+/**
+ * Single-select repeat chip. Maps the 3 canonical patterns to chip
+ * options + a "None" option that clears the rule. Always uses
+ * interval=1 — the more elaborate variants (interval > 1, weekdays
+ * subset, end_date) are surfaced from task detail when we build
+ * that out.
+ */
+function RecurrenceChip({
+  rule,
+  onChange,
+  disabled,
+}: {
+  rule: TaskRecurrenceRule | null;
+  onChange: (next: TaskRecurrenceRule | null) => void;
+  disabled?: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  // Close on outside click.
+  useEffect(() => {
+    if (!open) return;
+    function onDocClick(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", onDocClick);
+    return () => document.removeEventListener("mousedown", onDocClick);
+  }, [open]);
+
+  const label =
+    rule == null
+      ? "Repeat"
+      : (RECURRENCE_LABEL[rule.pattern] ?? "Custom") +
+        (rule.interval > 1 ? ` ×${rule.interval}` : "");
+
+  function setPattern(pattern: "daily" | "weekly" | "monthly" | null) {
+    if (pattern == null) {
+      onChange(null);
+    } else {
+      onChange({ pattern, interval: 1 });
+    }
+    setOpen(false);
+  }
+
+  return (
+    <div className="relative" ref={ref}>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        disabled={disabled}
+        title={rule == null ? "One-shot — click to make recurring" : `Repeats ${label}`}
+        className={cn(
+          "flex items-center gap-1 rounded-sm border border-border bg-bg-2 px-1.5 py-0.5 text-[11px]",
+          rule == null
+            ? "text-text-3 hover:bg-bg-3 hover:text-text-1"
+            : "text-text-1 hover:bg-bg-3",
+          disabled && "opacity-50",
+        )}
+      >
+        <Repeat className="h-3 w-3" aria-hidden="true" />
+        <span>{label}</span>
+      </button>
+      {open ? (
+        <div
+          role="menu"
+          className="absolute left-0 top-full z-20 mt-1 flex w-32 flex-col rounded-sm border border-border bg-bg-1 py-1 text-xs shadow-lg"
+        >
+          {(
+            [
+              { val: null, label: "None" },
+              { val: "daily", label: "Daily" },
+              { val: "weekly", label: "Weekly" },
+              { val: "monthly", label: "Monthly" },
+            ] as const
+          ).map((opt) => {
+            const active =
+              (rule == null && opt.val == null) || rule?.pattern === opt.val;
+            return (
+              <button
+                key={String(opt.val)}
+                type="button"
+                onClick={() => setPattern(opt.val)}
+                role="menuitemradio"
+                aria-checked={active}
+                className={cn(
+                  "flex items-center justify-between px-2 py-1 text-left text-text-1 hover:bg-bg-2 hover:text-text-0",
+                  active && "bg-bg-2 text-text-0",
+                )}
+              >
+                <span>{opt.label}</span>
+                {active ? (
+                  <span aria-hidden="true" className="text-accent">
+                    ✓
+                  </span>
+                ) : null}
+              </button>
+            );
+          })}
+        </div>
+      ) : null}
+    </div>
   );
 }

--- a/apps/web/src/components/TasksPane.tsx
+++ b/apps/web/src/components/TasksPane.tsx
@@ -11,6 +11,7 @@ import {
   MessageSquare,
   Maximize2,
   ListTodo,
+  Repeat,
   Send,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -25,7 +26,11 @@ const CommentThread = dynamic(
   () => import("./CommentThread").then((m) => ({ default: m.CommentThread })),
   { ssr: false },
 );
-import { TaskComposer, type TaskComposerMember } from "./TaskComposer";
+import {
+  TaskComposer,
+  type TaskComposerMember,
+  type TaskComposerSubmit,
+} from "./TaskComposer";
 import { SubtasksList, type Subtask } from "./SubtasksList";
 import {
   PriorityDots,
@@ -33,7 +38,7 @@ import {
   DueChip,
 } from "./primitives";
 import { groupTasks, type TaskGroupMode } from "@/lib/task-grouping";
-import type { TaskStatus } from "@rokki/db";
+import type { TaskRecurrenceRule, TaskStatus } from "@rokki/db";
 
 interface TaskAssignee {
   user_id: string;
@@ -55,6 +60,7 @@ interface Task {
   latest_status_at?: string | null;
   assignees?: TaskAssignee[];
   external_assignee_emails?: string[];
+  recurrence_rule?: TaskRecurrenceRule | null;
   /**
    * Sparse-integer manual-sort position. May be null for legacy rows
    * created before the column existed; the GET endpoint coerces NULLs
@@ -531,14 +537,7 @@ export function TasksPane({ ticker, projectId, currentUserId }: TasksPaneProps) 
    * success. Throws on failure so the composer can surface the error
    * inline.
    */
-  async function createTask(input: {
-    title: string;
-    priority: number | null;
-    due_date: string | null;
-    labels: string[];
-    assignee_ids: string[];
-    external_assignee_emails: string[];
-  }) {
+  async function createTask(input: TaskComposerSubmit) {
     const r = await offlineFetch(`/api/v1/projects/${ticker}/tasks`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -553,6 +552,7 @@ export function TasksPane({ ticker, projectId, currentUserId }: TasksPaneProps) 
           input.external_assignee_emails.length > 0
             ? input.external_assignee_emails
             : undefined,
+        recurrence_rule: input.recurrence_rule,
       }),
       label: `Create task: ${input.title}`,
     });
@@ -982,10 +982,37 @@ function TaskRow({
         <Send className="h-3 w-3" />
       </button>
       {task.due_date ? <DueChip date={task.due_date} /> : null}
+      {task.recurrence_rule ? (
+        <span
+          className="flex flex-shrink-0 items-center gap-0.5 rounded-sm border border-border bg-bg-2 px-1 py-0.5 text-[10px] uppercase tracking-wide text-text-2"
+          title={`Repeats ${recurrenceLabel(task.recurrence_rule)}`}
+        >
+          <Repeat className="h-2.5 w-2.5" aria-hidden="true" />
+          {recurrenceShortLabel(task.recurrence_rule)}
+        </span>
+      ) : null}
       <PriorityDots priority={task.priority} />
       <StatusPill status={task.status} />
     </div>
   );
+}
+
+/** Long form for tooltips: "Daily", "Weekly", "Monthly ×2". */
+function recurrenceLabel(rule: TaskRecurrenceRule): string {
+  const base =
+    rule.pattern === "daily"
+      ? "Daily"
+      : rule.pattern === "weekly"
+        ? "Weekly"
+        : "Monthly";
+  return rule.interval > 1 ? `${base} ×${rule.interval}` : base;
+}
+
+/** Single-char chip glyph: "D", "W", "M" (+ optional interval). */
+function recurrenceShortLabel(rule: TaskRecurrenceRule): string {
+  const letter =
+    rule.pattern === "daily" ? "D" : rule.pattern === "weekly" ? "W" : "M";
+  return rule.interval > 1 ? `${letter}${rule.interval}` : letter;
 }
 
 function SkeletonList() {


### PR DESCRIPTION
The `tasks.recurrence_rule` column + validator + API have been live for weeks but had no UI. Adds a RecurrenceChip to the composer (None / Daily / Weekly / Monthly) and a D/W/M chip on task rows so recurring tasks are visually distinct.

No schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)