### PR TITLE
feat(modules): Phase 4 — pin API + F-key shortcuts + reorder + ⌘1/⌘2/⌘4

### DIFF
--- a/apps/web/src/app/api/v1/me/module-pins/route.ts
+++ b/apps/web/src/app/api/v1/me/module-pins/route.ts
@@ -1,0 +1,258 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { withObservability } from "@/lib/observability";
+
+/**
+ * Per-user module pin endpoints — drive the pane-strip ordering +
+ * F-key bindings for the calling user only. RLS on
+ * `user_module_pins` enforces "own rows only" so the handlers don't
+ * need extra authz checks.
+ *
+ * GET  /api/v1/me/module-pins?scope=<kind>&scope_id=<uuid>
+ *   List the caller's pins for a given scope. `scope` is one of
+ *   "user", "space", "terminal". `scope_id` is required for space and
+ *   terminal scopes, omitted for user.
+ *
+ * PUT  /api/v1/me/module-pins
+ *   Replace the caller's pins for a single (scope_kind, scope_id)
+ *   bucket. Body: { scope_kind, scope_id?, pins: [{ slug, display_order, fn_key? }] }.
+ *   Upsert + delete-missing semantics: anything missing from the new
+ *   pins list is removed from the bucket. This makes drag-reorder
+ *   trivial — send the whole list every drop.
+ *
+ * PATCH /api/v1/me/module-pins
+ *   Tweak a single pin's `fn_key`. Body:
+ *   { scope_kind, scope_id?, slug, fn_key | null }
+ *   Convenience endpoint for the F-key picker; equivalent to PUT
+ *   with one row mutated.
+ */
+
+async function handleGet(req: NextRequest) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return unauth();
+
+  const url = new URL(req.url);
+  const scopeKind = url.searchParams.get("scope") ?? "user";
+  const scopeId = url.searchParams.get("scope_id");
+  if (!["user", "space", "terminal"].includes(scopeKind))
+    return badRequest("scope must be user, space, or terminal");
+  if (scopeKind !== "user" && !scopeId)
+    return badRequest("scope_id is required for space and terminal scopes");
+
+  let query = supabase
+    .from("user_module_pins")
+    .select("slug, display_order, fn_key")
+    .eq("user_id", user.id)
+    .eq("scope_kind", scopeKind);
+  if (scopeKind === "user") {
+    query = query.is("scope_id", null);
+  } else {
+    query = query.eq("scope_id", scopeId!);
+  }
+  const { data } = await query.order("display_order", { ascending: true });
+  return NextResponse.json({ data: data ?? [] });
+}
+
+interface PinInput {
+  slug: string;
+  display_order: number;
+  fn_key?: number | null;
+}
+
+async function handlePut(req: NextRequest) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return unauth();
+
+  let body: {
+    scope_kind?: string;
+    scope_id?: string | null;
+    pins?: PinInput[];
+  };
+  try {
+    body = (await req.json()) as typeof body;
+  } catch {
+    return badRequest("Invalid JSON body");
+  }
+
+  const scopeKind = body.scope_kind ?? "";
+  if (!["user", "space", "terminal"].includes(scopeKind))
+    return badRequest("scope_kind must be user, space, or terminal");
+  const scopeId = scopeKind === "user" ? null : body.scope_id ?? null;
+  if (scopeKind !== "user" && !scopeId)
+    return badRequest("scope_id is required for space and terminal scopes");
+  const pins = body.pins;
+  if (!Array.isArray(pins))
+    return badRequest("pins must be an array");
+
+  // Validate each pin row.
+  for (const p of pins) {
+    if (typeof p.slug !== "string" || p.slug.trim() === "")
+      return badRequest("each pin needs a non-empty slug");
+    if (typeof p.display_order !== "number")
+      return badRequest("each pin needs a numeric display_order");
+    if (
+      p.fn_key != null &&
+      (typeof p.fn_key !== "number" || p.fn_key < 5 || p.fn_key > 10)
+    )
+      return badRequest("fn_key must be between 5 and 10 (or null)");
+  }
+
+  // Delete-and-replace for the bucket. Cheaper than computing a diff
+  // for small N; users have at most ~20 pins per scope.
+  let del = supabase
+    .from("user_module_pins")
+    .delete()
+    .eq("user_id", user.id)
+    .eq("scope_kind", scopeKind);
+  if (scopeId === null) {
+    del = del.is("scope_id", null);
+  } else {
+    del = del.eq("scope_id", scopeId);
+  }
+  const { error: delErr } = await del;
+  if (delErr)
+    return NextResponse.json(
+      { errors: [{ code: "internal_error", message: delErr.message }] },
+      { status: 500 },
+    );
+
+  if (pins.length === 0) {
+    return NextResponse.json({ data: [] });
+  }
+
+  const payload = pins.map((p) => ({
+    user_id: user.id,
+    scope_kind: scopeKind,
+    scope_id: scopeId,
+    slug: p.slug,
+    display_order: p.display_order,
+    fn_key: p.fn_key ?? null,
+  }));
+  const { data, error } = await supabase
+    .from("user_module_pins")
+    .insert(payload as never)
+    .select("slug, display_order, fn_key");
+  if (error)
+    return NextResponse.json(
+      { errors: [{ code: "internal_error", message: error.message }] },
+      { status: 500 },
+    );
+  return NextResponse.json({ data: data ?? [] });
+}
+
+async function handlePatch(req: NextRequest) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return unauth();
+
+  let body: {
+    scope_kind?: string;
+    scope_id?: string | null;
+    slug?: string;
+    fn_key?: number | null;
+  };
+  try {
+    body = (await req.json()) as typeof body;
+  } catch {
+    return badRequest("Invalid JSON body");
+  }
+  const scopeKind = body.scope_kind ?? "";
+  if (!["user", "space", "terminal"].includes(scopeKind))
+    return badRequest("scope_kind must be user, space, or terminal");
+  const scopeId = scopeKind === "user" ? null : body.scope_id ?? null;
+  const slug = body.slug?.trim() ?? "";
+  if (!slug) return badRequest("slug is required");
+  const fnKey = body.fn_key;
+  if (
+    fnKey != null &&
+    (typeof fnKey !== "number" || fnKey < 5 || fnKey > 10)
+  )
+    return badRequest("fn_key must be 5-10 or null");
+
+  // Clear any pin row that already claims this fn_key in the bucket
+  // so two slugs never share an F-key. Only meaningful when fnKey is
+  // a number; null means "unbind".
+  if (typeof fnKey === "number") {
+    let clear = supabase
+      .from("user_module_pins")
+      .update({ fn_key: null } as never)
+      .eq("user_id", user.id)
+      .eq("scope_kind", scopeKind)
+      .eq("fn_key", fnKey)
+      .neq("slug", slug);
+    if (scopeId === null) {
+      clear = clear.is("scope_id", null);
+    } else {
+      clear = clear.eq("scope_id", scopeId);
+    }
+    const { error } = await clear;
+    if (error)
+      return NextResponse.json(
+        { errors: [{ code: "internal_error", message: error.message }] },
+        { status: 500 },
+      );
+  }
+
+  let update = supabase
+    .from("user_module_pins")
+    .update({ fn_key: fnKey ?? null } as never)
+    .eq("user_id", user.id)
+    .eq("scope_kind", scopeKind)
+    .eq("slug", slug);
+  if (scopeId === null) {
+    update = update.is("scope_id", null);
+  } else {
+    update = update.eq("scope_id", scopeId);
+  }
+  const { data, error } = await update
+    .select("slug, display_order, fn_key")
+    .maybeSingle();
+  if (error)
+    return NextResponse.json(
+      { errors: [{ code: "internal_error", message: error.message }] },
+      { status: 500 },
+    );
+  if (!data)
+    return NextResponse.json(
+      {
+        errors: [
+          {
+            code: "not_found",
+            message:
+              "No pin exists for that slug yet — create it via PUT first.",
+          },
+        ],
+      },
+      { status: 404 },
+    );
+  return NextResponse.json({ data });
+}
+
+function unauth() {
+  return NextResponse.json(
+    { errors: [{ code: "unauthenticated", message: "Sign in required" }] },
+    { status: 401 },
+  );
+}
+
+function badRequest(message: string) {
+  return NextResponse.json(
+    { errors: [{ code: "invalid_request", message }] },
+    { status: 400 },
+  );
+}
+
+export const GET = withObservability(handleGet, "GET /api/v1/me/module-pins");
+export const PUT = withObservability(handlePut, "PUT /api/v1/me/module-pins");
+export const PATCH = withObservability(
+  handlePatch,
+  "PATCH /api/v1/me/module-pins",
+);

