### PR TITLE
feat(modules): Phase 0 — module-system foundation

### DIFF
--- a/apps/mcp-server/src/tools.ts
+++ b/apps/mcp-server/src/tools.ts
@@ -3309,6 +3309,330 @@ const TOOLS: ToolDefinition[] = [
       return textResult(lines.join("\n"));
     },
   },
+
+  /* ───────────────── Module system (Phase 0) ───────────────── */
+  // Mirrors the REST endpoints under /api/v1/{spaces|terminals}/[id]/modules
+  // so an LLM client can install / archive / list modules on the same
+  // surface a UI user can. Per ADR 0003 + the API+MCP-parity rule in
+  // CLAUDE.md, every UI-available module action MUST be MCP-callable.
+
+  {
+    name: "rokki_module_list_for_scope",
+    description:
+      "List modules installed on a scope. Pass either { space: <slug-or-name> } for a space, or { terminal: <ticker> } for a terminal. Archived modules are excluded.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        space: {
+          type: "string",
+          description: "Space slug or name (for space-scope listings).",
+        },
+        terminal: {
+          type: "string",
+          description: "Terminal ticker or name (for terminal-scope listings).",
+        },
+      },
+      additionalProperties: false,
+    },
+    handler: async (args, session) => {
+      const spaceHint = typeof args.space === "string" ? args.space.trim() : "";
+      const terminalHint =
+        typeof args.terminal === "string" ? args.terminal.trim() : "";
+      if (!spaceHint && !terminalHint)
+        return textResult("Pass either `space` or `terminal`.", true);
+      if (spaceHint && terminalHint)
+        return textResult("Pass exactly one of `space` or `terminal`.", true);
+
+      if (terminalHint) {
+        const terminal = await resolveProject(session, terminalHint);
+        if (!terminal)
+          return textResult(`Terminal "${terminalHint}" not found.`, true);
+        const { data } = await admin
+          .from("terminal_modules")
+          .select("slug, installed_at, modules_catalog(name)")
+          .eq("terminal_id", terminal.id)
+          .is("archived_at", null)
+          .order("display_order", { ascending: true });
+        type Row = {
+          slug: string;
+          installed_at: string;
+          modules_catalog: { name: string } | null;
+        };
+        const rows = (data ?? []) as Row[];
+        if (rows.length === 0)
+          return textResult(`${terminal.name} has no modules installed.`);
+        return textResult(
+          `${terminal.name} — installed modules:\n` +
+            rows
+              .map(
+                (r) =>
+                  `• ${r.modules_catalog?.name ?? r.slug} (${r.slug}) — installed ${r.installed_at.slice(0, 10)}`,
+              )
+              .join("\n"),
+        );
+      }
+
+      const space = await resolveSpaceByHint(session.userId, spaceHint);
+      if (!space)
+        return textResult(`Space "${spaceHint}" not found.`, true);
+      const { data } = await admin
+        .from("space_modules")
+        .select("slug, installed_at, modules_catalog(name)")
+        .eq("space_id", space.id)
+        .is("archived_at", null)
+        .order("display_order", { ascending: true });
+      type Row = {
+        slug: string;
+        installed_at: string;
+        modules_catalog: { name: string } | null;
+      };
+      const rows = (data ?? []) as Row[];
+      if (rows.length === 0)
+        return textResult(`${space.name} has no modules installed.`);
+      return textResult(
+        `${space.name} — installed modules:\n` +
+          rows
+            .map(
+              (r) =>
+                `• ${r.modules_catalog?.name ?? r.slug} (${r.slug}) — installed ${r.installed_at.slice(0, 10)}`,
+            )
+            .join("\n"),
+      );
+    },
+  },
+
+  {
+    name: "rokki_module_install",
+    description:
+      "Install a module on a scope. Pass { space, slug } to install on a space (caller must be owner/admin), or { terminal, slug } for a terminal (caller must be owner/manager). Reinstalling a previously-archived module restores its data. Requires write scope.",
+    requiresWrite: true,
+    inputSchema: {
+      type: "object",
+      properties: {
+        space: { type: "string", description: "Space slug or name." },
+        terminal: { type: "string", description: "Terminal ticker or name." },
+        slug: {
+          type: "string",
+          description:
+            "Module slug from modules_catalog (e.g. 'tasks', 'files', 'goals').",
+        },
+      },
+      required: ["slug"],
+      additionalProperties: false,
+    },
+    handler: async (args, session) => {
+      const slug = String(args.slug ?? "").trim();
+      if (!slug) return textResult("`slug` is required.", true);
+      const spaceHint =
+        typeof args.space === "string" ? args.space.trim() : "";
+      const terminalHint =
+        typeof args.terminal === "string" ? args.terminal.trim() : "";
+      if (!spaceHint && !terminalHint)
+        return textResult("Pass either `space` or `terminal`.", true);
+      if (spaceHint && terminalHint)
+        return textResult(
+          "Pass exactly one of `space` or `terminal`.",
+          true,
+        );
+
+      // Confirm the catalog has this slug. (FK would catch this too, but
+      // a clearer error helps the LLM client.)
+      const { data: catalog } = await admin
+        .from("modules_catalog")
+        .select("slug, name, scopes")
+        .eq("slug", slug)
+        .maybeSingle();
+      if (!catalog)
+        return textResult(
+          `No module "${slug}" in the catalog. Use rokki_module_list_for_scope to discover what's available.`,
+          true,
+        );
+
+      if (spaceHint) {
+        if (!(catalog.scopes as string[]).includes("space"))
+          return textResult(
+            `Module "${slug}" doesn't support space scope.`,
+            true,
+          );
+        const space = await resolveSpaceByHint(session.userId, spaceHint);
+        if (!space)
+          return textResult(`Space "${spaceHint}" not found.`, true);
+        const member = await isSpaceAdmin(session.userId, space.id);
+        if (!member)
+          return textResult(
+            `Only space owners or admins can install modules on ${space.name}.`,
+            true,
+          );
+
+        const { data: existing } = await admin
+          .from("space_modules")
+          .select("id, archived_at")
+          .eq("space_id", space.id)
+          .eq("slug", slug)
+          .maybeSingle();
+        if (existing) {
+          if (existing.archived_at) {
+            await admin
+              .from("space_modules")
+              .update({ archived_at: null })
+              .eq("id", existing.id);
+            return textResult(
+              `Reinstalled ${catalog.name} on ${space.name} (previous data preserved).`,
+            );
+          }
+          return textResult(
+            `${catalog.name} is already installed on ${space.name}.`,
+            true,
+          );
+        }
+        const ins = await admin
+          .from("space_modules")
+          .insert({
+            space_id: space.id,
+            slug,
+            installed_by: session.userId,
+          })
+          .select("id")
+          .single();
+        if (ins.error)
+          return textResult(`Install failed: ${ins.error.message}`, true);
+        return textResult(`Installed ${catalog.name} on ${space.name}.`);
+      }
+
+      // terminal scope
+      if (!(catalog.scopes as string[]).includes("terminal"))
+        return textResult(
+          `Module "${slug}" doesn't support terminal scope.`,
+          true,
+        );
+      const terminal = await resolveProject(session, terminalHint);
+      if (!terminal)
+        return textResult(`Terminal "${terminalHint}" not found.`, true);
+      const ok = await isTerminalManager(session.userId, terminal.id);
+      if (!ok)
+        return textResult(
+          `Only terminal owners or managers can install modules on ${terminal.name}.`,
+          true,
+        );
+
+      const { data: existing } = await admin
+        .from("terminal_modules")
+        .select("id, archived_at")
+        .eq("terminal_id", terminal.id)
+        .eq("slug", slug)
+        .maybeSingle();
+      if (existing) {
+        if (existing.archived_at) {
+          await admin
+            .from("terminal_modules")
+            .update({ archived_at: null })
+            .eq("id", existing.id);
+          return textResult(
+            `Reinstalled ${catalog.name} on ${terminal.name} (previous data preserved).`,
+          );
+        }
+        return textResult(
+          `${catalog.name} is already installed on ${terminal.name}.`,
+          true,
+        );
+      }
+      const ins = await admin
+        .from("terminal_modules")
+        .insert({
+          terminal_id: terminal.id,
+          slug,
+          installed_by: session.userId,
+        })
+        .select("id")
+        .single();
+      if (ins.error)
+        return textResult(`Install failed: ${ins.error.message}`, true);
+      return textResult(`Installed ${catalog.name} on ${terminal.name}.`);
+    },
+  },
+
+  {
+    name: "rokki_module_archive",
+    description:
+      "Archive (uninstall) a module from a scope. Pass { space|terminal, slug }. Data the module wrote stays — reinstalling restores it. Requires write scope.",
+    requiresWrite: true,
+    inputSchema: {
+      type: "object",
+      properties: {
+        space: { type: "string", description: "Space slug or name." },
+        terminal: { type: "string", description: "Terminal ticker or name." },
+        slug: { type: "string", description: "Module slug to archive." },
+      },
+      required: ["slug"],
+      additionalProperties: false,
+    },
+    handler: async (args, session) => {
+      const slug = String(args.slug ?? "").trim();
+      if (!slug) return textResult("`slug` is required.", true);
+      const spaceHint =
+        typeof args.space === "string" ? args.space.trim() : "";
+      const terminalHint =
+        typeof args.terminal === "string" ? args.terminal.trim() : "";
+      if (!spaceHint && !terminalHint)
+        return textResult("Pass either `space` or `terminal`.", true);
+      if (spaceHint && terminalHint)
+        return textResult(
+          "Pass exactly one of `space` or `terminal`.",
+          true,
+        );
+
+      if (spaceHint) {
+        const space = await resolveSpaceByHint(session.userId, spaceHint);
+        if (!space)
+          return textResult(`Space "${spaceHint}" not found.`, true);
+        if (!(await isSpaceAdmin(session.userId, space.id)))
+          return textResult(
+            `Only space owners or admins can archive modules on ${space.name}.`,
+            true,
+          );
+        const { data, error } = await admin
+          .from("space_modules")
+          .update({ archived_at: new Date().toISOString() })
+          .eq("space_id", space.id)
+          .eq("slug", slug)
+          .is("archived_at", null)
+          .select("id")
+          .maybeSingle();
+        if (error)
+          return textResult(`Archive failed: ${error.message}`, true);
+        if (!data)
+          return textResult(
+            `${slug} isn't installed on ${space.name}.`,
+            true,
+          );
+        return textResult(`Archived ${slug} from ${space.name}.`);
+      }
+
+      const terminal = await resolveProject(session, terminalHint);
+      if (!terminal)
+        return textResult(`Terminal "${terminalHint}" not found.`, true);
+      if (!(await isTerminalManager(session.userId, terminal.id)))
+        return textResult(
+          `Only terminal owners or managers can archive modules on ${terminal.name}.`,
+          true,
+        );
+      const { data, error } = await admin
+        .from("terminal_modules")
+        .update({ archived_at: new Date().toISOString() })
+        .eq("terminal_id", terminal.id)
+        .eq("slug", slug)
+        .is("archived_at", null)
+        .select("id")
+        .maybeSingle();
+      if (error) return textResult(`Archive failed: ${error.message}`, true);
+      if (!data)
+        return textResult(
+          `${slug} isn't installed on ${terminal.name}.`,
+          true,
+        );
+      return textResult(`Archived ${slug} from ${terminal.name}.`);
+    },
+  },
 ];
 
 /* -------------------------------------------------------------------------- */
@@ -3618,6 +3942,33 @@ async function resolveSpaceByHint(
     rows.find((s) => s.name.toLowerCase().includes(lower)) ??
     null
   );
+}
+
+/** Is the user an owner/admin of the given space? Used by module install/archive. */
+async function isSpaceAdmin(userId: string, spaceId: string): Promise<boolean> {
+  const { data } = await admin
+    .from("space_members")
+    .select("role")
+    .eq("user_id", userId)
+    .eq("space_id", spaceId)
+    .maybeSingle();
+  const role = (data as { role: string } | null)?.role;
+  return role === "owner" || role === "admin";
+}
+
+/** Is the user an owner/manager of the given terminal? Used by module install/archive. */
+async function isTerminalManager(
+  userId: string,
+  terminalId: string,
+): Promise<boolean> {
+  const { data } = await admin
+    .from("terminal_members")
+    .select("role")
+    .eq("user_id", userId)
+    .eq("terminal_id", terminalId)
+    .maybeSingle();
+  const role = (data as { role: string } | null)?.role;
+  return role === "owner" || role === "manager";
 }
 
 function textResult(text: string, isError = false) {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -25,6 +25,7 @@
     "@codemirror/lang-javascript": "^6.2.5",
     "@codemirror/lang-json": "^6.0.2",
     "@rokki/db": "workspace:*",
+    "@rokki/sdk": "workspace:*",
     "@sentry/nextjs": "^10.50.0",
     "@supabase/ssr": "^0.5.1",
     "@supabase/supabase-js": "^2.45.4",

--- a/apps/web/src/app/api/v1/me/modules/route.ts
+++ b/apps/web/src/app/api/v1/me/modules/route.ts
@@ -1,0 +1,131 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { withObservability } from "@/lib/observability";
+
+/**
+ * GET /api/v1/me/modules
+ *
+ * Returns the union of module installations across every scope the
+ * caller can see: their personal pins (scope_kind='user'), each space
+ * they belong to, and each terminal they belong to. The pane shell
+ * uses this to build the global "where is module X installed?"
+ * picture for the cross-scope command palette.
+ *
+ * Result shape:
+ *   {
+ *     data: {
+ *       installations: Array<{
+ *         scope_kind: 'space' | 'terminal';
+ *         scope_id: string;
+ *         scope_label: string;     // space name OR `${spaceName} / ${terminalName}`
+ *         slug: string;
+ *         name: string;            // from modules_catalog
+ *         icon: string | null;
+ *         installed_at: string;
+ *       }>;
+ *       pins: Array<{
+ *         scope_kind: 'user' | 'space' | 'terminal';
+ *         scope_id: string | null;
+ *         slug: string;
+ *         display_order: number;
+ *         fn_key: number | null;
+ *       }>;
+ *     }
+ *   }
+ */
+async function handleGet(_req: NextRequest) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user)
+    return NextResponse.json(
+      { errors: [{ code: "unauthenticated", message: "Sign in required" }] },
+      { status: 401 },
+    );
+
+  // RLS scopes both queries to the caller's visible rows already, so
+  // there's no need for an extra WHERE here.
+  const [spaceMods, terminalMods, pins] = await Promise.all([
+    supabase
+      .from("space_modules")
+      .select(
+        "slug, installed_at, spaces:space_id(id, name), modules_catalog(name, icon)",
+      )
+      .is("archived_at", null),
+    supabase
+      .from("terminal_modules")
+      .select(
+        "slug, installed_at, terminals:terminal_id(id, name, space:space_id(name)), modules_catalog(name, icon)",
+      )
+      .is("archived_at", null),
+    supabase
+      .from("user_module_pins")
+      .select("scope_kind, scope_id, slug, display_order, fn_key")
+      .eq("user_id", user.id),
+  ]);
+
+  type SpaceRow = {
+    slug: string;
+    installed_at: string;
+    spaces: { id: string; name: string } | null;
+    modules_catalog: { name: string; icon: string | null } | null;
+  };
+  type TerminalRow = {
+    slug: string;
+    installed_at: string;
+    terminals:
+      | {
+          id: string;
+          name: string;
+          space: { name: string } | null;
+        }
+      | null;
+    modules_catalog: { name: string; icon: string | null } | null;
+  };
+
+  const installations: Array<{
+    scope_kind: "space" | "terminal";
+    scope_id: string;
+    scope_label: string;
+    slug: string;
+    name: string;
+    icon: string | null;
+    installed_at: string;
+  }> = [];
+
+  for (const r of (spaceMods.data ?? []) as SpaceRow[]) {
+    if (!r.spaces) continue;
+    installations.push({
+      scope_kind: "space",
+      scope_id: r.spaces.id,
+      scope_label: r.spaces.name,
+      slug: r.slug,
+      name: r.modules_catalog?.name ?? r.slug,
+      icon: r.modules_catalog?.icon ?? null,
+      installed_at: r.installed_at,
+    });
+  }
+  for (const r of (terminalMods.data ?? []) as TerminalRow[]) {
+    if (!r.terminals) continue;
+    const spaceName = r.terminals.space?.name ?? "Unknown space";
+    installations.push({
+      scope_kind: "terminal",
+      scope_id: r.terminals.id,
+      scope_label: `${spaceName} / ${r.terminals.name}`,
+      slug: r.slug,
+      name: r.modules_catalog?.name ?? r.slug,
+      icon: r.modules_catalog?.icon ?? null,
+      installed_at: r.installed_at,
+    });
+  }
+
+  return NextResponse.json({
+    data: {
+      installations,
+      pins: pins.data ?? [],
+    },
+  });
+}
+
+export const GET = withObservability(handleGet, "GET /api/v1/me/modules");

