### PR TITLE
fix: 4 production bugs (add members, delete refresh, calendar sync, task click)

### DIFF
--- a/.github/workflows/calendar-sync.yml
+++ b/.github/workflows/calendar-sync.yml
@@ -1,10 +1,15 @@
 name: Calendar sync tick
 
 # Vercel's Hobby tier only allows daily cron, so we drive the calendar
-# sync from GitHub Actions instead. Every 15 minutes, POST to the cron
+# sync from GitHub Actions instead. Every 5 minutes, POST to the cron
 # endpoint with the shared secret. The endpoint refreshes any expired
 # Microsoft/Google access tokens, fetches the next 14 days of events
 # for each connected calendar, and upserts them into calendar_events.
+#
+# 5 minutes is the minimum GitHub Actions cron allows, and is paired
+# with a server-side "sync on visit if stale" trigger in the calendar
+# page so an active user always sees fresh data. Background users
+# fall back to this tick for at-most-5-minute staleness.
 #
 # Secrets required:
 #   ROKKI_CRON_SECRET — must match the CRON_SECRET env var on Vercel.
@@ -12,7 +17,7 @@ name: Calendar sync tick
 # Manual run: Actions tab → "Calendar sync tick" → Run workflow.
 on:
   schedule:
-    - cron: "*/15 * * * *"
+    - cron: "*/5 * * * *"
   workflow_dispatch:
 
 # Limit to one in-flight run at a time. If a tick is slow we'd rather

--- a/apps/web/src/app/calendar/page.tsx
+++ b/apps/web/src/app/calendar/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from "next/navigation";
 import Link from "next/link";
 import { createClient } from "@/lib/supabase/server";