--- a/apps/web/src/app/dev/pane-shell/PaneShellFixture.tsx
+++ b/apps/web/src/app/dev/pane-shell/PaneShellFixture.tsx
@@ -5,6 +5,7 @@ import { PaneArea } from "@/components/pane/PaneArea";
 import { PaneShell } from "@/components/pane/PaneShell";
 import { ScopeRail, type ScopeRailSpace } from "@/components/pane/ScopeRail";
 import { usePinnedModules } from "@/components/pane/usePinnedModules";
+import { useFKeyShortcuts } from "@/components/pane/useFKeyShortcuts";
 import type { InstalledModuleEntry, PaneScope } from "@/components/pane/types";
 
 /**
@@ -23,6 +24,25 @@ export function PaneShellFixture() {
     scope,
     maxPinned: 5,
   });
+
+  // F-key shortcuts: F5 → Goals, F6 → Schedule (matching the shelf
+  // labels below). Pin set is hard-coded here for the fixture; the
+  // real dashboard will pull from /api/v1/me/module-pins.
+  useFKeyShortcuts(
+    {
+      kind: scope.kind,
+      key:
+        scope.kind === "space"
+          ? scope.slug
+          : scope.kind === "terminal"
+            ? scope.ticker
+            : undefined,
+    },
+    [
+      { slug: "goals", fnKey: 5 },
+      { slug: "schedule", fnKey: 6 },
+    ],
+  );
 
   return (
     <div className="grid h-[100dvh] grid-cols-[240px_1fr] grid-rows-[44px_1fr_28px] overflow-hidden bg-bg-0">

--- a/apps/web/src/components/pane/PaneArea.tsx
+++ b/apps/web/src/components/pane/PaneArea.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { Columns2, Grid2x2, Square } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { usePaneLayoutShortcuts } from "./usePaneLayoutShortcuts";
 
 export type PaneLayout = "single" | "split-2" | "grid-4";
 
@@ -27,6 +28,10 @@ export function PaneArea({
   initialLayout = "single",
 }: PaneAreaProps) {
   const [layout, setLayout] = useState<PaneLayout>(initialLayout);
+  // ⌘1 / ⌘2 / ⌘4 keyboard shortcuts. The handler skips when the
+  // user is in a text field, so a digit key during typing doesn't
+  // accidentally split the layout.
+  usePaneLayoutShortcuts(setLayout);
 
   return (
     <div className="relative flex h-full min-h-0 flex-col">

--- a/apps/web/src/components/pane/PaneTabStrip.tsx
+++ b/apps/web/src/components/pane/PaneTabStrip.tsx
@@ -11,6 +11,16 @@ interface PaneTabStripProps {
   activeSlug: string | null;
   onSelect?: (slug: string) => void;
   onAddModule?: () => void;
+  /**
+   * Drag handlers from `usePinReorder`. When provided, each pinned
+   * tab becomes draggable. Omit to keep tabs static.
+   */
+  drag?: {
+    onDragStart: (slug: string) => (e: React.DragEvent) => void;
+    onDragOver: (slug: string) => (e: React.DragEvent) => void;
+    onDrop: (slug: string) => (e: React.DragEvent) => void;
+    dragging: string | null;
+  };
 }
 
 /**
@@ -27,6 +37,7 @@ export function PaneTabStrip({
   activeSlug,
   onSelect,
   onAddModule,
+  drag,
 }: PaneTabStripProps) {
   const [overflowOpen, setOverflowOpen] = useState(false);
   const stripRef = useRef<HTMLDivElement>(null);
@@ -60,6 +71,7 @@ export function PaneTabStrip({
     >
       {modules.pinned.map((m) => {
         const active = m.slug === activeSlug;
+        const isDragging = drag?.dragging === m.slug;
         return (
           <button
             key={m.slug}
@@ -67,11 +79,17 @@ export function PaneTabStrip({
             role="tab"
             aria-selected={active}
             onClick={() => handleSelect(m.slug)}
+            draggable={!!drag}
+            onDragStart={drag?.onDragStart(m.slug)}
+            onDragOver={drag?.onDragOver(m.slug)}
+            onDrop={drag?.onDrop(m.slug)}
             className={cn(
               "rounded-sm px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide transition-colors",
               active
                 ? "bg-bg-3 text-text-0"
                 : "text-text-2 hover:bg-bg-2 hover:text-text-0",
+              isDragging && "opacity-50",
+              drag && "cursor-grab active:cursor-grabbing",
             )}
           >
             {m.name}

--- a/apps/web/src/components/pane/useFKeyShortcuts.ts
+++ b/apps/web/src/components/pane/useFKeyShortcuts.ts
@@ -1,0 +1,41 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { isEditableTarget } from "@/lib/shortcuts";
+import {
+  resolveFKey,
+  type FKeyPin,
+  type FKeyScope,
+} from "@/lib/modules/fkey-resolver";
+
+/**
+ * Wire F1-F10 to navigate. F1-F4 are fixed (Help / Tasks /
+ * Messenger / Tools-greyed); F5-F10 are user-pinnable via
+ * `user_module_pins.fn_key`.
+ *
+ * The hook mounts a single keydown listener on `window` and uses
+ * `resolveFKey` (pure) to compute the navigation target. Skips when
+ * the user is typing in an input/textarea/contenteditable so the
+ * shortcut doesn't fight a real keystroke.
+ *
+ * Pins are passed in from the server-rendered page; the hook itself
+ * doesn't fetch. That keeps the resolver synchronous and
+ * test-friendly.
+ */
+export function useFKeyShortcuts(scope: FKeyScope, pins: FKeyPin[]): void {
+  const router = useRouter();
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (isEditableTarget(e.target)) return;
+      // No modifiers — F-keys are bare keypresses.
+      if (e.metaKey || e.ctrlKey || e.altKey || e.shiftKey) return;
+      const href = resolveFKey(e.key, scope, pins);
+      if (!href) return;
+      e.preventDefault();
+      router.push(href);
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [scope, pins, router]);
+}

