### PR TITLE
fix(tasks-card): wire the 'X more' footer; show all tasks when expanded

### DIFF
--- a/apps/web/src/app/tasks/delegated/page.tsx
+++ b/apps/web/src/app/tasks/delegated/page.tsx
@@ -42,6 +42,7 @@ export default async function DelegatedTasksPage() {
             delegated={delegated}
             tickerById={tickerById}
             terminalNameById={terminalNameById}
+            expanded
           />
         </div>
       </main>

--- a/apps/web/src/app/tasks/mine/page.tsx
+++ b/apps/web/src/app/tasks/mine/page.tsx
@@ -42,6 +42,7 @@ export default async function MyTasksPage() {
             delegated={delegated}
             tickerById={tickerById}
             terminalNameById={terminalNameById}
+            expanded
           />
         </div>
       </main>

--- a/apps/web/src/components/dashboard/TasksCard.tsx
+++ b/apps/web/src/components/dashboard/TasksCard.tsx
@@ -39,6 +39,14 @@ interface TasksCardProps {
   createHref?: string | null;
   /** Disable the create button (e.g. user has zero terminals). */
   createDisabled?: boolean;
+  /**
+   * When true, render every visible task (no ROW_LIMIT truncation,
+   * no "X more" footer). The card body scrolls inside whatever
+   * height the parent gives it — meant for full-page views like
+   * `/tasks/mine` and `/tasks/delegated`. Default false, so the
+   * dashboard card keeps its bounded "first 10" + footer behaviour.
+   */
+  expanded?: boolean;
 }
 
 /**
@@ -61,10 +69,13 @@ export function TasksCard({
   terminalNameById,
   createHref = "/?new=task",
   createDisabled,
+  expanded = false,
 }: TasksCardProps) {
-  // Show ~10 rows per the spec; users with more get a "see all" link to a
-  // dedicated full-list page.
-  const ROW_LIMIT = 10;
+  // Dashboard caps at 10 to keep the card bounded; full-page views
+  // (/tasks/mine, /tasks/delegated) pass `expanded` and we lift the
+  // cap so the user sees everything, scrolling within the parent's
+  // height instead of clicking through a fake "open the full list".
+  const ROW_LIMIT = expanded ? Number.POSITIVE_INFINITY : 10;
 
   const router = useRouter();
   useRealtimeTable<{ id: string }>(
@@ -303,10 +314,18 @@ export function TasksCard({
           );
         })()
       )}
-      {visibleAssigned.length > ROW_LIMIT ? (
-        <p className="px-3 py-1 text-center text-[10px] text-text-3">
+      {!expanded && visibleAssigned.length > ROW_LIMIT ? (
+        // Dashboard footer: real Link to the full-page view for the
+        // active tab. The old <p> was decorative-only ("13 more —
+        // open the full list" but no href), which read as broken.
+        // overdue/week/all all live inside "Mine" so they route there;
+        // "delegated" has its own page.
+        <Link
+          href={tab === "delegated" ? "/tasks/delegated" : "/tasks/mine"}
+          className="block px-3 py-1 text-center text-[10px] text-text-3 hover:bg-bg-2 hover:text-text-1"
+        >
           {visibleAssigned.length - ROW_LIMIT} more — open the full list
-        </p>
+        </Link>
       ) : null}
     </DashboardCard>
   );


### PR DESCRIPTION
Two Zack-reported issues in one PR.

## 1. \"13 more — open the full list\" did nothing on click
It was rendered as a plain \`<p>\`, not a Link — pure text dressed up to
look interactive. Now it's an actual \`<Link>\` that routes to
\`/tasks/mine\` (or \`/tasks/delegated\` when the Delegated tab is active),
the destinations that already render the full list as a full-page
\`TasksCard\`.

## 2. The expanded views shouldn't show the footer at all
\`/tasks/mine\` and \`/tasks/delegated\` ARE the full list, so a \"X more —
open the full list\" footer there is nonsense. Added an
\`expanded?: boolean\` prop to \`TasksCard\`. When true:
  - \`ROW_LIMIT\` becomes Infinity → every visible task renders
  - The footer doesn't render

The body already lives inside \`DashboardCard\`'s
\`min-h-0 flex-1 overflow-y-auto\`, and both pages wrap the card in
\`<div className=\"h-[80vh]\">\`, so excess rows scroll within the card
without any new wiring.

Dashboard stays bounded at 10 rows with the now-working footer link.

## Test plan
- [ ] Dashboard with >10 assigned tasks: footer reads \"X more — open
      the full list\" and clicking navigates to /tasks/mine
- [ ] Dashboard with Delegated tab + >10 delegated: same, routes to
      /tasks/delegated
- [ ] /tasks/mine: all tasks render, no footer, list scrolls within
      the card if it overflows
- [ ] /tasks/delegated: same

🤖 Generated with [Claude Code](https://claude.com/claude-code)