+import { runCalendarSyncForUser } from "@/lib/calendar-sync";
 import { TopBar } from "@/components/TopBar";
 import { CalendarClient } from "@/components/calendar/CalendarClient";
 import {
@@ -8,6 +9,15 @@ import {
   type CalendarSource,
   type CalendarView,
 } from "@/lib/calendar-queries";
+
+/** Refresh threshold for on-visit calendar sync. Connections whose
+ * last successful sync is older than this trigger a fresh fetch
+ * before the page renders, so a hard reload or fresh load always
+ * shows up-to-the-minute events without waiting for the 5-min cron.
+ * Set tight enough to feel instant on manual refresh, loose enough
+ * that a back-and-forth between tabs doesn't hit Google/Microsoft
+ * once per click. */
+const SYNC_FRESHNESS_MS = 30 * 1000;
 
 interface Props {
   searchParams: Promise<{
@@ -63,7 +73,7 @@ export default async function CalendarPage({ searchParams }: Props) {
   // email so the chip order is stable across loads.
   const { data: connectionRows } = await supabase
     .from("calendar_connections")
-    .select("id, provider, account_email")
+    .select("id, provider, account_email, last_sync_at")
     .eq("user_id", user.id)
     .is("revoked_at", null)
     .order("provider", { ascending: true })
@@ -73,8 +83,28 @@ export default async function CalendarPage({ searchParams }: Props) {
     id: string;
     provider: "google" | "microsoft";
     account_email: string;
+    last_sync_at: string | null;
   };
   const connections = (connectionRows ?? []) as ConnectionRow[];
+
+  // Pull fresh events on page load if any connection hasn't synced
+  // within SYNC_FRESHNESS_MS. This is the "instant sync" path —
+  // opening or refreshing the calendar always shows the latest
+  // events without waiting for the cron tick. We swallow errors
+  // because a Google/Microsoft outage shouldn't break the page.
+  const now = Date.now();
+  const staleConn = connections.some((c) => {
+    const last = c.last_sync_at ? new Date(c.last_sync_at).getTime() : 0;
+    return now - last > SYNC_FRESHNESS_MS;
+  });
+  if (staleConn) {
+    try {
+      await runCalendarSyncForUser(user.id);
+    } catch {
+      // Surface stale data rather than blocking the page on a sync
+      // hiccup; the cron tick will catch up on the next pass.
+    }
+  }
 
   // Sources: one per connection + a fixed "Rokki tasks" pseudo-row
   // so the user can hide due-date markers independently from synced

--- a/apps/web/src/app/p/[ticker]/settings/TerminalSettingsForm.tsx
+++ b/apps/web/src/app/p/[ticker]/settings/TerminalSettingsForm.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { Archive, UserMinus, Check, AlertTriangle } from "lucide-react";
+import { Archive, UserMinus, UserPlus, Check, AlertTriangle, Mail } from "lucide-react";
 import { Avatar } from "@/components/primitives";
 import { RichTextarea } from "@/components/ui/RichTextarea";
 import { cn } from "@/lib/utils";
@@ -92,7 +92,12 @@ export function TerminalSettingsForm({
         ticker={initial.ticker}
         archived={initial.archived}
         canManage={canManage}
-        onArchived={() => router.push("/")}
+        // Hard navigation — router.push() leaves the dashboard's RSC
+        // cache holding a stale terminal row that just got archived,
+        // so the user lands back on the dashboard and still sees the
+        // terminal they thought they killed. window.location.assign()
+        // refetches from the server with the freshest data.
+        onArchived={() => window.location.assign("/")}
       />
     </div>
   );
@@ -243,7 +248,61 @@ function MembersCard({
   myUserId: string;
   onChange: (next: TerminalMember[]) => void;
 }) {
+  const router = useRouter();
   const [error, setError] = useState<string | null>(null);
+  const [inviteEmail, setInviteEmail] = useState("");
+  const [inviteRole, setInviteRole] = useState<ProjectRole>("guest");
+  const [inviting, setInviting] = useState(false);
+  const [inviteStatus, setInviteStatus] = useState<string | null>(null);
+
+  /**
+   * Add a teammate by email. Same endpoint as the F7 Team pane —
+   * if the email already belongs to a Rokki user we add them
+   * directly; otherwise we create a pending invite and send a
+   * magic-link. On success we refresh the parent Server Component
+   * so the new row appears without a manual reload.
+   */
+  async function invite(e: React.FormEvent) {
+    e.preventDefault();
+    if (inviting) return;
+    const email = inviteEmail.trim().toLowerCase();
+    if (!email) return;
+    setInviting(true);
+    setError(null);
+    setInviteStatus(null);
+    try {
+      const r = await fetch(`/api/v1/projects/${ticker}/members`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({ email, role: inviteRole }),
+      });
+      const body = (await r.json().catch(() => ({}))) as {
+        data?: { added?: boolean; invited?: boolean };
+        errors?: { message: string }[];
+      };
+      if (!r.ok) {
+        setError(body.errors?.[0]?.message ?? `HTTP ${r.status}`);
+        return;
+      }
+      setInviteEmail("");
+      setInviteRole("guest");
+      setInviteStatus(
+        body.data?.added
+          ? `Added ${email} to the terminal.`
+          : `Invite sent to ${email}.`,
+      );
+      // Refresh the page so the new row lands in the list. The server
+      // re-renders the members table and the realtime channel mirrors
+      // it for any other tab the user has open.
+      router.refresh();
+      window.setTimeout(() => setInviteStatus(null), 2500);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Network error");
+    } finally {
+      setInviting(false);
+    }
+  }
 
   async function setRole(userId: string, role: ProjectRole) {
     setError(null);
@@ -346,10 +405,71 @@ function MembersCard({
           {error}
         </p>
       ) : null}
-      <div className="border-t border-border bg-bg-2 px-4 py-2 text-[11px] text-text-3">
-        To invite someone, go to the terminal&apos;s Team pane (F7) — this page
-        only edits existing members.
-      </div>
+      {canManage ? (
+        <form
+          onSubmit={(e) => void invite(e)}
+          className="flex flex-wrap items-end gap-2 border-t border-border bg-bg-2 px-4 py-3"
+        >
+          <label className="flex min-w-[200px] flex-1 flex-col gap-1">
+            <span className="text-[10px] uppercase tracking-wide text-text-3">
+              Add by email
+            </span>
+            <div className="flex items-center gap-2 rounded-sm border border-border bg-bg-0 px-2">
+              <Mail className="h-3.5 w-3.5 flex-shrink-0 text-text-3" aria-hidden="true" />
+              <input
+                type="email"
+                value={inviteEmail}
+                onChange={(e) => setInviteEmail(e.target.value)}
+                placeholder="teammate@example.com"
+                disabled={inviting}
+                aria-label="Email to invite"
+                className="flex-1 bg-transparent py-1.5 text-sm text-text-0 outline-none placeholder:text-text-3 disabled:opacity-50"
+              />
+            </div>
+          </label>
+          <label className="flex flex-col gap-1">
+            <span className="text-[10px] uppercase tracking-wide text-text-3">
+              Role
+            </span>
+            <select
+              value={inviteRole}
+              onChange={(e) => setInviteRole(e.target.value as ProjectRole)}
+              disabled={inviting}
+              aria-label="Role for new member"
+              className="rounded-sm border border-border bg-bg-0 px-2 py-1.5 font-mono text-xs uppercase text-text-0 outline-none focus:border-border-focus disabled:opacity-50"
+            >
+              {ROLES.map((r) => (
+                <option key={r} value={r}>
+                  {r}
+                </option>
+              ))}
+            </select>
+          </label>
+          <button
+            type="submit"
+            disabled={inviting || !inviteEmail.trim()}
+            className={cn(
+              "inline-flex items-center gap-1.5 rounded-sm bg-accent px-3 py-1.5 text-xs font-semibold uppercase tracking-wide text-bg-0",
+              (inviting || !inviteEmail.trim()) &&
+                "cursor-not-allowed opacity-50",
+            )}
+          >
+            <UserPlus className="h-3 w-3" />
+            {inviting ? "Adding…" : "Add"}
+          </button>
+          {inviteStatus ? (
+            <p className="w-full text-xs text-success">{inviteStatus}</p>
+          ) : null}
+          <p className="w-full text-[10px] text-text-3">
+            Existing Rokki users are added immediately. New emails get a
+            magic-link invite that auto-accepts on click.
+          </p>
+        </form>
+      ) : (
+        <div className="border-t border-border bg-bg-2 px-4 py-2 text-[11px] text-text-3">
+          Only owners and managers can invite teammates.
+        </div>
+      )}
     </Card>
   );
 }

--- a/apps/web/src/components/TasksPane.tsx
+++ b/apps/web/src/components/TasksPane.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import dynamic from "next/dynamic";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import {
   ChevronDown,
   ChevronRight,
@@ -1006,6 +1007,7 @@ function TaskRow({
         <InlineTitleEditor
           title={task.title}
           done={done}
+          href={`/p/${ticker}/task/${task.ticker_seq}`}
           onCommit={onRename}
         />
         {status ? (
@@ -1103,10 +1105,15 @@ function recurrenceShortLabel(rule: TaskRecurrenceRule): string {
 }
 
 /**
- * Inline title editor for a task row. Renders as a plain `<span>` in
- * its default state — double-click (or hit Enter when the row is
- * selected) flips to a focused `<input>`. Enter commits, Escape
- * cancels, blur commits the current value.
+ * Inline title editor for a task row. Renders as a clickable title in
+ * its default state — single click navigates to the task detail page,
+ * double-click flips to a focused `<input>` for rename. Enter commits,
+ * Escape cancels, blur commits the current value.
+ *
+ * Single vs. double click is disambiguated with a short timer: the
+ * navigate fires ~220ms after click unless a dblclick lands first and
+ * cancels it. Matches the gesture used by Finder/Notes for "click =
+ * open, double-click = rename".
  *
  * Commit semantics:
  *   - Trim → compare to original. If unchanged: silent revert.
@@ -1122,15 +1129,28 @@ function recurrenceShortLabel(rule: TaskRecurrenceRule): string {
 function InlineTitleEditor({
   title,
   done,
+  href,
   onCommit,
 }: {
   title: string;
   done: boolean;
+  /**
+   * Destination for a single-click on the title (the task detail page).
+   * The row's own click handler still selects the row; navigation runs
+   * on its own short timer so a dblclick can cancel it and enter
+   * rename mode instead.
+   */
+  href: string;
   onCommit: (next: string) => void;
 }) {
+  const router = useRouter();
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(title);
   const inputRef = useRef<HTMLInputElement | null>(null);
+  // Holds the pending navigation timer started by a single click. A
+  // subsequent dblclick clears it so we don't navigate-and-rename in
+  // the same gesture.
+  const clickTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Reset the draft whenever the upstream title changes — handles the
   // case where another collaborator renames the row while we're not
@@ -1147,6 +1167,14 @@ function InlineTitleEditor({
       inputRef.current?.select();
     }
   }, [editing]);
+
+  // Cancel any pending nav timer on unmount so a row that scrolls off
+  // mid-gesture doesn't try to navigate later.
+  useEffect(() => {
+    return () => {
+      if (clickTimerRef.current) clearTimeout(clickTimerRef.current);
+    };
+  }, []);
 
   function commit() {
     const next = draft.trim();
@@ -1168,12 +1196,31 @@ function InlineTitleEditor({
     return (
       <span
         className={cn(
-          "truncate text-sm",
+          "cursor-pointer truncate text-sm hover:underline",
           done ? "text-text-3 line-through" : "text-text-0",
         )}
-        title="Double-click to rename"
+        role="link"
+        title="Click to open · double-click to rename"
+        onClick={(e) => {
+          // Don't bubble — the row's own onClick should still fire to
+          // select the row, but we want full control over the timer.
+          // `setSelectedIdx` lives on the outer row click; calling it
+          // here too is redundant but harmless. We stopPropagation to
+          // avoid double-selection animations.
+          e.stopPropagation();
+          if (clickTimerRef.current) clearTimeout(clickTimerRef.current);
+          clickTimerRef.current = setTimeout(() => {
+            clickTimerRef.current = null;
+            router.push(href);
+          }, 220);
+        }}
         onDoubleClick={(e) => {
           e.stopPropagation();
+          // Cancel the pending navigate from the preceding single click.
+          if (clickTimerRef.current) {
+            clearTimeout(clickTimerRef.current);
+            clickTimerRef.current = null;
+          }
           setEditing(true);
         }}
       >

--- a/apps/web/src/components/TeamPane.tsx
+++ b/apps/web/src/components/TeamPane.tsx
@@ -85,9 +85,14 @@ export function TeamPane({ ticker, projectId, canInvite }: TeamPaneProps) {
       void load();
     }, 250);
   }, [load]);
+  // Table was renamed from `project_members` → `terminal_members` in
+  // migration 20260423010000 — the old name doesn't exist anymore and
+  // the realtime channel silently never fired, so adds/removes from
+  // other tabs (or from the F7 invite flow) didn't appear here until
+  // a manual reload.
   useRealtimeTable<Record<string, unknown>>(
     {
-      table: "project_members",
+      table: "terminal_members",
       filter: `terminal_id=eq.${projectId}`,
       channelKey: `members:${projectId}`,
     },


### PR DESCRIPTION
Reported by Zack. Four independent fixes, single PR because they ship together.

## 1. Can't add team members to a terminal
- Terminal Settings → Members card had no invite UI, just a pointer to F7.
  Added an inline email + role form that POSTs to the existing
  \`/api/v1/projects/:ticker/members\` endpoint (same flow as the Team pane).
- \`TeamPane\` realtime channel was still subscribed to the old
  \`project_members\` table, which was renamed to \`terminal_members\` in
  migration \`20260423010000\` — adds/removes never streamed in until manual
  reload. Updated the subscription to the current table name.

## 2. Deleting a space or terminal doesn't remove it from the UI
- Terminal archive used \`router.push(\"/\")\`, which keeps the dashboard's
  RSC cache holding the just-archived terminal row.
- Switched to \`window.location.assign(\"/\")\` for a hard reload so the
  terminal is genuinely gone from every list. Space delete already used
  this approach; now both flows match.

## 3. Calendar sync needs to be instant
- \`calendar/page.tsx\` now runs \`runCalendarSyncForUser\` before loading
  items if any connection's \`last_sync_at\` is older than 30s. A refresh
  always shows fresh events without waiting for the background tick.
- Bumped GH Actions cron from \`*/15\` to \`*/5\` (the GH minimum) so
  background users see at-most-5-minute staleness instead of 15.

## 4. Clicking a task title doesn't open the detail
- \`InlineTitleEditor\` now navigates to \`/p/:ticker/task/:seq\` on single
  click and enters rename mode on double-click. A 220ms timer
  disambiguates — dblclick cancels the pending navigation. Matches the
  Finder/Notes gesture.

## Test plan
- [ ] Settings → Members card on a terminal: enter teammate's email,
      pick a role, click Add → row appears (or invite-sent toast)
- [ ] Archive a terminal from Settings → land on dashboard, terminal
      is gone from Explorer Rail and lists
- [ ] Connect a Google/Microsoft calendar → wait 30s → reload
      \`/calendar\` and confirm events appear without manually hitting
      Sync now
- [ ] In Tasks pane: single-click a task title → opens detail page;
      double-click → enters inline rename

🤖 Generated with [Claude Code](https://claude.com/claude-code)