--- a/apps/web/src/components/pane/usePaneLayoutShortcuts.ts
+++ b/apps/web/src/components/pane/usePaneLayoutShortcuts.ts
@@ -1,0 +1,43 @@
+"use client";
+
+import { useEffect } from "react";
+import { isEditableTarget } from "@/lib/shortcuts";
+import type { PaneLayout } from "./PaneArea";
+
+/**
+ * ⌘1 / ⌘2 / ⌘4 — switch pane layout. Mirrors the cmd-K convention
+ * for global shortcuts: requires the meta/ctrl modifier so a bare
+ * digit press inside a text field doesn't fight the user.
+ *
+ * Per `docs/08_UI_DESIGN.md §8.15.4`:
+ *   ⌘1 → single
+ *   ⌘2 → split-2
+ *   ⌘4 → grid-4
+ *
+ * The caller owns `setLayout` so this hook stays free of routing or
+ * persistence opinions. Phase 4.x will persist the choice
+ * per-user via `localStorage` or settings; for now it's session-only.
+ */
+export function usePaneLayoutShortcuts(
+  setLayout: (next: PaneLayout) => void,
+): void {
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (isEditableTarget(e.target)) return;
+      if (!(e.metaKey || e.ctrlKey)) return;
+      if (e.shiftKey || e.altKey) return;
+      if (e.key === "1") {
+        e.preventDefault();
+        setLayout("single");
+      } else if (e.key === "2") {
+        e.preventDefault();
+        setLayout("split-2");
+      } else if (e.key === "4") {
+        e.preventDefault();
+        setLayout("grid-4");
+      }
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [setLayout]);
+}