--- a/apps/web/src/app/api/v1/spaces/[id]/modules/[slug]/route.ts
+++ b/apps/web/src/app/api/v1/spaces/[id]/modules/[slug]/route.ts
@@ -1,0 +1,73 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { withObservability } from "@/lib/observability";
+
+interface Props {
+  params: Promise<{ id: string; slug: string }>;
+}
+
+/**
+ * DELETE /api/v1/spaces/:id/modules/:slug
+ *   → archive the module (sets `archived_at`). Data tables the module
+ *     wrote stay intact. Reinstalling restores configuration.
+ *
+ * Per locked decision #5 (`MODULE_PLAN.md §8`) and the rollback rules,
+ * we never hard-delete. Archive is the only "uninstall" operation.
+ */
+async function handleDelete(_req: NextRequest, { params }: Props) {
+  const { id: spaceId, slug } = await params;
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user)
+    return NextResponse.json(
+      { errors: [{ code: "unauthenticated", message: "Sign in required" }] },
+      { status: 401 },
+    );
+
+  const { data, error } = await supabase
+    .from("space_modules")
+    .update({ archived_at: new Date().toISOString() } as never)
+    .eq("space_id", spaceId)
+    .eq("slug", slug)
+    .is("archived_at", null)
+    .select()
+    .maybeSingle();
+
+  if (error) {
+    if (error.code === "42501") {
+      return NextResponse.json(
+        {
+          errors: [
+            {
+              code: "forbidden",
+              message: "Only space owners or admins can archive modules",
+            },
+          ],
+        },
+        { status: 403 },
+      );
+    }
+    return NextResponse.json(
+      { errors: [{ code: "internal_error", message: error.message }] },
+      { status: 500 },
+    );
+  }
+  if (!data) {
+    return NextResponse.json(
+      {
+        errors: [
+          { code: "not_found", message: "Module is not installed on this space" },
+        ],
+      },
+      { status: 404 },
+    );
+  }
+  return NextResponse.json({ data });
+}
+
+export const DELETE = withObservability(
+  handleDelete,
+  "DELETE /api/v1/spaces/[id]/modules/[slug]",
+);

--- a/apps/web/src/app/api/v1/spaces/[id]/modules/route.ts
+++ b/apps/web/src/app/api/v1/spaces/[id]/modules/route.ts
@@ -1,0 +1,161 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { withObservability } from "@/lib/observability";
+import { getModuleManifest } from "@rokki/sdk";
+
+interface Props {
+  params: Promise<{ id: string }>;
+}
+
+/**
+ * GET  /api/v1/spaces/:id/modules
+ *   → list modules installed on this space (archived = false). Returns
+ *     each entry decorated with catalog info (name, icon) so the UI
+ *     can render without a separate roundtrip.
+ *
+ * POST /api/v1/spaces/:id/modules { slug, config? }
+ *   → install a module on this space. Permission check is enforced by
+ *     `space_modules` RLS (owner/admin only). Returns 201 with the new
+ *     row.
+ *
+ * Both endpoints rely entirely on RLS for authz — no extra checks
+ * here. Per the API+MCP-parity non-negotiable, the same operations are
+ * exposed as MCP tools `module.install` and `module.list_for_scope`.
+ */
+
+async function handleGet(_req: NextRequest, { params }: Props) {
+  const { id: spaceId } = await params;
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return unauth();
+
+  const { data, error } = await supabase
+    .from("space_modules")
+    .select(
+      "id, slug, display_order, config, installed_by, installed_at, archived_at, modules_catalog(name, icon, scopes)",
+    )
+    .eq("space_id", spaceId)
+    .is("archived_at", null)
+    .order("display_order", { ascending: true });
+
+  if (error) {
+    return NextResponse.json(
+      { errors: [{ code: "internal_error", message: error.message }] },
+      { status: 500 },
+    );
+  }
+  return NextResponse.json({ data: data ?? [] });
+}
+
+async function handlePost(req: NextRequest, { params }: Props) {
+  const { id: spaceId } = await params;
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return unauth();
+
+  let body: { slug?: string; config?: Record<string, unknown> };
+  try {
+    body = (await req.json()) as typeof body;
+  } catch {
+    return badRequest("Invalid JSON body");
+  }
+  const slug = typeof body.slug === "string" ? body.slug.trim() : "";
+  if (!slug) return badRequest("`slug` is required");
+
+  // Validate against the in-process manifest registry so a bogus slug
+  // can't squeak past the catalog FK on a stale read. The catalog FK
+  // is still the ultimate guard.
+  const manifest = getModuleManifest(slug);
+  if (manifest && !manifest.scopes.includes("space")) {
+    return badRequest(`Module "${slug}" doesn't support space scope`);
+  }
+
+  // Idempotent install: if the row exists archived, unarchive it
+  // instead of failing on the unique constraint. Reinstalling restores
+  // the previous configuration intact (data layer never deletes).
+  const { data: existingRaw } = await supabase
+    .from("space_modules")
+    .select("id, archived_at")
+    .eq("space_id", spaceId)
+    .eq("slug", slug)
+    .maybeSingle();
+  const existing = existingRaw as
+    | { id: string; archived_at: string | null }
+    | null;
+
+  if (existing) {
+    if (existing.archived_at) {
+      const { data, error } = await supabase
+        .from("space_modules")
+        .update({ archived_at: null, config: body.config ?? {} } as never)
+        .eq("id", existing.id)
+        .select()
+        .single();
+      if (error) return rlsOrErr(error);
+      return NextResponse.json({ data }, { status: 200 });
+    }
+    return NextResponse.json(
+      { errors: [{ code: "conflict", message: "Module already installed" }] },
+      { status: 409 },
+    );
+  }
+
+  const { data, error } = await supabase
+    .from("space_modules")
+    .insert({
+      space_id: spaceId,
+      slug,
+      installed_by: user.id,
+      config: body.config ?? {},
+    } as never)
+    .select()
+    .single();
+  if (error) return rlsOrErr(error);
+  return NextResponse.json({ data }, { status: 201 });
+}
+
+function unauth() {
+  return NextResponse.json(
+    { errors: [{ code: "unauthenticated", message: "Sign in required" }] },
+    { status: 401 },
+  );
+}
+
+function badRequest(message: string) {
+  return NextResponse.json(
+    { errors: [{ code: "invalid_request", message }] },
+    { status: 400 },
+  );
+}
+
+function rlsOrErr(error: { message: string; code?: string }) {
+  // RLS denials surface as code 42501 in PostgREST. Anything else is
+  // a real server problem.
+  if (error.code === "42501") {
+    return NextResponse.json(
+      {
+        errors: [
+          {
+            code: "forbidden",
+            message: "Only space owners or admins can install modules",
+          },
+        ],
+      },
+      { status: 403 },
+    );
+  }
+  return NextResponse.json(
+    { errors: [{ code: "internal_error", message: error.message }] },
+    { status: 500 },
+  );
+}
+
+export const GET = withObservability(handleGet, "GET /api/v1/spaces/[id]/modules");
+export const POST = withObservability(
+  handlePost,
+  "POST /api/v1/spaces/[id]/modules",
+);

--- a/apps/web/src/app/api/v1/terminals/[id]/modules/[slug]/route.ts
+++ b/apps/web/src/app/api/v1/terminals/[id]/modules/[slug]/route.ts
@@ -1,0 +1,75 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { withObservability } from "@/lib/observability";
+
+interface Props {
+  params: Promise<{ id: string; slug: string }>;
+}
+
+/**
+ * DELETE /api/v1/terminals/:id/modules/:slug
+ *   → archive the module (sets `archived_at`). Mirror of the
+ *     space-scoped archive endpoint; RLS gates to terminal owners and
+ *     managers.
+ */
+async function handleDelete(_req: NextRequest, { params }: Props) {
+  const { id: terminalId, slug } = await params;
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user)
+    return NextResponse.json(
+      { errors: [{ code: "unauthenticated", message: "Sign in required" }] },
+      { status: 401 },
+    );
+
+  const { data, error } = await supabase
+    .from("terminal_modules")
+    .update({ archived_at: new Date().toISOString() } as never)
+    .eq("terminal_id", terminalId)
+    .eq("slug", slug)
+    .is("archived_at", null)
+    .select()
+    .maybeSingle();
+
+  if (error) {
+    if (error.code === "42501") {
+      return NextResponse.json(
+        {
+          errors: [
+            {
+              code: "forbidden",
+              message:
+                "Only terminal owners or managers can archive modules",
+            },
+          ],
+        },
+        { status: 403 },
+      );
+    }
+    return NextResponse.json(
+      { errors: [{ code: "internal_error", message: error.message }] },
+      { status: 500 },
+    );
+  }
+  if (!data) {
+    return NextResponse.json(
+      {
+        errors: [
+          {
+            code: "not_found",
+            message: "Module is not installed on this terminal",
+          },
+        ],
+      },
+      { status: 404 },
+    );
+  }
+  return NextResponse.json({ data });
+}
+
+export const DELETE = withObservability(
+  handleDelete,
+  "DELETE /api/v1/terminals/[id]/modules/[slug]",
+);

--- a/apps/web/src/app/api/v1/terminals/[id]/modules/route.ts
+++ b/apps/web/src/app/api/v1/terminals/[id]/modules/route.ts
@@ -1,0 +1,152 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { withObservability } from "@/lib/observability";
+import { getModuleManifest } from "@rokki/sdk";
+
+interface Props {
+  params: Promise<{ id: string }>;
+}
+
+/**
+ * GET  /api/v1/terminals/:id/modules
+ *   → list modules installed on this terminal (archived = false).
+ *
+ * POST /api/v1/terminals/:id/modules { slug, config? }
+ *   → install a module on this terminal. RLS gates this to terminal
+ *     owners/managers per `MODULE_PLAN.md §5`.
+ *
+ * Mirror of the space-scoped equivalent — same error envelope, same
+ * idempotent-unarchive behavior, same fallthrough to RLS for authz.
+ */
+
+async function handleGet(_req: NextRequest, { params }: Props) {
+  const { id: terminalId } = await params;
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return unauth();
+
+  const { data, error } = await supabase
+    .from("terminal_modules")
+    .select(
+      "id, slug, display_order, config, installed_by, installed_at, archived_at, modules_catalog(name, icon, scopes)",
+    )
+    .eq("terminal_id", terminalId)
+    .is("archived_at", null)
+    .order("display_order", { ascending: true });
+
+  if (error) {
+    return NextResponse.json(
+      { errors: [{ code: "internal_error", message: error.message }] },
+      { status: 500 },
+    );
+  }
+  return NextResponse.json({ data: data ?? [] });
+}
+
+async function handlePost(req: NextRequest, { params }: Props) {
+  const { id: terminalId } = await params;
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return unauth();
+
+  let body: { slug?: string; config?: Record<string, unknown> };
+  try {
+    body = (await req.json()) as typeof body;
+  } catch {
+    return badRequest("Invalid JSON body");
+  }
+  const slug = typeof body.slug === "string" ? body.slug.trim() : "";
+  if (!slug) return badRequest("`slug` is required");
+
+  const manifest = getModuleManifest(slug);
+  if (manifest && !manifest.scopes.includes("terminal")) {
+    return badRequest(`Module "${slug}" doesn't support terminal scope`);
+  }
+
+  const { data: existingRaw } = await supabase
+    .from("terminal_modules")
+    .select("id, archived_at")
+    .eq("terminal_id", terminalId)
+    .eq("slug", slug)
+    .maybeSingle();
+  const existing = existingRaw as
+    | { id: string; archived_at: string | null }
+    | null;
+
+  if (existing) {
+    if (existing.archived_at) {
+      const { data, error } = await supabase
+        .from("terminal_modules")
+        .update({ archived_at: null, config: body.config ?? {} } as never)
+        .eq("id", existing.id)
+        .select()
+        .single();
+      if (error) return rlsOrErr(error);
+      return NextResponse.json({ data }, { status: 200 });
+    }
+    return NextResponse.json(
+      { errors: [{ code: "conflict", message: "Module already installed" }] },
+      { status: 409 },
+    );
+  }
+
+  const { data, error } = await supabase
+    .from("terminal_modules")
+    .insert({
+      terminal_id: terminalId,
+      slug,
+      installed_by: user.id,
+      config: body.config ?? {},
+    } as never)
+    .select()
+    .single();
+  if (error) return rlsOrErr(error);
+  return NextResponse.json({ data }, { status: 201 });
+}
+
+function unauth() {
+  return NextResponse.json(
+    { errors: [{ code: "unauthenticated", message: "Sign in required" }] },
+    { status: 401 },
+  );
+}
+
+function badRequest(message: string) {
+  return NextResponse.json(
+    { errors: [{ code: "invalid_request", message }] },
+    { status: 400 },
+  );
+}
+
+function rlsOrErr(error: { message: string; code?: string }) {
+  if (error.code === "42501") {
+    return NextResponse.json(
+      {
+        errors: [
+          {
+            code: "forbidden",
+            message: "Only terminal owners or managers can install modules",
+          },
+        ],
+      },
+      { status: 403 },
+    );
+  }
+  return NextResponse.json(
+    { errors: [{ code: "internal_error", message: error.message }] },
+    { status: 500 },
+  );
+}
+
+export const GET = withObservability(
+  handleGet,
+  "GET /api/v1/terminals/[id]/modules",
+);
+export const POST = withObservability(
+  handlePost,
+  "POST /api/v1/terminals/[id]/modules",
+);

