### PR TITLE
fix(tasks): cancel in-flight fetch on Auto/Manual toggle (stale-fetch race)

### DIFF
--- a/apps/web/src/components/TasksPane.tsx
+++ b/apps/web/src/components/TasksPane.tsx
@@ -240,7 +240,20 @@ export function TasksPane({ ticker, projectId, currentUserId }: TasksPaneProps) 
     });
   }
 
+  // Cancel any in-flight `load()` when a new one starts. Without this,
+  // toggling Auto ↔ Manual rapidly leaves two requests racing — the
+  // slower one's response would overwrite the faster (newer) one,
+  // dropping tasks that arrived via realtime in between and sometimes
+  // landing the wrong sort. The aborted fetch throws an AbortError
+  // which the catch block silently swallows.
+  const loadAbortRef = useRef<AbortController | null>(null);
   const load = useCallback(async () => {
+    // Abort any prior in-flight fetch before starting a new one so its
+    // response can't race past us and clobber state.
+    loadAbortRef.current?.abort();
+    const controller = new AbortController();
+    loadAbortRef.current = controller;
+
     setLoading(true);
     try {
       const url = new URL(
@@ -259,11 +272,17 @@ export function TasksPane({ ticker, projectId, currentUserId }: TasksPaneProps) 
       const r = await fetch(url.toString(), {
         credentials: "include",
         cache: "no-store",
+        signal: controller.signal,
       });
+      // Bail if this fetch is no longer the latest one — the response
+      // body is already in flight when abort() fires, so the AbortError
+      // may or may not throw before we get here. Belt-and-suspenders.
+      if (controller.signal.aborted) return;
       const body = (await r.json()) as {
         data?: Task[];
         errors?: { message: string }[];
       };
+      if (controller.signal.aborted) return;
       if (!r.ok) {
         setError(body.errors?.[0]?.message ?? "Failed to load tasks");
         return;
@@ -271,11 +290,29 @@ export function TasksPane({ ticker, projectId, currentUserId }: TasksPaneProps) 
       setTasks(body.data ?? []);
       setError(null);
     } catch (e) {
+      // Aborted by a newer load() — silent.
+      if (e instanceof DOMException && e.name === "AbortError") return;
+      // Some browsers wrap network/abort errors in TypeError before
+      // throwing — same intent, swallow.
+      if (controller.signal.aborted) return;
       setError(e instanceof Error ? e.message : "Network error");
     } finally {
-      setLoading(false);
+      // Only the latest controller's request flips loading back off.
+      // An older aborted request leaving loading=false here would race
+      // a newer request that just set loading=true.
+      if (loadAbortRef.current === controller) {
+        setLoading(false);
+      }
     }
   }, [ticker, sortMode]);
+
+  // Abort whatever's in flight when the component unmounts so we don't
+  // try to setState on a dead component (and don't leak request handles).
+  useEffect(() => {
+    return () => {
+      loadAbortRef.current?.abort();
+    };
+  }, []);
 
   useEffect(() => {
     void load();


### PR DESCRIPTION
Reported by Zack: toggling between Auto and Manual sort doesn't load
all tasks. Have to toggle back and forth a few times before everything
appears.

## Root cause

\`load()\` in TasksPane has no abort guard. Each \`sortMode\` change
creates a new \`load()\` via \`useEffect\` → \`useCallback\` dependency, but
the previous load's fetch keeps running. Whichever response lands LAST
writes to state.

  1. Click Manual → load #1 fires (\`?sort=position\`)
  2. Click Auto   → load #2 fires (no sort param)
  3. load #1 returns AFTER load #2
  4. \`setTasks(position-sorted list)\` overwrites the auto-sorted state
  5. UI shows position order even though the toggle reads Auto; any
     task that arrived via realtime between #1 and #2 is gone

## Fix

\`AbortController\` per \`load()\` call. New load aborts the prior one;
the aborted fetch throws an \`AbortError\` that's silently swallowed.
Belt-and-suspenders \`signal.aborted\` checks bail before any setState.
The \`loading\` flag is only flipped off by the latest controller so an
older aborted request can't reset it underneath a newer one.

Also cleans up the in-flight request on unmount.

## Test plan
- [ ] Open a terminal with 20+ tasks. Toggle Auto → Manual → Auto →
      Manual rapidly. Every settle should show the full list in the
      expected order.
- [ ] Slow the network in DevTools. Toggle once. List should populate
      eventually without flicker; toggling mid-load should not leave
      ghost rows.
- [ ] Navigate away mid-load. No console warnings about setState on
      unmounted component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)