--- a/apps/web/src/components/pane/usePinReorder.test.ts
+++ b/apps/web/src/components/pane/usePinReorder.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { reorder } from "./usePinReorder";
+import type { InstalledModuleEntry } from "./types";
+
+const M = (slug: string, displayOrder: number): InstalledModuleEntry => ({
+  slug,
+  name: slug,
+  icon: "x",
+  scope: "space",
+  displayOrder,
+  pinned: true,
+});
+
+describe("reorder — pure pin-reorder logic", () => {
+  it("moves source before target and renumbers display orders", () => {
+    const before = [M("a", 0), M("b", 1), M("c", 2), M("d", 3)];
+    const after = reorder(before, "d", "b");
+    expect(after.map((m) => m.slug)).toEqual(["a", "d", "b", "c"]);
+    expect(after.map((m) => m.displayOrder)).toEqual([0, 1, 2, 3]);
+  });
+
+  it("no-op when source not found", () => {
+    const before = [M("a", 0), M("b", 1)];
+    const after = reorder(before, "x", "b");
+    expect(after).toBe(before);
+  });
+
+  it("no-op when source == target", () => {
+    const before = [M("a", 0), M("b", 1)];
+    const after = reorder(before, "a", "a");
+    // source is removed before findIndex(target) runs → target not found
+    expect(after).toBe(before);
+  });
+
+  it("renumbers when moving to first position", () => {
+    const before = [M("a", 0), M("b", 1), M("c", 2)];
+    const after = reorder(before, "c", "a");
+    expect(after.map((m) => m.slug)).toEqual(["c", "a", "b"]);
+    expect(after.map((m) => m.displayOrder)).toEqual([0, 1, 2]);
+  });
+});
+
+describe("reorder — property: 200 random scenarios", () => {
+  it("invariants hold across 200 randomized inputs", () => {
+    function rng(seed: number) {
+      let s = seed;
+      return () => {
+        s = (s * 1664525 + 1013904223) % 2 ** 32;
+        return s / 2 ** 32;
+      };
+    }
+    const rand = rng(11);
+    const slugs = ["a", "b", "c", "d", "e", "f", "g", "h"];
+
+    for (let i = 0; i < 200; i++) {
+      const k = 2 + Math.floor(rand() * (slugs.length - 1));
+      const items = slugs
+        .slice(0, k)
+        .map((s, idx) => M(s, idx));
+      const source = items[Math.floor(rand() * items.length)]!.slug;
+      const target = items[Math.floor(rand() * items.length)]!.slug;
+      const result = reorder(items, source, target);
+
+      // Invariant 1: length preserved
+      expect(result.length).toBe(items.length);
+      // Invariant 2: same set of slugs
+      const inSlugs = new Set(items.map((m) => m.slug));
+      const outSlugs = new Set(result.map((m) => m.slug));
+      expect(outSlugs).toEqual(inSlugs);
+      // Invariant 3: display_order is contiguous 0..N-1
+      result.forEach((m, idx) => {
+        expect(m.displayOrder).toBe(idx);
+      });
+    }
+  });
+});

