### PR TITLE
feat(dashboard): Week card source filter + range, Ticker time window

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -5,6 +5,7 @@ import { DashboardClient } from "@/components/DashboardClient";
 import {
   loadDashSpaces,
   loadDashTerminals,
+  type WeekRange,
 } from "@/lib/dashboard-queries";
 import { TasksCardServer } from "@/components/dashboard/TasksCardServer";
 import { WeekCardServer } from "@/components/dashboard/WeekCardServer";
@@ -21,6 +22,12 @@ interface Props {
     space?: string;
     /** Dashboard scope filter — focus all cards on a single terminal id. */
     focus?: string;
+    /** Week card time window: "today" | "week" | "month". Default "week". */
+    week_range?: string;
+    /** Comma-separated `calendar_connections.id` list to HIDE in Week card. */
+    week_sources?: string;
+    /** Ticker time window: "today" | "week" | "all". Default "all". */
+    activity_range?: string;
   }>;
 }
 
@@ -109,6 +116,24 @@ export default async function DashboardPage({ searchParams }: Props) {
       ? params.focus
       : null;
 
+  // Week card filter state. URL is the source of truth so deep links
+  // and browser-back work for free.
+  const weekRange: WeekRange =
+    params.week_range === "today" || params.week_range === "month"
+      ? (params.week_range as WeekRange)
+      : "week";
+  const weekHiddenSources = (params.week_sources ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  // Ticker time window — "today" / "week" / "all". The default keeps
+  // the original "top 30 most recent" behaviour intact.
+  const activityRange: "today" | "week" | "all" =
+    params.activity_range === "today" || params.activity_range === "week"
+      ? (params.activity_range as "today" | "week")
+      : "all";
+
   return (
     <DashboardClient
       spaces={spaces}
@@ -128,14 +153,19 @@ export default async function DashboardPage({ searchParams }: Props) {
       // slot so the queries scope at the DB level where possible.
       tickerSlot={
         <Suspense fallback={<TickerTapeSkeleton />}>
-          <TickerTapeServer projectId={focusTerminalId ?? undefined} />
+          <TickerTapeServer
+            projectId={focusTerminalId ?? undefined}
+            range={activityRange}
+          />
         </Suspense>
       }
       weekSlot={
-        <Suspense fallback={<WeekCardSkeleton />}>
+        <Suspense fallback={<WeekCardSkeleton range={weekRange} />}>
           <WeekCardServer
             userId={user.id}
             scopeTerminalId={focusTerminalId}
+            range={weekRange}
+            hiddenSourceIds={weekHiddenSources}
           />
         </Suspense>
       }

--- a/apps/web/src/components/TickerTape.tsx
+++ b/apps/web/src/components/TickerTape.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
 import { Activity, Sparkles } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -8,6 +9,8 @@ import { createClient } from "@/lib/supabase/client";
 import { useRealtimeTable } from "@/lib/supabase/realtime";
 import { summarizeActivity } from "@/lib/activity-summary";
 import { withToolTips } from "@/lib/ticker-tips";
+
+type ActivityRange = "today" | "week" | "all";
 
 interface TickerItem {
   id: string;
@@ -39,6 +42,13 @@ interface TickerTapeProps {
    * streams into the tape. Omit to hear about everything the caller can see.
    */
   projectId?: string;
+  /**
+   * Time window for the initial fetch. The toggle on the tape's right
+   * edge mutates the URL (`?activity_range=`); the server re-renders
+   * and feeds a narrowed initial item list. Realtime updates are not
+   * filtered by date — new rows always stream in.
+   */
+  range?: ActivityRange;
 }
 
 type SyncStatus = "connected" | "reconnecting" | "offline";
@@ -54,9 +64,15 @@ type SyncStatus = "connected" | "reconnecting" | "offline";
  *   - a rotating "💡 Try …" tool tip every ~10 items so tools stay
  *     discoverable without a dedicated card
  */
-export function TickerTape({ items: initial, projectId }: TickerTapeProps) {
+export function TickerTape({
+  items: initial,
+  projectId,
+  range = "all",
+}: TickerTapeProps) {
   const [liveRows, setLiveRows] = useState<TickerItem[]>([]);
   const [sync, setSync] = useState<SyncStatus>("connected");
+  const router = useRouter();
+  const searchParams = useSearchParams();
 
   useRealtimeTable<ActivityRow>(
     {
@@ -120,6 +136,14 @@ export function TickerTape({ items: initial, projectId }: TickerTapeProps) {
     offline: "Offline — showing cached activity",
   }[sync];
 
+  /** Push a new ?activity_range= without touching other params. */
+  function selectRange(next: ActivityRange) {
+    const params = new URLSearchParams(searchParams.toString());
+    if (next === "all") params.delete("activity_range");
+    else params.set("activity_range", next);
+    router.push(`/${params.size ? `?${params.toString()}` : ""}`);
+  }
+
   if (combined.length === 0) {
     return (
       <div className="flex h-8 flex-shrink-0 items-center gap-2 border-b border-border bg-bg-1 px-3 text-xs text-text-3">
@@ -129,7 +153,16 @@ export function TickerTape({ items: initial, projectId }: TickerTapeProps) {
           aria-label={dotTitle}
         />
         <Activity className="h-3 w-3" aria-hidden="true" />
-        <span>No recent activity.</span>
+        <span>
+          {range === "today"
+            ? "No activity today yet."
+            : range === "week"
+              ? "No activity this week."
+              : "No recent activity."}
+        </span>
+        <div className="ml-auto flex-shrink-0">
+          <RangeToggle range={range} onSelect={selectRange} />
+        </div>
       </div>
     );
   }
@@ -150,7 +183,7 @@ export function TickerTape({ items: initial, projectId }: TickerTapeProps) {
       />
       <div
         className={cn(
-          "flex gap-6 whitespace-nowrap",
+          "flex min-w-0 flex-1 gap-6 overflow-hidden whitespace-nowrap",
           "animate-[scroll_90s_linear_infinite] [&:hover]:[animation-play-state:paused]",
         )}
       >
@@ -158,12 +191,55 @@ export function TickerTape({ items: initial, projectId }: TickerTapeProps) {
           <TickerRow key={`${item.id}-${i}`} item={item} />
         ))}
       </div>
+      <div className="flex-shrink-0">
+        <RangeToggle range={range} onSelect={selectRange} />
+      </div>
       <style>{`
         @keyframes scroll {
           from { transform: translateX(0); }
           to { transform: translateX(-50%); }
         }
       `}</style>
+    </div>
+  );
+}
+
+/**
+ * Compact segmented control rendered on the right edge of the tape.
+ * Mirrors the Week card's RangeToggle visually but at a smaller scale
+ * so it fits inside the 32px-tall tape without crowding the scroll.
+ */
+function RangeToggle({
+  range,
+  onSelect,
+}: {
+  range: ActivityRange;
+  onSelect: (r: ActivityRange) => void;
+}) {
+  return (
+    <div
+      role="tablist"
+      aria-label="Activity time range"
+      className="flex overflow-hidden rounded-sm border border-border bg-bg-2"
+    >
+      {(["today", "week", "all"] as const).map((r, i) => (
+        <button
+          key={r}
+          type="button"
+          role="tab"
+          aria-selected={range === r}
+          onClick={() => onSelect(r)}
+          className={cn(
+            "px-1.5 py-0 text-[9px] font-semibold uppercase tracking-wide transition-colors",
+            i > 0 && "border-l border-border",
+            range === r
+              ? "bg-accent text-bg-0"
+              : "text-text-3 hover:bg-bg-3 hover:text-text-1",
+          )}
+        >
+          {r === "today" ? "1d" : r === "week" ? "7d" : "All"}
+        </button>
+      ))}
     </div>
   );
 }

--- a/apps/web/src/components/dashboard/CardSkeletons.tsx
+++ b/apps/web/src/components/dashboard/CardSkeletons.tsx
@@ -54,9 +54,19 @@ export function TasksCardSkeleton() {
   );
 }
 
-export function WeekCardSkeleton() {
+export function WeekCardSkeleton({
+  range = "week",
+}: {
+  range?: "today" | "week" | "month";
+}) {
+  const title =
+    range === "today"
+      ? "Today"
+      : range === "month"
+        ? "Next 30 days"
+        : "This week";
   return (
-    <CardChrome title="This week">
+    <CardChrome title={title}>
       {Array.from({ length: 4 }).map((_, i) => (
         <div key={i} className="flex items-center gap-2 py-1">
           <span className="h-3 w-10 flex-shrink-0 animate-pulse rounded-sm bg-bg-3" />

--- a/apps/web/src/components/dashboard/TickerTapeServer.tsx
+++ b/apps/web/src/components/dashboard/TickerTapeServer.tsx
@@ -12,15 +12,32 @@ interface ActivityRow {
   created_at: string;
 }
 
+export type ActivityRange = "today" | "week" | "all";
+
 /**
  * Server-Component wrapper for the activity ticker. Pulls the most
- * recent 30 activity rows and hands them to the (Client) TickerTape
+ * recent N activity rows and hands them to the (Client) TickerTape
  * for live streaming + tip injection.
  *
  * Hoisted out of `page.tsx`'s main Promise.all so the dashboard
  * shell + faster cards can paint before this query resolves.
+ *
+ * `range` narrows the initial query window:
+ *   - "today" → activity since midnight local-equivalent (UTC midnight
+ *     used here; precision is fine for a rolling ticker)
+ *   - "week"  → last 7 days
+ *   - "all"   → no time floor (default, original behaviour)
+ *
+ * The realtime channel itself doesn't filter by date — new rows
+ * always stream in. The `range` only affects what's pre-loaded.
  */
-export async function TickerTapeServer({ projectId }: { projectId?: string }) {
+export async function TickerTapeServer({
+  projectId,
+  range = "all",
+}: {
+  projectId?: string;
+  range?: ActivityRange;
+}) {
   const supabase = await createClient();
   let query = supabase
     .from("activity")
@@ -31,6 +48,12 @@ export async function TickerTapeServer({ projectId }: { projectId?: string }) {
     .limit(30);
   if (projectId) {
     query = query.eq("terminal_id", projectId);
+  }
+  if (range !== "all") {
+    const since = new Date();
+    since.setHours(0, 0, 0, 0);
+    if (range === "week") since.setDate(since.getDate() - 7);
+    query = query.gte("created_at", since.toISOString());
   }
   const { data } = await query;
   const items = ((data ?? []) as ActivityRow[]).map((a) => ({
@@ -43,7 +66,7 @@ export async function TickerTapeServer({ projectId }: { projectId?: string }) {
     }),
     when: relativeTime(a.created_at),
   }));
-  return <TickerTape items={items} projectId={projectId} />;
+  return <TickerTape items={items} projectId={projectId} range={range} />;
 }
 
 function relativeTime(iso: string): string {

--- a/apps/web/src/components/dashboard/WeekCard.tsx
+++ b/apps/web/src/components/dashboard/WeekCard.tsx
@@ -1,24 +1,52 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useMemo, useState } from "react";
-import { Diamond, Calendar as CalIcon } from "lucide-react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  Diamond,
+  Calendar as CalIcon,
+  Check,
+  ChevronDown,
+  Filter,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
 import { DashboardCard } from "./DashboardCard";
-import type { WeekItem } from "@/lib/dashboard-queries";
+import type {
+  WeekItem,
+  WeekRange,
+  WeekSource,
+} from "@/lib/dashboard-queries";
 
 interface WeekCardProps {
   items: WeekItem[];
+  /** Calendar sources visible to the viewer — fed to the source filter. */
+  sources: WeekSource[];
+  /** Active time-window. Default "week". */
+  range: WeekRange;
+  /** Connection ids the viewer has chosen to hide. */
+  hiddenSourceIds: string[];
 }
 
 /**
- * "This Week" list calendar. Rows are grouped by day. Each row is clickable
- * and jumps to its source (task detail) — the expand arrow goes to the
- * full /calendar view.
+ * Schedule card — calendar events for the chosen range (today, this
+ * week, or next 30 days). Filters live in the header:
  *
- * Phase 1 only renders Rokki tasks with a due_date. External calendar
- * events land in a later slice when the sync connector is live.
+ *   ┌ SCHEDULE ────── [Today | Week | Month] [Filter ▾] [↗] ┐
+ *   │ Mon Aug 12                                              │
+ *   │   09:00  Standup        TICKER                          │
+ *   │   …                                                     │
+ *   └─────────────────────────────────────────────────────────┘
+ *
+ * State is URL-driven (`?week_range=`, `?week_sources=`) so deep
+ * links work and the server re-runs with the narrowed query.
  */
-export function WeekCard({ items }: WeekCardProps) {
+export function WeekCard({
+  items,
+  sources,
+  range,
+  hiddenSourceIds,
+}: WeekCardProps) {
   // Defer the grouped/rendered content to client mount. The grouping
   // depends on `new Date()` (server's UTC vs. browser's local TZ) and
   // the day/time labels go through toLocaleDateString /
@@ -33,6 +61,18 @@ export function WeekCard({ items }: WeekCardProps) {
     setMounted(true);
   }, []);
 
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const hiddenSet = useMemo(
+    () => new Set(hiddenSourceIds),
+    [hiddenSourceIds],
+  );
+
+  // Number of day buckets the grouped renderer should produce. Today
+  // = 1, week = 7, month = 30 — matches the server-side window so
+  // empty days within the window still render with an em-dash.
+  const dayCount = range === "today" ? 1 : range === "week" ? 7 : 30;
+
   const grouped = useMemo(() => {
     if (!mounted) return [];
     const days = new Map<string, WeekItem[]>();
@@ -41,11 +81,10 @@ export function WeekCard({ items }: WeekCardProps) {
       if (!days.has(key)) days.set(key, []);
       days.get(key)!.push(it);
     }
-    // Ensure we render every day of the current 7 even if empty.
     const start = new Date();
     start.setHours(0, 0, 0, 0);
     const out: { key: string; label: string; items: WeekItem[] }[] = [];
-    for (let i = 0; i < 7; i++) {
+    for (let i = 0; i < dayCount; i++) {
       const d = new Date(start);
       d.setDate(d.getDate() + i);
       const key = d.toISOString().slice(0, 10);
@@ -58,16 +97,61 @@ export function WeekCard({ items }: WeekCardProps) {
       });
     }
     return out;
-  }, [items, mounted]);
+  }, [items, mounted, dayCount]);
+
+  /** Push a URL patch — only touches the params this card owns. */
+  function patchUrl(patch: {
+    range?: WeekRange;
+    sources?: string[] | null;
+  }) {
+    const params = new URLSearchParams(searchParams.toString());
+    if (patch.range !== undefined) {
+      // "week" is the default — strip it so the URL stays clean.
+      if (patch.range === "week") params.delete("week_range");
+      else params.set("week_range", patch.range);
+    }
+    if (patch.sources !== undefined) {
+      if (patch.sources == null || patch.sources.length === 0) {
+        params.delete("week_sources");
+      } else {
+        params.set("week_sources", patch.sources.join(","));
+      }
+    }
+    router.push(`/${params.size ? `?${params.toString()}` : ""}`);
+  }
+
+  function toggleSource(id: string) {
+    const next = new Set(hiddenSet);
+    if (next.has(id)) next.delete(id);
+    else next.add(id);
+    patchUrl({ sources: Array.from(next) });
+  }
+
+  const title = titleFor(range);
 
   return (
     <DashboardCard
-      title="This week"
+      title={title}
       count={items.length}
       expandHref="/calendar"
+      headerRight={
+        <div className="flex items-center gap-1.5">
+          <RangeToggle
+            range={range}
+            onSelect={(r) => patchUrl({ range: r })}
+          />
+          {sources.length > 0 ? (
+            <SourceFilter
+              sources={sources}
+              hidden={hiddenSet}
+              onToggle={toggleSource}
+            />
+          ) : null}
+        </div>
+      }
     >
       {items.length === 0 ? (
-        <EmptyWeek />
+        <EmptyWeek range={range} filtered={hiddenSourceIds.length > 0} />
       ) : (
         <ul className="divide-y divide-border/60 text-xs">
           {grouped.map((day) => (
@@ -96,6 +180,152 @@ export function WeekCard({ items }: WeekCardProps) {
     </DashboardCard>
   );
 }
+
+/* ----------------------------------------------------------------- */
+/* Range toggle                                                       */
+/* ----------------------------------------------------------------- */
+
+function RangeToggle({
+  range,
+  onSelect,
+}: {
+  range: WeekRange;
+  onSelect: (r: WeekRange) => void;
+}) {
+  return (
+    <div
+      role="tablist"
+      aria-label="Time range"
+      className="flex overflow-hidden rounded-sm border border-border bg-bg-2"
+    >
+      {(["today", "week", "month"] as const).map((r, i) => (
+        <button
+          key={r}
+          type="button"
+          role="tab"
+          aria-selected={range === r}
+          onClick={() => onSelect(r)}
+          className={cn(
+            "px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide transition-colors",
+            i > 0 && "border-l border-border",
+            range === r
+              ? "bg-accent text-bg-0"
+              : "text-text-2 hover:bg-bg-3 hover:text-text-0",
+          )}
+        >
+          {labelFor(r)}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+/* ----------------------------------------------------------------- */
+/* Source filter                                                      */
+/* ----------------------------------------------------------------- */
+
+function SourceFilter({
+  sources,
+  hidden,
+  onToggle,
+}: {
+  sources: WeekSource[];
+  hidden: Set<string>;
+  onToggle: (id: string) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  const visibleCount = sources.length - hidden.size;
+
+  useEffect(() => {
+    if (!open) return;
+    function onDocClick(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", onDocClick);
+    return () => document.removeEventListener("mousedown", onDocClick);
+  }, [open]);
+
+  return (
+    <div className="relative" ref={ref}>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        aria-haspopup="true"
+        title="Filter calendar sources"
+        className={cn(
+          "flex items-center gap-1 rounded-sm border border-border px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide transition-colors",
+          open
+            ? "bg-bg-3 text-text-0"
+            : "bg-bg-2 text-text-1 hover:bg-bg-3 hover:text-text-0",
+        )}
+      >
+        <Filter className="h-3 w-3" aria-hidden="true" />
+        <span className="hidden sm:inline">Sources</span>
+        <span className="rounded-sm bg-bg-3 px-1 font-mono text-[9px] text-text-2">
+          {visibleCount}/{sources.length}
+        </span>
+        <ChevronDown
+          className={cn(
+            "h-3 w-3 transition-transform",
+            open && "rotate-180",
+          )}
+          aria-hidden="true"
+        />
+      </button>
+      {open ? (
+        <div className="absolute right-0 top-full z-30 mt-1 w-72 overflow-hidden rounded-sm border border-border bg-bg-1 shadow-lg">
+          <header className="flex items-center justify-between border-b border-border bg-bg-2 px-3 py-1.5 text-[10px] font-semibold uppercase tracking-wide text-text-3">
+            <span>Calendars</span>
+            <span className="font-mono text-text-2">
+              {visibleCount} of {sources.length} shown
+            </span>
+          </header>
+          <ul className="max-h-72 overflow-y-auto py-1 text-xs">
+            {sources.map((s) => {
+              const isHidden = hidden.has(s.id);
+              return (
+                <li key={s.id}>
+                  <button
+                    type="button"
+                    onClick={() => onToggle(s.id)}
+                    className={cn(
+                      "flex w-full items-center gap-2 px-3 py-2 text-left hover:bg-bg-2",
+                      isHidden ? "text-text-3" : "text-text-1",
+                    )}
+                  >
+                    <span
+                      className={cn(
+                        "flex h-4 w-4 flex-shrink-0 items-center justify-center rounded-sm border",
+                        isHidden
+                          ? "border-border bg-bg-0"
+                          : "border-accent bg-accent text-bg-0",
+                      )}
+                      aria-hidden="true"
+                    >
+                      {!isHidden ? <Check className="h-3 w-3" /> : null}
+                    </span>
+                    <span className="flex-1 truncate">{s.label}</span>
+                    <span className="font-mono text-[10px] uppercase text-text-3">
+                      {s.provider === "google" ? "Google" : "Outlook"}
+                    </span>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+/* ----------------------------------------------------------------- */
+/* Row + empty state                                                  */
+/* ----------------------------------------------------------------- */
 
 function WeekRow({ item }: { item: WeekItem }) {
   const href = item.terminal_ticker
@@ -136,16 +366,47 @@ function WeekRow({ item }: { item: WeekItem }) {
   );
 }
 
-function EmptyWeek() {
+function EmptyWeek({
+  range,
+  filtered,
+}: {
+  range: WeekRange;
+  filtered: boolean;
+}) {
+  const headline = filtered
+    ? "No events match this filter."
+    : range === "today"
+      ? "Nothing scheduled today."
+      : range === "week"
+        ? "Your week is clear."
+        : "Nothing scheduled this month.";
   return (
     <div className="flex flex-col items-center justify-center gap-2 p-6 text-center">
       <CalIcon className="h-5 w-5 text-text-3" aria-hidden="true" />
-      <p className="text-xs text-text-2">Your week is clear.</p>
+      <p className="text-xs text-text-2">{headline}</p>
       <p className="text-[11px] text-text-3">
-        Tasks with a due date will appear here.
+        {filtered
+          ? "Re-enable a source above to see more."
+          : "Calendar events from connected accounts appear here."}
       </p>
     </div>
   );
+}
+
+/* ----------------------------------------------------------------- */
+/* Helpers                                                            */
+/* ----------------------------------------------------------------- */
+
+function titleFor(range: WeekRange): string {
+  if (range === "today") return "Today";
+  if (range === "month") return "Next 30 days";
+  return "This week";
+}
+
+function labelFor(r: WeekRange): string {
+  if (r === "today") return "Today";
+  if (r === "week") return "Week";
+  return "Month";
 }
 
 function formatDayLabel(d: Date, isToday: boolean): string {

--- a/apps/web/src/components/dashboard/WeekCardServer.tsx
+++ b/apps/web/src/components/dashboard/WeekCardServer.tsx
@@ -1,25 +1,43 @@
 import { createClient } from "@/lib/supabase/server";
-import { loadWeekItems } from "@/lib/dashboard-queries";
+import {
+  loadWeekItems,
+  loadWeekSources,
+  type WeekRange,
+} from "@/lib/dashboard-queries";
 import { WeekCard } from "./WeekCard";
 
 /**
  * Server-Component wrapper around `WeekCard`. Owns the week-items
- * fetch (calendar events + tasks-as-due) so the rest of the
- * dashboard can render while this slot is still loading.
+ * fetch (calendar events) and the source-list fetch so the card can
+ * render filter chips without a follow-up roundtrip.
  *
- * `scopeTerminalId` is the dashboard's terminal-focus filter — when
- * set, the query pre-filters events to that terminal at the DB
- * level (single index lookup) instead of fetching the whole week
- * and throwing rows away client-side.
+ * Filters that change the underlying query (scope, range, hidden
+ * sources) are URL-driven and threaded in from the parent route. The
+ * card itself only mutates the URL via Link clicks; the server
+ * re-runs and feeds fresh data.
  */
 export async function WeekCardServer({
   userId,
   scopeTerminalId,
+  range,
+  hiddenSourceIds,
 }: {
   userId: string;
   scopeTerminalId?: string | null;
+  range: WeekRange;
+  hiddenSourceIds: string[];
 }) {
   const supabase = await createClient();
-  const items = await loadWeekItems(supabase, userId, scopeTerminalId);
-  return <WeekCard items={items} />;
+  const [items, sources] = await Promise.all([
+    loadWeekItems(supabase, userId, scopeTerminalId, range, hiddenSourceIds),
+    loadWeekSources(supabase, userId),
+  ]);
+  return (
+    <WeekCard
+      items={items}
+      sources={sources}
+      range={range}
+      hiddenSourceIds={hiddenSourceIds}
+    />
+  );
 }

--- a/apps/web/src/lib/dashboard-queries.ts
+++ b/apps/web/src/lib/dashboard-queries.ts
@@ -53,7 +53,29 @@ export interface WeekItem {
   when: string; // ISO date (full datetime for event, date-only for due)
   terminal_id: string | null;
   terminal_ticker: string | null;
+  /**
+   * Source-id for the source filter chip in the Week card. Either a
+   * `calendar_connections.id` (events) or null (no source — shouldn't
+   * happen for current data but typed permissively).
+   */
+  source_id: string | null;
 }
+
+/**
+ * Calendar source the user can show/hide in the Week card. Mirrors
+ * the shape used by the full /calendar page so the dashboard's
+ * source filter reads identically.
+ */
+export interface WeekSource {
+  /** `calendar_connections.id`. */
+  id: string;
+  /** Display label — the connected account email. */
+  label: string;
+  provider: "google" | "microsoft";
+}
+
+/** Allowed time-window values for the Week card. */
+export type WeekRange = "today" | "week" | "month";
 
 export async function loadDashSpaces(
   supabase: AnySupabaseClient,
@@ -220,15 +242,34 @@ export async function loadDelegatedTasks(
 }
 
 /**
+ * Compute the date window for the Week card based on the user's
+ * range selection. Half-open: `[start, end)`.
+ *
+ *   today → midnight today → midnight tomorrow
+ *   week  → midnight today → +7 days
+ *   month → midnight today → +30 days
+ */
+function rangeWindow(range: WeekRange): { start: Date; end: Date } {
+  const start = new Date();
+  start.setHours(0, 0, 0, 0);
+  const end = new Date(start);
+  if (range === "today") end.setDate(end.getDate() + 1);
+  else if (range === "week") end.setDate(end.getDate() + 7);
+  else end.setDate(end.getDate() + 30);
+  return { start, end };
+}
+
+/**
  * Produce the "This Week" list:
- *   - Rokki tasks with a due_date between today and 7 days out
  *   - external calendar events synced from the user's connected providers
  *
  * Each row is decorated with a terminal ticker when we can infer one. The
  * list is sorted by `when` in the UI; this function just returns the union.
  *
- * When `scopeTerminalId` is set, the events are pre-filtered at the DB
- * level so a focused dashboard only pulls that terminal's rows.
+ * Filters applied at the DB level (each a single indexed predicate):
+ *   - `scopeTerminalId`: narrow to one terminal's events
+ *   - `range`: "today" | "week" | "month" controls the date window
+ *   - `hiddenSourceIds`: list of `calendar_connections.id` to EXCLUDE
  */
 export async function loadWeekItems(
   supabase: AnySupabaseClient,
@@ -239,18 +280,23 @@ export async function loadWeekItems(
   // dates with richer context).
   _userId: string,
   scopeTerminalId?: string | null,
+  range: WeekRange = "week",
+  hiddenSourceIds: string[] = [],
 ): Promise<WeekItem[]> {
   return traceSpan(
     {
       name: "db.dashboard.week_items",
       op: "db.query",
-      attributes: scopeTerminalId ? { scope: scopeTerminalId } : {},
+      attributes: {
+        range,
+        ...(scopeTerminalId ? { scope: scopeTerminalId } : {}),
+        ...(hiddenSourceIds.length
+          ? { hidden_sources: hiddenSourceIds.length }
+          : {}),
+      },
     },
     async () => {
-      const start = new Date();
-      start.setHours(0, 0, 0, 0);
-      const end = new Date(start);
-      end.setDate(end.getDate() + 7);
+      const { start, end } = rangeWindow(range);
 
       // External calendar events only — tasks were dropped from this
       // view per UX feedback ("Due dates for tasks are showing up in
@@ -258,9 +304,9 @@ export async function loadWeekItems(
       // where their due dates are surfaced more usefully.
       let eventsQuery = supabase
         .from("calendar_events")
-        .select("id, title, starts_at, terminal_id")
+        .select("id, title, starts_at, terminal_id, connection_id")
         .gte("starts_at", start.toISOString())
-        .lte("starts_at", end.toISOString())
+        .lt("starts_at", end.toISOString())
         .is("deleted_at", null);
       if (scopeTerminalId) {
         eventsQuery = eventsQuery.eq("terminal_id", scopeTerminalId);
@@ -271,8 +317,14 @@ export async function loadWeekItems(
         title: string;
         starts_at: string;
         terminal_id: string | null;
+        connection_id: string | null;
       };
-      const eventRows = (events ?? []) as E[];
+      // Post-filter hidden sources. Cheaper than a `not.in(...)` PostgREST
+      // filter for small N and avoids the URL-length cap on long lists.
+      const hidden = new Set(hiddenSourceIds);
+      const eventRows = ((events ?? []) as E[]).filter(
+        (e) => !e.connection_id || !hidden.has(e.connection_id),
+      );
       const terminalIds = new Set(
         eventRows
           .map((e) => e.terminal_id)
@@ -299,6 +351,45 @@ export async function loadWeekItems(
         terminal_ticker: e.terminal_id
           ? (tickerById.get(e.terminal_id) ?? null)
           : null,
+        source_id: e.connection_id,
+      }));
+    },
+  );
+}
+
+/**
+ * Load the viewer's calendar source list — used to render the source
+ * filter chips on the Week card. Returns one row per non-revoked
+ * connection (the same shape /calendar uses). Empty list means the
+ * filter button hides itself.
+ */
+export async function loadWeekSources(
+  supabase: AnySupabaseClient,
+  userId: string,
+): Promise<WeekSource[]> {
+  return traceSpan(
+    {
+      name: "db.dashboard.week_sources",
+      op: "db.query",
+      attributes: { table: "calendar_connections" },
+    },
+    async () => {
+      const { data } = await supabase
+        .from("calendar_connections")
+        .select("id, provider, account_email")
+        .eq("user_id", userId)
+        .is("revoked_at", null)
+        .order("provider", { ascending: true })
+        .order("account_email", { ascending: true });
+      type Row = {
+        id: string;
+        provider: "google" | "microsoft";
+        account_email: string;
+      };
+      return ((data ?? []) as Row[]).map((r) => ({
+        id: r.id,
+        label: r.account_email,
+        provider: r.provider,
       }));
     },
   );


### PR DESCRIPTION
## Summary

Stacks on #159 (focus filter). Adds filters #2 and #3 you asked for — Week card source filter + time range, and the Activity ticker time range. (Base set to `feat/dashboard-scope-filter` so this stays a clean diff on top of #159; once #159 merges, this rebases trivially to main.)

## Week card

- **Time-range toggle (Today / Week / Month)** in the header. Today is just today, Week is the existing 7-day default, Month expands to 30 days. Title swaps to match ("Today" / "This week" / "Next 30 days") so the user knows what they're looking at. URL-driven via `?week_range=`.
- **Source filter** (Filter ▾ N/Total chip) for users with multiple connected calendars (Google work + Outlook personal, etc.). Mirrors the calendar's `SourceFilter` shape: popover with checkbox-style toggles per connection. URL-driven via `?week_sources=` (comma-separated hidden ids). Hides itself for users with no connections.
- **`loadWeekItems`** now applies the date window and `connection_id` filter — date at the DB level (single index lookup), hidden sources post-fetch (cheaper than a `not.in(…)` for small N and dodges the URL-length cap).
- **Empty state copy** adapts to the active filter so an empty "Today" doesn't read like an empty "Week", and a fully-filtered view explains "Re-enable a source above to see more."

## Activity ticker

- Compact **1d / 7d / All segment** on the right edge of the tape. URL-driven via `?activity_range=`. Default "All" keeps the original "top 30 most recent" behaviour intact; the narrower options floor the initial query at midnight today or 7 days back.
- Realtime updates still stream in regardless — the range only affects what's pre-loaded. (Filtering live inserts by date would mean the tape silently drops new events the user just saw happen, which reads as broken.)

## Test plan

- [ ] `?week_range=today` shows just today's events with title "Today"; `?week_range=month` shows 30 days with title "Next 30 days"
- [ ] Toggling Today/Week/Month in the header round-trips through the URL and the title swaps cleanly
- [ ] With multiple calendar connections, the Source filter chip shows `N/Total` and toggling sources updates the Week card in place
- [ ] With zero connections, the Source filter button doesn't render (no UI gap, no broken popover)
- [ ] Activity ticker shows `1d 7d All` on the right; clicking narrows the initial fetch
- [ ] A new activity row in the focused terminal streams into the tape regardless of the active range setting
- [ ] Suspended skeletons match the resolved card title (no "This week" flash before "Today")
- [ ] Deep links like `/?focus=<id>&week_range=today&activity_range=week` work and survive reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)