### PR TITLE
chore(observability): wrap remaining 51 user-facing API routes

### DIFF
--- a/apps/web/src/app/api/dev/session-as/route.ts
+++ b/apps/web/src/app/api/dev/session-as/route.ts
@@ -6,6 +6,7 @@ import {
 import { createClient as createAdminClient } from "@supabase/supabase-js";
 import type { Database } from "@rokki/db";
 
+import { withObservability } from "@/lib/observability";
 interface CookieToSet {
   name: string;
   value: string;
@@ -19,7 +20,7 @@ interface CookieToSet {
  *
  * Returns 404 in production. Refuses any email not on @test.rokki.ai.
  */
-export async function POST(request: NextRequest) {
+async function handlePost(request: NextRequest) {
   if (process.env.NODE_ENV === "production") {
     return NextResponse.json({ errors: [{ code: "not_found" }] }, { status: 404 });
   }
@@ -108,3 +109,8 @@ export async function POST(request: NextRequest) {
 
   return response;
 }
+
+export const POST = withObservability(
+  handlePost,
+  "POST /api/dev/session-as",
+);

--- a/apps/web/src/app/api/v1/approvals/[id]/route.ts
+++ b/apps/web/src/app/api/v1/approvals/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextResponse, type NextRequest } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { emitEvent } from "@/lib/events";
 
+import { withObservability } from "@/lib/observability";
 interface Props {
   params: Promise<{ id: string }>;
 }
@@ -11,7 +12,7 @@ interface Props {
  *
  * Only space owners/admins of the approval's `approver_space_id` may act.
  */
-export async function PATCH(request: NextRequest, { params }: Props) {
+async function handlePatch(request: NextRequest, { params }: Props) {
   const { id } = await params;
   const supabase = await createClient();
   const {
@@ -124,3 +125,8 @@ function internal(msg: string) {
     { status: 500 },
   );
 }
+
+export const PATCH = withObservability<Props>(
+  handlePatch,
+  "PATCH /api/v1/approvals/:id",
+);

--- a/apps/web/src/app/api/v1/approvals/bulk/route.ts
+++ b/apps/web/src/app/api/v1/approvals/bulk/route.ts
@@ -2,6 +2,7 @@ import { NextResponse, type NextRequest } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { emitEvent } from "@/lib/events";
 
+import { withObservability } from "@/lib/observability";
 interface ApprovalRow {
   id: string;
   type: string;
@@ -34,7 +35,7 @@ interface ItemResult {
  * Returns a per-id result so the UI can show what succeeded vs. what was
  * skipped (e.g. "you don't admin that space" or "already resolved").
  */
-export async function POST(request: NextRequest) {
+async function handlePost(request: NextRequest) {
   const supabase = await createClient();
   const {
     data: { user },
@@ -195,3 +196,8 @@ function internal(msg: string) {
     { status: 500 },
   );
 }
+
+export const POST = withObservability(
+  handlePost,
+  "POST /api/v1/approvals/bulk",
+);

--- a/apps/web/src/app/api/v1/approvals/route.ts
+++ b/apps/web/src/app/api/v1/approvals/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 
+import { withObservability } from "@/lib/observability";
 /**
  * GET /api/v1/approvals?scope=mine|inbox
  *
@@ -8,7 +9,7 @@ import { createClient } from "@/lib/supabase/server";
  *   - scope=inbox → approvals awaiting my action (I'm an owner/admin of
  *                   the approver_space_id)
  */
-export async function GET(request: NextRequest) {
+async function handleGet(request: NextRequest) {
   const url = new URL(request.url);
   const scope = (url.searchParams.get("scope") ?? "mine") as "mine" | "inbox";
 
@@ -60,3 +61,8 @@ function internal(msg: string) {
     { status: 500 },
   );
 }
+
+export const GET = withObservability(
+  handleGet,
+  "GET /api/v1/approvals",
+);

--- a/apps/web/src/app/api/v1/auth/accounts/add/route.ts
+++ b/apps/web/src/app/api/v1/auth/accounts/add/route.ts
@@ -14,6 +14,7 @@ import {
 } from "@/lib/account-ring";
 import { rateLimitCheck, rateLimitToken } from "@/lib/ratelimit";
 
+import { withObservability } from "@/lib/observability";
 interface CookieToSet {
   name: string;
   value: string;
@@ -37,7 +38,7 @@ const USERNAME_MAP: Record<string, string> = {
   admin: "admin@rokki.local",
 };
 
-export async function POST(request: NextRequest) {
+async function handlePost(request: NextRequest) {
   const body = (await request.json().catch(() => ({}))) as {
     username?: string;
     email?: string;
@@ -188,3 +189,8 @@ function forbidden(msg: string) {
     { status: 403 },
   );
 }
+
+export const POST = withObservability(
+  handlePost,
+  "POST /api/v1/auth/accounts/add",
+);

--- a/apps/web/src/app/api/v1/auth/accounts/route.ts
+++ b/apps/web/src/app/api/v1/auth/accounts/route.ts
@@ -6,13 +6,14 @@ import {
 } from "@/lib/account-ring";
 import { createClient } from "@/lib/supabase/server";
 
+import { withObservability } from "@/lib/observability";
 /**
  * GET /api/v1/auth/accounts
  *   Returns the public view of the account ring + which one is currently
  *   active (matched against the Supabase session). Used by the
  *   AccountSwitcher dropdown.
  */
-export async function GET(request: NextRequest) {
+async function handleGet(request: NextRequest) {
   const ring = parseRing(request.cookies.get(RING_COOKIE)?.value);
 
   let activeUserId: string | null = null;
@@ -33,3 +34,8 @@ export async function GET(request: NextRequest) {
     },
   });
 }
+
+export const GET = withObservability(
+  handleGet,
+  "GET /api/v1/auth/accounts",
+);

--- a/apps/web/src/app/api/v1/auth/accounts/switch/route.ts
+++ b/apps/web/src/app/api/v1/auth/accounts/switch/route.ts
@@ -4,6 +4,7 @@ import {
   type CookieOptions,
 } from "@supabase/ssr";
 import type { Database } from "@rokki/db";
+import { withObservability } from "@/lib/observability";
 import {
   RING_COOKIE,
   parseRing,
@@ -30,7 +31,7 @@ interface CookieToSet {
  * (Supabase rotates them) so the next switch back to this account also
  * works.
  */
-export async function POST(request: NextRequest) {
+async function handlePost(request: NextRequest) {
   const body = (await request.json().catch(() => ({}))) as {
     user_id?: string;
   };
@@ -129,3 +130,8 @@ export async function POST(request: NextRequest) {
 
   return response;
 }
+
+export const POST = withObservability(
+  handlePost,
+  "POST /api/v1/auth/accounts/switch",
+);

--- a/apps/web/src/app/api/v1/calendar/callback/[provider]/route.ts
+++ b/apps/web/src/app/api/v1/calendar/callback/[provider]/route.ts
@@ -12,6 +12,7 @@ import {
 import { encryptToken } from "@/lib/token-crypto";
 import type { Database } from "@rokki/db";
 
+import { withObservability } from "@/lib/observability";
 interface Props {
   params: Promise<{ provider: string }>;
 }
@@ -24,7 +25,7 @@ interface Props {
  * calendar_connection. Redirects back to /settings/calendars with a
  * status flag so the UI can render success or error inline.
  */
-export async function GET(request: NextRequest, { params }: Props) {
+async function handleGet(request: NextRequest, { params }: Props) {
   const { provider: raw } = await params;
   const appUrl =
     process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
@@ -132,3 +133,8 @@ export async function GET(request: NextRequest, { params }: Props) {
 
   return settings("connected", provider);
 }
+
+export const GET = withObservability<Props>(
+  handleGet,
+  "GET /api/v1/calendar/callback/:provider",
+);

--- a/apps/web/src/app/api/v1/calendar/connect/[provider]/route.ts
+++ b/apps/web/src/app/api/v1/calendar/connect/[provider]/route.ts
@@ -2,6 +2,7 @@ import { NextResponse, type NextRequest } from "next/server";
 import { cookies } from "next/headers";
 import crypto from "node:crypto";
 import { createClient } from "@/lib/supabase/server";
+import { withObservability } from "@/lib/observability";
 import {
   authorizeUrl,
   providerConfig,
@@ -19,7 +20,7 @@ interface Props {
  * and redirects to the provider. The callback route verifies the state
  * and completes the exchange.
  */
-export async function GET(_req: NextRequest, { params }: Props) {
+async function handleGet(_req: NextRequest, { params }: Props) {
   const { provider: raw } = await params;
   if (raw !== "google" && raw !== "microsoft") {
     return NextResponse.json(
@@ -65,3 +66,8 @@ function unavailable(provider: Provider) {
   url.searchParams.set("provider", provider);
   return NextResponse.redirect(url);
 }
+
+export const GET = withObservability<Props>(
+  handleGet,
+  "GET /api/v1/calendar/connect/:provider",
+);

--- a/apps/web/src/app/api/v1/calendar/connections/[id]/route.ts
+++ b/apps/web/src/app/api/v1/calendar/connections/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 
+import { withObservability } from "@/lib/observability";
 interface Props {
   params: Promise<{ id: string }>;
 }
@@ -11,7 +12,7 @@ interface Props {
  * user can see what we used to sync, then a background job can hard-delete
  * after 30 days.
  */
-export async function DELETE(_req: NextRequest, { params }: Props) {
+async function handleDelete(_req: NextRequest, { params }: Props) {
   const { id } = await params;
   const supabase = await createClient();
   const {
@@ -36,3 +37,8 @@ export async function DELETE(_req: NextRequest, { params }: Props) {
     );
   return new NextResponse(null, { status: 204 });
 }
+
+export const DELETE = withObservability<Props>(
+  handleDelete,
+  "DELETE /api/v1/calendar/connections/:id",
+);

--- a/apps/web/src/app/api/v1/calendar/sync-now/route.ts
+++ b/apps/web/src/app/api/v1/calendar/sync-now/route.ts
@@ -2,6 +2,7 @@ import { NextResponse, type NextRequest } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { runCalendarSyncForUser } from "@/lib/calendar-sync";
 
+import { withObservability } from "@/lib/observability";
 /**
  * POST /api/v1/calendar/sync-now
  *
@@ -14,7 +15,7 @@ import { runCalendarSyncForUser } from "@/lib/calendar-sync";
 export const dynamic = "force-dynamic";
 export const maxDuration = 60;
 
-export async function POST(_req: NextRequest) {
+async function handlePost(_req: NextRequest) {
   const supabase = await createClient();
   const {
     data: { user },
@@ -28,3 +29,8 @@ export async function POST(_req: NextRequest) {
   const result = await runCalendarSyncForUser(user.id);
   return NextResponse.json({ data: result });
 }
+
+export const POST = withObservability(
+  handlePost,
+  "POST /api/v1/calendar/sync-now",
+);

--- a/apps/web/src/app/api/v1/drawings/[fileId]/annotations/route.ts
+++ b/apps/web/src/app/api/v1/drawings/[fileId]/annotations/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 
+import { withObservability } from "@/lib/observability";
 interface Props {
   params: Promise<{ fileId: string }>;
 }
@@ -11,7 +12,7 @@ interface Props {
  *
  * RLS scopes this to members of the file's terminal.
  */
-export async function GET(_req: NextRequest, { params }: Props) {
+async function handleGet(_req: NextRequest, { params }: Props) {
   const { fileId } = await params;
   const supabase = await createClient();
   const {
@@ -60,7 +61,7 @@ export async function GET(_req: NextRequest, { params }: Props) {
   });
 }
 
-export async function POST(request: NextRequest, { params }: Props) {
+async function handlePost(request: NextRequest, { params }: Props) {
   const { fileId } = await params;
   const supabase = await createClient();
   const {
@@ -130,3 +131,12 @@ function internal(msg: string) {
     { status: 500 },
   );
 }
+
+export const GET = withObservability<Props>(
+  handleGet,
+  "GET /api/v1/drawings/:fileId/annotations",
+);
+export const POST = withObservability<Props>(
+  handlePost,
+  "POST /api/v1/drawings/:fileId/annotations",
+);

--- a/apps/web/src/app/api/v1/drawings/annotations/[id]/route.ts
+++ b/apps/web/src/app/api/v1/drawings/annotations/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 
+import { withObservability } from "@/lib/observability";
 interface Props {
   params: Promise<{ id: string }>;
 }
@@ -9,7 +10,7 @@ interface Props {
  * PATCH  /api/v1/drawings/annotations/:id  { body?, resolved?: boolean }
  * DELETE /api/v1/drawings/annotations/:id  (soft delete)
  */
-export async function PATCH(request: NextRequest, { params }: Props) {
+async function handlePatch(request: NextRequest, { params }: Props) {
   const { id } = await params;
   const supabase = await createClient();
   const {
@@ -40,7 +41,7 @@ export async function PATCH(request: NextRequest, { params }: Props) {
   return new NextResponse(null, { status: 204 });
 }
 
-export async function DELETE(_req: NextRequest, { params }: Props) {
+async function handleDelete(_req: NextRequest, { params }: Props) {
   const { id } = await params;
   const supabase = await createClient();
   const {
@@ -75,3 +76,12 @@ function internal(msg: string) {
     { status: 500 },
   );
 }
+
+export const PATCH = withObservability<Props>(
+  handlePatch,
+  "PATCH /api/v1/drawings/annotations/:id",
+);
+export const DELETE = withObservability<Props>(
+  handleDelete,
+  "DELETE /api/v1/drawings/annotations/:id",
+);

--- a/apps/web/src/app/api/v1/files/[id]/download/route.ts
+++ b/apps/web/src/app/api/v1/files/[id]/download/route.ts
@@ -2,6 +2,7 @@ import { NextResponse, type NextRequest } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { getObjectStream } from "@/lib/storage";
 
+import { withObservability } from "@/lib/observability";
 interface Props {
   params: Promise<{ id: string }>;
 }
@@ -11,7 +12,7 @@ interface Props {
  * enforcing RLS via the file's visibility policy. Phase 1: simple proxy.
  * Phase 2 will redirect to a signed URL for direct-to-storage download.
  */
-export async function GET(_req: NextRequest, { params }: Props) {
+async function handleGet(_req: NextRequest, { params }: Props) {
   const { id } = await params;
   const supabase = await createClient();
   const {
@@ -108,3 +109,8 @@ function internal(msg: string) {
     { status: 500 },
   );
 }
+
+export const GET = withObservability<Props>(
+  handleGet,
+  "GET /api/v1/files/:id/download",
+);

--- a/apps/web/src/app/api/v1/files/[id]/duplicate/route.ts
+++ b/apps/web/src/app/api/v1/files/[id]/duplicate/route.ts
@@ -3,6 +3,7 @@ import { createClient } from "@/lib/supabase/server";
 import { buildBlobKey, copyObject } from "@/lib/storage";
 import crypto from "node:crypto";
 
+import { withObservability } from "@/lib/observability";
 interface Props {
   params: Promise<{ id: string }>;
 }
@@ -15,7 +16,7 @@ interface Props {
  * the payload. Destination defaults to the source's folder and "(copy)"-suffixed
  * filename; both can be overridden.
  */
-export async function POST(request: NextRequest, { params }: Props) {
+async function handlePost(request: NextRequest, { params }: Props) {
   const { id } = await params;
   const supabase = await createClient();
   const {
@@ -158,3 +159,8 @@ function internal(msg: string) {
     { status: 500 },
   );
 }
+
+export const POST = withObservability<Props>(
+  handlePost,
+  "POST /api/v1/files/:id/duplicate",
+);

--- a/apps/web/src/app/api/v1/files/[id]/permanent/route.ts
+++ b/apps/web/src/app/api/v1/files/[id]/permanent/route.ts
@@ -2,6 +2,7 @@ import { NextResponse, type NextRequest } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { deleteObject } from "@/lib/storage";
 
+import { withObservability } from "@/lib/observability";
 interface Props {
   params: Promise<{ id: string }>;
 }
@@ -12,7 +13,7 @@ interface Props {
  * trash (deleted_at IS NOT NULL) to prevent accidental skipping of the bin.
  * RLS still enforces uploader-or-manager.
  */
-export async function DELETE(_req: NextRequest, { params }: Props) {
+async function handleDelete(_req: NextRequest, { params }: Props) {
   const { id } = await params;
   const supabase = await createClient();
   const {
@@ -95,3 +96,8 @@ function internal(msg: string) {
     { status: 500 },
   );
 }
+
+export const DELETE = withObservability<Props>(
+  handleDelete,
+  "DELETE /api/v1/files/:id/permanent",
+);

--- a/apps/web/src/app/api/v1/files/[id]/restore/route.ts
+++ b/apps/web/src/app/api/v1/files/[id]/restore/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 
+import { withObservability } from "@/lib/observability";
 interface Props {
   params: Promise<{ id: string }>;
 }
@@ -9,7 +10,7 @@ interface Props {
  * POST /api/v1/files/:id/restore — un-trash a soft-deleted file.
  * Bytes are still in storage because the original delete was soft only.
  */
-export async function POST(_req: NextRequest, { params }: Props) {
+async function handlePost(_req: NextRequest, { params }: Props) {
   const { id } = await params;
   const supabase = await createClient();
   const {
@@ -80,3 +81,8 @@ function internal(msg: string) {
     { status: 500 },
   );
 }
+
+export const POST = withObservability<Props>(
+  handlePost,
+  "POST /api/v1/files/:id/restore",
+);

--- a/apps/web/src/app/api/v1/files/[id]/share-links/route.ts
+++ b/apps/web/src/app/api/v1/files/[id]/share-links/route.ts
@@ -2,6 +2,7 @@ import { NextResponse, type NextRequest } from "next/server";
 import crypto from "node:crypto";
 import { createClient } from "@/lib/supabase/server";
 
+import { withObservability } from "@/lib/observability";
 interface Props {
   params: Promise<{ id: string }>;
 }
@@ -12,7 +13,7 @@ interface Props {
  *   { label?, expires_in_days?, max_views?, require_email? }
  */
 
-export async function GET(_req: NextRequest, { params }: Props) {
+async function handleGet(_req: NextRequest, { params }: Props) {
   const { id } = await params;
   const supabase = await createClient();
   const {
@@ -54,7 +55,7 @@ export async function GET(_req: NextRequest, { params }: Props) {
   return NextResponse.json({ data: decorated });
 }
 
-export async function POST(request: NextRequest, { params }: Props) {
+async function handlePost(request: NextRequest, { params }: Props) {
   const { id } = await params;
   const supabase = await createClient();
   const {
@@ -107,3 +108,12 @@ function internal(msg: string) {
     { status: 500 },
   );
 }
+
+export const GET = withObservability<Props>(
+  handleGet,
+  "GET /api/v1/files/:id/share-links",
+);
+export const POST = withObservability<Props>(
+  handlePost,
+  "POST /api/v1/files/:id/share-links",
+);

--- a/apps/web/src/app/api/v1/files/[id]/signed-url/route.ts
+++ b/apps/web/src/app/api/v1/files/[id]/signed-url/route.ts
@@ -2,6 +2,7 @@ import { NextResponse, type NextRequest } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { getSignedDownloadUrl } from "@/lib/storage";
 
+import { withObservability } from "@/lib/observability";
 interface Props {
   params: Promise<{ id: string }>;
 }
@@ -14,7 +15,7 @@ interface Props {
  *
  * RLS ensures the caller can see the file before we hand out a URL.
  */
-export async function GET(_req: NextRequest, { params }: Props) {
+async function handleGet(_req: NextRequest, { params }: Props) {
   const { id } = await params;
   const supabase = await createClient();
   const {
@@ -45,3 +46,8 @@ export async function GET(_req: NextRequest, { params }: Props) {
     data: { url, mime_type: file.mime_type, filename: file.filename },
   });
 }
+
+export const GET = withObservability<Props>(
+  handleGet,
+  "GET /api/v1/files/:id/signed-url",
+);

--- a/apps/web/src/app/api/v1/folders/[id]/duplicate/route.ts
+++ b/apps/web/src/app/api/v1/folders/[id]/duplicate/route.ts
@@ -6,6 +6,7 @@ import { joinPath } from "@/lib/folder-path";
 import type { Database } from "@rokki/db";
 import crypto from "node:crypto";
 
+import { withObservability } from "@/lib/observability";
 interface Props {
   params: Promise<{ id: string }>;
 }
@@ -19,7 +20,7 @@ interface Props {
  * can't individually insert via RLS; entry is authorized by the caller's RLS
  * check on the source folder.
  */
-export async function POST(_req: NextRequest, { params }: Props) {
+async function handlePost(_req: NextRequest, { params }: Props) {
   const { id } = await params;
   const supabase = await createClient();
   const {
@@ -225,3 +226,8 @@ function internal(msg: string) {
     { status: 500 },
   );
 }
+
+export const POST = withObservability<Props>(
+  handlePost,
+  "POST /api/v1/folders/:id/duplicate",
+);

--- a/apps/web/src/app/api/v1/folders/[id]/route.ts
+++ b/apps/web/src/app/api/v1/folders/[id]/route.ts
@@ -4,6 +4,7 @@ import { createClient } from "@/lib/supabase/server";
 import { isValidFolderName, joinPath, parentOf } from "@/lib/folder-path";
 import type { Database } from "@rokki/db";
 
+import { withObservability } from "@/lib/observability";
 interface Props {
   params: Promise<{ id: string }>;
 }
@@ -17,7 +18,7 @@ interface Props {
  * Cascades run through the service-role client because the caller's RLS only
  * grants update on their own files/folders, not on every descendant.
  */
-export async function PATCH(request: NextRequest, { params }: Props) {
+async function handlePatch(request: NextRequest, { params }: Props) {
   const { id } = await params;
   const supabase = await createClient();
   const {
@@ -128,7 +129,7 @@ export async function PATCH(request: NextRequest, { params }: Props) {
   });
 }
 
-export async function DELETE(_req: NextRequest, { params }: Props) {
+async function handleDelete(_req: NextRequest, { params }: Props) {
   const { id } = await params;
   const supabase = await createClient();
   const {
@@ -227,3 +228,12 @@ function internal(msg: string) {
     { status: 500 },
   );
 }
+
+export const PATCH = withObservability<Props>(
+  handlePatch,
+  "PATCH /api/v1/folders/:id",
+);
+export const DELETE = withObservability<Props>(
+  handleDelete,
+  "DELETE /api/v1/folders/:id",
+);

--- a/apps/web/src/app/api/v1/health/route.ts
+++ b/apps/web/src/app/api/v1/health/route.ts
@@ -1,7 +1,8 @@
 import { NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 
-export async function GET() {
+import { withObservability } from "@/lib/observability";
+async function handleGet() {
   const checks: Record<string, { ok: boolean; error?: string }> = {};
 
   try {
@@ -27,3 +28,8 @@ export async function GET() {
     { status: allOk ? 200 : 503 },
   );
 }
+
+export const GET = withObservability(
+  handleGet,
+  "GET /api/v1/health",
+);

--- a/apps/web/src/app/api/v1/history/route.ts
+++ b/apps/web/src/app/api/v1/history/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 
+import { withObservability } from "@/lib/observability";
 /**
  * GET /api/v1/history?entity_type=task|terminal|space|file|comment&entity_id=<uuid>&limit=50
  *
@@ -18,7 +19,7 @@ import { createClient } from "@/lib/supabase/server";
 
 const VALID_ENTITY_TYPES = new Set(["task", "terminal", "space", "file", "comment"]);
 
-export async function GET(request: NextRequest) {
+async function handleGet(request: NextRequest) {
   const supabase = await createClient();
   const {
     data: { user },
@@ -71,3 +72,8 @@ function internal(msg: string) {
     { status: 500 },
   );
 }
+
+export const GET = withObservability(
+  handleGet,
+  "GET /api/v1/history",
+);

--- a/apps/web/src/app/api/v1/me/announcements/[id]/dismiss/route.ts
+++ b/apps/web/src/app/api/v1/me/announcements/[id]/dismiss/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 
+import { withObservability } from "@/lib/observability";
 interface Props {
   params: Promise<{ id: string }>;
 }
@@ -9,7 +10,7 @@ interface Props {
  * POST /api/v1/me/announcements/:id/dismiss
  *   Marks the announcement dismissed for the current user.
  */
-export async function POST(_request: NextRequest, { params }: Props) {
+async function handlePost(_request: NextRequest, { params }: Props) {
   const { id } = await params;
   const supabase = await createClient();
   const {
@@ -30,3 +31,8 @@ export async function POST(_request: NextRequest, { params }: Props) {
 
   return NextResponse.json({ data: { dismissed: true } });
 }
+
+export const POST = withObservability<Props>(
+  handlePost,
+  "POST /api/v1/me/announcements/:id/dismiss",
+);

--- a/apps/web/src/app/api/v1/me/announcements/route.ts
+++ b/apps/web/src/app/api/v1/me/announcements/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 
+import { withObservability } from "@/lib/observability";
 /**
  * GET /api/v1/me/announcements
  *   Returns active announcements visible to the caller, with the
@@ -11,7 +12,7 @@ import { createClient } from "@/lib/supabase/server";
  *     - audience='admins' → only platform admins
  *     - audience='space'  → only members of the targeted space
  */
-export async function GET(_request: NextRequest) {
+async function handleGet(_request: NextRequest) {
   const supabase = await createClient();
   const {
     data: { user },
@@ -96,3 +97,8 @@ export async function GET(_request: NextRequest) {
     data: visible.map((v) => ({ ...v, dismissed: dismissed.has(v.id) })),
   });
 }
+
+export const GET = withObservability(
+  handleGet,
+  "GET /api/v1/me/announcements",
+);

--- a/apps/web/src/app/api/v1/me/api-keys/[id]/route.ts
+++ b/apps/web/src/app/api/v1/me/api-keys/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 
+import { withObservability } from "@/lib/observability";
 interface Props {
   params: Promise<{ id: string }>;
 }
@@ -8,7 +9,7 @@ interface Props {
 /**
  * DELETE /api/v1/me/api-keys/:id  — forget a BYOK key.
  */
-export async function DELETE(_req: NextRequest, { params }: Props) {
+async function handleDelete(_req: NextRequest, { params }: Props) {
   const { id } = await params;
   const supabase = await createClient();
   const {
@@ -32,3 +33,8 @@ export async function DELETE(_req: NextRequest, { params }: Props) {
     );
   return new NextResponse(null, { status: 204 });
 }
+
+export const DELETE = withObservability<Props>(
+  handleDelete,
+  "DELETE /api/v1/me/api-keys/:id",
+);

--- a/apps/web/src/app/api/v1/me/api-keys/route.ts
+++ b/apps/web/src/app/api/v1/me/api-keys/route.ts
@@ -2,6 +2,7 @@ import { NextResponse, type NextRequest } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { encryptToken, cryptoEnabled } from "@/lib/token-crypto";
 
+import { withObservability } from "@/lib/observability";
 /**
  * GET  /api/v1/me/api-keys           — my stored provider keys (metadata only)
  * POST /api/v1/me/api-keys  { provider, secret, key_hint? }
@@ -14,7 +15,7 @@ import { encryptToken, cryptoEnabled } from "@/lib/token-crypto";
  */
 const PROVIDERS = ["anthropic", "openai", "google", "mistral", "cohere"];
 
-export async function GET() {
+async function handleGet() {
   const supabase = await createClient();
   const {
     data: { user },
@@ -30,7 +31,7 @@ export async function GET() {
   return NextResponse.json({ data: data ?? [] });
 }
 
-export async function POST(request: NextRequest) {
+async function handlePost(request: NextRequest) {
   const supabase = await createClient();
   const {
     data: { user },
@@ -126,3 +127,12 @@ function internal(msg: string) {
     { status: 500 },
   );
 }
+
+export const GET = withObservability(
+  handleGet,
+  "GET /api/v1/me/api-keys",
+);
+export const POST = withObservability(
+  handlePost,
+  "POST /api/v1/me/api-keys",
+);

--- a/apps/web/src/app/api/v1/me/flags/route.ts
+++ b/apps/web/src/app/api/v1/me/flags/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 
+import { withObservability } from "@/lib/observability";
 /**
  * GET /api/v1/me/flags
  *   Returns a `{ key: value }` map for the current user, resolving
@@ -10,7 +11,7 @@ import { createClient } from "@/lib/supabase/server";
  *   Rollout percentage is applied at this layer using a stable hash
  *   of (user_id + key) so a user always gets the same answer.
  */
-export async function GET() {
+async function handleGet() {
   const supabase = await createClient();
   const {
     data: { user },
@@ -91,3 +92,8 @@ function stableBucket(seed: string): number {
   }
   return h % 100;
 }
+
+export const GET = withObservability(
+  handleGet,
+  "GET /api/v1/me/flags",
+);

--- a/apps/web/src/app/api/v1/me/push-subscriptions/route.ts
+++ b/apps/web/src/app/api/v1/me/push-subscriptions/route.ts
@@ -1,13 +1,14 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 
+import { withObservability } from "@/lib/observability";
 /**
  * GET  /api/v1/me/push-subscriptions          — list this user's subs
  * POST /api/v1/me/push-subscriptions  { endpoint, keys: { p256dh, auth } }
  *
  * Idempotent on (user_id, endpoint) — re-subscribing updates `last_seen_at`.
  */
-export async function GET() {
+async function handleGet() {
   const supabase = await createClient();
   const {
     data: { user },
@@ -23,7 +24,7 @@ export async function GET() {
   return NextResponse.json({ data: data ?? [] });
 }
 
-export async function POST(request: NextRequest) {
+async function handlePost(request: NextRequest) {
   const supabase = await createClient();
   const {
     data: { user },
@@ -87,7 +88,7 @@ export async function POST(request: NextRequest) {
   return NextResponse.json({ data: { subscribed: true } }, { status: 201 });
 }
 
-export async function DELETE(request: NextRequest) {
+async function handleDelete(request: NextRequest) {
   const supabase = await createClient();
   const {
     data: { user },
@@ -116,3 +117,16 @@ function bad(msg: string) {
     { status: 400 },
   );
 }
+
+export const GET = withObservability(
+  handleGet,
+  "GET /api/v1/me/push-subscriptions",
+);
+export const POST = withObservability(
+  handlePost,
+  "POST /api/v1/me/push-subscriptions",
+);
+export const DELETE = withObservability(
+  handleDelete,
+  "DELETE /api/v1/me/push-subscriptions",
+);

--- a/apps/web/src/app/api/v1/me/tokens/[id]/route.ts
+++ b/apps/web/src/app/api/v1/me/tokens/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 
+import { withObservability } from "@/lib/observability";
 interface Props {
   params: Promise<{ id: string }>;
 }
@@ -10,7 +11,7 @@ interface Props {
  * Active MCP sessions using the token are disconnected within 30s
  * (MCP server re-validates on every keep-alive ping).
  */
-export async function DELETE(_req: NextRequest, { params }: Props) {
+async function handleDelete(_req: NextRequest, { params }: Props) {
   const { id } = await params;
   const supabase = await createClient();
   const {
@@ -44,3 +45,8 @@ function internal(msg: string) {
     { status: 500 },
   );
 }
+
+export const DELETE = withObservability<Props>(
+  handleDelete,
+  "DELETE /api/v1/me/tokens/:id",
+);

--- a/apps/web/src/app/api/v1/me/tokens/route.ts
+++ b/apps/web/src/app/api/v1/me/tokens/route.ts
@@ -3,6 +3,7 @@ import { createClient } from "@/lib/supabase/server";
 import { generateToken } from "@/lib/tokens";
 import type { TokenScope } from "@rokki/db";
 
+import { withObservability } from "@/lib/observability";
 /**
  * GET  /api/v1/me/tokens          — list my active tokens (prefix only; plaintext never stored)
  * POST /api/v1/me/tokens { name, scopes?, expires_in_days? }
@@ -10,7 +11,7 @@ import type { TokenScope } from "@rokki/db";
  *
  * See docs/04_AUTH_SECURITY.md §4.2.
  */
-export async function GET() {
+async function handleGet() {
   const supabase = await createClient();
   const {
     data: { user },
@@ -28,7 +29,7 @@ export async function GET() {
   return NextResponse.json({ data: data ?? [] });
 }
 
-export async function POST(request: NextRequest) {
+async function handlePost(request: NextRequest) {
   const supabase = await createClient();
   const {
     data: { user },
@@ -108,3 +109,12 @@ function internal(msg: string) {
     { status: 500 },
   );
 }
+
+export const GET = withObservability(
+  handleGet,
+  "GET /api/v1/me/tokens",
+);
+export const POST = withObservability(
+  handlePost,
+  "POST /api/v1/me/tokens",
+);

--- a/apps/web/src/app/api/v1/notifications/mark-all-read/route.ts
+++ b/apps/web/src/app/api/v1/notifications/mark-all-read/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 
+import { withObservability } from "@/lib/observability";
 /**
  * PATCH /api/v1/notifications/mark-all-read
  * Sets read_at = now() for every unread notification belonging to the
@@ -10,7 +11,7 @@ import { createClient } from "@/lib/supabase/server";
  * Returns 204 on success. Single-shot, idempotent — repeated calls are
  * cheap (a no-op once everything is read).
  */
-export async function PATCH() {
+async function handlePatch() {
   const supabase = await createClient();
   const {
     data: { user },
@@ -37,3 +38,8 @@ export async function PATCH() {
 
   return new NextResponse(null, { status: 204 });
 }
+
+export const PATCH = withObservability(
+  handlePatch,
+  "PATCH /api/v1/notifications/mark-all-read",
+);

--- a/apps/web/src/app/api/v1/orgs/[slug]/members/[userId]/route.ts
+++ b/apps/web/src/app/api/v1/orgs/[slug]/members/[userId]/route.ts
@@ -3,6 +3,7 @@ import { createClient } from "@/lib/supabase/server";
 import { emitEvent } from "@/lib/events";
 import { revokeSessions } from "@/lib/revocations";
 
+import { withObservability } from "@/lib/observability";
 interface Props {
   params: Promise<{ slug: string; userId: string }>;
 }
@@ -20,7 +21,7 @@ const VALID_ROLES: SpaceRole[] = ["owner", "admin", "member"];
  * via CASCADE — that's intentional.
  */
 
-export async function PATCH(request: NextRequest, { params }: Props) {
+async function handlePatch(request: NextRequest, { params }: Props) {
   const { slug, userId } = await params;
   const supabase = await createClient();
   const {
@@ -75,7 +76,7 @@ export async function PATCH(request: NextRequest, { params }: Props) {
   return NextResponse.json({ data: { user_id: userId, role: body.role } });
 }
 
-export async function DELETE(_req: NextRequest, { params }: Props) {
+async function handleDelete(_req: NextRequest, { params }: Props) {
   const { slug, userId } = await params;
   const supabase = await createClient();
   const {
@@ -185,3 +186,12 @@ function internal(msg: string) {
     { status: 500 },
   );
 }
+
+export const PATCH = withObservability<Props>(
+  handlePatch,
+  "PATCH /api/v1/orgs/:slug/members/:userId",
+);
+export const DELETE = withObservability<Props>(
+  handleDelete,
+  "DELETE /api/v1/orgs/:slug/members/:userId",
+);

--- a/apps/web/src/app/api/v1/orgs/[slug]/members/route.ts
+++ b/apps/web/src/app/api/v1/orgs/[slug]/members/route.ts
@@ -5,6 +5,7 @@ import { emitEvent } from "@/lib/events";
 import type { Database } from "@rokki/db";
 import crypto from "node:crypto";
 
+import { withObservability } from "@/lib/observability";
 interface Props {
   params: Promise<{ slug: string }>;
 }
@@ -22,7 +23,7 @@ type SpaceRole = "owner" | "admin" | "member";
  */
 const VALID_ROLES: SpaceRole[] = ["owner", "admin", "member"];
 
-export async function GET(_req: NextRequest, { params }: Props) {
+async function handleGet(_req: NextRequest, { params }: Props) {
   const { slug } = await params;
   const supabase = await createClient();
   const {
@@ -82,7 +83,7 @@ export async function GET(_req: NextRequest, { params }: Props) {
   });
 }
 
-export async function POST(request: NextRequest, { params }: Props) {
+async function handlePost(request: NextRequest, { params }: Props) {
   const { slug } = await params;
   const supabase = await createClient();
   const {
@@ -235,3 +236,12 @@ function internal(msg: string) {
     { status: 500 },
   );
 }
+
+export const GET = withObservability<Props>(
+  handleGet,
+  "GET /api/v1/orgs/:slug/members",
+);
+export const POST = withObservability<Props>(
+  handlePost,
+  "POST /api/v1/orgs/:slug/members",
+);

--- a/apps/web/src/app/api/v1/orgs/[slug]/vendors/route.ts
+++ b/apps/web/src/app/api/v1/orgs/[slug]/vendors/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 
+import { withObservability } from "@/lib/observability";
 interface Props {
   params: Promise<{ slug: string }>;
 }
@@ -9,7 +10,7 @@ interface Props {
  * GET  /api/v1/orgs/:slug/vendors
  * POST /api/v1/orgs/:slug/vendors  { name, contact_name?, contact_email?, contact_phone?, website?, tags?, notes? }
  */
-export async function GET(_req: NextRequest, { params }: Props) {
+async function handleGet(_req: NextRequest, { params }: Props) {
   const { slug } = await params;
   const supabase = await createClient();
   const space = await resolveSpace(supabase, slug);
@@ -25,7 +26,7 @@ export async function GET(_req: NextRequest, { params }: Props) {
   return NextResponse.json({ data: data ?? [] });
 }
 
-export async function POST(request: NextRequest, { params }: Props) {
+async function handlePost(request: NextRequest, { params }: Props) {
   const { slug } = await params;
   const supabase = await createClient();
   const {
@@ -107,3 +108,12 @@ function internal(msg: string) {
     { status: 500 },
   );
 }
+
+export const GET = withObservability<Props>(
+  handleGet,
+  "GET /api/v1/orgs/:slug/vendors",
+);
+export const POST = withObservability<Props>(
+  handlePost,
+  "POST /api/v1/orgs/:slug/vendors",
+);

--- a/apps/web/src/app/api/v1/orgs/route.ts
+++ b/apps/web/src/app/api/v1/orgs/route.ts
@@ -1,13 +1,14 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 
+import { withObservability } from "@/lib/observability";
 /**
  * GET  /api/v1/orgs           — list my orgs
  * POST /api/v1/orgs           — create a new org (caller becomes owner via trigger)
  *
  * See docs/02_API.md §2.5.
  */
-export async function GET() {
+async function handleGet() {
   const supabase = await createClient();
   const {
     data: { user },
@@ -23,7 +24,7 @@ export async function GET() {
   return NextResponse.json({ data });
 }
 
-export async function POST(request: NextRequest) {
+async function handlePost(request: NextRequest) {
   const supabase = await createClient();
   const {
     data: { user },
@@ -109,3 +110,12 @@ function internal(msg: string) {
     { status: 500 },
   );
 }
+
+export const GET = withObservability(
+  handleGet,
+  "GET /api/v1/orgs",
+);
+export const POST = withObservability(
+  handlePost,
+  "POST /api/v1/orgs",
+);

--- a/apps/web/src/app/api/v1/projects/[ticker]/budget/route.ts
+++ b/apps/web/src/app/api/v1/projects/[ticker]/budget/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 
+import { withObservability } from "@/lib/observability";
 interface Props {
   params: Promise<{ ticker: string }>;
 }
@@ -9,7 +10,7 @@ interface Props {
  * GET  /api/v1/projects/:ticker/budget
  * POST /api/v1/projects/:ticker/budget  { category, description?, amount_cents, status?, vendor_id?, incurred_on? }
  */
-export async function GET(_req: NextRequest, { params }: Props) {
+async function handleGet(_req: NextRequest, { params }: Props) {
   const { ticker } = await params;
   const supabase = await createClient();
   const terminal = await resolveTerminal(supabase, ticker);
@@ -27,7 +28,7 @@ export async function GET(_req: NextRequest, { params }: Props) {
   return NextResponse.json({ data: data ?? [] });
 }
 
-export async function POST(request: NextRequest, { params }: Props) {
+async function handlePost(request: NextRequest, { params }: Props) {
   const { ticker } = await params;
   const supabase = await createClient();
   const {
@@ -110,3 +111,12 @@ function internal(msg: string) {
     { status: 500 },
   );
 }
+
+export const GET = withObservability<Props>(
+  handleGet,
+  "GET /api/v1/projects/:ticker/budget",
+);
+export const POST = withObservability<Props>(
+  handlePost,
+  "POST /api/v1/projects/:ticker/budget",
+);

--- a/apps/web/src/app/api/v1/projects/[ticker]/folders/route.ts
+++ b/apps/web/src/app/api/v1/projects/[ticker]/folders/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { createClient } from "@/lib/supabase/server";
+import { withObservability } from "@/lib/observability";
 import {
   isValidFolderName,
   joinPath,
@@ -15,7 +16,7 @@ interface Props {
  * POST /api/v1/projects/:ticker/folders  { name, parent? }
  *                                                    — create a new folder
  */
-export async function GET(_req: NextRequest, { params }: Props) {
+async function handleGet(_req: NextRequest, { params }: Props) {
   const { ticker } = await params;
   const supabase = await createClient();
   const {
@@ -37,7 +38,7 @@ export async function GET(_req: NextRequest, { params }: Props) {
   return NextResponse.json({ data });
 }
 
-export async function POST(request: NextRequest, { params }: Props) {
+async function handlePost(request: NextRequest, { params }: Props) {
   const { ticker } = await params;
   const supabase = await createClient();
   const {
@@ -139,3 +140,12 @@ function internal(msg: string) {
     { status: 500 },
   );
 }
+
+export const GET = withObservability<Props>(
+  handleGet,
+  "GET /api/v1/projects/:ticker/folders",
+);
+export const POST = withObservability<Props>(
+  handlePost,
+  "POST /api/v1/projects/:ticker/folders",
+);

--- a/apps/web/src/app/api/v1/projects/[ticker]/members/[userId]/route.ts
+++ b/apps/web/src/app/api/v1/projects/[ticker]/members/[userId]/route.ts
@@ -4,6 +4,7 @@ import { emitEvent } from "@/lib/events";
 import { revokeSessions } from "@/lib/revocations";
 import type { ProjectRole } from "@rokki/db";
 
+import { withObservability } from "@/lib/observability";
 interface Props {
   params: Promise<{ ticker: string; userId: string }>;
 }
@@ -27,7 +28,7 @@ const VALID_ROLES: ProjectRole[] = [
   "guest",
 ];
 
-export async function PATCH(request: NextRequest, { params }: Props) {
+async function handlePatch(request: NextRequest, { params }: Props) {
   const { ticker, userId } = await params;
   const supabase = await createClient();
   const {
@@ -78,7 +79,7 @@ export async function PATCH(request: NextRequest, { params }: Props) {
   return NextResponse.json({ data: { user_id: userId, role: body.role } });
 }
 
-export async function DELETE(_req: NextRequest, { params }: Props) {
+async function handleDelete(_req: NextRequest, { params }: Props) {
   const { ticker, userId } = await params;
   const supabase = await createClient();
   const {
@@ -206,3 +207,12 @@ function internal(msg: string) {
     { status: 500 },
   );
 }
+
+export const PATCH = withObservability<Props>(
+  handlePatch,
+  "PATCH /api/v1/projects/:ticker/members/:userId",
+);
+export const DELETE = withObservability<Props>(
+  handleDelete,
+  "DELETE /api/v1/projects/:ticker/members/:userId",
+);

--- a/apps/web/src/app/api/v1/projects/[ticker]/members/route.ts
+++ b/apps/web/src/app/api/v1/projects/[ticker]/members/route.ts
@@ -4,6 +4,7 @@ import { createClient } from "@/lib/supabase/server";
 import type { Database, ProjectRole } from "@rokki/db";
 import crypto from "node:crypto";
 
+import { withObservability } from "@/lib/observability";
 interface Props {
   params: Promise<{ ticker: string }>;
 }
@@ -19,7 +20,7 @@ interface Props {
  *      scoped so that when the recipient clicks it, /auth/callback auto-accepts
  *      the invite (see apps/web/src/app/auth/callback/route.ts).
  */
-export async function GET(_req: NextRequest, { params }: Props) {
+async function handleGet(_req: NextRequest, { params }: Props) {
   const { ticker } = await params;
   const supabase = await createClient();
   const {
@@ -84,7 +85,7 @@ export async function GET(_req: NextRequest, { params }: Props) {
   });
 }
 
-export async function POST(request: NextRequest, { params }: Props) {
+async function handlePost(request: NextRequest, { params }: Props) {
   const { ticker } = await params;
   const supabase = await createClient();
   const {
@@ -270,3 +271,12 @@ function internal(msg: string) {
     { status: 500 },
   );
 }
+
+export const GET = withObservability<Props>(
+  handleGet,
+  "GET /api/v1/projects/:ticker/members",
+);
+export const POST = withObservability<Props>(
+  handlePost,
+  "POST /api/v1/projects/:ticker/members",
+);

--- a/apps/web/src/app/api/v1/projects/[ticker]/permits/route.ts
+++ b/apps/web/src/app/api/v1/projects/[ticker]/permits/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 
+import { withObservability } from "@/lib/observability";
 interface Props {
   params: Promise<{ ticker: string }>;
 }
@@ -9,7 +10,7 @@ interface Props {
  * GET  /api/v1/projects/:ticker/permits
  * POST /api/v1/projects/:ticker/permits  { kind, number?, authority?, status?, applied_on?, expires_on? }
  */
-export async function GET(_req: NextRequest, { params }: Props) {
+async function handleGet(_req: NextRequest, { params }: Props) {
   const { ticker } = await params;
   const supabase = await createClient();
   const terminal = await resolveTerminal(supabase, ticker);
@@ -27,7 +28,7 @@ export async function GET(_req: NextRequest, { params }: Props) {
   return NextResponse.json({ data: data ?? [] });
 }
 
-export async function POST(request: NextRequest, { params }: Props) {
+async function handlePost(request: NextRequest, { params }: Props) {
   const { ticker } = await params;
   const supabase = await createClient();
   const {
@@ -110,3 +111,12 @@ function internal(msg: string) {
     { status: 500 },
   );
 }
+
+export const GET = withObservability<Props>(
+  handleGet,
+  "GET /api/v1/projects/:ticker/permits",
+);
+export const POST = withObservability<Props>(
+  handlePost,
+  "POST /api/v1/projects/:ticker/permits",
+);

--- a/apps/web/src/app/api/v1/projects/[ticker]/route.ts
+++ b/apps/web/src/app/api/v1/projects/[ticker]/route.ts
@@ -3,6 +3,7 @@ import { createClient } from "@/lib/supabase/server";
 import { emitEvent } from "@/lib/events";
 import type { ProjectStatus } from "@rokki/db";
 
+import { withObservability } from "@/lib/observability";
 interface Props {
   params: Promise<{ ticker: string }>;
 }
@@ -27,7 +28,7 @@ const VALID_STATUSES: ProjectStatus[] = [
   "archived",
 ];
 
-export async function GET(_req: NextRequest, { params }: Props) {
+async function handleGet(_req: NextRequest, { params }: Props) {
   const { ticker } = await params;
   const supabase = await createClient();
   const {
@@ -47,7 +48,7 @@ export async function GET(_req: NextRequest, { params }: Props) {
   return NextResponse.json({ data });
 }
 
-export async function PATCH(request: NextRequest, { params }: Props) {
+async function handlePatch(request: NextRequest, { params }: Props) {
   const { ticker } = await params;
   const supabase = await createClient();
   const {
@@ -118,7 +119,7 @@ export async function PATCH(request: NextRequest, { params }: Props) {
   return NextResponse.json({ data });
 }
 
-export async function DELETE(_req: NextRequest, { params }: Props) {
+async function handleDelete(_req: NextRequest, { params }: Props) {
   const { ticker } = await params;
   const supabase = await createClient();
   const {
@@ -241,3 +242,16 @@ function internal(msg: string) {
     { status: 500 },
   );
 }
+
+export const GET = withObservability<Props>(
+  handleGet,
+  "GET /api/v1/projects/:ticker",
+);
+export const PATCH = withObservability<Props>(
+  handlePatch,
+  "PATCH /api/v1/projects/:ticker",
+);
+export const DELETE = withObservability<Props>(
+  handleDelete,
+  "DELETE /api/v1/projects/:ticker",
+);

--- a/apps/web/src/app/api/v1/projects/[ticker]/schedule/route.ts
+++ b/apps/web/src/app/api/v1/projects/[ticker]/schedule/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 
+import { withObservability } from "@/lib/observability";
 interface Props {
   params: Promise<{ ticker: string }>;
 }
@@ -9,7 +10,7 @@ interface Props {
  * GET  /api/v1/projects/:ticker/schedule
  * POST /api/v1/projects/:ticker/schedule  { title, start_date, end_date, color?, depends_on? }
  */
-export async function GET(_req: NextRequest, { params }: Props) {
+async function handleGet(_req: NextRequest, { params }: Props) {
   const { ticker } = await params;
   const supabase = await createClient();
   const terminal = await resolveTerminal(supabase, ticker);
@@ -26,7 +27,7 @@ export async function GET(_req: NextRequest, { params }: Props) {
   return NextResponse.json({ data: data ?? [] });
 }
 
-export async function POST(request: NextRequest, { params }: Props) {
+async function handlePost(request: NextRequest, { params }: Props) {
   const { ticker } = await params;
   const supabase = await createClient();
   const {
@@ -106,3 +107,12 @@ function internal(msg: string) {
     { status: 500 },
   );
 }
+
+export const GET = withObservability<Props>(
+  handleGet,
+  "GET /api/v1/projects/:ticker/schedule",
+);
+export const POST = withObservability<Props>(
+  handlePost,
+  "POST /api/v1/projects/:ticker/schedule",
+);

--- a/apps/web/src/app/api/v1/projects/route.ts
+++ b/apps/web/src/app/api/v1/projects/route.ts
@@ -4,13 +4,14 @@ import { isValidTicker, suggestTicker, uniqueTicker } from "@/lib/ticker";
 import { emitEvent } from "@/lib/events";
 import type { ProjectStatus } from "@rokki/db";
 
+import { withObservability } from "@/lib/observability";
 /**
  * GET  /api/v1/projects                       — all accessible projects
  * POST /api/v1/projects  { space_id, name, ticker?, description?, type?, metadata? }
  *
  * See docs/02_API.md §2.6.
  */
-export async function GET() {
+async function handleGet() {
   const supabase = await createClient();
   const {
     data: { user },
@@ -29,7 +30,7 @@ export async function GET() {
   return NextResponse.json({ data });
 }
 
-export async function POST(request: NextRequest) {
+async function handlePost(request: NextRequest) {
   const supabase = await createClient();
   const {
     data: { user },
@@ -178,3 +179,12 @@ function internal(msg: string) {
     { status: 500 },
   );
 }
+
+export const GET = withObservability(
+  handleGet,
+  "GET /api/v1/projects",
+);
+export const POST = withObservability(
+  handlePost,
+  "POST /api/v1/projects",
+);

--- a/apps/web/src/app/api/v1/share-links/[id]/route.ts
+++ b/apps/web/src/app/api/v1/share-links/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 
+import { withObservability } from "@/lib/observability";
 interface Props {
   params: Promise<{ id: string }>;
 }
@@ -9,7 +10,7 @@ interface Props {
  * DELETE /api/v1/share-links/:id  — revoke (soft). Any existing holder of
  * the link will immediately see a "link expired" page.
  */
-export async function DELETE(_req: NextRequest, { params }: Props) {
+async function handleDelete(_req: NextRequest, { params }: Props) {
   const { id } = await params;
   const supabase = await createClient();
   const {
@@ -33,3 +34,8 @@ export async function DELETE(_req: NextRequest, { params }: Props) {
     );
   return new NextResponse(null, { status: 204 });
 }
+
+export const DELETE = withObservability<Props>(
+  handleDelete,
+  "DELETE /api/v1/share-links/:id",
+);

--- a/apps/web/src/app/api/v1/share/[token]/route.ts
+++ b/apps/web/src/app/api/v1/share/[token]/route.ts
@@ -3,6 +3,7 @@ import { createClient as createAdminClient } from "@supabase/supabase-js";
 import { getSignedDownloadUrl } from "@/lib/storage";
 import type { Database } from "@rokki/db";
 
+import { withObservability } from "@/lib/observability";
 interface Props {
   params: Promise<{ token: string }>;
 }
@@ -17,7 +18,7 @@ interface Props {
  *
  * ?download=1 marks the access as a download instead of a view.
  */
-export async function GET(request: NextRequest, { params }: Props) {
+async function handleGet(request: NextRequest, { params }: Props) {
   const { token } = await params;
   const admin = createAdminClient<Database>(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
@@ -123,3 +124,8 @@ function friendly(reason: string): string {
       return "Access denied.";
   }
 }
+
+export const GET = withObservability<Props>(
+  handleGet,
+  "GET /api/v1/share/:token",
+);

--- a/apps/web/src/app/api/v1/tasks/[id]/assignees/route.ts
+++ b/apps/web/src/app/api/v1/tasks/[id]/assignees/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 
+import { withObservability } from "@/lib/observability";
 interface Props {
   params: Promise<{ id: string }>;
 }
@@ -12,7 +13,7 @@ interface Props {
  * Assignees are scoped by terminal membership through RLS (task_assignees
  * policies check that both parties see the parent terminal).
  */
-export async function POST(request: NextRequest, { params }: Props) {
+async function handlePost(request: NextRequest, { params }: Props) {
   const { id: taskId } = await params;
   const supabase = await createClient();
   const {
@@ -40,7 +41,7 @@ export async function POST(request: NextRequest, { params }: Props) {
   return new NextResponse(null, { status: 204 });
 }
 
-export async function DELETE(request: NextRequest, { params }: Props) {
+async function handleDelete(request: NextRequest, { params }: Props) {
   const { id: taskId } = await params;
   const supabase = await createClient();
   const {
@@ -78,3 +79,12 @@ function internal(msg: string) {
     { status: 500 },
   );
 }
+
+export const POST = withObservability<Props>(
+  handlePost,
+  "POST /api/v1/tasks/:id/assignees",
+);
+export const DELETE = withObservability<Props>(
+  handleDelete,
+  "DELETE /api/v1/tasks/:id/assignees",
+);

--- a/apps/web/src/app/api/v1/tasks/[id]/dependencies/route.ts
+++ b/apps/web/src/app/api/v1/tasks/[id]/dependencies/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 
+import { withObservability } from "@/lib/observability";
 interface Props {
   params: Promise<{ id: string }>;
 }
@@ -14,7 +15,7 @@ interface Props {
  * The RLS policies on task_dependencies require the caller to see both
  * tasks involved.
  */
-export async function POST(request: NextRequest, { params }: Props) {
+async function handlePost(request: NextRequest, { params }: Props) {
   const { id: taskId } = await params;
   const supabase = await createClient();
   const {
@@ -51,7 +52,7 @@ export async function POST(request: NextRequest, { params }: Props) {
   return new NextResponse(null, { status: 204 });
 }
 
-export async function DELETE(request: NextRequest, { params }: Props) {
+async function handleDelete(request: NextRequest, { params }: Props) {
   const { id: taskId } = await params;
   const supabase = await createClient();
   const {
@@ -89,3 +90,12 @@ function internal(msg: string) {
     { status: 500 },
   );
 }
+
+export const POST = withObservability<Props>(
+  handlePost,
+  "POST /api/v1/tasks/:id/dependencies",
+);
+export const DELETE = withObservability<Props>(
+  handleDelete,
+  "DELETE /api/v1/tasks/:id/dependencies",
+);

--- a/apps/web/src/app/api/v1/tasks/by-seq/[ticker]/[seq]/route.ts
+++ b/apps/web/src/app/api/v1/tasks/by-seq/[ticker]/[seq]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 
+import { withObservability } from "@/lib/observability";
 interface Props {
   params: Promise<{ ticker: string; seq: string }>;
 }
@@ -16,7 +17,7 @@ interface Props {
  *
  * Scoped by RLS: if the caller can't see the terminal, they get 404.
  */
-export async function GET(_req: NextRequest, { params }: Props) {
+async function handleGet(_req: NextRequest, { params }: Props) {
   const { ticker, seq: seqStr } = await params;
   const seq = Number(seqStr);
   if (!Number.isInteger(seq))
@@ -211,3 +212,8 @@ function notFound() {
     { status: 404 },
   );
 }
+
+export const GET = withObservability<Props>(
+  handleGet,
+  "GET /api/v1/tasks/by-seq/:ticker/:seq",
+);

--- a/apps/web/src/app/api/v1/tools/[slug]/route.ts
+++ b/apps/web/src/app/api/v1/tools/[slug]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 
+import { withObservability } from "@/lib/observability";
 interface Props {
   params: Promise<{ slug: string }>;
 }
@@ -13,7 +14,7 @@ interface Props {
  * DELETE /api/v1/tools/:slug           — soft delete
  */
 
-export async function GET(_req: NextRequest, { params }: Props) {
+async function handleGet(_req: NextRequest, { params }: Props) {
   const { slug } = await params;
   const supabase = await createClient();
   const {
@@ -47,7 +48,7 @@ export async function GET(_req: NextRequest, { params }: Props) {
   });
 }
 
-export async function PATCH(request: NextRequest, { params }: Props) {
+async function handlePatch(request: NextRequest, { params }: Props) {
   const { slug } = await params;
   const supabase = await createClient();
   const {
@@ -132,7 +133,7 @@ export async function PATCH(request: NextRequest, { params }: Props) {
   return NextResponse.json({ data: { slug, ...patch } });
 }
 
-export async function DELETE(_req: NextRequest, { params }: Props) {
+async function handleDelete(_req: NextRequest, { params }: Props) {
   const { slug } = await params;
   const supabase = await createClient();
   const {
@@ -195,3 +196,16 @@ function internal(msg: string) {
     { status: 500 },
   );
 }
+
+export const GET = withObservability<Props>(
+  handleGet,
+  "GET /api/v1/tools/:slug",
+);
+export const PATCH = withObservability<Props>(
+  handlePatch,
+  "PATCH /api/v1/tools/:slug",
+);
+export const DELETE = withObservability<Props>(
+  handleDelete,
+  "DELETE /api/v1/tools/:slug",
+);

--- a/apps/web/src/app/api/v1/tools/route.ts
+++ b/apps/web/src/app/api/v1/tools/route.ts
@@ -4,13 +4,14 @@ import { validateBearer } from "@/lib/api-auth";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@rokki/db";
 
+import { withObservability } from "@/lib/observability";
 /**
  * GET  /api/v1/tools                  — tools visible to the caller
  * POST /api/v1/tools  { name, slug?, description, input_schema, output_schema?,
  *                       code, timeout_seconds?, tags? }
  *                                     — register a new tool, publishes v1.0.0
  */
-export async function GET(request: NextRequest) {
+async function handleGet(request: NextRequest) {
   const bearer = await validateBearer(request);
 
   let supabase: SupabaseClient<Database>;
@@ -35,7 +36,7 @@ export async function GET(request: NextRequest) {
   return NextResponse.json({ data });
 }
 
-export async function POST(request: NextRequest) {
+async function handlePost(request: NextRequest) {
   // Accept either a signed-in cookie session OR a personal access token
   // via Authorization: Bearer. The CLI uses Bearer; the web UI uses cookies.
   let supabase: SupabaseClient<Database>;
@@ -173,3 +174,12 @@ function internal(msg: string) {
     { status: 500 },
   );
 }
+
+export const GET = withObservability(
+  handleGet,
+  "GET /api/v1/tools",
+);
+export const POST = withObservability(
+  handlePost,
+  "POST /api/v1/tools",
+);


### PR DESCRIPTION
Closes the observability sweep. After this every `/api/v1/**` route ships structured logs + Sentry context. Used the same `scripts/wrap-observability.py` script as PR #149.

🤖 Generated with [Claude Code](https://claude.com/claude-code)