--- a/apps/web/src/components/pane/usePinReorder.ts
+++ b/apps/web/src/components/pane/usePinReorder.ts
@@ -1,0 +1,111 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+import type { InstalledModuleEntry } from "./types";
+
+export interface PinReorderHandle {
+  /** Current visual order. */
+  order: InstalledModuleEntry[];
+  /** Drag handlers for each tab. */
+  onDragStart: (slug: string) => (e: React.DragEvent) => void;
+  onDragOver: (slug: string) => (e: React.DragEvent) => void;
+  onDrop: (slug: string) => (e: React.DragEvent) => void;
+  /** Slug currently being dragged. UI may dim its tab. */
+  dragging: string | null;
+}
+
+interface UsePinReorderArgs {
+  scopeKind: "user" | "space" | "terminal";
+  scopeId: string | null;
+  initial: InstalledModuleEntry[];
+  /**
+   * Called with the new full pin set after each successful drop.
+   * Debounce + persist via /api/v1/me/module-pins. The hook reorders
+   * optimistically; the parent's persistence layer can fall back to
+   * the optimistic value if the API fails.
+   */
+  onCommit?: (next: InstalledModuleEntry[]) => void;
+}
+
+/**
+ * Drag-to-reorder for the pane tab strip. Tracks a local copy of the
+ * order so the UI updates immediately on drop; the caller persists
+ * via the /api/v1/me/module-pins PUT endpoint.
+ *
+ * Phase 4: HTML5 drag/drop is enough — the strip is short and the
+ * interaction is rare. If we move to keyboard-driven reorder later,
+ * swap this for a different state machine.
+ */
+export function usePinReorder({
+  scopeKind: _scopeKind,
+  scopeId: _scopeId,
+  initial,
+  onCommit,
+}: UsePinReorderArgs): PinReorderHandle {
+  const [order, setOrder] = useState<InstalledModuleEntry[]>(initial);
+  const [dragging, setDragging] = useState<string | null>(null);
+  const lastCommittedRef = useRef<string>(initial.map((m) => m.slug).join(","));
+
+  const onDragStart = useCallback(
+    (slug: string) => (e: React.DragEvent) => {
+      e.dataTransfer.effectAllowed = "move";
+      e.dataTransfer.setData("text/plain", slug);
+      setDragging(slug);
+    },
+    [],
+  );
+
+  const onDragOver = useCallback(
+    (_slug: string) => (e: React.DragEvent) => {
+      e.preventDefault();
+      e.dataTransfer.dropEffect = "move";
+    },
+    [],
+  );
+
+  const onDrop = useCallback(
+    (targetSlug: string) => (e: React.DragEvent) => {
+      e.preventDefault();
+      const sourceSlug = e.dataTransfer.getData("text/plain") || dragging;
+      setDragging(null);
+      if (!sourceSlug || sourceSlug === targetSlug) return;
+      setOrder((cur) => {
+        const next = reorder(cur, sourceSlug, targetSlug);
+        const sig = next.map((m) => m.slug).join(",");
+        if (sig !== lastCommittedRef.current) {
+          lastCommittedRef.current = sig;
+          onCommit?.(next);
+        }
+        return next;
+      });
+    },
+    [dragging, onCommit],
+  );
+
+  return { order, onDragStart, onDragOver, onDrop, dragging };
+}
+
+/**
+ * Move `sourceSlug` to immediately before `targetSlug` and renumber
+ * displayOrder. Pure, exported so the unit test can hit it directly.
+ */
+export function reorder(
+  list: InstalledModuleEntry[],
+  sourceSlug: string,
+  targetSlug: string,
+): InstalledModuleEntry[] {
+  const source = list.find((m) => m.slug === sourceSlug);
+  if (!source) return list;
+  const without = list.filter((m) => m.slug !== sourceSlug);
+  const targetIdx = without.findIndex((m) => m.slug === targetSlug);
+  if (targetIdx < 0) {
+    // target was the dragged item; no-op
+    return list;
+  }
+  const reordered = [
+    ...without.slice(0, targetIdx),
+    source,
+    ...without.slice(targetIdx),
+  ];
+  return reordered.map((m, i) => ({ ...m, displayOrder: i }));
+}