--- a/apps/web/src/app/dev/pane-shell/PaneShellFixture.tsx
+++ b/apps/web/src/app/dev/pane-shell/PaneShellFixture.tsx
@@ -1,0 +1,270 @@
+"use client";
+
+import { useState } from "react";
+import { PaneArea } from "@/components/pane/PaneArea";
+import { PaneShell } from "@/components/pane/PaneShell";
+import { ScopeRail, type ScopeRailSpace } from "@/components/pane/ScopeRail";
+import { usePinnedModules } from "@/components/pane/usePinnedModules";
+import type { InstalledModuleEntry, PaneScope } from "@/components/pane/types";
+
+/**
+ * Static fixture matching the v5 sketch. No DB reads — every value is
+ * in memory so the page paints fast and we can verify the pane-shell
+ * components hang together visually.
+ *
+ * Wire-up to live data lands in Phase 1+.
+ */
+export function PaneShellFixture() {
+  const [scope, setScope] = useState<PaneScope>(FIXTURE_SCOPE_HELIOS);
+  const [activeSlug, setActiveSlug] = useState<string | null>("goals");
+
+  const modules = usePinnedModules({
+    installed: scopeModules(scope),
+    scope,
+    maxPinned: 5,
+  });
+
+  return (
+    <div className="grid h-[100dvh] grid-cols-[240px_1fr] grid-rows-[44px_1fr_28px] overflow-hidden bg-bg-0">
+      {/* Top bar */}
+      <header className="col-span-2 flex items-center gap-3 border-b border-border bg-bg-1 px-4">
+        <span className="font-display text-base font-semibold text-text-0">
+          Rokki<span className="ml-1 text-accent">·</span>
+        </span>
+        <span className="font-mono text-[10px] uppercase tracking-wide text-text-2">
+          {breadcrumb(scope, activeSlug, modules)}
+        </span>
+        <span className="ml-auto rounded-sm border border-border bg-bg-2 px-2 py-1 text-[11px] text-text-3">
+          Pane-shell fixture · Phase 0
+        </span>
+      </header>
+
+      {/* Sidebar */}
+      <aside className="border-r border-border bg-bg-1">
+        <ScopeRail
+          spaces={FIXTURE_SPACES}
+          activeId={scopeActiveId(scope)}
+          onSelectHome={() => {
+            setScope({ kind: "user", label: "Home" });
+            setActiveSlug(null);
+          }}
+          onSelectSpace={(s) => {
+            setScope({
+              kind: "space",
+              id: s.id,
+              slug: s.slug,
+              label: s.name.toUpperCase(),
+            });
+            setActiveSlug(null);
+          }}
+          onSelectTerminal={(t, s) => {
+            setScope({
+              kind: "terminal",
+              id: t.id,
+              ticker: t.ticker,
+              label: `${s.name.toUpperCase()} / ${t.name}`,
+            });
+            setActiveSlug(null);
+          }}
+          onAddTerminal={(s) => alert(`Would open: new terminal in ${s.name}`)}
+          onSpaceSettings={(s) => alert(`Would open: ${s.name} settings`)}
+          onTerminalSettings={(t) => alert(`Would open: ${t.name} settings`)}
+        />
+      </aside>
+
+      {/* Pane area */}
+      <main className="min-h-0 overflow-hidden">
+        <PaneArea initialLayout="single">
+          <PaneShell
+            scope={scope}
+            modules={modules}
+            activeSlug={activeSlug}
+            focused
+            onSelectTab={setActiveSlug}
+            onAddModule={() =>
+              alert(`Would open: add module to ${scope.label}`)
+            }
+            onSettings={() => alert("Would open: module settings")}
+            onClose={null}
+          >
+            <FixtureBody scope={scope} activeSlug={activeSlug} />
+          </PaneShell>
+        </PaneArea>
+      </main>
+
+      {/* F-key shelf */}
+      <footer className="col-span-2 flex items-center gap-4 border-t border-border bg-bg-1 px-3 text-[11px] text-text-2">
+        <Fn k="F1" l="Help" />
+        <Fn k="F2" l="Tasks" />
+        <Fn k="F3" l="Files" />
+        <Fn k="F4" l="Tools" muted />
+        <Fn k="F5" l="Goals" />
+        <Fn k="F6" l="Schedule" />
+        <Fn k="⌘K" l="Search" />
+        <Fn k="⌘2" l="Split" />
+        <span className="ml-auto font-mono text-[10px] text-text-3">
+          Static fixture · no live data
+        </span>
+      </footer>
+    </div>
+  );
+}
+
+/* ───────────────────────────────────────────────────────────────── */
+/* Helpers                                                            */
+/* ───────────────────────────────────────────────────────────────── */
+
+function Fn({ k, l, muted }: { k: string; l: string; muted?: boolean }) {
+  return (
+    <span
+      className={muted ? "text-text-3 opacity-60" : "text-text-2"}
+      title={muted ? `${l} — coming back later (locked decision #5)` : undefined}
+    >
+      <span className="rounded-sm border border-border bg-bg-2 px-1 font-mono text-[9px] text-text-1">
+        {k}
+      </span>{" "}
+      {l}
+    </span>
+  );
+}
+
+function breadcrumb(
+  scope: PaneScope,
+  activeSlug: string | null,
+  modules: ReturnType<typeof usePinnedModules>,
+): string {
+  const all = [...modules.pinned, ...modules.overflow];
+  const moduleName = activeSlug
+    ? (all.find((m) => m.slug === activeSlug)?.name ?? "Overview")
+    : "Overview";
+  return `${scope.label} / ${moduleName.toUpperCase()}`;
+}
+
+function scopeActiveId(scope: PaneScope): string | null {
+  if (scope.kind === "user") return null;
+  return scope.id;
+}
+
+function scopeModules(scope: PaneScope): InstalledModuleEntry[] {
+  // Phase 0 just returns a fixed per-scope-kind set so the tab strip
+  // looks plausible. Real data lands in Phase 1.
+  const TASKS: InstalledModuleEntry = {
+    slug: "tasks",
+    name: "Tasks",
+    icon: "check-square",
+    scope: scope.kind,
+    displayOrder: 1,
+    pinned: true,
+  };
+  const FILES: InstalledModuleEntry = {
+    slug: "files",
+    name: "Files",
+    icon: "folder",
+    scope: scope.kind,
+    displayOrder: 2,
+    pinned: true,
+  };
+  const MESSENGER: InstalledModuleEntry = {
+    slug: "messenger",
+    name: "Messenger",
+    icon: "message-square",
+    scope: scope.kind,
+    displayOrder: 3,
+    pinned: true,
+  };
+  const SCHEDULE: InstalledModuleEntry = {
+    slug: "schedule",
+    name: "Schedule",
+    icon: "calendar",
+    scope: scope.kind,
+    displayOrder: 4,
+    pinned: true,
+  };
+  const GOALS: InstalledModuleEntry = {
+    slug: "goals",
+    name: "Goals",
+    icon: "target",
+    scope: scope.kind,
+    displayOrder: 5,
+    pinned: true,
+  };
+  // Extras to populate the overflow.
+  const DOCUMENTS: InstalledModuleEntry = {
+    slug: "documents",
+    name: "Documents",
+    icon: "file-text",
+    scope: scope.kind,
+    displayOrder: 6,
+    pinned: false,
+  };
+  const REPORTS: InstalledModuleEntry = {
+    slug: "reports",
+    name: "Reports",
+    icon: "bar-chart",
+    scope: scope.kind,
+    displayOrder: 7,
+    pinned: false,
+  };
+
+  if (scope.kind === "user") {
+    return [TASKS, SCHEDULE, MESSENGER, GOALS];
+  }
+  return [TASKS, FILES, MESSENGER, SCHEDULE, GOALS, DOCUMENTS, REPORTS];
+}
+
+function FixtureBody({
+  scope,
+  activeSlug,
+}: {
+  scope: PaneScope;
+  activeSlug: string | null;
+}) {
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-2 p-8 text-center">
+      <p className="text-xs uppercase tracking-wide text-text-3">
+        Fixture body
+      </p>
+      <p className="text-sm text-text-1">
+        {activeSlug
+          ? `Active module "${activeSlug}" for scope ${scope.label}`
+          : `Overview screen for ${scope.label} (no module loaded)`}
+      </p>
+      <p className="max-w-md text-xs text-text-3">
+        Phase 1 mounts the real module content here.
+      </p>
+    </div>
+  );
+}
+
+/* ───────────────────────────────────────────────────────────────── */
+/* Fixture data                                                       */
+/* ───────────────────────────────────────────────────────────────── */
+
+const FIXTURE_SPACES: ScopeRailSpace[] = [
+  {
+    id: "space-helios",
+    slug: "helios",
+    name: "HELIOS",
+    dotColor: "#e0b973",
+    terminals: [
+      { id: "t-casa", ticker: "CASA", name: "Casablanca" },
+      { id: "t-hm", ticker: "HM", name: "Helen Mar" },
+      { id: "t-bh", ticker: "BH", name: "Bay House" },
+      { id: "t-ccp", ticker: "CCP", name: "Coco Palm" },
+    ],
+  },
+  {
+    id: "space-personal",
+    slug: "personal",
+    name: "Personal",
+    dotColor: "#7aa0c4",
+    terminals: [],
+  },
+];
+
+const FIXTURE_SCOPE_HELIOS: PaneScope = {
+  kind: "space",
+  id: "space-helios",
+  slug: "helios",
+  label: "HELIOS",
+};

--- a/apps/web/src/app/dev/pane-shell/page.tsx
+++ b/apps/web/src/app/dev/pane-shell/page.tsx
@@ -1,0 +1,32 @@
+import { notFound, redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { paneShellEnabled } from "@/lib/featureFlags";
+import { PaneShellFixture } from "./PaneShellFixture";
+
+/**
+ * Phase 0 verification page for the pane-shell UI.
+ *
+ * Gated by the `pane_shell_enabled` feature flag — when the flag is
+ * off, this route is invisible (404). When on, it renders a static
+ * fixture matching `Claude/rokki-goals/public/sketch.html` so Zack
+ * can dogfood the new pane shell without touching the live dashboard.
+ *
+ * Phase 1+ moves this into the real dashboard route, replacing the
+ * current `app/page.tsx` shell. This page stays as a "what does the
+ * fixture look like in isolation" reference.
+ */
+export default async function PaneShellDevPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) redirect("/login");
+
+  // Flag-gated. The middleware already requires auth for any non-public
+  // route; we layer the feature flag on top so users who haven't been
+  // opted-in see a 404 rather than a preview of unfinished UI.
+  const enabled = await paneShellEnabled(user.id);
+  if (!enabled) notFound();
+
+  return <PaneShellFixture />;
+}

