### PR TITLE
ui: remove ticker chips from explorer + cards, tighten explorer indent

### DIFF
--- a/apps/web/src/components/calendar/CalendarClient.tsx
+++ b/apps/web/src/components/calendar/CalendarClient.tsx
@@ -957,9 +957,9 @@ function DetailMeta({ item }: { item: CalendarItem }) {
           <span className="ml-2">
             <Link
               href={`/p/${item.terminal_ticker}`}
-              className="font-mono text-accent hover:underline"
+              className="text-accent hover:underline"
             >
-              {item.terminal_ticker}
+              Open terminal
             </Link>
           </span>
         </p>

--- a/apps/web/src/components/dashboard/ExplorerRail.tsx
+++ b/apps/web/src/components/dashboard/ExplorerRail.tsx
@@ -253,9 +253,6 @@ export function ExplorerRail({
                       className="flex items-center gap-2 rounded-sm px-2 py-0.5 text-text-1 hover:bg-bg-2 hover:text-text-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-focus"
                     >
                       <Clock className="h-3 w-3 flex-shrink-0 text-text-3" />
-                      <span className="w-12 flex-shrink-0 truncate font-mono text-[10px] text-text-3">
-                        {r.ticker}
-                      </span>
                       <span className="flex-1 truncate text-xs">{r.name}</span>
                     </Link>
                   </li>
@@ -335,12 +332,18 @@ export function ExplorerRail({
                           <li key={t.id}>
                             <Link
                               href={`/p/${t.ticker}`}
-                              className="flex items-center gap-2 rounded-sm py-0.5 pl-7 pr-2 text-text-1 hover:bg-bg-2 hover:text-text-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-focus"
+                              // pl-5 gives terminals a clear "child of"
+                              // indent under the space row's chevron
+                              // (chevron sits at px-1 + 14px = ~18px;
+                              // pl-5 = 20px lands the name just past
+                              // it). The old pl-7 was sized to align
+                              // with a 48px ticker column that we just
+                              // removed — keeping the same indent
+                              // would leave terminals visually orphaned
+                              // far from their parent.
+                              className="flex items-center gap-2 rounded-sm py-0.5 pl-5 pr-2 text-text-1 hover:bg-bg-2 hover:text-text-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-focus"
                               title={t.name}
                             >
-                              <span className="w-12 flex-shrink-0 truncate font-mono text-[10px] text-text-3">
-                                {t.ticker}
-                              </span>
                               <span className="flex-1 truncate text-xs">
                                 {t.name}
                               </span>

--- a/apps/web/src/components/dashboard/TasksCard.tsx
+++ b/apps/web/src/components/dashboard/TasksCard.tsx
@@ -14,11 +14,7 @@ import {
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { DashboardCard } from "./DashboardCard";
-import {
-  PriorityDots,
-  DueChip,
-  TickerChip,
-} from "@/components/primitives";
+import { PriorityDots, DueChip } from "@/components/primitives";
 import { useRealtimeTable } from "@/lib/supabase/realtime";
 import { bucketDashTasks } from "@/lib/task-grouping";
 import type { AssignedTask, DelegatedTask } from "@/lib/dashboard-queries";
@@ -432,7 +428,6 @@ function AssignedRow({
   // inside the same `<li>`.
   const linkContent = (
     <>
-      {ticker ? <TickerChip>{ticker}</TickerChip> : null}
       <span
         className={cn(
           "flex-1 truncate",
@@ -507,7 +502,6 @@ function DelegatedRow({
       className="flex items-center gap-2 px-3 py-1 text-xs hover:bg-bg-2"
     >
       <ArrowRight className="h-3 w-3 flex-shrink-0 text-text-3" />
-      {ticker ? <TickerChip>{ticker}</TickerChip> : null}
       <span className="flex-1 truncate text-text-0">{task.title}</span>
       <span
         className="hidden truncate text-text-2 md:inline max-w-[14ch]"

--- a/apps/web/src/components/dashboard/WeekCard.tsx
+++ b/apps/web/src/components/dashboard/WeekCard.tsx
@@ -348,11 +348,6 @@ function WeekRow({ item }: { item: WeekItem }) {
         />
       )}
       <span className="flex-1 truncate text-text-0">{item.title}</span>
-      {item.terminal_ticker ? (
-        <span className="font-mono text-[10px] text-text-3">
-          {item.terminal_ticker}
-        </span>
-      ) : null}
     </div>
   );
   return href ? (

--- a/apps/web/src/components/space/SpaceTasksCard.tsx
+++ b/apps/web/src/components/space/SpaceTasksCard.tsx
@@ -5,11 +5,7 @@ import { useState } from "react";
 import { Check, AlertOctagon, Clock, User as UserIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { DashboardCard, CardSection } from "@/components/dashboard/DashboardCard";
-import {
-  PriorityDots,
-  TickerChip,
-  DueChip,
-} from "@/components/primitives";
+import { PriorityDots, DueChip } from "@/components/primitives";
 import type { SpaceTaskRow } from "@/lib/space-queries";
 
 interface SpaceTasksCardProps {
@@ -201,7 +197,6 @@ function TaskRow({ task }: { task: SpaceTaskRow }) {
 
   const linkContent = (
     <>
-      {task.ticker ? <TickerChip>{task.ticker}</TickerChip> : null}
       <span
         className={cn(
           "flex-1 truncate",


### PR DESCRIPTION
Zack's feedback: tickers everywhere are noisy, and the Explorer Rail's
horizontal gap between a space row and its terminals looks way too big.

Both come down to the same root cause: a fixed 48px (\`w-12\`) monospace
column rendering the ticker before each terminal/task name. With names
present and meaningful, the ticker chip was decorative redundancy AND
the column pushed terminal names ~60px to the right of their parent
space, breaking the visual hierarchy.

## Removed
- \`ExplorerRail\`: ticker column in Recent + tree-of-terminals
- Dashboard \`TasksCard\`: \`TickerChip\` on assigned and delegated rows
- \`SpaceTasksCard\`: \`TickerChip\`
- Dashboard \`WeekCard\`: trailing ticker on event/due rows
- Calendar drawer: \"Terminal: BRKL\" → \"Open terminal\"

## Spacing
Terminal rows in the explorer now indent with \`pl-5\` (20px) instead of
\`pl-7\` (28px). \`pl-7\` was sized to make the old ticker column align
under the chevron; without the ticker, \`pl-5\` lands the terminal name
just past the space chevron for a clean child-of feel.

## Kept (functional, not decorative)
- URLs: \`/p/:ticker\`, \`/p/:ticker/task/:seq\`
- generateMetadata \`<title>\` (browser tab)
- Command palette \"Terminal settings\" subtitle (search context)
- Task IDs (\"TICKER-N\") in task-detail breadcrumbs

If you also want those gone, say the word and I'll do a second pass —
the URL ones I'd want to keep but the breadcrumbs are negotiable.

## Test plan
- [ ] Explorer rail: space row → terminal rows look tightly nested,
      no big horizontal jump, no BRKL chips
- [ ] Dashboard cards: task rows show name + assignee + priority,
      no BRKL chip before titles
- [ ] Week card events: just title + when, no trailing ticker
- [ ] Calendar event drawer: shows \"Open terminal\" link instead of
      a raw ticker chip
- [ ] All terminal links still navigate correctly (URL unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)