--- a/apps/web/src/lib/modules/fkey-resolver.test.ts
+++ b/apps/web/src/lib/modules/fkey-resolver.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { resolveFKey, urlForSlug } from "./fkey-resolver";
+import {
+  registerModule,
+  __resetModuleRegistryForTests,
+} from "@rokki/sdk";
+
+beforeEach(() => {
+  __resetModuleRegistryForTests();
+  registerModule({
+    slug: "tasks",
+    name: "Tasks",
+    description: "t",
+    icon: "check-square",
+    scopes: ["user", "space", "terminal"],
+    routes: {
+      user: "/app/tasks",
+      space: "/s/[slug]/tasks",
+      terminal: "/p/[ticker]/tasks",
+    },
+  });
+  registerModule({
+    slug: "goals",
+    name: "Goals",
+    description: "g",
+    icon: "target",
+    scopes: ["space", "terminal"],
+    routes: { space: "/s/[slug]/goals", terminal: "/p/[ticker]/goals" },
+  });
+  registerModule({
+    slug: "files",
+    name: "Files",
+    description: "f",
+    icon: "folder",
+    scopes: ["space", "terminal"],
+    routes: { space: "/s/[slug]/files", terminal: "/p/[ticker]/files" },
+  });
+});
+
+describe("urlForSlug", () => {
+  it("substitutes [slug] for space scope", () => {
+    expect(urlForSlug("tasks", { kind: "space", key: "helios" })).toBe(
+      "/s/helios/tasks",
+    );
+    expect(urlForSlug("goals", { kind: "space", key: "personal" })).toBe(
+      "/s/personal/goals",
+    );
+  });
+
+  it("substitutes [ticker] for terminal scope", () => {
+    expect(urlForSlug("tasks", { kind: "terminal", key: "CASA" })).toBe(
+      "/p/CASA/tasks",
+    );
+  });
+
+  it("returns user-scope route as-is", () => {
+    expect(urlForSlug("tasks", { kind: "user" })).toBe("/app/tasks");
+  });
+
+  it("returns null when manifest doesn't support the scope", () => {
+    expect(urlForSlug("goals", { kind: "user" })).toBeNull();
+    expect(urlForSlug("files", { kind: "user" })).toBeNull();
+  });
+
+  it("returns null for unknown slugs", () => {
+    expect(urlForSlug("nonexistent", { kind: "user" })).toBeNull();
+  });
+
+  it("returns null when space/terminal scope has no key", () => {
+    expect(urlForSlug("tasks", { kind: "space" })).toBeNull();
+    expect(urlForSlug("tasks", { kind: "terminal" })).toBeNull();
+  });
+});
+
+describe("resolveFKey — fixed bindings", () => {
+  it("F1 → /help (always)", () => {
+    expect(resolveFKey("F1", { kind: "user" }, [])).toBe("/help");
+  });
+  it("F2 → /app/tasks", () => {
+    expect(resolveFKey("F2", { kind: "user" }, [])).toBe("/app/tasks");
+  });
+  it("F3 → /app/messenger", () => {
+    expect(resolveFKey("F3", { kind: "user" }, [])).toBe("/app/messenger");
+  });
+  it("F4 → null (Tools out of scope per locked decision #5)", () => {
+    expect(resolveFKey("F4", { kind: "user" }, [])).toBeNull();
+  });
+});
+
+describe("resolveFKey — user pins", () => {
+  it("F5 resolves to a pinned module's URL at current scope", () => {
+    const pins = [{ slug: "goals", fnKey: 5 }];
+    expect(resolveFKey("F5", { kind: "space", key: "helios" }, pins)).toBe(
+      "/s/helios/goals",
+    );
+  });
+
+  it("F5 returns null when nothing is pinned to it", () => {
+    expect(resolveFKey("F5", { kind: "space", key: "helios" }, [])).toBeNull();
+  });
+
+  it("F11+ returns null (out of range)", () => {
+    expect(
+      resolveFKey("F11", { kind: "space", key: "helios" }, [
+        { slug: "goals", fnKey: 5 },
+      ]),
+    ).toBeNull();
+  });
+
+  it("non-F keys return null", () => {
+    expect(
+      resolveFKey("a", { kind: "space", key: "helios" }, [
+        { slug: "goals", fnKey: 5 },
+      ]),
+    ).toBeNull();
+  });
+
+  it("user-scope F5 with a space-only module returns null (manifest gate)", () => {
+    // goals doesn't have a user route — pin to F5 is pointless at user scope
+    const pins = [{ slug: "goals", fnKey: 5 }];
+    expect(resolveFKey("F5", { kind: "user" }, pins)).toBeNull();
+  });
+});
+
+describe("resolveFKey — property: 200 random scenarios", () => {
+  it("invariants hold across 200 random inputs", () => {
+    const slugs = ["tasks", "goals", "files"];
+    const scopes: Array<Parameters<typeof resolveFKey>[1]> = [
+      { kind: "user" },
+      { kind: "space", key: "helios" },
+      { kind: "space", key: "personal" },
+      { kind: "terminal", key: "CASA" },
+      { kind: "terminal", key: "HM" },
+    ];
+
+    function rng(seed: number) {
+      let s = seed;
+      return () => {
+        s = (s * 1664525 + 1013904223) % 2 ** 32;
+        return s / 2 ** 32;
+      };
+    }
+    const rand = rng(7);
+
+    for (let i = 0; i < 200; i++) {
+      const fkeyN = 1 + Math.floor(rand() * 12); // F1..F12
+      const scope = scopes[Math.floor(rand() * scopes.length)]!;
+      // Random pin set, possibly with conflicting fkeys (handler should
+      // pick the first match in array order).
+      const pins: { slug: string; fnKey: number }[] = [];
+      for (const s of slugs) {
+        if (rand() > 0.5) {
+          pins.push({ slug: s, fnKey: 5 + Math.floor(rand() * 6) });
+        }
+      }
+      const result = resolveFKey(`F${fkeyN}`, scope, pins);
+
+      // Invariant: result is either null or a non-empty string
+      if (result !== null) {
+        expect(typeof result).toBe("string");
+        expect((result as string).length).toBeGreaterThan(0);
+      }
+      // Invariant: F1..F3 always non-null; F4 always null
+      if (fkeyN === 1 || fkeyN === 2 || fkeyN === 3) {
+        expect(result).not.toBeNull();
+      }
+      if (fkeyN === 4) {
+        expect(result).toBeNull();
+      }
+      // Invariant: F11+ always null
+      if (fkeyN > 10) {
+        expect(result).toBeNull();
+      }
+    }
+  });
+});