--- a/apps/web/src/components/pane/PaneArea.tsx
+++ b/apps/web/src/components/pane/PaneArea.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useState } from "react";
+import { Columns2, Grid2x2, Square } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export type PaneLayout = "single" | "split-2" | "grid-4";
+
+interface PaneAreaProps {
+  /** Children = panes. The area renders them in the active layout. */
+  children: React.ReactNode;
+  /** Initial layout. Defaults to "single". Phase 4 persists per-user. */
+  initialLayout?: PaneLayout;
+}
+
+/**
+ * Multi-pane container. Hosts 1, 2, or 4 `PaneShell`s and exposes a
+ * compact layout switcher in the top-right corner.
+ *
+ * Phase 0 wires the switcher purely as UI — actual multi-pane routing
+ * (each pane with independent scope + module state) lands in Phase 4
+ * along with `⌘1` / `⌘2` / `⌘4` and `⌘[` / `⌘]` shortcuts. Until
+ * then the area renders whatever single child you hand it.
+ */
+export function PaneArea({
+  children,
+  initialLayout = "single",
+}: PaneAreaProps) {
+  const [layout, setLayout] = useState<PaneLayout>(initialLayout);
+
+  return (
+    <div className="relative flex h-full min-h-0 flex-col">
+      <LayoutSwitcher layout={layout} onChange={setLayout} />
+      <div
+        className={cn(
+          "min-h-0 flex-1 p-3",
+          layout === "single" && "grid grid-cols-1",
+          layout === "split-2" && "grid grid-cols-1 gap-3 lg:grid-cols-2",
+          layout === "grid-4" && "grid grid-cols-1 gap-3 lg:grid-cols-2 lg:grid-rows-2",
+        )}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}
+
+function LayoutSwitcher({
+  layout,
+  onChange,
+}: {
+  layout: PaneLayout;
+  onChange: (next: PaneLayout) => void;
+}) {
+  return (
+    <div className="absolute right-3 top-3 z-10 flex overflow-hidden rounded-sm border border-border bg-bg-2">
+      {(
+        [
+          { key: "single", label: "Single pane (⌘1)", icon: Square },
+          { key: "split-2", label: "Split 2 (⌘2)", icon: Columns2 },
+          { key: "grid-4", label: "Grid 4 (⌘4)", icon: Grid2x2 },
+        ] as const
+      ).map(({ key, label, icon: Icon }, i) => (
+        <button
+          key={key}
+          type="button"
+          aria-label={label}
+          aria-pressed={layout === key}
+          title={label}
+          onClick={() => onChange(key)}
+          className={cn(
+            "px-1.5 py-0.5 text-text-2 transition-colors",
+            i > 0 && "border-l border-border",
+            layout === key
+              ? "bg-accent text-bg-0"
+              : "hover:bg-bg-3 hover:text-text-0",
+          )}
+        >
+          <Icon className="h-3 w-3" aria-hidden="true" />
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/pane/PaneOverflowMenu.tsx
+++ b/apps/web/src/components/pane/PaneOverflowMenu.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { Plus, Settings } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { InstalledModuleEntry } from "./types";
+
+interface PaneOverflowMenuProps {
+  items: InstalledModuleEntry[];
+  activeSlug: string | null;
+  onSelect: (slug: string) => void;
+  onAddModule?: () => void;
+}
+
+/**
+ * Dropdown content for the `⋯ More` button on the tab strip. Lists
+ * the overflow modules (those installed but not pinned) plus the
+ * "Add module…" and "Manage modules…" footer actions. The strip
+ * owns open/close state and outside-click dismissal; this component
+ * only renders.
+ */
+export function PaneOverflowMenu({
+  items,
+  activeSlug,
+  onSelect,
+  onAddModule,
+}: PaneOverflowMenuProps) {
+  return (
+    <div
+      role="menu"
+      aria-label="More modules"
+      className="absolute right-2 top-full z-30 mt-1 w-64 overflow-hidden rounded-sm border border-border bg-bg-1 shadow-lg"
+    >
+      {items.length > 0 ? (
+        <>
+          <p className="border-b border-border bg-bg-2 px-3 py-1.5 text-[10px] font-semibold uppercase tracking-wide text-text-3">
+            Installed · in this scope
+          </p>
+          <ul className="py-1 text-xs">
+            {items.map((m) => {
+              const active = m.slug === activeSlug;
+              return (
+                <li key={m.slug}>
+                  <button
+                    type="button"
+                    role="menuitemradio"
+                    aria-checked={active}
+                    onClick={() => onSelect(m.slug)}
+                    className={cn(
+                      "flex w-full items-center gap-2 px-3 py-1.5 text-left",
+                      active
+                        ? "bg-bg-3 text-text-0"
+                        : "text-text-1 hover:bg-bg-2",
+                    )}
+                  >
+                    <span aria-hidden="true">◎</span>
+                    <span className="flex-1 truncate">{m.name}</span>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        </>
+      ) : (
+        <p className="px-3 py-2 text-[11px] text-text-3">
+          No additional modules installed here.
+        </p>
+      )}
+      <div className="border-t border-border bg-bg-1 py-1 text-xs">
+        {onAddModule ? (
+          <button
+            type="button"
+            onClick={onAddModule}
+            className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-text-1 hover:bg-bg-2"
+          >
+            <Plus className="h-3 w-3 flex-shrink-0" aria-hidden="true" />
+            <span>Add module…</span>
+          </button>
+        ) : null}
+        <button
+          type="button"
+          // Phase 3 wires this to /s/[slug]/settings/modules etc.
+          disabled
+          title="Marketplace lands in Phase 3"
+          className="flex w-full cursor-not-allowed items-center gap-2 px-3 py-1.5 text-left text-text-3"
+        >
+          <Settings className="h-3 w-3 flex-shrink-0" aria-hidden="true" />
+          <span>Manage modules…</span>
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/pane/PaneShell.tsx
+++ b/apps/web/src/components/pane/PaneShell.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { Settings, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { PaneTabStrip } from "./PaneTabStrip";
+import type { PaneScope, ResolvedModules } from "./types";
+
+interface PaneShellProps {
+  /** Where this pane is rooted — drives the crumb + module list. */
+  scope: PaneScope;
+  /** Active module slug, or `null` for the synthesized Overview screen. */
+  activeSlug: string | null;
+  /** Modules installed at this scope, split into pinned + overflow. */
+  modules: ResolvedModules;
+  /** Pane content — the active module renders here. */
+  children: React.ReactNode;
+  /** True for the focused pane in a multi-pane layout. */
+  focused?: boolean;
+  /** Click handler for the close `×` icon. Pass `null` to hide. */
+  onClose?: (() => void) | null;
+  /** Click handler for the module-settings `⚙` icon. */
+  onSettings?: (() => void) | null;
+  /** Click handler when the user selects a tab. */
+  onSelectTab?: (slug: string) => void;
+  /** Click handler when the user clicks the `＋` add-module button. */
+  onAddModule?: () => void;
+}
+
+/**
+ * One pane: scope crumb + module tab strip + module content.
+ *
+ * Phase 0 renders a static fixture wired up against in-memory data —
+ * no DB reads. The shell becomes the live mount surface for Tasks /
+ * Schedule / Messenger / Files / Goals in Phase 1+.
+ *
+ * Layout:
+ *
+ *   ┌ scope · MODULE ────────── ⚙ × ┐
+ *   │ Tab Tab [Tab] Tab Tab    ⋯ ＋ │
+ *   ├────────────────────────────────┤
+ *   │                                │
+ *   │       module content           │
+ *   │                                │
+ *   └────────────────────────────────┘
+ *
+ * Focused panes show a 1px accent ring. F-key shortcuts target the
+ * focused pane (wired in Phase 4).
+ */
+export function PaneShell({
+  scope,
+  activeSlug,
+  modules,
+  children,
+  focused = false,
+  onClose,
+  onSettings,
+  onSelectTab,
+  onAddModule,
+}: PaneShellProps) {
+  const activeName = resolveActiveName(activeSlug, modules);
+  return (
+    <section
+      aria-label={`${scope.label} pane`}
+      className={cn(
+        "flex h-full min-h-0 flex-col overflow-hidden rounded border bg-bg-1",
+        focused ? "border-accent/50 ring-1 ring-accent/20" : "border-border",
+      )}
+    >
+      {/* Header: scope crumb + active module + controls */}
+      <header className="flex items-center justify-between border-b border-border bg-bg-1 px-3 py-1.5">
+        <div className="flex min-w-0 items-baseline gap-2">
+          <span className="font-mono text-[10px] uppercase tracking-wide text-text-3">
+            {scope.label}
+          </span>
+          {activeName ? (
+            <>
+              <span className="text-text-3">·</span>
+              <span className="truncate text-xs font-semibold text-text-0">
+                {activeName}
+              </span>
+            </>
+          ) : null}
+        </div>
+        <div className="flex flex-shrink-0 items-center gap-1">
+          {onSettings ? (
+            <button
+              type="button"
+              onClick={onSettings}
+              aria-label="Module settings"
+              className="rounded-sm p-1 text-text-3 hover:bg-bg-2 hover:text-text-0"
+            >
+              <Settings className="h-3 w-3" aria-hidden="true" />
+            </button>
+          ) : null}
+          {onClose ? (
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label="Close pane"
+              className="rounded-sm p-1 text-text-3 hover:bg-bg-2 hover:text-text-0"
+            >
+              <X className="h-3 w-3" aria-hidden="true" />
+            </button>
+          ) : null}
+        </div>
+      </header>
+      {/* Tab strip: pinned modules + overflow + add */}
+      <PaneTabStrip
+        modules={modules}
+        activeSlug={activeSlug}
+        onSelect={onSelectTab}
+        onAddModule={onAddModule}
+      />
+      {/* Body: active module content (or Overview synthetic) */}
+      <div className="min-h-0 flex-1 overflow-y-auto">{children}</div>
+    </section>
+  );
+}
+
+function resolveActiveName(
+  activeSlug: string | null,
+  modules: ResolvedModules,
+): string {
+  if (!activeSlug) return "Overview";
+  const all = [...modules.pinned, ...modules.overflow];
+  return all.find((m) => m.slug === activeSlug)?.name ?? "Overview";
+}

--- a/apps/web/src/components/pane/PaneTabStrip.tsx
+++ b/apps/web/src/components/pane/PaneTabStrip.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { ChevronDown, Plus } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { PaneOverflowMenu } from "./PaneOverflowMenu";
+import type { ResolvedModules } from "./types";
+
+interface PaneTabStripProps {
+  modules: ResolvedModules;
+  activeSlug: string | null;
+  onSelect?: (slug: string) => void;
+  onAddModule?: () => void;
+}
+
+/**
+ * The pinned-modules tab row with `⋯ More(N)` overflow + `＋` add.
+ *
+ * Pinned modules render in `modules.pinned` order. The shell decides
+ * how many fit; the rest live in the overflow dropdown.
+ *
+ * Phase 0 is a static row — Phase 4 adds drag-to-reorder that writes
+ * to `user_module_pins.display_order` (debounced).
+ */
+export function PaneTabStrip({
+  modules,
+  activeSlug,
+  onSelect,
+  onAddModule,
+}: PaneTabStripProps) {
+  const [overflowOpen, setOverflowOpen] = useState(false);
+  const stripRef = useRef<HTMLDivElement>(null);
+
+  // Close overflow on outside click.
+  useEffect(() => {
+    if (!overflowOpen) return;
+    function onDocClick(e: MouseEvent) {
+      if (
+        stripRef.current &&
+        !stripRef.current.contains(e.target as Node)
+      ) {
+        setOverflowOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", onDocClick);
+    return () => document.removeEventListener("mousedown", onDocClick);
+  }, [overflowOpen]);
+
+  function handleSelect(slug: string) {
+    setOverflowOpen(false);
+    onSelect?.(slug);
+  }
+
+  return (
+    <div
+      ref={stripRef}
+      role="tablist"
+      aria-label="Modules"
+      className="relative flex items-center gap-1 border-b border-border bg-bg-1 px-2 py-1"
+    >
+      {modules.pinned.map((m) => {
+        const active = m.slug === activeSlug;
+        return (
+          <button
+            key={m.slug}
+            type="button"
+            role="tab"
+            aria-selected={active}
+            onClick={() => handleSelect(m.slug)}
+            className={cn(
+              "rounded-sm px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide transition-colors",
+              active
+                ? "bg-bg-3 text-text-0"
+                : "text-text-2 hover:bg-bg-2 hover:text-text-0",
+            )}
+          >
+            {m.name}
+          </button>
+        );
+      })}
+      <div className="flex-1" />
+      {modules.overflow.length > 0 ? (
+        <button
+          type="button"
+          onClick={() => setOverflowOpen((v) => !v)}
+          aria-expanded={overflowOpen}
+          aria-haspopup="true"
+          className={cn(
+            "flex items-center gap-1 rounded-sm border border-border px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide transition-colors",
+            overflowOpen
+              ? "bg-bg-3 text-text-0"
+              : "bg-bg-2 text-text-2 hover:bg-bg-3 hover:text-text-0",
+          )}
+          title="More modules"
+        >
+          <span>⋯ More</span>
+          <span className="rounded-sm bg-bg-3 px-1 font-mono text-[9px] text-text-3">
+            {modules.overflow.length}
+          </span>
+          <ChevronDown
+            className={cn(
+              "h-3 w-3 transition-transform",
+              overflowOpen && "rotate-180",
+            )}
+            aria-hidden="true"
+          />
+        </button>
+      ) : null}
+      {onAddModule ? (
+        <button
+          type="button"
+          onClick={onAddModule}
+          aria-label="Add module to this scope"
+          title="Add module"
+          className="rounded-sm border border-border bg-bg-2 p-1 text-text-2 hover:bg-bg-3 hover:text-text-0"
+        >
+          <Plus className="h-3 w-3" aria-hidden="true" />
+        </button>
+      ) : null}
+      {overflowOpen ? (
+        <PaneOverflowMenu
+          items={modules.overflow}
+          activeSlug={activeSlug}
+          onSelect={handleSelect}
+          onAddModule={onAddModule}
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/components/pane/ScopeRail.tsx
+++ b/apps/web/src/components/pane/ScopeRail.tsx
@@ -1,0 +1,222 @@
+"use client";
+
+import { useState } from "react";
+import { ChevronDown, Plus, Settings, Home } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+/**
+ * Sidebar refit for the module-system UI. Scope-only — Home + Spaces
+ * (collapsible) + Terminals (flat under their space). Modules do NOT
+ * appear here; they live in the pane tab strip (see `PaneTabStrip`).
+ *
+ * Hover affordances on each row:
+ *   - Space rows: `+` (new terminal) and `⚙` (space settings)
+ *   - Terminal rows: `⚙` (terminal settings)
+ *
+ * Phase 0 wires this against in-memory fixtures. Phase 1 swaps the
+ * fixture for real spaces/terminals data when the flag flips on for
+ * the dashboard.
+ */
+
+export interface ScopeRailSpace {
+  id: string;
+  slug: string;
+  name: string;
+  dotColor?: string;
+  terminals: Array<{
+    id: string;
+    ticker: string;
+    name: string;
+  }>;
+}
+
+interface ScopeRailProps {
+  spaces: ScopeRailSpace[];
+  /** id of the active scope (terminal id or space id) so the row highlights. */
+  activeId?: string | null;
+  /** Click handler for the Home row. */
+  onSelectHome?: () => void;
+  onSelectSpace?: (space: ScopeRailSpace) => void;
+  onSelectTerminal?: (
+    terminal: ScopeRailSpace["terminals"][number],
+    space: ScopeRailSpace,
+  ) => void;
+  onAddTerminal?: (space: ScopeRailSpace) => void;
+  onSpaceSettings?: (space: ScopeRailSpace) => void;
+  onTerminalSettings?: (
+    terminal: ScopeRailSpace["terminals"][number],
+    space: ScopeRailSpace,
+  ) => void;
+}
+
+export function ScopeRail({
+  spaces,
+  activeId = null,
+  onSelectHome,
+  onSelectSpace,
+  onSelectTerminal,
+  onAddTerminal,
+  onSpaceSettings,
+  onTerminalSettings,
+}: ScopeRailProps) {
+  return (
+    <nav
+      aria-label="Spaces and terminals"
+      className="flex h-full min-h-0 flex-col overflow-y-auto bg-bg-1 py-2"
+    >
+      <button
+        type="button"
+        onClick={onSelectHome}
+        className={cn(
+          "mx-2 flex items-center gap-2 rounded-sm px-2 py-1 text-left text-xs text-text-1 hover:bg-bg-2 hover:text-text-0",
+          activeId === null && "bg-bg-2 text-text-0",
+        )}
+      >
+        <Home className="h-3 w-3" aria-hidden="true" />
+        <span>Home</span>
+      </button>
+      <ul role="list" className="mt-2 flex flex-col gap-0.5">
+        {spaces.map((s) => (
+          <SpaceRow
+            key={s.id}
+            space={s}
+            activeId={activeId}
+            onSelectSpace={onSelectSpace}
+            onSelectTerminal={onSelectTerminal}
+            onAddTerminal={onAddTerminal}
+            onSpaceSettings={onSpaceSettings}
+            onTerminalSettings={onTerminalSettings}
+          />
+        ))}
+      </ul>
+    </nav>
+  );
+}
+
+function SpaceRow({
+  space,
+  activeId,
+  onSelectSpace,
+  onSelectTerminal,
+  onAddTerminal,
+  onSpaceSettings,
+  onTerminalSettings,
+}: {
+  space: ScopeRailSpace;
+  activeId: string | null;
+  onSelectSpace?: ScopeRailProps["onSelectSpace"];
+  onSelectTerminal?: ScopeRailProps["onSelectTerminal"];
+  onAddTerminal?: ScopeRailProps["onAddTerminal"];
+  onSpaceSettings?: ScopeRailProps["onSpaceSettings"];
+  onTerminalSettings?: ScopeRailProps["onTerminalSettings"];
+}) {
+  const [open, setOpen] = useState(true);
+  const isActive = activeId === space.id;
+  return (
+    <li role="listitem">
+      <div
+        className={cn(
+          "group flex items-center gap-1.5 px-2 py-1 text-xs text-text-1 hover:bg-bg-2",
+          isActive && "bg-bg-2 text-text-0",
+        )}
+      >
+        <button
+          type="button"
+          aria-label={open ? "Collapse space" : "Expand space"}
+          onClick={() => setOpen((v) => !v)}
+          className="rounded-sm p-0.5 text-text-3 hover:text-text-0"
+        >
+          <ChevronDown
+            className={cn(
+              "h-3 w-3 transition-transform",
+              !open && "-rotate-90",
+            )}
+            aria-hidden="true"
+          />
+        </button>
+        <span
+          aria-hidden="true"
+          className="h-2 w-2 flex-shrink-0 rounded-full"
+          style={{ background: space.dotColor ?? "#7aa0c4" }}
+        />
+        <button
+          type="button"
+          onClick={() => onSelectSpace?.(space)}
+          className="flex-1 truncate text-left font-semibold uppercase tracking-wide text-[11px] text-text-0"
+        >
+          {space.name}
+        </button>
+        <span className="hidden gap-0.5 group-hover:flex">
+          {onAddTerminal ? (
+            <button
+              type="button"
+              onClick={() => onAddTerminal(space)}
+              aria-label={`New terminal in ${space.name}`}
+              title={`New terminal in ${space.name}`}
+              className="rounded-sm p-0.5 text-text-3 hover:bg-bg-3 hover:text-text-0"
+            >
+              <Plus className="h-3 w-3" aria-hidden="true" />
+            </button>
+          ) : null}
+          {onSpaceSettings ? (
+            <button
+              type="button"
+              onClick={() => onSpaceSettings(space)}
+              aria-label={`${space.name} settings`}
+              title={`${space.name} settings — modules, members, integrations`}
+              className="rounded-sm p-0.5 text-text-3 hover:bg-bg-3 hover:text-text-0"
+            >
+              <Settings className="h-3 w-3" aria-hidden="true" />
+            </button>
+          ) : null}
+        </span>
+      </div>
+      {open ? (
+        <ul role="list" className="mt-0.5 flex flex-col gap-0.5">
+          {space.terminals.length === 0 ? (
+            <li className="px-7 py-1 text-[10px] italic text-text-3">
+              no terminals yet
+            </li>
+          ) : null}
+          {space.terminals.map((t) => {
+            const active = activeId === t.id;
+            return (
+              <li key={t.id} role="listitem">
+                <div
+                  className={cn(
+                    "group flex items-center gap-2 pl-7 pr-2 py-1 text-xs text-text-1 hover:bg-bg-2",
+                    active && "bg-bg-2 text-text-0",
+                  )}
+                >
+                  <span
+                    aria-hidden="true"
+                    className="h-1.5 w-1.5 flex-shrink-0 rounded-full bg-text-3"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => onSelectTerminal?.(t, space)}
+                    className="flex-1 truncate text-left"
+                  >
+                    {t.name}
+                  </button>
+                  {onTerminalSettings ? (
+                    <button
+                      type="button"
+                      onClick={() => onTerminalSettings(t, space)}
+                      aria-label={`${t.name} settings`}
+                      title={`${t.name} settings`}
+                      className="hidden rounded-sm p-0.5 text-text-3 hover:bg-bg-3 hover:text-text-0 group-hover:inline-flex"
+                    >
+                      <Settings className="h-3 w-3" aria-hidden="true" />
+                    </button>
+                  ) : null}
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      ) : null}
+    </li>
+  );
+}
+

--- a/apps/web/src/components/pane/types.ts
+++ b/apps/web/src/components/pane/types.ts
@@ -1,0 +1,46 @@
+/**
+ * Shared types for the module-system pane shell.
+ *
+ * These mirror the DB-side shapes (`space_modules`, `terminal_modules`,
+ * `modules_catalog`) but are intentionally smaller — only what the UI
+ * actually needs to render tabs. Heavy queries / mutations stay on
+ * the server side (in `actions/modules.ts` and the SDK).
+ */
+import type { ModuleScope } from "@rokki/sdk";
+
+/**
+ * The "where you are" in the rail. Drives the scope crumb at the top
+ * of the pane and the scope of each tab strip.
+ */
+export type PaneScope =
+  | { kind: "user"; label: string }
+  | { kind: "space"; id: string; slug: string; label: string }
+  | { kind: "terminal"; id: string; ticker: string; label: string };
+
+/**
+ * One installed module surfaced as a tab or in the overflow menu.
+ */
+export interface InstalledModuleEntry {
+  /** Matches `modules_catalog.slug` and the manifest. */
+  slug: string;
+  /** Display name (from `modules_catalog.name`). */
+  name: string;
+  /** Lucide icon name. */
+  icon: string;
+  /** Scope this module is installed at — for rendering the route. */
+  scope: ModuleScope;
+  /** Per-user display order from `user_module_pins`, or default. */
+  displayOrder: number;
+  /** True when the entry is pinned (shown in tab strip). */
+  pinned: boolean;
+}
+
+/**
+ * Result of resolving installed modules + user pins for the current
+ * scope. The shell renders `pinned` as tabs and `overflow` in the
+ * `⋯ More` dropdown.
+ */
+export interface ResolvedModules {
+  pinned: InstalledModuleEntry[];
+  overflow: InstalledModuleEntry[];
+}

--- a/apps/web/src/components/pane/usePinnedModules.ts
+++ b/apps/web/src/components/pane/usePinnedModules.ts
@@ -1,0 +1,63 @@
+"use client";
+
+import { useMemo } from "react";
+import type {
+  InstalledModuleEntry,
+  PaneScope,
+  ResolvedModules,
+} from "./types";
+
+interface UsePinnedModulesArgs {
+  /** All modules the scope has installed (from `space_modules` / `terminal_modules`). */
+  installed: InstalledModuleEntry[];
+  /** Current pane scope — used to namespace pin lookups by scope kind. */
+  scope: PaneScope;
+  /** Max tabs that fit in the strip. Surplus goes to overflow. Default 5. */
+  maxPinned?: number;
+}
+
+/**
+ * Split installed modules into pinned (in the tab strip) and overflow
+ * (in the `⋯ More` dropdown).
+ *
+ * Phase 0 returns a straight first-N split with the existing pin
+ * metadata applied. Phase 4 adds drag-to-reorder + per-user pin
+ * writes to `user_module_pins`; this hook becomes the consumer of
+ * that data.
+ *
+ * `scope` is currently unused at runtime — it's accepted so the
+ * caller doesn't have to refactor when scope-aware bucketing lands.
+ */
+export function usePinnedModules({
+  installed,
+  scope: _scope,
+  maxPinned = 5,
+}: UsePinnedModulesArgs): ResolvedModules {
+  return useMemo<ResolvedModules>(() => {
+    // Stable ordering: pinned first (by display_order), then the rest
+    // sorted likewise. Pinning surfaces what the user has chosen to
+    // see at a glance; non-pinned still get a deterministic order
+    // when they appear in the overflow.
+    const sorted = [...installed].sort((a, b) => {
+      if (a.pinned !== b.pinned) return a.pinned ? -1 : 1;
+      return a.displayOrder - b.displayOrder;
+    });
+    const pinnedFromFlag = sorted.filter((m) => m.pinned);
+    const rest = sorted.filter((m) => !m.pinned);
+
+    // If too few are explicitly pinned, top up from the rest until we
+    // hit `maxPinned`. Without this every fresh scope would render an
+    // empty tab strip until the user opens the menu.
+    const pinned = pinnedFromFlag.slice(0, maxPinned);
+    let cursor = 0;
+    while (pinned.length < maxPinned && cursor < rest.length) {
+      pinned.push(rest[cursor]!);
+      cursor += 1;
+    }
+    const overflow = [
+      ...pinnedFromFlag.slice(maxPinned),
+      ...rest.slice(cursor),
+    ];
+    return { pinned, overflow };
+  }, [installed, maxPinned]);
+}

--- a/apps/web/src/instrumentation.ts
+++ b/apps/web/src/instrumentation.ts
@@ -12,6 +12,10 @@ import * as Sentry from "@sentry/nextjs";
 export async function register() {
   if (process.env.NEXT_RUNTIME === "nodejs") {
     await import("../sentry.server.config");
+    // Register the module-system manifests at server boot. Importing
+    // for the side effect (the index file calls `registerModule(...)`
+    // for each manifest); no symbols are consumed from the import.
+    await import("./modules");
   }
   if (process.env.NEXT_RUNTIME === "edge") {
     await import("../sentry.edge.config");

--- a/apps/web/src/lib/featureFlags.ts
+++ b/apps/web/src/lib/featureFlags.ts
@@ -1,0 +1,117 @@
+/**
+ * Server-side feature-flag resolution.
+ *
+ * For client code, use the `useFlag` hook from `@/lib/flags` — it
+ * fetches the same flag map via `/api/v1/me/flags` and caches per-tab.
+ * This module is the SSR / server-action / route-handler equivalent:
+ * read a single flag value with one DB hit using the same precedence
+ * rules (user override > space override > global).
+ *
+ * Precedence and rollout matching mirror `/api/v1/me/flags` exactly,
+ * so a flag flipped on for a user via the API responds identically to
+ * the equivalent server-side check.
+ */
+import { createClient } from "@/lib/supabase/server";
+
+type FlagScope = "global" | "space" | "user";
+
+interface FlagRow {
+  key: string;
+  scope: FlagScope;
+  scope_id: string | null;
+  value: unknown;
+  rollout_percentage: number;
+}
+
+/**
+ * Resolve `pane_shell_enabled` for the given user. Returns `false`
+ * when no flag row matches or the rollout bucket excludes this user.
+ *
+ * Reads:
+ *   - feature_flags (RLS: every authenticated user can read)
+ *   - space_members (to resolve space-scoped flags for the caller)
+ *
+ * Cost: 2 round-trips per call. Cache at the caller if you need to
+ * gate many components — a single resolution per request is fine.
+ */
+export async function paneShellEnabled(userId: string): Promise<boolean> {
+  const v = await readBooleanFlag(userId, "pane_shell_enabled");
+  return v ?? false;
+}
+
+/**
+ * Generic helper — read a boolean-valued flag for the current
+ * server-rendered request. Returns `null` if no row matches (so the
+ * caller can distinguish "explicitly false" from "no flag exists").
+ *
+ * Use the typed helpers above for known flag keys; this lower-level
+ * one exists so we don't have to write a new function per flag.
+ */
+export async function readBooleanFlag(
+  userId: string,
+  key: string,
+): Promise<boolean | null> {
+  const supabase = await createClient();
+
+  // 1. Pull every row for this key. The flag-row count per key is
+  //    small (global + maybe per-space + maybe per-user); filtering
+  //    here is fine.
+  const { data: flagRows } = await supabase
+    .from("feature_flags")
+    .select("key, scope, scope_id, value, rollout_percentage")
+    .eq("key", key);
+  const rows = (flagRows ?? []) as FlagRow[];
+  if (rows.length === 0) return null;
+
+  // 2. Resolve which space scopes apply to this viewer.
+  const { data: memberships } = await supabase
+    .from("space_members")
+    .select("space_id")
+    .eq("user_id", userId);
+  const spaceIds = ((memberships ?? []) as { space_id: string }[]).map(
+    (r) => r.space_id,
+  );
+
+  // 3. Filter candidates the caller can see.
+  const candidates = rows.filter((r) => {
+    if (r.scope === "user") return r.scope_id === userId;
+    if (r.scope === "space") return r.scope_id && spaceIds.includes(r.scope_id);
+    return true; // global
+  });
+  if (candidates.length === 0) return null;
+
+  // 4. Highest-precedence candidate that passes the rollout bucket
+  //    wins. Same algorithm as /api/v1/me/flags so client + server
+  //    agree on the same answer.
+  candidates.sort((a, b) => rank(b.scope) - rank(a.scope));
+  for (const cand of candidates) {
+    const bucket = stableBucket(`${userId}:${key}`);
+    if (bucket < cand.rollout_percentage) {
+      if (typeof cand.value === "boolean") return cand.value;
+      // JSON `true` / `false` may arrive as the literal strings on
+      // some configurations — coerce defensively.
+      if (cand.value === "true") return true;
+      if (cand.value === "false") return false;
+      return null;
+    }
+  }
+  return null;
+}
+
+function rank(scope: FlagScope): number {
+  return scope === "user" ? 3 : scope === "space" ? 2 : 1;
+}
+
+/**
+ * FNV-1a 32-bit hash → 0..99 bucket. Matches the bucket function in
+ * `/api/v1/me/flags` so a user assigned to bucket N by one path lands
+ * in the same bucket on the other.
+ */
+function stableBucket(seed: string): number {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < seed.length; i++) {
+    h ^= seed.charCodeAt(i);
+    h = (h + ((h << 1) + (h << 4) + (h << 7) + (h << 8) + (h << 24))) >>> 0;
+  }
+  return h % 100;
+}

--- a/apps/web/src/modules/files/manifest.ts
+++ b/apps/web/src/modules/files/manifest.ts
@@ -1,0 +1,24 @@
+/**
+ * Files module manifest.
+ *
+ * Phase 0 stub. Files is the biggest new build in Phase 1: standalone
+ * module surfaces at space and terminal scope, with upload UI, folder
+ * tree, search, and Azure Blob integration per `docs/05_FILES.md`.
+ *
+ * No user-scope view in v1 — a cross-space file rollup is a future
+ * conversation.
+ */
+import type { ModuleManifest } from "@rokki/sdk";
+
+export const filesManifest: ModuleManifest = {
+  slug: "files",
+  name: "Files",
+  description: "Upload, organize, and find documents and assets.",
+  icon: "folder",
+  scopes: ["space", "terminal"],
+  routes: {
+    space: "/s/[slug]/files",
+    terminal: "/p/[ticker]/files",
+  },
+  fnKey: { label: "Files", default: 3 },
+};

--- a/apps/web/src/modules/goals/manifest.ts
+++ b/apps/web/src/modules/goals/manifest.ts
@@ -1,0 +1,28 @@
+/**
+ * Goals module manifest.
+ *
+ * Phase 0 stub. Phase 2 ports the standalone `Claude/rokki-goals/`
+ * Next.js app into a first-class Rokki module: translate the JSON
+ * store to Postgres tables with `space_id` / `terminal_id` columns,
+ * mount routes at `/app/goals`, `/s/[slug]/goals`, `/p/[ticker]/goals`,
+ * and ship a one-off import script at
+ * `Claude/rokki-goals/scripts/import-to-supabase.ts`.
+ *
+ * Not `enabled_by_default` in `modules_catalog` — Goals is an opt-in
+ * module, installed via marketplace per scope.
+ */
+import type { ModuleManifest } from "@rokki/sdk";
+
+export const goalsManifest: ModuleManifest = {
+  slug: "goals",
+  name: "Goals",
+  description: "Weekly numeric targets with daily entries.",
+  icon: "target",
+  scopes: ["user", "space", "terminal"],
+  routes: {
+    user: "/app/goals",
+    space: "/s/[slug]/goals",
+    terminal: "/p/[ticker]/goals",
+  },
+  fnKey: { label: "Goals", default: 5 },
+};

--- a/apps/web/src/modules/index.ts
+++ b/apps/web/src/modules/index.ts
@@ -1,0 +1,40 @@
+/**
+ * Module registration entry point.
+ *
+ * Importing this file registers every v1 module's manifest with the
+ * in-process registry. Server-side: import once at app boot (root
+ * layout or instrumentation). Client-side: not needed — the pane
+ * shell server-renders module lists from the DB and serializes them
+ * down.
+ *
+ * Adding a module: create `<slug>/manifest.ts`, then add the import
+ * + `registerModule(...)` call here. Also add the slug to the
+ * `modules_catalog` seed in the next migration.
+ */
+import { registerModule } from "@rokki/sdk";
+import { tasksManifest } from "./tasks/manifest";
+import { filesManifest } from "./files/manifest";
+import { messengerManifest } from "./messenger/manifest";
+import { scheduleManifest } from "./schedule/manifest";
+import { goalsManifest } from "./goals/manifest";
+
+let registered = false;
+
+/**
+ * Register every v1 module manifest. Idempotent — safe to call
+ * repeatedly (the registry rejects duplicate registrations with a
+ * different object, but identity match is a no-op).
+ */
+export function registerAllModules(): void {
+  if (registered) return;
+  registerModule(tasksManifest);
+  registerModule(filesManifest);
+  registerModule(messengerManifest);
+  registerModule(scheduleManifest);
+  registerModule(goalsManifest);
+  registered = true;
+}
+
+// Auto-register on module load. The function above stays exported
+// for tests that want explicit control.
+registerAllModules();

--- a/apps/web/src/modules/messenger/manifest.ts
+++ b/apps/web/src/modules/messenger/manifest.ts
@@ -1,0 +1,22 @@
+/**
+ * Messenger module manifest.
+ *
+ * Phase 0 stub. Phase 1 wraps the existing `apps/web/src/app/messages/`
+ * page at `/app/messenger`, adds a space-scope view that shows channels
+ * per space, and a terminal-scope view that surfaces one thread per
+ * terminal.
+ */
+import type { ModuleManifest } from "@rokki/sdk";
+
+export const messengerManifest: ModuleManifest = {
+  slug: "messenger",
+  name: "Messenger",
+  description: "Real-time chat with threads, mentions, and reactions.",
+  icon: "message-square",
+  scopes: ["user", "space", "terminal"],
+  routes: {
+    user: "/app/messenger",
+    space: "/s/[slug]/messages",
+    terminal: "/p/[ticker]/messages",
+  },
+};

--- a/apps/web/src/modules/schedule/manifest.ts
+++ b/apps/web/src/modules/schedule/manifest.ts
@@ -1,0 +1,28 @@
+/**
+ * Schedule module manifest.
+ *
+ * Phase 0 stub. Phase 1 renames `apps/web/src/app/calendar/` →
+ * `apps/web/src/app/schedule/` (with a redirect on the old path) and
+ * wraps it in the pane shell at `/app/schedule`. The terminal-scope
+ * route already exists at `apps/web/src/app/p/[ticker]/schedule/` and
+ * just needs the manifest wrap.
+ *
+ * Space view (`/s/[slug]/schedule`) is new and aggregates events
+ * across that space's terminals.
+ */
+import type { ModuleManifest } from "@rokki/sdk";
+
+export const scheduleManifest: ModuleManifest = {
+  slug: "schedule",
+  name: "Schedule",
+  description:
+    "Calendar of events, deadlines, milestones, and dependencies.",
+  icon: "calendar",
+  scopes: ["user", "space", "terminal"],
+  routes: {
+    user: "/app/schedule",
+    space: "/s/[slug]/schedule",
+    terminal: "/p/[ticker]/schedule",
+  },
+  fnKey: { label: "Schedule", default: 6 },
+};

--- a/apps/web/src/modules/tasks/manifest.ts
+++ b/apps/web/src/modules/tasks/manifest.ts
@@ -1,0 +1,26 @@
+/**
+ * Tasks module manifest.
+ *
+ * Phase 0 stub — declares the module's slug, scopes, and target
+ * routes. The actual routes (`/app/tasks`, `/s/[slug]/tasks`,
+ * `/p/[ticker]/tasks`) are wired in Phase 1 by wrapping the existing
+ * pages at `apps/web/src/app/tasks/` and `apps/web/src/app/p/[ticker]/task/`.
+ *
+ * Until then the pane shell can advertise this module in its tab
+ * strip; clicking the tab is a no-op (the route doesn't resolve yet).
+ */
+import type { ModuleManifest } from "@rokki/sdk";
+
+export const tasksManifest: ModuleManifest = {
+  slug: "tasks",
+  name: "Tasks",
+  description: "Track to-dos with priorities, assignees, and due dates.",
+  icon: "check-square",
+  scopes: ["user", "space", "terminal"],
+  routes: {
+    user: "/app/tasks",
+    space: "/s/[slug]/tasks",
+    terminal: "/p/[ticker]/tasks",
+  },
+  fnKey: { label: "Tasks", default: 2 },
+};

--- a/docs/01_DATA_MODEL.md
+++ b/docs/01_DATA_MODEL.md
@@ -1092,3 +1092,170 @@ All indexes declared inline above. Summary of composite / partial indexes that m
 - **Task `ticker_seq` is set by trigger.** Do not set it from the application. Race conditions are handled by the trigger using `MAX()` — acceptable for low write rate; if you ever exceed ~100 task-inserts/sec per project, switch to a per-project sequence.
 - **`access_tokens.token_hash`** is sha256 of the plaintext token. The plaintext is shown to the user exactly once. Do not store plaintext, do not return plaintext after creation.
 - **Every RLS policy has been reviewed for the "what if the actor is in a different org" case.** Do not add a policy that allows cross-org access without explicit review.
+
+## 1.13 Module system
+
+Added 2026-05-13. Implements pluggable modules per `MODULE_PLAN.md`.
+
+The module system splits "what the user sees" from "where they are." A
+**scope** is a `space` or `terminal` (or the user's global Home).
+**Modules** install into a scope and render as tabs inside that scope's
+pane. Per-user pinning controls which modules show as tabs vs. live in
+the `⋯ More` overflow.
+
+Four tables, all additive — nothing in the existing schema changes.
+
+### 1.13.1 `modules_catalog` — registry of installable module slugs
+
+```sql
+CREATE TABLE modules_catalog (
+  slug TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  description TEXT NOT NULL,
+  icon TEXT,                              -- lucide icon name
+  scopes TEXT[] NOT NULL,                 -- ['user','space','terminal']
+  vertical TEXT NULL,                     -- 'realestate' | 'construction' | NULL
+  enabled_by_default BOOLEAN NOT NULL DEFAULT FALSE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE modules_catalog ENABLE ROW LEVEL SECURITY;
+-- Catalog is read-only for everyone authenticated. Writes are seed-only
+-- (migrations + platform-admin tooling, both via service role).
+CREATE POLICY "modules_catalog_read" ON modules_catalog
+  FOR SELECT TO authenticated USING (TRUE);
+```
+
+Seed at migration time with the five v1 slugs: `tasks`, `files`,
+`messenger`, `schedule`, `goals`. Adding a new module slug is a
+migration — never application code.
+
+### 1.13.2 `space_modules` — which modules are installed on a space
+
+```sql
+CREATE TABLE space_modules (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  space_id UUID NOT NULL REFERENCES spaces(id) ON DELETE CASCADE,
+  slug TEXT NOT NULL REFERENCES modules_catalog(slug),
+  display_order INT NOT NULL DEFAULT 0,
+  config JSONB NOT NULL DEFAULT '{}'::jsonb,
+  installed_by UUID NOT NULL REFERENCES auth.users(id),
+  installed_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  archived_at TIMESTAMPTZ,
+  UNIQUE (space_id, slug)
+);
+
+CREATE INDEX idx_space_modules_space ON space_modules(space_id)
+  WHERE archived_at IS NULL;
+
+ALTER TABLE space_modules ENABLE ROW LEVEL SECURITY;
+-- Members of the space see installed modules.
+CREATE POLICY "space_modules_read" ON space_modules
+  FOR SELECT TO authenticated USING (
+    space_id IN (SELECT space_id FROM space_members WHERE user_id = auth.uid())
+  );
+-- Only owners/admins of the space can install or archive.
+CREATE POLICY "space_modules_write" ON space_modules
+  FOR ALL TO authenticated USING (
+    space_id IN (
+      SELECT space_id FROM space_members
+      WHERE user_id = auth.uid() AND role IN ('owner','admin')
+    )
+  )
+  WITH CHECK (
+    space_id IN (
+      SELECT space_id FROM space_members
+      WHERE user_id = auth.uid() AND role IN ('owner','admin')
+    )
+  );
+```
+
+Archive (`archived_at IS NOT NULL`) is the only "uninstall." Data the
+module wrote stays — reinstalling restores it.
+
+### 1.13.3 `terminal_modules` — which modules are installed on a terminal
+
+```sql
+CREATE TABLE terminal_modules (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  terminal_id UUID NOT NULL REFERENCES terminals(id) ON DELETE CASCADE,
+  slug TEXT NOT NULL REFERENCES modules_catalog(slug),
+  display_order INT NOT NULL DEFAULT 0,
+  config JSONB NOT NULL DEFAULT '{}'::jsonb,
+  installed_by UUID NOT NULL REFERENCES auth.users(id),
+  installed_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  archived_at TIMESTAMPTZ,
+  UNIQUE (terminal_id, slug)
+);
+
+CREATE INDEX idx_terminal_modules_terminal ON terminal_modules(terminal_id)
+  WHERE archived_at IS NULL;
+
+ALTER TABLE terminal_modules ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "terminal_modules_read" ON terminal_modules
+  FOR SELECT TO authenticated USING (
+    terminal_id IN (SELECT terminal_id FROM terminal_members WHERE user_id = auth.uid())
+  );
+CREATE POLICY "terminal_modules_write" ON terminal_modules
+  FOR ALL TO authenticated USING (
+    terminal_id IN (
+      SELECT terminal_id FROM terminal_members
+      WHERE user_id = auth.uid() AND role IN ('owner','manager')
+    )
+  )
+  WITH CHECK (
+    terminal_id IN (
+      SELECT terminal_id FROM terminal_members
+      WHERE user_id = auth.uid() AND role IN ('owner','manager')
+    )
+  );
+```
+
+### 1.13.4 `user_module_pins` — per-user tab order + F-key bindings
+
+```sql
+CREATE TABLE user_module_pins (
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  scope_kind TEXT NOT NULL CHECK (scope_kind IN ('user','space','terminal')),
+  scope_id UUID NULL,                     -- NULL for scope_kind='user'
+  slug TEXT NOT NULL REFERENCES modules_catalog(slug),
+  display_order INT NOT NULL,
+  fn_key INT NULL CHECK (fn_key IS NULL OR fn_key BETWEEN 5 AND 10),
+  PRIMARY KEY (user_id, scope_kind, scope_id, slug)
+);
+
+ALTER TABLE user_module_pins ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "user_module_pins_own" ON user_module_pins
+  FOR ALL TO authenticated
+  USING (user_id = auth.uid())
+  WITH CHECK (user_id = auth.uid());
+```
+
+Pinning is a personal preference — never visible to other users and
+never enforced cross-user. F-key range is 5..10 because F1-F4 are
+reserved (Help / Tasks / Files / Tools per the UI design).
+
+### 1.13.5 Permissions matrix
+
+| Action | Who |
+|---|---|
+| Install/archive module on a space | Space owner or admin |
+| Install/archive module on a terminal | Terminal owner or manager |
+| Reorder/pin modules (own view) | Any user — `user_module_pins` |
+| Create catalog entries | Migration / platform-admin only |
+
+All enforced by RLS above — no application-layer permission checks.
+
+### 1.13.6 Feature flag
+
+A row in the existing `feature_flags` table gates the new UI cutover:
+
+```sql
+INSERT INTO feature_flags (key, scope, value, rollout_percentage, description)
+VALUES ('pane_shell_enabled', 'global', 'false'::jsonb, 0,
+        'Module system pane shell — gates the new sidebar+tabs UI');
+```
+
+Off (0% rollout) by default. Per-user overrides (scope = `user`,
+`scope_id = <uid>`, `value = true`) let staff dogfood without flipping
+for everyone.

--- a/docs/08_UI_DESIGN.md
+++ b/docs/08_UI_DESIGN.md
@@ -744,3 +744,97 @@ Stories serve as a visual regression test target via Chromatic or Percy.
 - **Loading spinners for operations < 300ms are worse than nothing.** Use optimistic UI for fast operations; reserve spinners for operations ≥ 500ms. For operations whose duration you can't predict, show a spinner after a 300ms delay (not immediately).
 - **Empty states are prime places for over-design.** Rokki empty states are a single line and a button. Reject anything with illustrations beyond a tiny icon.
 - **When you change typography or spacing tokens,** audit every view. A 1px shift can break alignment in dense tables.
+
+## 8.15 Pane shell + module tab pattern
+
+Added 2026-05-13. The pane shell is the primary content surface in the
+module-system UI (gated by `pane_shell_enabled`). It replaces the
+previous "sidebar with module links" pattern; see ADR 0004 for the
+rationale.
+
+### 8.15.1 Sidebar = scope only
+
+The left rail shows **where you are**, not **what you're doing**. Three
+levels:
+
+- **Home** — your cross-space landing.
+- **Space rows** — collapsible. Hover reveals two icon buttons:
+  `+` (new terminal) and `⚙` (space settings — modules, members,
+  integrations).
+- **Terminal rows** — flat under their space. Hover reveals `⚙`
+  (terminal settings).
+
+No module links in the sidebar. Adding modules to the rail recreates
+the muddle the pane-tab pattern fixed.
+
+### 8.15.2 Pane shell
+
+```
+┌ scope crumb ─────────── ⚙ × ┐
+│ Tab Tab [Tab] Tab Tab  ⋯ ＋ │   ← tab strip
+├──────────────────────────────┤
+│                              │
+│   active module's content    │
+│                              │
+└──────────────────────────────┘
+```
+
+Components live under `apps/web/src/components/pane/`:
+
+- `PaneShell.tsx` — wraps one pane (scope crumb + tab strip + module content)
+- `PaneTabStrip.tsx` — pinned-modules row + `⋯ More` overflow + `＋` add
+- `PaneOverflowMenu.tsx` — the dropdown for non-pinned modules
+- `PaneArea.tsx` — multi-pane container (single / split-2 / grid-4)
+- `usePinnedModules.ts` — reads `user_module_pins`, returns `{ pinned, overflow }`
+
+### 8.15.3 Tab strip rules
+
+- The active module's tab is highlighted with `bg-bg-3 text-text-0`.
+- Pinned modules render in `user_module_pins.display_order`.
+- The strip shows as many tabs as fit; the rest go into `⋯ More(N)`
+  with N = overflow count.
+- The trailing `＋` button opens the module marketplace for the current
+  scope. Disabled with tooltip if the user lacks install permission.
+- "Overview" is **not** a module — it's a synthesized landing view the
+  shell renders when no specific module is active. Never appears in
+  `modules_catalog`.
+
+### 8.15.4 Multi-pane
+
+A `PaneArea` may host 1, 2, or 4 panes. Switcher in the area's
+top-right (`▢` / `▢▢` / `⊞`). Each pane has independent scope +
+active module. The focused pane has a 1px accent ring; F-key
+shortcuts target the focused pane.
+
+Shortcuts:
+- `⌘1` — single pane
+- `⌘2` — split 2
+- `⌘4` — grid 4
+- `⌘[` / `⌘]` — cycle focus between panes
+
+### 8.15.5 F-key shelf
+
+Bottom 28px strip:
+
+- `F1` Help (always)
+- `F2` Tasks (always)
+- `F3` Files (always)
+- `F4` Tools (greyed in v1 — locked decision in `MODULE_PLAN.md §8`)
+- `F5`–`F10` — user-pinnable. `user_module_pins.fn_key` stores the binding.
+- `⌘K` Search (always)
+- `⌘2` Split layout shortcut hint
+- Ticker right-aligned (live activity highlights)
+
+### 8.15.6 Common pitfalls (this pattern)
+
+- **Never put module links in the sidebar.** The whole point of this
+  redesign is that scope and module are orthogonal — keep them visually
+  orthogonal too.
+- **The marketplace `＋` is install-only.** Uninstall/manage flows live
+  in space/terminal settings, not the tab strip — destructive actions
+  don't belong on hot affordances.
+- **Pin reordering writes to `user_module_pins.display_order`** and
+  must be debounced; a drag-to-reorder fires many writes per second.
+- **Empty pane** (no module loaded for a scope) renders the synthesized
+  Overview, not a "pick a module" placeholder. The user picked the
+  scope already; show them something.

--- a/docs/11_ACCEPTANCE.md
+++ b/docs/11_ACCEPTANCE.md
@@ -384,3 +384,89 @@ A feature is done when:
 7. Observability: it emits logs + metrics where relevant
 
 Anything less is not done — it's "partially implemented," which is the exact failure mode we set out to avoid.
+
+## 11.13 Module system acceptance (added 2026-05-13)
+
+Phase gates for the work tracked in `MODULE_PLAN.md`. Each phase ships
+behind the `pane_shell_enabled` feature flag (off by default) until
+its acceptance passes.
+
+### 11.13.1 Phase 0 — Foundation
+
+- [ ] `pnpm install && pnpm dev` boots clean off `feature/module-system`
+- [ ] Migration `20260513010000_modules_init.sql` applies cleanly via `supabase db reset`
+- [ ] Paired rollback at `supabase/migrations/rollbacks/20260513010000_modules_init.down.sql` returns the schema to the prior state cleanly (verified by `pnpm migrations:test`)
+- [ ] All four new tables exist with RLS enabled (`modules_catalog`, `space_modules`, `terminal_modules`, `user_module_pins`)
+- [ ] `modules_catalog` seeded with five rows: `tasks`, `files`, `messenger`, `schedule`, `goals`
+- [ ] `feature_flags` row `pane_shell_enabled` exists with `value=false, rollout_percentage=0`
+- [ ] RLS verified by `pnpm test:rls` (or `vitest --config vitest.rls.config.ts`)
+- [ ] `ModuleManifest` type lives in `packages/sdk/src/modules.ts` (no `tools` field per locked decision #5)
+- [ ] Stub manifests exist for all five v1 slugs at `apps/web/src/modules/<slug>/manifest.ts`
+- [ ] `PaneShell`, `PaneTabStrip`, `PaneOverflowMenu`, `PaneArea` render a static fixture matching `Claude/rokki-goals/public/sketch.html`
+- [ ] `paneShellEnabled(userId)` helper at `apps/web/src/lib/featureFlags.ts` returns the flag value
+- [ ] With flag on, sidebar shows only Home + Spaces + Terminals (no module rows). Hover reveals `+ ⚙` on space rows, `⚙` on terminal rows.
+- [ ] With flag off, the old layout renders unchanged (no regressions on `/`, `/tasks`, `/calendar`, `/messages`, `/p/[ticker]`, `/s/[slug]`)
+- [ ] Server actions: `installSpaceModule`, `installTerminalModule`, `archiveModule`, `pinModuleToFnKey`, `reorderPins`
+- [ ] REST endpoints exist and return 2xx for happy path:
+  - `POST /api/v1/spaces/:id/modules`
+  - `DELETE /api/v1/spaces/:id/modules/:slug`
+  - `POST /api/v1/terminals/:id/modules`
+  - `DELETE /api/v1/terminals/:id/modules/:slug`
+  - `GET /api/v1/me/modules`
+- [ ] MCP tools available: `module.install`, `module.archive`, `module.list_for_scope`
+
+**Done when:** the rail is clean, pane shell renders the fixture, and modules install/archive via API even though none mount to a route yet.
+
+### 11.13.2 Phase 1 — Wrap existing modules (Tasks / Schedule / Messenger / Files)
+
+- [ ] Tasks accessible at `/app/tasks` (user), `/s/[slug]/tasks` (space, new), `/p/[ticker]/tasks` (terminal, renamed from `/task/`)
+- [ ] Schedule accessible at `/app/schedule` (user, redirected from old `/calendar`), `/s/[slug]/schedule`, `/p/[ticker]/schedule`
+- [ ] Messenger accessible at all three scopes; terminal view is one thread per terminal
+- [ ] Files module built from scratch with upload UI, folder tree, search, Azure Blob integration per `docs/05_FILES.md`
+- [ ] Each module's tab appears in `PaneTabStrip` when the user navigates to a scope with it installed
+- [ ] Old `/tasks`, `/calendar`, `/messages` paths still respond (redirect or alongside) — no regressions when flag is off
+
+**Done when:** all four modules render inside `PaneShell` at every applicable scope and the old paths still work.
+
+### 11.13.3 Phase 2 — Port Goals from rokki-goals
+
+- [ ] DB migration translates `Claude/rokki-goals/lib/db.ts` schema into Postgres tables
+- [ ] Each Goals table has both `space_id` and `terminal_id` columns; exactly one is set (CHECK constraint)
+- [ ] RLS uses `space_members` / `terminal_members` membership
+- [ ] Routes mounted: `/app/goals` (user), `/s/[slug]/goals`, `/p/[ticker]/goals`
+- [ ] One-off import script at `Claude/rokki-goals/scripts/import-to-supabase.ts` reads `data/rokki-goals.json` and inserts into a chosen space
+- [ ] Installing Goals on HELIOS keeps its data separate from Goals installed on a terminal; `/app/goals` rolls both up with badges
+
+**Done when:** Goals lives at both scopes, the user-aggregated view shows both rolled up, and the JSON-store version can be imported once.
+
+### 11.13.4 Phase 3 — Marketplace + install flow
+
+- [ ] Marketplace UI at `/s/[slug]/settings/modules` and `/p/[ticker]/settings/modules`
+- [ ] Lists `modules_catalog` filtered by `scopes` containing the current scope kind
+- [ ] Install button calls `installSpaceModule` / `installTerminalModule`
+- [ ] Per-module config wizard when a module declares one
+- [ ] Tab strip `＋` button opens the marketplace for the current scope
+- [ ] `⋯ More` overflow footer has "Add module" and "Manage modules" actions
+- [ ] Archive then reinstall preserves data (data tables aren't dropped on archive)
+
+**Done when:** any space owner can install a new module into HELIOS without engineering involvement; same for terminal owners on terminals.
+
+### 11.13.5 Phase 4 — Polish
+
+- [ ] `⌘1` / `⌘2` / `⌘4` switch pane layouts; each pane has independent scope + active module
+- [ ] `⌘[` / `⌘]` cycles focus between panes
+- [ ] F5–F10 user-pinnable per scope; `user_module_pins.fn_key` stores binding
+- [ ] Drag-to-reorder tabs in the pane strip writes to `user_module_pins.display_order` (debounced)
+- [ ] `⌘K` palette resolves "goals" to "load Goals in focused pane"
+- [ ] Templates auto-install module sets at terminal creation
+- [ ] No user-facing route regressions when the flag flips ON globally
+
+**Done when:** the live app matches the v5 mockup (`Claude/rokki-goals/public/sketch.html`) and feels at least as fast as the pre-module shell.
+
+### 11.13.6 Cross-cutting (every phase)
+
+- [ ] Every new endpoint has matching MCP tool (API+MCP parity, ADR 0003)
+- [ ] Every migration ships with paired `.down.sql` (rollback strategy, `MODULE_PLAN.md §11`)
+- [ ] No service-role DB access for user-initiated operations (CLAUDE.md non-negotiable)
+- [ ] No new `TODO`/`FIXME` in shipped code
+- [ ] Docs (this file, `01_DATA_MODEL.md §1.13`, `08_UI_DESIGN.md §8.15`) stay in sync with reality

--- a/docs/adr/0004-module-system-pane-tabs.md
+++ b/docs/adr/0004-module-system-pane-tabs.md
@@ -1,0 +1,135 @@
+# ADR 0004 — Module system: tabs in the pane header, not links in the sidebar
+
+**Date:** 2026-05-13
+**Status:** Accepted
+
+## Context
+
+Rokki is growing past "Tasks + Files + Calendar." Goals is ready to port
+in from `Claude/rokki-goals/`. Files is becoming its own surface.
+Messenger is a separate noun, not an afterthought. Future depth modules
+(Capital Stack, Title, Closing for real estate; Permits, Drawings,
+Schedule for construction) follow the same pattern: each is its own
+working surface that needs to mount at the user, space, and terminal
+levels.
+
+The current sidebar packs these as links — once we add 5+ modules per
+scope it stops scaling: the rail becomes a list of nouns the user has
+to scan for the noun they want, and the actual "which space am I in"
+context gets pushed off-screen.
+
+The alternative — putting modules in the pane header as tabs — was
+prototyped in `Claude/rokki-goals/public/sketch.html` and worked.
+
+Two questions to answer:
+1. **Where do modules live in the UI?** Sidebar links vs. pane tabs.
+2. **How do they install?** Per-scope (each space/terminal picks its
+   own set) vs. global (every scope has every module).
+
+## Decision
+
+**Modules render as tabs inside each pane's header.** Sidebar is
+scope-only (Home + Spaces + Terminals). Multi-pane (single / split-2 /
+grid-4) is supported so the user can have two modules visible at once
+without losing the scope context.
+
+**Modules install per-scope** with a per-user pin layer on top:
+
+- `space_modules` and `terminal_modules` track what's installed at each
+  scope. Install is an explicit action by a space/terminal admin.
+- `user_module_pins` is per-user-per-scope and controls which installed
+  modules show as tabs vs. live in the `⋯ More` overflow, plus optional
+  F-key bindings (F5–F10).
+
+A few specifics that come with this decision:
+
+- **"Overview" is not a module.** It's a synthesized landing screen the
+  pane shell renders when no specific module is loaded for a scope.
+  Never appears in `modules_catalog`.
+- **User-aggregated views get separate URLs.** Each module's user view
+  is at `/app/<slug>` (e.g. `/app/goals`, `/app/tasks`). Not a single
+  dashboard with filter chips.
+- **Templates carry module lists.** Each project template in
+  `apps/web/src/lib/project-templates.ts` declares the slugs it
+  auto-installs. No new templates table.
+- **Tools are not coupled to modules in v1.** Removed from the
+  `ModuleManifest` contract entirely; they'll return as a separate
+  effort per BUILD_SPEC Phase 2.
+
+The new UI ships behind the `pane_shell_enabled` feature flag, off by
+default until each phase passes acceptance.
+
+## Consequences
+
+**Positives:**
+- Sidebar stays scannable. 5+ spaces × 5+ terminals × 5+ modules used
+  to be a 75-link rail; it's now a 10-row rail with modules surfaced
+  only when the user is *in* a scope that uses them.
+- Per-scope install means a real-estate space gets RE modules without
+  forcing them on a Personal space. Templates make the common case
+  one click.
+- The pane-tab pattern composes — `⌘2` to split, look at Goals in one
+  pane and Tasks in the other, both rooted in the same scope.
+- Adding a module is a manifest entry + a route. No sidebar surgery,
+  no new top-level page.
+
+**Negatives / risks:**
+- **More tables than a pure links-in-sidebar approach.** Four new
+  tables (`modules_catalog`, `space_modules`, `terminal_modules`,
+  `user_module_pins`) instead of zero.
+  Mitigation: each is small, additive, and reversible. RLS policies
+  mirror the existing scope-membership patterns exactly.
+- **Per-scope install requires admin action.** A space owner has to
+  install Tasks on every terminal they create — friction.
+  Mitigation: templates do the bulk install at creation time; the
+  marketplace surface makes one-off installs cheap.
+- **Two ways to "go to Tasks": scope first then tab, or tab first
+  then scope.** We need to make sure the URL structure and `⌘K`
+  search make both flows feel native.
+- **Old routes stay for the duration of the rollout.** `/tasks`,
+  `/calendar`, `/messages` are alongside `/app/tasks`,
+  `/app/schedule`, `/app/messenger`. Deletion happens only after
+  the flag has been on for staff for ≥1 week without issue.
+
+## Rollback strategy
+
+See `MODULE_PLAN.md §11` for the full recipes. Summary:
+
+1. **Restore point:** tag `v0-pre-modules` on main before any code
+   lands. Permanent named pointer.
+2. **Additive only:** new tables, never `DROP COLUMN` or `ALTER TYPE`
+   on existing tables. Every migration has a paired `.down.sql`.
+3. **Feature flag:** `pane_shell_enabled` off by default. Staff flips
+   it for themselves first; users never see the new UI until the flag
+   flips for them.
+
+Reverting at any phase reduces to: flag off → revert merge commit →
+run `.down.sql`. User data in the new tables is orphaned but
+recoverable.
+
+## Alternatives considered
+
+**Modules as sidebar links (status quo, extended).** Rejected: doesn't
+scale past ~5 modules per scope; the rail becomes a noun-soup that
+buries the scope context.
+
+**One global module set (no per-scope install).** Rejected: a Personal
+space doesn't need Capital Stack, a HELIOS space does. Forcing every
+module on every scope clutters the tab strip and adds noise.
+
+**Modules as a top-level concept independent of scope (e.g. a "Goals"
+app that lists every space's goals).** Rejected as the primary surface:
+the user-aggregated views *do* exist (`/app/goals` etc.) but they're a
+secondary view, not the default. The default is "I'm in HELIOS, here's
+HELIOS's Goals."
+
+**Drag-to-rearrange-the-sidebar.** Rejected: customization without a
+strong default produces 100 unique UIs that we have to support.
+Per-user pins inside a stable scope structure is the compromise.
+
+## References
+
+- `Claude/rokki-goals/MODULE_PLAN.md` — full implementation plan
+- `Claude/rokki-goals/public/sketch.html` — clickable v5 mockup
+- `docs/08_UI_DESIGN.md §8.15` — pane shell + tab pattern spec
+- `docs/01_DATA_MODEL.md §1.13` — module system tables

--- a/packages/db/src/generated.ts
+++ b/packages/db/src/generated.ts
@@ -1312,6 +1312,170 @@ export type Database = {
           },
         ]
       }
+      modules_catalog: {
+        Row: {
+          slug: string
+          name: string
+          description: string
+          icon: string | null
+          scopes: string[]
+          vertical: string | null
+          enabled_by_default: boolean
+          created_at: string
+        }
+        Insert: {
+          slug: string
+          name: string
+          description: string
+          icon?: string | null
+          scopes: string[]
+          vertical?: string | null
+          enabled_by_default?: boolean
+          created_at?: string
+        }
+        Update: {
+          slug?: string
+          name?: string
+          description?: string
+          icon?: string | null
+          scopes?: string[]
+          vertical?: string | null
+          enabled_by_default?: boolean
+          created_at?: string
+        }
+        Relationships: []
+      }
+      space_modules: {
+        Row: {
+          id: string
+          space_id: string
+          slug: string
+          display_order: number
+          config: Json
+          installed_by: string
+          installed_at: string
+          archived_at: string | null
+        }
+        Insert: {
+          id?: string
+          space_id: string
+          slug: string
+          display_order?: number
+          config?: Json
+          installed_by: string
+          installed_at?: string
+          archived_at?: string | null
+        }
+        Update: {
+          id?: string
+          space_id?: string
+          slug?: string
+          display_order?: number
+          config?: Json
+          installed_by?: string
+          installed_at?: string
+          archived_at?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "space_modules_space_id_fkey"
+            columns: ["space_id"]
+            isOneToOne: false
+            referencedRelation: "spaces"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "space_modules_slug_fkey"
+            columns: ["slug"]
+            isOneToOne: false
+            referencedRelation: "modules_catalog"
+            referencedColumns: ["slug"]
+          },
+        ]
+      }
+      terminal_modules: {
+        Row: {
+          id: string
+          terminal_id: string
+          slug: string
+          display_order: number
+          config: Json
+          installed_by: string
+          installed_at: string
+          archived_at: string | null
+        }
+        Insert: {
+          id?: string
+          terminal_id: string
+          slug: string
+          display_order?: number
+          config?: Json
+          installed_by: string
+          installed_at?: string
+          archived_at?: string | null
+        }
+        Update: {
+          id?: string
+          terminal_id?: string
+          slug?: string
+          display_order?: number
+          config?: Json
+          installed_by?: string
+          installed_at?: string
+          archived_at?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "terminal_modules_terminal_id_fkey"
+            columns: ["terminal_id"]
+            isOneToOne: false
+            referencedRelation: "terminals"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "terminal_modules_slug_fkey"
+            columns: ["slug"]
+            isOneToOne: false
+            referencedRelation: "modules_catalog"
+            referencedColumns: ["slug"]
+          },
+        ]
+      }
+      user_module_pins: {
+        Row: {
+          user_id: string
+          scope_kind: string
+          scope_id: string | null
+          slug: string
+          display_order: number
+          fn_key: number | null
+        }
+        Insert: {
+          user_id: string
+          scope_kind: string
+          scope_id?: string | null
+          slug: string
+          display_order: number
+          fn_key?: number | null
+        }
+        Update: {
+          user_id?: string
+          scope_kind?: string
+          scope_id?: string | null
+          slug?: string
+          display_order?: number
+          fn_key?: number | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "user_module_pins_slug_fkey"
+            columns: ["slug"]
+            isOneToOne: false
+            referencedRelation: "modules_catalog"
+            referencedColumns: ["slug"]
+          },
+        ]
+      }
       notifications: {
         Row: {
           actor_id: string | null

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -84,3 +84,22 @@ export function createRokkiClient(config: RokkiClientConfig): RokkiClient {
 export { isErr, isOk };
 export type { RokkiClientConfig };
 export type * from "./types.js";
+
+// ─── Module system ────────────────────────────────────────────────
+// Manifest contract + in-process registry for the pluggable module
+// system. See `Claude/rokki-goals/MODULE_PLAN.md` for the design.
+export type {
+  ModuleManifest,
+  ModuleScope,
+  ModuleVertical,
+  InstallContext,
+} from "./modules.js";
+export { manifestSupportsScope } from "./modules.js";
+export {
+  registerModule,
+  getModuleManifest,
+  listModuleManifests,
+  listManifestsForScope,
+  routeForScope,
+  __resetModuleRegistryForTests,
+} from "./module-registry.js";

--- a/packages/sdk/src/module-registry.ts
+++ b/packages/sdk/src/module-registry.ts
@@ -1,0 +1,87 @@
+/**
+ * In-process module registry.
+ *
+ * Each module's `manifest.ts` calls `registerModule(manifest)` at
+ * import time. The pane shell, the marketplace UI, and the install
+ * server actions read from this registry to resolve a slug to its
+ * full manifest.
+ *
+ * Why in-process: the manifest is declarative + tiny, and there are
+ * five of them in v1. Loading them via `import` from
+ * `apps/web/src/modules/index.ts` (which side-effect-imports each
+ * `<slug>/manifest.ts`) keeps the registry warm without a DB
+ * round-trip.
+ *
+ * The DB-side truth — which modules are installed where — lives in
+ * `modules_catalog`, `space_modules`, `terminal_modules`. The
+ * registry is the in-process *capability* layer; the DB is the
+ * *state* layer.
+ */
+import type { ModuleManifest, ModuleScope } from "./modules.js";
+
+const REGISTRY = new Map<string, ModuleManifest>();
+
+/**
+ * Register a module manifest. Idempotent — calling twice with the
+ * same slug throws so a typo can't silently overwrite an existing
+ * registration during HMR.
+ */
+export function registerModule(manifest: ModuleManifest): void {
+  const existing = REGISTRY.get(manifest.slug);
+  if (existing && existing !== manifest) {
+    throw new Error(
+      `Module "${manifest.slug}" already registered with a different manifest. ` +
+        `Two manifests must not share a slug.`,
+    );
+  }
+  REGISTRY.set(manifest.slug, manifest);
+}
+
+/**
+ * Look up a manifest by slug. Returns undefined if unregistered —
+ * callers should treat that as "module not available in this
+ * deployment" rather than as a programming error.
+ */
+export function getModuleManifest(slug: string): ModuleManifest | undefined {
+  return REGISTRY.get(slug);
+}
+
+/**
+ * Snapshot every registered manifest. Order matches insertion order.
+ */
+export function listModuleManifests(): readonly ModuleManifest[] {
+  return Array.from(REGISTRY.values());
+}
+
+/**
+ * Filter the registry to manifests valid at the given scope. Used by
+ * the marketplace UI to show only modules a space can install vs.
+ * what a terminal can install.
+ */
+export function listManifestsForScope(
+  scope: ModuleScope,
+): readonly ModuleManifest[] {
+  return listModuleManifests().filter((m) => m.scopes.includes(scope));
+}
+
+/**
+ * Resolve the route a manifest exposes for a given scope. Returns
+ * undefined if the module doesn't support that scope. Caller is
+ * responsible for substituting URL parameters (`[slug]`, `[ticker]`).
+ */
+export function routeForScope(
+  manifest: ModuleManifest,
+  scope: ModuleScope,
+): string | undefined {
+  return manifest.routes[scope];
+}
+
+/**
+ * Test helper — clear the registry. Production code should never
+ * call this; the registry is built once at startup.
+ *
+ * @internal
+ */
+export function __resetModuleRegistryForTests(): void {
+  REGISTRY.clear();
+}

--- a/packages/sdk/src/modules.ts
+++ b/packages/sdk/src/modules.ts
@@ -1,0 +1,107 @@
+/**
+ * Rokki module-system manifest contract.
+ *
+ * Every module — old or new — exposes the same shape so the pane
+ * shell can mount it generically. The manifest is declarative — it
+ * tells the shell where the module's pages live and which scopes it
+ * applies to. Optional `install` / `uninstall` hooks let a module
+ * seed or archive its own data when it's added to or removed from a
+ * scope.
+ *
+ * Manifests live at `apps/web/src/modules/<slug>/manifest.ts` and
+ * register themselves with the registry at startup. See
+ * `packages/sdk/src/module-registry.ts` and
+ * `docs/adr/0004-module-system-pane-tabs.md` for the rationale.
+ *
+ * Locked-in for v1 (see `Claude/rokki-goals/MODULE_PLAN.md §8`):
+ *   - No `tools` field. Tools are a separate effort.
+ *   - "Overview" is NOT a manifest entry — it's a synthesized
+ *     landing screen rendered by the shell when no module is active.
+ *   - User-aggregated views live at `/app/<slug>`.
+ */
+
+export type ModuleScope = "user" | "space" | "terminal";
+export type ModuleVertical = "realestate" | "construction" | "legal";
+
+/**
+ * Manifest entry for a single module. The `slug` must match a row in
+ * the `modules_catalog` table.
+ */
+export interface ModuleManifest {
+  /** Stable identifier. Matches `modules_catalog.slug`. */
+  slug: string;
+  /** Display name shown in the marketplace and tab strip. */
+  name: string;
+  /** One-line description for the marketplace card. */
+  description: string;
+  /** Lucide icon name (e.g. `"check-square"`). */
+  icon: string;
+  /** Scopes this module supports — at least one. */
+  scopes: ModuleScope[];
+  /**
+   * Optional vertical filter. If set, the module only appears in the
+   * marketplace for spaces/terminals using a matching template. Leave
+   * undefined to make it universally available.
+   */
+  vertical?: ModuleVertical | null;
+  /**
+   * Where the module's pages live at each scope. Keys correspond to
+   * `scopes`. Use Next.js route patterns (`[slug]`, `[ticker]`).
+   */
+  routes: {
+    user?: string;
+    space?: string;
+    terminal?: string;
+  };
+  /**
+   * Optional install hook. Called once when the module is added to a
+   * scope — seed default config, create starter content, etc. The
+   * SQL-side install (writing to `space_modules` / `terminal_modules`)
+   * happens before this runs; only run "extras" here.
+   */
+  install?: (ctx: InstallContext) => Promise<void>;
+  /**
+   * Optional uninstall hook. Called when the module is archived from
+   * a scope. **Archive only — never delete the module's data tables.**
+   * Reinstalling the module should restore the user's previous
+   * configuration intact.
+   */
+  uninstall?: (ctx: InstallContext) => Promise<void>;
+  /**
+   * Optional default F-key binding (5..10). The user can override via
+   * `user_module_pins.fn_key`.
+   */
+  fnKey?: { label: string; default?: number };
+}
+
+/**
+ * Passed to install/uninstall hooks. The `supabase` client is
+ * authenticated as the caller and goes through RLS — the hook can
+ * only touch what the caller can already touch.
+ */
+export interface InstallContext {
+  // Loosely typed to avoid pulling the supabase-js types into the SDK
+  // bundle. The web app casts to `SupabaseClient<Database>` at the
+  // call site.
+  supabase: unknown;
+  scope: "space" | "terminal";
+  /** `spaces.id` or `terminals.id` depending on `scope`. */
+  scopeId: string;
+  /** `auth.users.id` of the actor. */
+  userId: string;
+  /** Optional config payload from the install wizard. */
+  config?: Record<string, unknown>;
+}
+
+/**
+ * Type guard: does this manifest support the given scope?
+ *
+ * Cheap helper used by the pane shell and the marketplace UI when
+ * filtering the catalog down to what's valid at a particular scope.
+ */
+export function manifestSupportsScope(
+  m: ModuleManifest,
+  scope: ModuleScope,
+): boolean {
+  return m.scopes.includes(scope);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,6 +135,9 @@ importers:
       '@rokki/db':
         specifier: workspace:*
         version: link:../../packages/db
+      '@rokki/sdk':
+        specifier: workspace:*
+        version: link:../../packages/sdk
       '@sentry/nextjs':
         specifier: ^10.50.0
         version: 10.50.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(next@15.5.18(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(webpack@5.106.2)

--- a/supabase/migrations/20260513010000_modules_init.sql
+++ b/supabase/migrations/20260513010000_modules_init.sql
@@ -1,0 +1,198 @@
+-- Module system foundation.
+--
+-- Four new tables, fully additive — nothing existing changes:
+--   - modules_catalog      — global registry of installable slugs
+--   - space_modules        — which modules a space has installed
+--   - terminal_modules     — which modules a terminal has installed
+--   - user_module_pins     — per-user tab ordering + F-key bindings
+--
+-- Plus one row in `feature_flags` to gate the new UI:
+--   - pane_shell_enabled = false, rollout_percentage = 0
+--
+-- See `docs/01_DATA_MODEL.md §1.13` for the full spec and
+-- `MODULE_PLAN.md` for context. Rollback at the bottom (and a paired
+-- copy at `supabase/migrations/rollbacks/20260513010000_modules_init.down.sql`).
+
+BEGIN;
+
+-- ───────────────────────────────────────────────────────────────────
+-- modules_catalog
+-- ───────────────────────────────────────────────────────────────────
+
+CREATE TABLE modules_catalog (
+  slug TEXT PRIMARY KEY,
+  name TEXT NOT NULL CHECK (char_length(name) BETWEEN 1 AND 64),
+  description TEXT NOT NULL CHECK (char_length(description) BETWEEN 1 AND 280),
+  icon TEXT,
+  scopes TEXT[] NOT NULL CHECK (
+    array_length(scopes, 1) >= 1
+    AND scopes <@ ARRAY['user','space','terminal']
+  ),
+  vertical TEXT NULL CHECK (vertical IS NULL OR vertical IN ('realestate','construction','legal')),
+  enabled_by_default BOOLEAN NOT NULL DEFAULT FALSE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE modules_catalog ENABLE ROW LEVEL SECURITY;
+
+-- Catalog is read-only for everyone authenticated. Writes happen via
+-- migrations (this file) or service-role tooling.
+CREATE POLICY "modules_catalog_read" ON modules_catalog
+  FOR SELECT TO authenticated USING (TRUE);
+
+-- ───────────────────────────────────────────────────────────────────
+-- space_modules
+-- ───────────────────────────────────────────────────────────────────
+
+CREATE TABLE space_modules (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  space_id UUID NOT NULL REFERENCES spaces(id) ON DELETE CASCADE,
+  slug TEXT NOT NULL REFERENCES modules_catalog(slug),
+  display_order INT NOT NULL DEFAULT 0,
+  config JSONB NOT NULL DEFAULT '{}'::jsonb,
+  installed_by UUID NOT NULL REFERENCES auth.users(id),
+  installed_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  archived_at TIMESTAMPTZ,
+  UNIQUE (space_id, slug)
+);
+
+CREATE INDEX idx_space_modules_active
+  ON space_modules(space_id)
+  WHERE archived_at IS NULL;
+
+ALTER TABLE space_modules ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "space_modules_read" ON space_modules
+  FOR SELECT TO authenticated USING (
+    space_id IN (SELECT space_id FROM space_members WHERE user_id = auth.uid())
+  );
+
+-- Install / archive / reorder gated to space owners and admins.
+-- Members without admin role can't change the installed-module set.
+CREATE POLICY "space_modules_write" ON space_modules
+  FOR ALL TO authenticated
+  USING (
+    space_id IN (
+      SELECT space_id FROM space_members
+      WHERE user_id = auth.uid() AND role IN ('owner','admin')
+    )
+  )
+  WITH CHECK (
+    space_id IN (
+      SELECT space_id FROM space_members
+      WHERE user_id = auth.uid() AND role IN ('owner','admin')
+    )
+  );
+
+-- ───────────────────────────────────────────────────────────────────
+-- terminal_modules
+-- ───────────────────────────────────────────────────────────────────
+
+CREATE TABLE terminal_modules (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  terminal_id UUID NOT NULL REFERENCES terminals(id) ON DELETE CASCADE,
+  slug TEXT NOT NULL REFERENCES modules_catalog(slug),
+  display_order INT NOT NULL DEFAULT 0,
+  config JSONB NOT NULL DEFAULT '{}'::jsonb,
+  installed_by UUID NOT NULL REFERENCES auth.users(id),
+  installed_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  archived_at TIMESTAMPTZ,
+  UNIQUE (terminal_id, slug)
+);
+
+CREATE INDEX idx_terminal_modules_active
+  ON terminal_modules(terminal_id)
+  WHERE archived_at IS NULL;
+
+ALTER TABLE terminal_modules ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "terminal_modules_read" ON terminal_modules
+  FOR SELECT TO authenticated USING (
+    terminal_id IN (SELECT terminal_id FROM terminal_members WHERE user_id = auth.uid())
+  );
+
+-- Install / archive / reorder gated to terminal owners and managers.
+CREATE POLICY "terminal_modules_write" ON terminal_modules
+  FOR ALL TO authenticated
+  USING (
+    terminal_id IN (
+      SELECT terminal_id FROM terminal_members
+      WHERE user_id = auth.uid() AND role IN ('owner','manager')
+    )
+  )
+  WITH CHECK (
+    terminal_id IN (
+      SELECT terminal_id FROM terminal_members
+      WHERE user_id = auth.uid() AND role IN ('owner','manager')
+    )
+  );
+
+-- ───────────────────────────────────────────────────────────────────
+-- user_module_pins
+-- ───────────────────────────────────────────────────────────────────
+
+CREATE TABLE user_module_pins (
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  scope_kind TEXT NOT NULL CHECK (scope_kind IN ('user','space','terminal')),
+  scope_id UUID NULL,
+  slug TEXT NOT NULL REFERENCES modules_catalog(slug),
+  display_order INT NOT NULL,
+  fn_key INT NULL CHECK (fn_key IS NULL OR fn_key BETWEEN 5 AND 10),
+  PRIMARY KEY (user_id, scope_kind, scope_id, slug),
+  -- scope_id NULL only for scope_kind='user'; non-null otherwise.
+  CONSTRAINT user_module_pins_scope_shape CHECK (
+    (scope_kind = 'user' AND scope_id IS NULL)
+    OR (scope_kind IN ('space','terminal') AND scope_id IS NOT NULL)
+  )
+);
+
+ALTER TABLE user_module_pins ENABLE ROW LEVEL SECURITY;
+
+-- Pins are private to their owner. No cross-user reads, no cross-user
+-- writes. The pane shell merges pins with installed-module rows for
+-- the current scope at read time.
+CREATE POLICY "user_module_pins_own" ON user_module_pins
+  FOR ALL TO authenticated
+  USING (user_id = auth.uid())
+  WITH CHECK (user_id = auth.uid());
+
+-- ───────────────────────────────────────────────────────────────────
+-- Seed catalog
+-- ───────────────────────────────────────────────────────────────────
+
+-- Five v1 module slugs. "tasks", "messenger", and "schedule" already
+-- have working implementations under apps/web/src/app/ — Phase 1
+-- wraps them in manifests. "files" is built from scratch in Phase 1.
+-- "goals" is ported from Claude/rokki-goals/ in Phase 2.
+INSERT INTO modules_catalog (slug, name, description, icon, scopes, enabled_by_default) VALUES
+  ('tasks',     'Tasks',     'Track to-dos with priorities, assignees, and due dates.',  'check-square',   ARRAY['user','space','terminal'], TRUE),
+  ('files',     'Files',     'Upload, organize, and find documents and assets.',         'folder',         ARRAY['space','terminal'],        TRUE),
+  ('messenger', 'Messenger', 'Real-time chat with threads, mentions, and reactions.',    'message-square', ARRAY['user','space','terminal'], TRUE),
+  ('schedule',  'Schedule',  'Calendar of events, deadlines, milestones, dependencies.', 'calendar',       ARRAY['user','space','terminal'], TRUE),
+  ('goals',     'Goals',     'Weekly numeric targets with daily entries.',               'target',         ARRAY['space','terminal'],        FALSE);
+
+-- ───────────────────────────────────────────────────────────────────
+-- Feature flag (off by default)
+-- ───────────────────────────────────────────────────────────────────
+
+-- Gates the new sidebar + pane-shell UI. Until this flips on per-user,
+-- the old layout renders.
+INSERT INTO feature_flags (key, scope, value, rollout_percentage, description)
+VALUES (
+  'pane_shell_enabled',
+  'global',
+  'false'::jsonb,
+  0,
+  'Module system: gates the new scope-only sidebar + module tab strip + pane shell UI. Set value=true for a specific user (scope=user, scope_id=<uid>) to dogfood.'
+);
+
+COMMIT;
+
+-- ROLLBACK:
+-- BEGIN;
+-- DELETE FROM feature_flags WHERE key = 'pane_shell_enabled';
+-- DROP TABLE IF EXISTS user_module_pins CASCADE;
+-- DROP TABLE IF EXISTS terminal_modules CASCADE;
+-- DROP TABLE IF EXISTS space_modules CASCADE;
+-- DROP TABLE IF EXISTS modules_catalog CASCADE;
+-- COMMIT;

--- a/supabase/migrations/rollbacks/20260513010000_modules_init.down.sql
+++ b/supabase/migrations/rollbacks/20260513010000_modules_init.down.sql
@@ -1,0 +1,23 @@
+-- Rollback for 20260513010000_modules_init.sql
+--
+-- Drops the four module-system tables and the pane_shell_enabled
+-- feature-flag row. Mirrors the inline `-- ROLLBACK:` block in the
+-- forward migration; this file exists so the rollback is callable
+-- as a standalone .sql (per MODULE_PLAN.md §11.2).
+--
+-- Apply with:
+--   psql $DATABASE_URL < supabase/migrations/rollbacks/20260513010000_modules_init.down.sql
+
+BEGIN;
+
+DELETE FROM feature_flags WHERE key = 'pane_shell_enabled';
+
+-- Drop in reverse dependency order. user_module_pins references
+-- modules_catalog; space_modules and terminal_modules reference it
+-- too. modules_catalog goes last.
+DROP TABLE IF EXISTS user_module_pins CASCADE;
+DROP TABLE IF EXISTS terminal_modules CASCADE;
+DROP TABLE IF EXISTS space_modules CASCADE;
+DROP TABLE IF EXISTS modules_catalog CASCADE;
+
+COMMIT;


### PR DESCRIPTION
**Draft.** Phase 0 of the `MODULE_PLAN.md` plan. Foundation only — no existing module is migrated, no production path changes, the new UI is invisible behind `pane_shell_enabled=false`.

## What landed

### Docs (per CLAUDE.md "update doc before code")
- `docs/01_DATA_MODEL.md §1.13` — four new tables + RLS + flag seed
- `docs/08_UI_DESIGN.md §8.15` — pane shell + module tab pattern
- `docs/adr/0004-module-system-pane-tabs.md` — ADR: why tabs in pane header, not sidebar links
- `docs/11_ACCEPTANCE.md §11.13` — Phase 0–4 acceptance gates

### Migration
- `supabase/migrations/20260513010000_modules_init.sql` (additive — no `ALTER`/`DROP` on existing tables)
- Paired rollback: `supabase/migrations/rollbacks/20260513010000_modules_init.down.sql` (new directory)
- Inline `-- ROLLBACK:` block too so `pnpm migrations:test` recognises it
- Seeds 5 catalog rows (`tasks`, `files`, `messenger`, `schedule`, `goals`) + inserts `pane_shell_enabled=false` into the existing `feature_flags` table (Q1 decision: reuse Rokki's homegrown flags system, no GrowthBook)

### SDK (`packages/sdk/`)
- `modules.ts` — `ModuleManifest` contract (no `tools` field per locked decision #5)
- `module-registry.ts` — in-process registry

### Web app
- `modules/{tasks,files,messenger,schedule,goals}/manifest.ts` — stub manifests declaring `/app/<slug>` user routes (Q3 decision: declare future paths now, Phase 1 mounts them)
- `modules/index.ts` registers all five at server boot via `instrumentation.ts`
- `lib/featureFlags.ts` — `paneShellEnabled(userId)` mirroring the precedence rules of `/api/v1/me/flags`
- `components/pane/` — `PaneShell`, `PaneTabStrip`, `PaneOverflowMenu`, `PaneArea`, `ScopeRail`, `usePinnedModules`
- `app/dev/pane-shell/` — flag-gated static fixture (renders 404 when flag is off; visible match for the v5 sketch when on)
- `app/api/v1/{spaces,terminals}/[id]/modules` + `[slug]` — install/list/archive
- `app/api/v1/me/modules` — user-aggregated view

### MCP (`apps/mcp-server/src/tools.ts`)
- `rokki_module_list_for_scope`, `rokki_module_install`, `rokki_module_archive` (snake_case to match the codebase's convention; brief spec'd `module.*`)

### Restore point
- Tag `v0-pre-modules` → `f823596` on main (pushed)
- Branch `feature/module-system` off main (this branch)

## What I tested

- `pnpm typecheck` clean across web, sdk, mcp-server
- `pnpm migrations:test` reports `[ROLLBACK] 20260513010000_modules_init.sql`
- New routes' imports resolve through workspace deps (added `"@rokki/sdk": "workspace:*"` to `apps/web/package.json`)
- Lint clean on all new files

## What I haven't tested (needs your local DB / staging)

- Forward+rollback round-trip against a live Supabase (`pnpm migrations:test --apply`)
- `vitest --config vitest.rls.config.ts` for the new tables' RLS policies
- Live MCP tool calls
- Visual confirmation of `/dev/pane-shell` with the flag flipped on

## Notes on plan vs. reality

1. **Feature flags** — Rokki already had `feature_flags` table + `/api/v1/me/flags` + `lib/flags.ts`. I reused that system. Q1 was approved on this.
2. **DB types** — Added the four new tables to `packages/db/src/generated.ts` manually so the web typechecks. After applying the migration locally, regenerate with `supabase gen types typescript --local > packages/db/src/generated.ts` to capture the same shapes from the live DB; should produce a zero-diff or near-zero-diff update.
3. **`.insert()` casts** — Supabase's TypeScript generics resolve `Insert` payloads as `never` in this monorepo (a pre-existing condition you'll see in `app/api/v1/admin/impersonate/route.ts` etc.). New routes follow the same `as never` cast pattern.
4. **MCP tool names** — used `rokki_module_*` to match the rest of the registry; the brief's `module.install` style maps cleanly.

## Acceptance items still pending live verification

See `docs/11_ACCEPTANCE.md §11.13.1`. The items needing a live DB:
- Migration round-trip via `pnpm migrations:test --apply`
- `pnpm test:rls` for the four new tables
- `/dev/pane-shell` renders matching the sketch (visual check after flipping the flag on for yourself)

🤖 Generated with [Claude Code](https://claude.com/claude-code)