### PR TITLE
infra(deploy): wire staging.rokki.ai + manual prod-deploy workflow

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,0 +1,121 @@
+name: Deploy production
+
+# Plan A: production deploys are MANUAL. Trigger this workflow when
+# staging has been verified and you want to promote `main` to
+# https://rokki.ai.
+#
+# What it does:
+#   1. Apply any new migrations to the production Supabase project.
+#   2. Fast-forward the `production` branch to current `main` HEAD.
+#   3. Vercel sees the push to the production branch and auto-builds +
+#      deploys to rokki.ai using the production env vars (prod Supabase).
+#   4. Smoke-test rokki.ai for a healthy response.
+#
+# Requires the `production` GitHub Environment with you as the required
+# reviewer — every run pauses for your approval before applying the
+# migration. Approving = "I have eyes on this; ship it."
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: 'Type "yes" to confirm production deploy'
+        required: true
+        type: string
+      skip_migrations:
+        description: 'Skip running supabase db push (use only if migrations were already applied out-of-band)'
+        required: false
+        default: 'false'
+        type: choice
+        options: ['false', 'true']
+
+concurrency:
+  group: deploy-prod
+  cancel-in-progress: false
+
+jobs:
+  preflight:
+    name: Confirm input
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - name: Verify confirmation
+        run: |
+          if [ "${{ inputs.confirm }}" != "yes" ]; then
+            echo "::error::Production deploy not confirmed (typed: '${{ inputs.confirm }}', need: 'yes')"
+            exit 1
+          fi
+
+  migrate-prod-db:
+    name: Apply migrations → prod Supabase
+    runs-on: ubuntu-latest
+    needs: preflight
+    environment:
+      name: production
+      url: https://rokki.ai
+    timeout-minutes: 10
+    if: ${{ inputs.skip_migrations != 'true' }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: main
+      - name: Install Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: latest
+      - name: Push migrations to production
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+        run: |
+          supabase link --project-ref ${{ vars.SUPABASE_PROD_REF }} \
+            --password "${{ secrets.SUPABASE_PROD_DB_PASSWORD }}"
+          supabase db push --include-all \
+            --password "${{ secrets.SUPABASE_PROD_DB_PASSWORD }}"
+
+  promote-vercel:
+    name: Promote main → production branch (triggers Vercel prod deploy)
+    runs-on: ubuntu-latest
+    needs: [preflight, migrate-prod-db]
+    # The `if` here keeps the dependency on migrate-prod-db symbolic even
+    # when skip_migrations is true — `needs` only enforces order, not
+    # success when the upstream is skipped. always() reduces to "did the
+    # prior jobs not fail or cancel" which matches our intent.
+    if: ${{ always() && needs.preflight.result == 'success' && (needs.migrate-prod-db.result == 'success' || needs.migrate-prod-db.result == 'skipped') }}
+    environment:
+      name: production
+      url: https://rokki.ai
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Fast-forward production to main HEAD
+        run: |
+          git config user.name "rokki-deploy[bot]"
+          git config user.email "deploy@rokki.ai"
+          git fetch origin main:main
+          git push origin main:production
+          echo "Pushed main → production. Vercel will auto-build."
+
+  smoke-test-prod:
+    name: Smoke-test rokki.ai
+    runs-on: ubuntu-latest
+    needs: promote-vercel
+    environment:
+      name: production
+      url: https://rokki.ai
+    timeout-minutes: 10
+    steps:
+      - name: Wait for rokki.ai to respond healthy
+        run: |
+          for i in $(seq 1 60); do
+            status=$(curl -sS -o /dev/null -w "%{http_code}" https://rokki.ai/ || echo "000")
+            echo "attempt $i — HTTP $status"
+            if [ "$status" != "000" ] && [ "$status" -lt 500 ]; then
+              echo "✓ production responding"
+              exit 0
+            fi
+            sleep 10
+          done
+          echo "✗ production never came up healthy — manual rollback may be needed"
+          exit 1

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,62 @@
+name: Deploy staging
+
+# Plan A: every push to `main` is automatically deployed to
+# https://staging.rokki.ai.
+#
+# - Vercel auto-builds + deploys on the push (`main` is a non-production
+#   git branch on the project, aliased to `staging.rokki.ai`).
+# - This workflow runs the DB-migration side of the deploy: applying any
+#   new SQL in `supabase/migrations/` against the staging Supabase project.
+# - Production deploys are a separate manual workflow (`deploy-prod.yml`).
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-staging
+  cancel-in-progress: false
+
+jobs:
+  migrate-staging-db:
+    name: Apply migrations → staging Supabase
+    runs-on: ubuntu-latest
+    environment: staging
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: latest
+      - name: Push migrations to staging
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+        run: |
+          supabase link --project-ref ${{ vars.SUPABASE_STAGING_REF }} \
+            --password "${{ secrets.SUPABASE_STAGING_DB_PASSWORD }}"
+          supabase db push --include-all \
+            --password "${{ secrets.SUPABASE_STAGING_DB_PASSWORD }}"
+
+  smoke-test:
+    name: Smoke-test staging URL
+    runs-on: ubuntu-latest
+    needs: migrate-staging-db
+    timeout-minutes: 5
+    steps:
+      # Vercel's auto-deploy can take 60-120s to finalize after the push
+      # that triggered this workflow. We poll for the staging URL to
+      # respond with a non-5xx before declaring success.
+      - name: Wait for staging.rokki.ai to respond
+        run: |
+          for i in $(seq 1 30); do
+            status=$(curl -sS -o /dev/null -w "%{http_code}" https://staging.rokki.ai/ || echo "000")
+            echo "attempt $i — HTTP $status"
+            if [ "$status" != "000" ] && [ "$status" -lt 500 ]; then
+              echo "✓ staging responding"
+              exit 0
+            fi
+            sleep 10
+          done
+          echo "✗ staging never came up healthy"
+          exit 1

--- a/docs/09_ENVIRONMENTS.md
+++ b/docs/09_ENVIRONMENTS.md
@@ -7,10 +7,40 @@
 | Env | URL | Purpose | Data |
 |---|---|---|---|
 | local | `http://localhost:3000` | Developer machine | Local Postgres (via Supabase CLI) |
-| staging | `https://staging.rokki.ai` | Pre-production testing | Separate Supabase + Azure resources |
-| production | `https://rokki.ai` | Live users | Production Supabase + Azure |
+| staging | `https://staging.rokki.ai` | Pre-production testing | Supabase project `rokki-staging` (`hqsdhwlokfwcitfitees`) |
+| production | `https://rokki.ai` | Live users | Supabase project `rokki-production` (`bwtmtpcgilvrkhougjdo`) |
 
 Never share credentials between environments. Never point local/staging at production data.
+
+### 9.1.1 Vercel branch model (Plan A — staging-first promotion)
+
+The Vercel `rokki-web` project is configured so:
+
+- `main` branch → **staging deployment** at `staging.rokki.ai`. Every push to
+  `main` auto-deploys via Vercel + `.github/workflows/deploy-staging.yml`
+  applies any new SQL migrations to the staging Supabase project.
+- `production` branch → **production deployment** at `rokki.ai`. The branch
+  only moves forward when triggered by
+  `.github/workflows/deploy-prod.yml`, which is a manual `workflow_dispatch`
+  with required reviewer (the owner). The workflow:
+  1. Confirms the `confirm=yes` input.
+  2. Applies migrations to the production Supabase project.
+  3. Fast-forwards `production` to `main` HEAD, triggering Vercel's prod build.
+  4. Smoke-tests `https://rokki.ai`.
+- Every PR → standard Vercel preview URL, also pointing at the staging
+  Supabase (via the `preview` env-var scope) so previews never touch prod
+  data.
+
+### 9.1.2 Vercel env-var scopes
+
+| Var | `production` value | `preview` value |
+|---|---|---|
+| `NEXT_PUBLIC_SUPABASE_URL` | prod project URL | staging project URL |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | prod anon key | staging anon key |
+| `SUPABASE_SERVICE_ROLE_KEY` | prod service-role key | staging service-role key |
+| `NEXT_PUBLIC_APP_URL` | `https://rokki.ai` | `https://staging.rokki.ai` |
+| `NEXT_PUBLIC_API_URL` | `https://rokki.ai/api` | `https://staging.rokki.ai/api` |
+| Sentry, Axiom, Redis, etc. | same value across both targets | same value across both targets |
 
 ## 9.2 Repository layout
 


### PR DESCRIPTION
Plan A — staging-first promotion is now wired end-to-end.

## What changed in the infrastructure (already done, this PR just lands the code)

- **Supabase**: created `rokki-staging` project (`hqsdhwlokfwcitfitees`, us-east-2). All 53 migrations applied including the unmerged module-system PRs (#162-#166) — staging DB is ready for those PRs to merge.
- **Vercel `rokki-web`**:
  - Production git branch switched from `main` → `production`
  - `staging.rokki.ai` added as a domain, aliased to deployments from `main`
  - Supabase + APP_URL env vars split: `production` scope keeps prod values; `preview` scope (which is what `main` + every PR uses now) points at the new staging Supabase + `https://staging.rokki.ai`
- **GitHub Environments**: `staging` (no protection) and `Production` (required reviewer = you)
- **GitHub Secrets**: `SUPABASE_ACCESS_TOKEN`, `SUPABASE_STAGING_DB_PASSWORD`, `VERCEL_TOKEN`
- **GitHub Variables**: `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`, `SUPABASE_STAGING_REF`, `SUPABASE_PROD_REF`

## What this PR adds

- `.github/workflows/deploy-staging.yml` — on push to `main`: applies migrations to staging Supabase, polls `staging.rokki.ai` for healthy response
- `.github/workflows/deploy-prod.yml` — `workflow_dispatch` only, requires `confirm=yes` input + required-reviewer approval. Applies migrations to prod, fast-forwards `production` branch to `main` HEAD (Vercel auto-builds), smoke-tests `rokki.ai`
- `docs/09_ENVIRONMENTS.md` updated with the actual branch model + env-var scoping table

## One manual step you still need to do

Add this CNAME in Namecheap → Advanced DNS for `rokki.ai`:

| Type | Host | Value | TTL |
|---|---|---|---|
| CNAME | `staging` | `f90b5dba5c90e912.vercel-dns-017.com.` | Automatic |

(I can't touch Namecheap without an API token; one CNAME is faster manually anyway.)

## One thing that's still needed for the first prod deploy

`SUPABASE_PROD_DB_PASSWORD` is not in GitHub Secrets yet (I don't have it — it's the password you set when you created the `rokki-production` project). When you're ready to run `Deploy production` for the first time, add it via:

```
gh secret set SUPABASE_PROD_DB_PASSWORD
```

The workflow won't run without it.

## How to use it

**Promote `main` → production:**
1. GitHub → Actions → "Deploy production" → "Run workflow"
2. Type `yes` in the `confirm` input
3. Approve the deployment in the GitHub UI (you're the required reviewer)
4. Workflow applies prod migrations, fast-forwards `production` branch, Vercel auto-deploys, smoke-test confirms `rokki.ai` is healthy

**Roll back production:**
1. Vercel dashboard → Deployments → pick a prior production deployment → "Promote to Production"
2. If a migration was the issue, write a forward-fix migration and re-run deploy-prod