--- a/apps/web/src/lib/modules/fkey-resolver.ts
+++ b/apps/web/src/lib/modules/fkey-resolver.ts
@@ -1,0 +1,87 @@
+/**
+ * F-key resolver — maps a function key event to a navigation target.
+ *
+ * F1-F4 are reserved (Help / Tasks / Files / Tools) per
+ * `docs/08_UI_DESIGN.md §8.15.5`. F5-F10 are user-pinnable via
+ * `user_module_pins.fn_key`.
+ *
+ * The resolver is pure: it takes a key + the current scope + the
+ * loaded pin map and returns either a URL string to navigate to or
+ * null. The handler that mounts it on `window` lives in
+ * `useFKeyShortcuts` (client hook).
+ *
+ * Kept separate from the hook so it can be unit-tested without
+ * jsdom.
+ */
+import { listManifestsForScope } from "@rokki/sdk";
+
+export type FKeyScopeKind = "user" | "space" | "terminal";
+
+export interface FKeyScope {
+  kind: FKeyScopeKind;
+  /** For space: slug. For terminal: ticker. Undefined for user. */
+  key?: string;
+}
+
+export interface FKeyPin {
+  slug: string;
+  fnKey: number; // 5..10
+}
+
+/**
+ * F1-F4 fixed assignments. These match the F-key shelf in the
+ * sketch and don't change per user.
+ *
+ * F4 (Tools) is intentionally null per locked decision #5 — Tools
+ * is out of scope for v1 modules. The shelf renders it greyed.
+ */
+const FIXED: Record<number, string | null> = {
+  1: "/help",
+  2: "/app/tasks",
+  3: "/app/messenger",
+  4: null,
+};
+
+/**
+ * Resolve a key like "F5" to a URL.
+ *
+ * Returns:
+ *   - a string href when the key has a binding
+ *   - null when the key is reserved-but-unbound (F4) or unpinned
+ *
+ * `pins` should be the *current scope's* pins. The caller is
+ * responsible for loading those (server load on page, or
+ * `/api/v1/me/module-pins` from the client).
+ */
+export function resolveFKey(
+  key: string,
+  scope: FKeyScope,
+  pins: FKeyPin[],
+): string | null {
+  const m = /^F(\d{1,2})$/.exec(key);
+  if (!m) return null;
+  const n = Number(m[1]);
+  if (Number.isNaN(n)) return null;
+  if (n in FIXED) return FIXED[n];
+  if (n < 5 || n > 10) return null;
+  const pin = pins.find((p) => p.fnKey === n);
+  if (!pin) return null;
+  return urlForSlug(pin.slug, scope);
+}
+
+/**
+ * Build a route for `slug` at the given scope by reading the
+ * manifest. Returns null if the manifest doesn't expose that scope.
+ *
+ * Exported for use by the command palette resolver too.
+ */
+export function urlForSlug(slug: string, scope: FKeyScope): string | null {
+  const m = listManifestsForScope(scope.kind).find((x) => x.slug === slug);
+  if (!m) return null;
+  const pattern = m.routes[scope.kind];
+  if (!pattern) return null;
+  if (scope.kind === "user") return pattern;
+  if (!scope.key) return null;
+  if (scope.kind === "space") return pattern.replace("[slug]", scope.key);
+  return pattern.replace("[ticker]", scope.key);
+}


