### PR TITLE
fix(login): SSR the CommandPalette provider so the nebula renders

### DIFF
--- a/apps/web/src/components/ChromeShell.tsx
+++ b/apps/web/src/components/ChromeShell.tsx
@@ -2,6 +2,7 @@
 
 import dynamic from "next/dynamic";
 import type { ReactNode } from "react";
+import { CommandPalette } from "./CommandPalette";
 
 /**
  * Client-side chrome wrapper used by the root layout.
@@ -21,16 +22,18 @@ import type { ReactNode } from "react";
  * (dashboard, terminal pages) hydrate the visible page first,
  * then the chrome streams in.
  *
- * Why `ssr: false` for all of them: they're either invisible
+ * Why `ssr: false` for the leaf components: they're either invisible
  * (keyboard handlers, service worker register, toast portal),
- * interaction-gated (command palette, shortcuts overlay, escape
- * probe), or banners we can accept a frame of absence for.
+ * interaction-gated (shortcuts overlay, escape probe), or banners
+ * we can accept a frame of absence for.
+ *
+ * CommandPalette is the exception — it's a context provider that
+ * wraps `{children}`, so it MUST SSR. Lazy-loading it with
+ * `ssr: false` would bail out the entire page (login, dashboard,
+ * everything) to client-side rendering, blanking the screen until
+ * the chunk loads. It's still code-split automatically because
+ * it's a Client Component.
  */
-const CommandPalette = dynamic(
-  () =>
-    import("./CommandPalette").then((m) => ({ default: m.CommandPalette })),
-  { ssr: false },
-);
 const GlobalShortcuts = dynamic(
   () =>
     import("./GlobalShortcuts").then((m) => ({ default: m.GlobalShortcuts })),


### PR DESCRIPTION
## What broke

The 4K nebula video on `/login` stopped rendering after the perf
work in #173. Visible symptom: black background instead of the
nebula. Confirmed on both production and sandbox.

## Root cause

In `ChromeShell.tsx`, `CommandPalette` was lazy-loaded with
`dynamic({ ssr: false })`. But CommandPalette is a **context
provider** that wraps `{children}` — so when the parent doesn't
SSR, neither do the children. The entire login page (including
`<LoginBackground />`) was being skipped during server rendering
and only appearing post-hydration.

Diagnostic: served HTML had 9 `BAILOUT_TO_CLIENT_SIDE_RENDERING`
templates and **zero** `<video>` / `space-nebula` references.

## Fix

Import `CommandPalette` normally so it server-renders. The other
9 chrome components stay `dynamic({ ssr: false })` because none
of them wrap children — they're leaf nodes (banners, toaster,
keyboard handlers).

CommandPalette is still code-split automatically because it's a
Client Component; we just don't skip its server rendering.

## Test plan

- [ ] After merge, visit https://sandbox.rokki.ai/login and
      confirm nebula video renders immediately on first paint
- [ ] View page source and confirm `<video>` + `space-nebula.mp4`
      appear in the HTML body (not just in JS chunks)
- [ ] Confirm ⌘K still opens the command palette on /dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)