### PR TITLE
fix(tasks): optimistic insert so new tasks appear instantly on Enter

### DIFF
--- a/apps/web/src/app/api/v1/projects/[ticker]/tasks/route.ts
+++ b/apps/web/src/app/api/v1/projects/[ticker]/tasks/route.ts
@@ -226,8 +226,14 @@ async function handlePost(request: NextRequest, { params }: Props) {
       external_assignee_emails: externalEmails,
       created_by: user.id,
     })
+    // Return the same column set the GET list endpoint returns so the
+    // client can drop the new row straight into local state without
+    // faking fields. The optimistic-insert path in TasksPane depends
+    // on this — any field missing here ends up as `undefined` on the
+    // freshly-created row and visibly differs from neighbouring rows
+    // until the next refetch lands.
     .select(
-      "id, ticker_seq, title, description, status, priority, due_date, labels, created_at",
+      "id, ticker_seq, title, description, status, priority, due_date, labels, position, latest_status_text, latest_status_author_id, latest_status_at, status_thread_id, external_assignee_emails, recurrence_rule, created_at, updated_at, completed_at",
     )
     .single();
 
@@ -292,7 +298,37 @@ async function handlePost(request: NextRequest, { params }: Props) {
     },
   });
 
-  return NextResponse.json({ data }, { status: 201 });
+  // Build the response in the same shape the list endpoint returns so
+  // the client can drop it straight into state. For a brand-new task
+  // the assignee list is known (we just inserted it) and the subtask
+  // aggregates are zero — no need for an extra round-trip.
+  const assigneeProfiles = toAssign.length
+    ? ((
+        await supabase
+          .from("profiles")
+          .select("user_id, full_name")
+          .in("user_id", toAssign)
+      ).data ?? [])
+    : [];
+  const profileById = new Map(
+    (assigneeProfiles as { user_id: string; full_name: string | null }[]).map(
+      (p) => [p.user_id, p.full_name],
+    ),
+  );
+  const responseTask = {
+    ...(data as Record<string, unknown>),
+    assignees: toAssign.map((uid) => ({
+      user_id: uid,
+      full_name: profileById.get(uid) ?? null,
+    })),
+    subtask_total: 0,
+    subtask_done: 0,
+    external_assignee_emails:
+      (data as { external_assignee_emails?: string[] | null })
+        .external_assignee_emails ?? externalEmails,
+  };
+
+  return NextResponse.json({ data: responseTask }, { status: 201 });
 }
 
 async function resolveProject(

--- a/apps/web/src/components/TasksPane.tsx
+++ b/apps/web/src/components/TasksPane.tsx
@@ -595,9 +595,22 @@ export function TasksPane({ ticker, projectId, currentUserId }: TasksPaneProps) 
   /**
    * POST a fully-formed task (title + chips) to the project's tasks
    * endpoint. The TaskComposer hands us the structured payload; we
-   * just translate it into the API's body shape and reload on
-   * success. Throws on failure so the composer can surface the error
-   * inline.
+   * translate it into the API's body shape, optimistically insert
+   * the returned row into local state, and let realtime reconcile.
+   *
+   * Why optimistic + no follow-up `load()`:
+   *   - Before this, the flow was POST → await load(). A slow refetch,
+   *     a transient realtime hiccup, or a brief replication lag could
+   *     each cause the freshly-created task to not appear until the
+   *     user manually refreshed.
+   *   - The POST response now returns the same shape as the GET list
+   *     (matching column set + assignees + subtask aggregates), so
+   *     dropping it straight into state gives the user instant feedback.
+   *   - The realtime channel still fires onInsert and deduplicates by
+   *     id (see `onInsert` above), so a slow round-trip + a fast
+   *     realtime push doesn't double-insert.
+   *
+   * Throws on failure so the composer can surface the error inline.
    */
   async function createTask(input: TaskComposerSubmit) {
     const r = await offlineFetch(`/api/v1/projects/${ticker}/tasks`, {
@@ -627,7 +640,31 @@ export function TasksPane({ ticker, projectId, currentUserId }: TasksPaneProps) 
       );
     }
     setCreating(false);
-    if (r.status !== 202) await load();
+    if (r.status === 202) {
+      // Offline-queued — there's no real row yet. Background drain
+      // will fire the realtime push when connectivity returns.
+      return;
+    }
+    // Parse the server's freshly-inserted row and slot it into state
+    // immediately. dedupe in case the realtime channel raced us.
+    try {
+      const body = (await r.json()) as { data?: Task };
+      const created = body.data;
+      if (created && created.id) {
+        setTasks((prev) =>
+          prev.some((t) => t.id === created.id)
+            ? prev
+            : sortTasks([created, ...prev], sortMode),
+        );
+      } else {
+        // Fall back to a refetch if the server didn't return what we
+        // expected — shouldn't happen on the current API but guards
+        // against a future shape regression silently breaking creates.
+        await load();
+      }
+    } catch {
+      await load();
+    }
   }
 
   function cancelCreate() {


### PR DESCRIPTION
Reported by Zack: sometimes hitting Enter on a new task doesn't make
it show up — have to refresh the page.

## Root cause

The create flow was POST → \`await load()\` (full refetch). If the
realtime channel hiccuped, the GET hit a brief replication lag, or
the connection was slow, the task wouldn't appear until the next
interaction triggered another fetch.

## Fix

Optimistic insert from the POST response.

1. **Server**: \`POST /api/v1/projects/:ticker/tasks\` now returns the
   same column set as the GET list endpoint (was missing \`position\`,
   \`latest_status_*\`, \`completed_at\`, \`recurrence_rule\`,
   \`updated_at\`), plus assignees and subtask aggregates (always 0/0
   for a fresh row). This lets the client drop the row straight into
   state without faking fields.

2. **Client**: \`createTask()\` parses the POST response and inserts
   the new task into local state immediately. The realtime
   \`onInsert\` handler already dedupes by id, so a slow round-trip +
   a fast realtime push won't double-insert.

3. Removed the \`await load()\` after POST — it was the source of the
   perceived delay. Fallback path uses \`load()\` if the response
   shape ever regresses.

Result: hit Enter, task appears in the same frame.

## Test plan
- [ ] In a terminal's Tasks pane, hit C, type a title, press Enter →
      task appears immediately (no flash, no missing row)
- [ ] Repeat 10× in quick succession → all rows show up; no dupes
- [ ] Open the same terminal in two tabs → create in tab A, watch
      tab B receive the row via realtime within ~100ms

🤖 Generated with [Claude Code](https://claude.com/claude-code)