### PR DESCRIPTION
**Draft. Stacks on #165.** Closes out the four-phase module system.

## Pin API — `/api/v1/me/module-pins`

| Method | Purpose |
|---|---|
| `GET ?scope=<kind>&scope_id=<uuid>` | List the caller's pins for a scope |
| `PUT` | Replace pins for one (scope_kind, scope_id) bucket — drag-reorder commits via this |
| `PATCH` | Bind/unbind an F-key for a single slug; auto-clears any conflicting F-key in the same bucket |

RLS on `user_module_pins` (own rows only) handles authz.

## F-key resolver — pure, testable

`lib/modules/fkey-resolver.ts` — `(key, scope, pins) → URL | null`.

- F1-F4 fixed (Help / Tasks / Messenger / Tools-greyed)
- F5-F10 user-pinnable per scope
- Substitutes `[slug]` / `[ticker]` into manifest route patterns
- Returns null when the scope doesn't match the module's declared scopes

`useFKeyShortcuts` hook mounts it on window with the standard editable-target skip.

## ⌘1/⌘2/⌘4 — pane layout shortcuts

`usePaneLayoutShortcuts` switches PaneArea between single / split-2 / grid-4. Already wired into `PaneArea`.

## Drag-to-reorder

`usePinReorder` + extended `PaneTabStrip` with a `drag` prop. HTML5 drag/drop; pure `reorder` function exported for unit test. Caller persists via the PUT pin endpoint.

## Tests — 39 passing across 4 suites

- `fkey-resolver.test.ts` — 16 tests including 200-iteration property fuzz
- `usePinReorder.test.ts` — 5 tests including 200-iteration property fuzz
- `goals-week.test.ts` (Phase 2) — 13 tests including 200-iteration property fuzz
- `scope.test.ts` (Phase 1) — 5 tests including 200-iteration property fuzz

**~800 random scenarios verified** across the 4 property suites (200 per suite). Invariants checked include: no duplicates, slug ∈ installed, contiguous display_order after reorder, Mon-start-and-7-day-span on every week boundary, F1-F3 always-non-null / F4 always-null / F11+ always-null.

## What's beyond Phase 4 v1 (small follow-ups)

- Per-pane independent scope + module state in multi-pane mode — `PaneArea` hosts any children, but the state machine that routes each pane independently lands when the dashboard flips to pane shell (separate PR; needs the sidebar rewrite from #163's ScopeRail to become the default).
- ⌘K "goals" → load Goals in focused pane — the existing TopBarSearch palette already routes; the module bridge is a tiny follow-up that pipes slugs through the SDK registry.
- Pin localStorage fallback for offline.

## Gaps still needing live env

- Migration round-trip (already covered by Phase 0 + 2 migrations)
- RLS for `user_module_pins` (added in Phase 0, asserted clean via `pnpm test:rls`)
- Actual F-key keydown UX on real hardware (the resolver is pure-tested; mounting the listener is a 3-line wiring)

🤖 Generated with [Claude Code](https://claude.com/claude-code)