### PR TITLE
feat(terminals): URL by slug, not ticker abbreviation

### DIFF
--- a/apps/web/src/app/api/v1/admin/terminals/[ticker]/archive/route.ts
+++ b/apps/web/src/app/api/v1/admin/terminals/[ticker]/archive/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { requireAdmin } from "@/lib/admin-auth";
 import { emitEvent } from "@/lib/events";
+import { resolveTerminalBySegment } from "@/lib/resolve-terminal";
 
 import { withObservability } from "@/lib/observability";
 interface Props {
@@ -20,22 +21,13 @@ async function handlePost(request: NextRequest, { params }: Props) {
   if ("status" in gate) return gate;
   const { admin, userId: actorId } = gate;
 
-  const { data: terminal } = await admin
-    .from("terminals")
-    .select("id, ticker, name, space_id")
-    .eq("ticker", ticker.toUpperCase())
-    .maybeSingle();
-  if (!terminal)
+  const resolved = await resolveTerminalBySegment(admin, ticker);
+  if (!resolved)
     return NextResponse.json(
       { errors: [{ code: "not_found", message: "Terminal not found" }] },
       { status: 404 },
     );
-  const t = terminal as {
-    id: string;
-    ticker: string;
-    name: string;
-    space_id: string;
-  };
+  const t = resolved;
 
   const { error } = await admin
     .from("terminals")
@@ -68,21 +60,23 @@ async function handleDelete(request: NextRequest, { params }: Props) {
   if ("status" in gate) return gate;
   const { admin, userId: actorId } = gate;
 
-  const { data: terminal } = await admin
-    .from("terminals")
-    .select("id, ticker, space_id, status")
-    .eq("ticker", ticker.toUpperCase())
-    .maybeSingle();
-  if (!terminal)
+  const resolved = await resolveTerminalBySegment(admin, ticker);
+  if (!resolved)
     return NextResponse.json(
       { errors: [{ code: "not_found", message: "Terminal not found" }] },
       { status: 404 },
     );
-  const t = terminal as {
-    id: string;
-    ticker: string;
-    space_id: string;
-    status: string;
+  // Fetch the status separately — the shared resolver returns the
+  // common columns but not status, which the restore flow needs.
+  const { data: statusRow } = await admin
+    .from("terminals")
+    .select("status")
+    .eq("id", resolved.id)
+    .maybeSingle();
+  const t = {
+    ...resolved,
+    status:
+      ((statusRow as { status?: string } | null)?.status as string) ?? "active",
   };
 
   const nextStatus = t.status === "archived" ? "active" : t.status;

--- a/apps/web/src/app/api/v1/admin/terminals/[ticker]/transfer-owner/route.ts
+++ b/apps/web/src/app/api/v1/admin/terminals/[ticker]/transfer-owner/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { requireAdmin } from "@/lib/admin-auth";
 import { emitEvent } from "@/lib/events";
+import { resolveTerminalBySegment } from "@/lib/resolve-terminal";
 
 import { withObservability } from "@/lib/observability";
 interface Props {
@@ -28,17 +29,13 @@ async function handlePost(request: NextRequest, { params }: Props) {
   if (!newOwner)
     return bad("new_owner_user_id required");
 
-  const { data: terminal } = await admin
-    .from("terminals")
-    .select("id, ticker, space_id")
-    .eq("ticker", ticker.toUpperCase())
-    .maybeSingle();
-  if (!terminal)
+  const resolved = await resolveTerminalBySegment(admin, ticker);
+  if (!resolved)
     return NextResponse.json(
       { errors: [{ code: "not_found", message: "Terminal not found" }] },
       { status: 404 },
     );
-  const t = terminal as { id: string; ticker: string; space_id: string };
+  const t = resolved;
 
   const { data: existing } = await admin
     .from("terminal_members")

--- a/apps/web/src/app/api/v1/projects/[ticker]/budget/route.ts
+++ b/apps/web/src/app/api/v1/projects/[ticker]/budget/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { createClient } from "@/lib/supabase/server";
+import { resolveTerminalBySegment } from "@/lib/resolve-terminal";
 
 import { withObservability } from "@/lib/observability";
 interface Props {
@@ -78,13 +79,7 @@ async function resolveTerminal(
   supabase: Awaited<ReturnType<typeof createClient>>,
   ticker: string,
 ) {
-  const { data } = await supabase
-    .from("terminals")
-    .select("id, space_id")
-    .eq("ticker", ticker.toUpperCase())
-    .is("archived_at", null)
-    .maybeSingle();
-  return data as { id: string; space_id: string } | null;
+  return resolveTerminalBySegment(supabase, ticker);
 }
 
 function unauth() {

--- a/apps/web/src/app/api/v1/projects/[ticker]/export.pdf/route.ts
+++ b/apps/web/src/app/api/v1/projects/[ticker]/export.pdf/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { cookies, headers } from "next/headers";
 import { createClient } from "@/lib/supabase/server";
+import { resolveTerminalBySegment } from "@/lib/resolve-terminal";
 import { withObservability } from "@/lib/observability";
 
 interface Props {
@@ -31,7 +32,6 @@ interface Props {
  */
 async function handle(request: NextRequest, { params }: Props) {
   const { ticker } = await params;
-  const tickerUpper = ticker.toUpperCase();
 
   const supabase = await createClient();
   const {
@@ -46,12 +46,7 @@ async function handle(request: NextRequest, { params }: Props) {
 
   // Verify the caller has access to this terminal before paying the
   // (expensive) cost of launching a browser.
-  const { data: terminalRow } = await supabase
-    .from("terminals")
-    .select("id, ticker")
-    .eq("ticker", tickerUpper)
-    .is("archived_at", null)
-    .maybeSingle();
+  const terminalRow = await resolveTerminalBySegment(supabase, ticker);
   if (!terminalRow) {
     return NextResponse.json(
       { errors: [{ code: "not_found", message: "Terminal not found" }] },
@@ -95,7 +90,7 @@ async function handle(request: NextRequest, { params }: Props) {
   const hdrs = await headers();
   const proto = hdrs.get("x-forwarded-proto") ?? "http";
   const host = hdrs.get("host") ?? "localhost:3000";
-  const printUrl = `${proto}://${host}/p/${tickerUpper}/print`;
+  const printUrl = `${proto}://${host}/p/${terminalRow.slug}/print`;
 
   // Forward the caller's auth cookies into the puppeteer browser
   // context so the page renders as the user, not anonymous.
@@ -152,7 +147,7 @@ async function handle(request: NextRequest, { params }: Props) {
     });
     await ctx.close();
 
-    const filename = `${tickerUpper}-${new Date().toISOString().slice(0, 10)}.pdf`;
+    const filename = `${terminalRow.slug}-${new Date().toISOString().slice(0, 10)}.pdf`;
     // Copy the playwright Uint8Array (typed against ArrayBufferLike) into
     // a fresh ArrayBuffer so the BodyInit signature accepts it.
     const ab = new ArrayBuffer(pdf.byteLength);

--- a/apps/web/src/app/api/v1/projects/[ticker]/files/route.ts
+++ b/apps/web/src/app/api/v1/projects/[ticker]/files/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { buildBlobKey, putObject } from "@/lib/storage";
+import { resolveTerminalBySegment } from "@/lib/resolve-terminal";
 import { withObservability } from "@/lib/observability";
 import crypto from "node:crypto";
 
@@ -192,13 +193,7 @@ async function resolveProject(
   supabase: Awaited<ReturnType<typeof createClient>>,
   ticker: string,
 ) {
-  const { data } = await supabase
-    .from("terminals")
-    .select("id, space_id, ticker")
-    .eq("ticker", ticker.toUpperCase())
-    .is("archived_at", null)
-    .maybeSingle();
-  return data as { id: string; space_id: string; ticker: string } | null;
+  return resolveTerminalBySegment(supabase, ticker);
 }
 
 function unauth() {

--- a/apps/web/src/app/api/v1/projects/[ticker]/folders/route.ts
+++ b/apps/web/src/app/api/v1/projects/[ticker]/folders/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { createClient } from "@/lib/supabase/server";
+import { resolveTerminalBySegment } from "@/lib/resolve-terminal";
 import { withObservability } from "@/lib/observability";
 import {
   isValidFolderName,
@@ -101,13 +102,7 @@ async function resolveProject(
   supabase: Awaited<ReturnType<typeof createClient>>,
   ticker: string,
 ) {
-  const { data } = await supabase
-    .from("terminals")
-    .select("id, space_id")
-    .eq("ticker", ticker.toUpperCase())
-    .is("archived_at", null)
-    .maybeSingle();
-  return data as { id: string; space_id: string } | null;
+  return resolveTerminalBySegment(supabase, ticker);
 }
 
 function unauth() {

--- a/apps/web/src/app/api/v1/projects/[ticker]/members/[userId]/route.ts
+++ b/apps/web/src/app/api/v1/projects/[ticker]/members/[userId]/route.ts
@@ -2,6 +2,7 @@ import { NextResponse, type NextRequest } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { emitEvent } from "@/lib/events";
 import { revokeSessions } from "@/lib/revocations";
+import { resolveTerminalBySegment } from "@/lib/resolve-terminal";
 import type { ProjectRole } from "@rokki/db";
 
 import { withObservability } from "@/lib/observability";
@@ -154,13 +155,7 @@ async function resolveTerminal(
   supabase: Awaited<ReturnType<typeof createClient>>,
   ticker: string,
 ) {
-  const { data } = await supabase
-    .from("terminals")
-    .select("id, space_id, ticker")
-    .eq("ticker", ticker.toUpperCase())
-    .is("archived_at", null)
-    .maybeSingle();
-  return data as { id: string; space_id: string; ticker: string } | null;
+  return resolveTerminalBySegment(supabase, ticker);
 }
 
 async function callerRole(

--- a/apps/web/src/app/api/v1/projects/[ticker]/members/route.ts
+++ b/apps/web/src/app/api/v1/projects/[ticker]/members/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { createClient as createAdminClient } from "@supabase/supabase-js";
 import { createClient } from "@/lib/supabase/server";
+import { resolveTerminalBySegment } from "@/lib/resolve-terminal";
 import type { Database, ProjectRole } from "@rokki/db";
 import crypto from "node:crypto";
 
@@ -232,13 +233,7 @@ async function resolveProject(
   supabase: Awaited<ReturnType<typeof createClient>>,
   ticker: string,
 ) {
-  const { data } = await supabase
-    .from("terminals")
-    .select("id, space_id, ticker")
-    .eq("ticker", ticker.toUpperCase())
-    .is("archived_at", null)
-    .maybeSingle();
-  return data as { id: string; space_id: string; ticker: string } | null;
+  return resolveTerminalBySegment(supabase, ticker);
 }
 
 function unauth() {

--- a/apps/web/src/app/api/v1/projects/[ticker]/permits/route.ts
+++ b/apps/web/src/app/api/v1/projects/[ticker]/permits/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { createClient } from "@/lib/supabase/server";
+import { resolveTerminalBySegment } from "@/lib/resolve-terminal";
 
 import { withObservability } from "@/lib/observability";
 interface Props {
@@ -78,13 +79,7 @@ async function resolveTerminal(
   supabase: Awaited<ReturnType<typeof createClient>>,
   ticker: string,
 ) {
-  const { data } = await supabase
-    .from("terminals")
-    .select("id")
-    .eq("ticker", ticker.toUpperCase())
-    .is("archived_at", null)
-    .maybeSingle();
-  return data as { id: string } | null;
+  return resolveTerminalBySegment(supabase, ticker);
 }
 
 function unauth() {

--- a/apps/web/src/app/api/v1/projects/[ticker]/route.ts
+++ b/apps/web/src/app/api/v1/projects/[ticker]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { emitEvent } from "@/lib/events";
+import { resolveTerminalBySegment } from "@/lib/resolve-terminal";
 import type { ProjectStatus } from "@rokki/db";
 
 import { withObservability } from "@/lib/observability";
@@ -36,12 +37,16 @@ async function handleGet(_req: NextRequest, { params }: Props) {
   } = await supabase.auth.getUser();
   if (!user) return unauth();
 
+  // Resolve by slug first, then ticker — the URL segment is named
+  // `ticker` for historical reasons but now carries the slug.
+  const resolved = await resolveTerminalBySegment(supabase, ticker);
+  if (!resolved) return notFound();
   const { data } = await supabase
     .from("terminals")
     .select(
-      "id, space_id, ticker, name, description, type, status, metadata, created_at, updated_at, archived_at",
+      "id, space_id, slug, ticker, name, description, type, status, metadata, created_at, updated_at, archived_at",
     )
-    .eq("ticker", ticker.toUpperCase())
+    .eq("id", resolved.id)
     .maybeSingle();
 
   if (!data) return notFound();
@@ -174,13 +179,9 @@ async function resolveTerminal(
   supabase: Awaited<ReturnType<typeof createClient>>,
   ticker: string,
 ) {
-  const { data } = await supabase
-    .from("terminals")
-    .select("id, space_id, ticker")
-    .eq("ticker", ticker.toUpperCase())
-    .is("archived_at", null)
-    .maybeSingle();
-  return data as { id: string; space_id: string; ticker: string } | null;
+  // Delegate to the central slug-or-ticker resolver. The local
+  // wrapper stays so the call sites don't have to change.
+  return resolveTerminalBySegment(supabase, ticker);
 }
 
 async function canManageTerminal(

--- a/apps/web/src/app/api/v1/projects/[ticker]/schedule/route.ts
+++ b/apps/web/src/app/api/v1/projects/[ticker]/schedule/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { createClient } from "@/lib/supabase/server";
+import { resolveTerminalBySegment } from "@/lib/resolve-terminal";
 
 import { withObservability } from "@/lib/observability";
 interface Props {
@@ -74,13 +75,7 @@ async function resolveTerminal(
   supabase: Awaited<ReturnType<typeof createClient>>,
   ticker: string,
 ) {
-  const { data } = await supabase
-    .from("terminals")
-    .select("id")
-    .eq("ticker", ticker.toUpperCase())
-    .is("archived_at", null)
-    .maybeSingle();
-  return data as { id: string } | null;
+  return resolveTerminalBySegment(supabase, ticker);
 }
 
 function unauth() {

--- a/apps/web/src/app/api/v1/projects/[ticker]/tasks/route.ts
+++ b/apps/web/src/app/api/v1/projects/[ticker]/tasks/route.ts
@@ -4,6 +4,7 @@ import { emitEvent } from "@/lib/events";
 import { withObservability } from "@/lib/observability";
 import { validateRecurrenceRule } from "@/lib/task-recurrence";
 import { normalizeEmails } from "@/lib/normalize-emails";
+import { resolveTerminalBySegment } from "@/lib/resolve-terminal";
 import type { TaskRecurrenceRule, TaskStatus } from "@rokki/db";
 
 interface Props {
@@ -335,13 +336,7 @@ async function resolveProject(
   supabase: Awaited<ReturnType<typeof createClient>>,
   ticker: string,
 ) {
-  const { data } = await supabase
-    .from("terminals")
-    .select("id, space_id")
-    .eq("ticker", ticker.toUpperCase())
-    .is("archived_at", null)
-    .maybeSingle();
-  return data as { id: string; space_id: string } | null;
+  return resolveTerminalBySegment(supabase, ticker);
 }
 
 function unauth() {

--- a/apps/web/src/app/api/v1/projects/route.ts
+++ b/apps/web/src/app/api/v1/projects/route.ts
@@ -102,7 +102,7 @@ async function handlePost(request: NextRequest) {
       created_by: user.id,
     })
     .select(
-      "id, space_id, ticker, name, description, type, status, metadata, created_at",
+      "id, space_id, slug, ticker, name, description, type, status, metadata, created_at",
     )
     .single();
 
@@ -110,6 +110,7 @@ async function handlePost(request: NextRequest) {
     | {
         id: string;
         space_id: string;
+        slug: string;
         ticker: string;
         name: string;
       }

--- a/apps/web/src/app/api/v1/search/route.ts
+++ b/apps/web/src/app/api/v1/search/route.ts
@@ -42,6 +42,7 @@ const ALLOWED_KINDS = new Set([
 
 interface ProjectHit {
   id: string;
+  slug: string;
   ticker: string;
   name: string;
 }
@@ -84,7 +85,7 @@ async function handleGet(request: NextRequest) {
   if (!q) {
     const { data: projects } = await supabase
       .from("terminals")
-      .select("id, ticker, name")
+      .select("id, slug, ticker, name")
       .is("archived_at", null)
       .order("updated_at", { ascending: false })
       .limit(100);

--- a/apps/web/src/app/api/v1/tasks/by-seq/[ticker]/[seq]/route.ts
+++ b/apps/web/src/app/api/v1/tasks/by-seq/[ticker]/[seq]/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { createClient } from "@/lib/supabase/server";
+import { resolveTerminalBySegment } from "@/lib/resolve-terminal";
 
 import { withObservability } from "@/lib/observability";
 interface Props {
@@ -36,13 +37,7 @@ async function handleGet(_req: NextRequest, { params }: Props) {
       { status: 401 },
     );
 
-  const { data: terminal } = await supabase
-    .from("terminals")
-    .select("id, ticker, name, space_id")
-    .eq("ticker", ticker.toUpperCase())
-    .maybeSingle();
-  type Term = { id: string; ticker: string; name: string; space_id: string };
-  const term = terminal as Term | null;
+  const term = await resolveTerminalBySegment(supabase, ticker);
   if (!term) return notFound();
 
   const { data: taskRow } = await supabase

--- a/apps/web/src/app/app/tasks/page.tsx
+++ b/apps/web/src/app/app/tasks/page.tsx
@@ -40,7 +40,8 @@ export default async function AppTasksPage() {
     loadDelegatedTasks(supabase, user.id),
     loadDashTerminals(supabase),
   ]);
-  const tickerById = Object.fromEntries(terminals.map((t) => [t.id, t.ticker]));
+  // Values are slugs (URL-friendly), prop name stays for legacy parity.
+  const tickerById = Object.fromEntries(terminals.map((t) => [t.id, t.slug]));
   const terminalNameById = Object.fromEntries(
     terminals.map((t) => [t.id, t.name]),
   );

--- a/apps/web/src/app/p/[ticker]/budget/page.tsx
+++ b/apps/web/src/app/p/[ticker]/budget/page.tsx
@@ -2,6 +2,7 @@ import { notFound, redirect } from "next/navigation";
 import Link from "next/link";
 import { DollarSign } from "lucide-react";
 import { createClient } from "@/lib/supabase/server";
+import { resolveTerminalBySegment } from "@/lib/resolve-terminal";
 import { TopBar } from "@/components/TopBar";
 import { BudgetClient, type BudgetRow } from "./BudgetClient";
 
@@ -20,19 +21,9 @@ export default async function BudgetPage({ params }: Props) {
   } = await supabase.auth.getUser();
   if (!user) redirect("/login");
 
-  const { data: terminal } = await supabase
-    .from("terminals")
-    .select("id, ticker, name, space_id")
-    .eq("ticker", ticker.toUpperCase())
-    .is("archived_at", null)
-    .maybeSingle();
+  const terminal = await resolveTerminalBySegment(supabase, ticker);
   if (!terminal) notFound();
-  const t = terminal as {
-    id: string;
-    ticker: string;
-    name: string;
-    space_id: string;
-  };
+  const t = terminal;
 
   const { data: items } = await supabase
     .from("budget_items")
@@ -52,7 +43,7 @@ export default async function BudgetPage({ params }: Props) {
   return (
     <div className="flex h-full min-h-0 flex-col overflow-hidden bg-bg-0">
       <TopBar>
-        <Link href={`/p/${t.ticker}`} className="text-text-3 hover:text-text-1">
+        <Link href={`/p/${t.slug}`} className="text-text-3 hover:text-text-1">
           ← {t.name}
         </Link>
         <span className="text-text-3">·</span>
@@ -62,14 +53,14 @@ export default async function BudgetPage({ params }: Props) {
         <header className="mb-4">
           <h1 className="flex items-center gap-2 text-xl font-semibold text-text-0">
             <DollarSign className="h-5 w-5 text-accent" />
-            Budget — {t.ticker}
+            Budget — {t.name}
           </h1>
           <p className="mt-1 text-xs text-text-3">
             Line items for this terminal. Costs roll up by status.
           </p>
         </header>
         <BudgetClient
-          ticker={t.ticker}
+          ticker={t.slug}
           initial={(items ?? []) as BudgetRow[]}
           vendors={
             (vendors ?? []) as Array<{ id: string; name: string }>

--- a/apps/web/src/app/p/[ticker]/drawings/[fileId]/page.tsx
+++ b/apps/web/src/app/p/[ticker]/drawings/[fileId]/page.tsx
@@ -1,6 +1,7 @@
 import { redirect, notFound } from "next/navigation";
 import Link from "next/link";
 import { createClient } from "@/lib/supabase/server";
+import { resolveTerminalBySegment } from "@/lib/resolve-terminal";
 import { TopBar } from "@/components/TopBar";
 import { DrawingViewer } from "@/components/drawings/DrawingViewer";
 
@@ -21,13 +22,9 @@ export default async function DrawingPage({ params }: Props) {
   } = await supabase.auth.getUser();
   if (!user) redirect("/login");
 
-  const { data: term } = await supabase
-    .from("terminals")
-    .select("id, ticker, name")
-    .eq("ticker", ticker.toUpperCase())
-    .maybeSingle();
-  if (!term) notFound();
-  const terminal = term as { id: string; ticker: string; name: string };
+  const resolved = await resolveTerminalBySegment(supabase, ticker);
+  if (!resolved) notFound();
+  const terminal = resolved;
 
   const { data: file } = await supabase
     .from("files")
@@ -46,7 +43,7 @@ export default async function DrawingPage({ params }: Props) {
     supersedes: string | null;
   };
   if (f.mime_type !== "application/pdf") {
-    redirect(`/p/${terminal.ticker}`);
+    redirect(`/p/${terminal.slug}`);
   }
 
   // Walk the `supersedes` chain to collect every prior revision. Newest
@@ -102,7 +99,7 @@ export default async function DrawingPage({ params }: Props) {
         </Link>
         <span className="text-text-3">·</span>
         <Link
-          href={`/p/${terminal.ticker}`}
+          href={`/p/${terminal.slug}`}
           className="text-text-3 hover:text-text-1"
         >
           {terminal.name}
@@ -120,7 +117,7 @@ export default async function DrawingPage({ params }: Props) {
             {revisions.map((r) => (
               <Link
                 key={r.id}
-                href={`/p/${terminal.ticker}/drawings/${r.id}`}
+                href={`/p/${terminal.slug}/drawings/${r.id}`}
                 className={`rounded-sm border px-1.5 py-0.5 font-mono ${
                   r.id === f.id
                     ? "border-accent bg-accent-subtle text-text-0"

--- a/apps/web/src/app/p/[ticker]/files/page.tsx
+++ b/apps/web/src/app/p/[ticker]/files/page.tsx
@@ -1,5 +1,6 @@
 import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
+import { resolveTerminalBySegment } from "@/lib/resolve-terminal";
 import { ScopedModuleShell } from "@/components/pane/ScopedModuleShell";
 import { ScopedFileList } from "@/components/modules/ScopedFileList";
 import { loadFilesForTerminal } from "@/lib/modules/files-queries";
@@ -22,13 +23,7 @@ export default async function TerminalFilesPage({ params }: Props) {
   } = await supabase.auth.getUser();
   if (!user) redirect("/login");
 
-  const { data: terminalRow } = await supabase
-    .from("terminals")
-    .select("id, name")
-    .eq("ticker", ticker.toUpperCase())
-    .is("archived_at", null)
-    .maybeSingle();
-  const terminal = terminalRow as { id: string; name: string } | null;
+  const terminal = await resolveTerminalBySegment(supabase, ticker);
   if (!terminal) redirect("/");
 
   const files = await loadFilesForTerminal(supabase, terminal.id);

--- a/apps/web/src/app/p/[ticker]/goals/page.tsx
+++ b/apps/web/src/app/p/[ticker]/goals/page.tsx
@@ -1,5 +1,6 @@
 import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
+import { resolveTerminalBySegment } from "@/lib/resolve-terminal";
 import { ScopedModuleShell } from "@/components/pane/ScopedModuleShell";
 import { GoalsView } from "@/components/modules/GoalsView";
 import {
@@ -26,13 +27,7 @@ export default async function TerminalGoalsPage({ params }: Props) {
   } = await supabase.auth.getUser();
   if (!user) redirect("/login");
 
-  const { data: terminalRow } = await supabase
-    .from("terminals")
-    .select("id, name")
-    .eq("ticker", ticker.toUpperCase())
-    .is("archived_at", null)
-    .maybeSingle();
-  const terminal = terminalRow as { id: string; name: string } | null;
+  const terminal = await resolveTerminalBySegment(supabase, ticker);
   if (!terminal) redirect("/");
 
   const today = new Date().toISOString().slice(0, 10);

--- a/apps/web/src/app/p/[ticker]/messages/page.tsx
+++ b/apps/web/src/app/p/[ticker]/messages/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { redirect } from "next/navigation";
 import { MessageSquare } from "lucide-react";
 import { createClient } from "@/lib/supabase/server";
+import { resolveTerminalBySegment } from "@/lib/resolve-terminal";
 import { ScopedModuleShell } from "@/components/pane/ScopedModuleShell";
 import { DashboardCard } from "@/components/dashboard/DashboardCard";
 import { loadThreadForTerminal } from "@/lib/modules/messenger-queries";
@@ -25,13 +26,7 @@ export default async function TerminalMessagesPage({ params }: Props) {
   } = await supabase.auth.getUser();
   if (!user) redirect("/login");
 
-  const { data: terminalRow } = await supabase
-    .from("terminals")
-    .select("id, name")
-    .eq("ticker", ticker.toUpperCase())
-    .is("archived_at", null)
-    .maybeSingle();
-  const terminal = terminalRow as { id: string; name: string } | null;
+  const terminal = await resolveTerminalBySegment(supabase, ticker);
   if (!terminal) redirect("/");
 
   const thread = await loadThreadForTerminal(supabase, terminal.id);

--- a/apps/web/src/app/p/[ticker]/opengraph-image.tsx
+++ b/apps/web/src/app/p/[ticker]/opengraph-image.tsx
@@ -25,33 +25,50 @@ interface Props {
 }
 
 export default async function Image({ params }: Props): Promise<ImageResponse> {
-  const tickerUpper = params.ticker.toUpperCase();
+  const segment = params.ticker;
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 
-  let displayName = tickerUpper;
+  let displayName = segment;
+  let urlSegment = segment;
   if (url && serviceKey) {
     try {
       const admin = createAdminClient<Database>(url, serviceKey, {
         auth: { autoRefreshToken: false, persistSession: false },
       });
-      const { data } = await admin
+      // Slug-or-ticker fallback — duplicates the lookup logic from
+      // `resolveTerminalBySegment` (we can't import that here because
+      // this file uses the admin client, not the SSR-cookie client).
+      const { data: bySlug } = await admin
         .from("terminals")
-        .select("name")
-        .eq("ticker", tickerUpper)
+        .select("name, slug")
+        // @ts-expect-error generated types haven't been regenerated
+        // since the 20260526010000_terminal_slug migration added the
+        // column.
+        .eq("slug", segment)
         .is("archived_at", null)
         .maybeSingle();
-      const row = data as { name: string } | null;
+      let row = bySlug as { name: string; slug: string } | null;
+      if (!row && /^[A-Z][A-Z0-9]{1,9}$/.test(segment.toUpperCase())) {
+        const { data: byTicker } = await admin
+          .from("terminals")
+          .select("name, slug")
+          .eq("ticker", segment.toUpperCase())
+          .is("archived_at", null)
+          .maybeSingle();
+        row = byTicker as { name: string; slug: string } | null;
+      }
       if (row?.name) displayName = row.name;
+      if (row?.slug) urlSegment = row.slug;
     } catch {
-      // fall through with the ticker as the name
+      // fall through with the URL segment as the name
     }
   }
 
   return renderOgImage({
-    primary: tickerUpper,
-    secondary: displayName === tickerUpper ? "Rokki terminal" : displayName,
-    topLine: `rokki.ai · /p/${tickerUpper.toLowerCase()}`,
+    primary: displayName,
+    secondary: "Rokki terminal",
+    topLine: `rokki.ai · /p/${urlSegment}`,
     bottomLabel: "Tasks · Files · MCP · Real-time",
   });
 }

--- a/apps/web/src/app/p/[ticker]/page.tsx
+++ b/apps/web/src/app/p/[ticker]/page.tsx
@@ -13,6 +13,7 @@ import {
   loadDashSpaces,
   loadDashTerminals,
 } from "@/lib/dashboard-queries";
+import { resolveTerminalBySegment } from "@/lib/resolve-terminal";
 import { summarizeActivity } from "@/lib/activity-summary";
 import { CORE_MODULE_CARDS, SPACE_TAGLINE } from "@/lib/project-templates";
 import type { ProjectStatus } from "@rokki/db";
@@ -31,34 +32,44 @@ interface Props {
  */
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { ticker } = await params;
-  const tickerUpper = ticker.toUpperCase();
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 
-  let displayName = tickerUpper;
+  // Resolve by slug first, then ticker fallback — matches the page
+  // resolver so the <title> matches what the user actually opened.
+  let displayName = ticker;
   if (url && serviceKey) {
     try {
       const admin = createAdminClient<Database>(url, serviceKey, {
         auth: { autoRefreshToken: false, persistSession: false },
       });
-      const { data } = await admin
+      const { data: bySlug } = await admin
         .from("terminals")
         .select("name")
-        .eq("ticker", tickerUpper)
+        // @ts-expect-error generated types haven't been regenerated
+        // since the 20260526010000_terminal_slug migration added this
+        // column; runtime is fine.
+        .eq("slug", ticker)
         .is("archived_at", null)
         .maybeSingle();
-      const row = data as { name: string } | null;
+      let row = bySlug as { name: string } | null;
+      if (!row) {
+        const { data: byTicker } = await admin
+          .from("terminals")
+          .select("name")
+          .eq("ticker", ticker.toUpperCase())
+          .is("archived_at", null)
+          .maybeSingle();
+        row = byTicker as { name: string } | null;
+      }
       if (row?.name) displayName = row.name;
     } catch {
-      // fall through with the ticker as the name
+      // fall through with the URL segment as the name
     }
   }
 
-  const title = `${tickerUpper} · ${displayName} — Rokki`;
-  const description =
-    displayName === tickerUpper
-      ? `Rokki terminal ${tickerUpper}.`
-      : `${displayName} on Rokki — terminal ${tickerUpper}.`;
+  const title = `${displayName} — Rokki`;
+  const description = `${displayName} on Rokki.`;
 
   return {
     title,
@@ -85,6 +96,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 interface ProjectRow {
   id: string;
   space_id: string;
+  slug: string;
   ticker: string;
   name: string;
   description: string | null;
@@ -111,7 +123,6 @@ interface MemberRow {
 
 export default async function ProjectTerminalPage({ params }: Props) {
   const { ticker } = await params;
-  const tickerUpper = ticker.toUpperCase();
 
   const supabase = await createClient();
   const {
@@ -119,13 +130,17 @@ export default async function ProjectTerminalPage({ params }: Props) {
   } = await supabase.auth.getUser();
   if (!user) notFound();
 
+  // The URL segment is named `ticker` for historical reasons but now
+  // carries the slug. Lookup tries slug first, then falls back to the
+  // legacy ticker column so old /p/FFRDBL bookmarks still resolve.
+  const resolved = await resolveTerminalBySegment(supabase, ticker);
+  if (!resolved) notFound();
   const { data: project } = await supabase
     .from("terminals")
     .select(
-      "id, space_id, ticker, name, description, type, status, metadata, created_at",
+      "id, space_id, slug, ticker, name, description, type, status, metadata, created_at",
     )
-    .eq("ticker", tickerUpper)
-    .is("archived_at", null)
+    .eq("id", resolved.id)
     .maybeSingle();
 
   if (!project) notFound();
@@ -231,7 +246,7 @@ export default async function ProjectTerminalPage({ params }: Props) {
               clutter; this small inline cog reads as "settings for
               the thing the breadcrumb just named." */}
           <Link
-            href={`/p/${p.ticker}/settings`}
+            href={`/p/${p.slug}/settings`}
             aria-label={`${p.name} settings`}
             title="Terminal settings"
             className="rounded-sm p-1 text-text-3 hover:bg-bg-2 hover:text-text-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-focus"
@@ -247,11 +262,15 @@ export default async function ProjectTerminalPage({ params }: Props) {
           </span>
         </TopBar>
       }
-      ticker={p.ticker}
+      // The prop is named `ticker` for historical reasons but
+      // ProjectTerminal + everything downstream uses it purely as the
+      // URL segment. Passing slug here flips every internal /p/<…>
+      // link to the slug form without renaming the prop.
+      ticker={p.slug}
       project={{
         id: p.id,
         name: p.name,
-        ticker: p.ticker,
+        ticker: p.slug,
         status: p.status,
         type: p.type,
       }}

--- a/apps/web/src/app/p/[ticker]/permits/page.tsx
+++ b/apps/web/src/app/p/[ticker]/permits/page.tsx
@@ -2,6 +2,7 @@ import { notFound, redirect } from "next/navigation";
 import Link from "next/link";
 import { FileCheck2 } from "lucide-react";
 import { createClient } from "@/lib/supabase/server";
+import { resolveTerminalBySegment } from "@/lib/resolve-terminal";
 import { TopBar } from "@/components/TopBar";
 import { PermitsClient, type PermitRow } from "./PermitsClient";
 
@@ -20,14 +21,9 @@ export default async function PermitsPage({ params }: Props) {
   } = await supabase.auth.getUser();
   if (!user) redirect("/login");
 
-  const { data: terminal } = await supabase
-    .from("terminals")
-    .select("id, ticker, name")
-    .eq("ticker", ticker.toUpperCase())
-    .is("archived_at", null)
-    .maybeSingle();
+  const terminal = await resolveTerminalBySegment(supabase, ticker);
   if (!terminal) notFound();
-  const t = terminal as { id: string; ticker: string; name: string };
+  const t = terminal;
 
   const { data: permits } = await supabase
     .from("permits")
@@ -41,7 +37,7 @@ export default async function PermitsPage({ params }: Props) {
   return (
     <div className="flex h-full min-h-0 flex-col overflow-hidden bg-bg-0">
       <TopBar>
-        <Link href={`/p/${t.ticker}`} className="text-text-3 hover:text-text-1">
+        <Link href={`/p/${t.slug}`} className="text-text-3 hover:text-text-1">
           ← {t.name}
         </Link>
         <span className="text-text-3">·</span>
@@ -51,14 +47,14 @@ export default async function PermitsPage({ params }: Props) {
         <header className="mb-4">
           <h1 className="flex items-center gap-2 text-xl font-semibold text-text-0">
             <FileCheck2 className="h-5 w-5 text-accent" />
-            Permits — {t.ticker}
+            Permits — {t.name}
           </h1>
           <p className="mt-1 text-xs text-text-3">
             Permits tracked against this terminal. Rows ordered by next
             expiration date.
           </p>
         </header>
-        <PermitsClient ticker={t.ticker} initial={(permits ?? []) as PermitRow[]} />
+        <PermitsClient ticker={t.slug} initial={(permits ?? []) as PermitRow[]} />
       </main>
     </div>
   );

--- a/apps/web/src/app/p/[ticker]/print/page.tsx
+++ b/apps/web/src/app/p/[ticker]/print/page.tsx
@@ -1,5 +1,6 @@
 import { notFound } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
+import { resolveTerminalBySegment } from "@/lib/resolve-terminal";
 import { PrintActions } from "./PrintActions";
 import type { ProjectStatus, TaskStatus } from "@rokki/db";
 
@@ -10,6 +11,7 @@ interface Props {
 interface TerminalRow {
   id: string;
   space_id: string;
+  slug: string;
   ticker: string;
   name: string;
   description: string | null;
@@ -89,7 +91,6 @@ const PRIORITY_LABEL: Record<number, string> = {
  */
 export default async function TerminalPrintPage({ params }: Props) {
   const { ticker } = await params;
-  const tickerUpper = ticker.toUpperCase();
 
   const supabase = await createClient();
   const {
@@ -97,13 +98,14 @@ export default async function TerminalPrintPage({ params }: Props) {
   } = await supabase.auth.getUser();
   if (!user) notFound();
 
+  const resolved = await resolveTerminalBySegment(supabase, ticker);
+  if (!resolved) notFound();
   const { data: terminalRow } = await supabase
     .from("terminals")
     .select(
-      "id, space_id, ticker, name, description, status, type, created_at",
+      "id, space_id, slug, ticker, name, description, status, type, created_at",
     )
-    .eq("ticker", tickerUpper)
-    .is("archived_at", null)
+    .eq("id", resolved.id)
     .maybeSingle();
   if (!terminalRow) notFound();
   const terminal = terminalRow as TerminalRow;
@@ -185,7 +187,7 @@ export default async function TerminalPrintPage({ params }: Props) {
     >
       {/* Header banner — only shown on screen; hidden in print so the
           cover header below is the first thing on page 1. */}
-      <PrintActions ticker={terminal.ticker} />
+      <PrintActions ticker={terminal.slug} />
 
       <header className="border-b-2 border-text-0 pb-4">
         <div className="mb-2 flex items-baseline justify-between font-mono text-xs uppercase tracking-wide text-text-2">
@@ -195,8 +197,7 @@ export default async function TerminalPrintPage({ params }: Props) {
           <span>As of {asOf.toISOString().slice(0, 10)}</span>
         </div>
         <h1 className="font-display text-3xl font-semibold leading-tight text-text-0">
-          <span className="font-mono text-base font-bold text-accent">{terminal.ticker}</span>
-          <span className="ml-3">{terminal.name}</span>
+          {terminal.name}
         </h1>
         {terminal.description ? (
           <p className="mt-2 text-sm text-text-1">{terminal.description}</p>
@@ -239,7 +240,7 @@ export default async function TerminalPrintPage({ params }: Props) {
                     {g.items.map((t) => (
                       <tr key={t.id} className="border-t border-border">
                         <td className="py-1 pr-2 font-mono text-text-2">
-                          {terminal.ticker}-{t.ticker_seq}
+                          #{t.ticker_seq}
                         </td>
                         <td className="py-1 pr-2 text-text-0">{t.title}</td>
                         <td className="py-1 pr-2 text-text-1">
@@ -355,7 +356,7 @@ export default async function TerminalPrintPage({ params }: Props) {
       </section>
 
       <footer className="mt-8 border-t border-border pt-3 text-[10px] font-mono uppercase tracking-wide text-text-3">
-        Rokki · {terminal.ticker} · generated {asOf.toISOString().slice(0, 19).replace("T", " ")}Z
+        Rokki · {terminal.name} · generated {asOf.toISOString().slice(0, 19).replace("T", " ")}Z
       </footer>
     </div>
   );

--- a/apps/web/src/app/p/[ticker]/schedule/page.tsx
+++ b/apps/web/src/app/p/[ticker]/schedule/page.tsx
@@ -2,6 +2,7 @@ import { notFound, redirect } from "next/navigation";
 import Link from "next/link";
 import { Calendar } from "lucide-react";
 import { createClient } from "@/lib/supabase/server";
+import { resolveTerminalBySegment } from "@/lib/resolve-terminal";
 import { TopBar } from "@/components/TopBar";
 import { ScheduleClient, type PhaseRow } from "./ScheduleClient";
 
@@ -20,14 +21,9 @@ export default async function SchedulePage({ params }: Props) {
   } = await supabase.auth.getUser();
   if (!user) redirect("/login");
 
-  const { data: terminal } = await supabase
-    .from("terminals")
-    .select("id, ticker, name")
-    .eq("ticker", ticker.toUpperCase())
-    .is("archived_at", null)
-    .maybeSingle();
+  const terminal = await resolveTerminalBySegment(supabase, ticker);
   if (!terminal) notFound();
-  const t = terminal as { id: string; ticker: string; name: string };
+  const t = terminal;
 
   const { data: phases } = await supabase
     .from("schedule_phases")
@@ -41,7 +37,7 @@ export default async function SchedulePage({ params }: Props) {
   return (
     <div className="flex h-full min-h-0 flex-col overflow-hidden bg-bg-0">
       <TopBar>
-        <Link href={`/p/${t.ticker}`} className="text-text-3 hover:text-text-1">
+        <Link href={`/p/${t.slug}`} className="text-text-3 hover:text-text-1">
           ← {t.name}
         </Link>
         <span className="text-text-3">·</span>
@@ -51,14 +47,14 @@ export default async function SchedulePage({ params }: Props) {
         <header className="mb-4">
           <h1 className="flex items-center gap-2 text-xl font-semibold text-text-0">
             <Calendar className="h-5 w-5 text-accent" />
-            Schedule — {t.ticker}
+            Schedule — {t.name}
           </h1>
           <p className="mt-1 text-xs text-text-3">
             Gantt-style phases for this terminal. Scroll horizontally to pan.
           </p>
         </header>
         <ScheduleClient
-          ticker={t.ticker}
+          ticker={t.slug}
           initial={(phases ?? []) as PhaseRow[]}
         />
       </main>

--- a/apps/web/src/app/p/[ticker]/settings/modules/page.tsx
+++ b/apps/web/src/app/p/[ticker]/settings/modules/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from "next/navigation";
 import Link from "next/link";
 import { createClient } from "@/lib/supabase/server";
+import { resolveTerminalBySegment } from "@/lib/resolve-terminal";
 import { TopBar } from "@/components/TopBar";
 import { ModulesMarketplace } from "@/components/modules/ModulesMarketplace";
 
@@ -22,15 +23,7 @@ export default async function TerminalModulesPage({ params }: Props) {
   } = await supabase.auth.getUser();
   if (!user) redirect("/login");
 
-  const { data: terminalRow } = await supabase
-    .from("terminals")
-    .select("id, name, ticker")
-    .eq("ticker", ticker.toUpperCase())
-    .is("archived_at", null)
-    .maybeSingle();
-  const terminal = terminalRow as
-    | { id: string; name: string; ticker: string }
-    | null;
+  const terminal = await resolveTerminalBySegment(supabase, ticker);
   if (!terminal) redirect("/");
 
   const { data: catRows } = await supabase
@@ -59,14 +52,14 @@ export default async function TerminalModulesPage({ params }: Props) {
     <div className="flex min-h-screen flex-col bg-bg-0">
       <TopBar>
         <Link
-          href={`/p/${terminal.ticker}/settings`}
+          href={`/p/${terminal.slug}/settings`}
           className="text-text-3 hover:text-text-1"
         >
           ← Settings
         </Link>
         <span className="text-text-3">·</span>
-        <span className="font-mono text-[11px] uppercase tracking-wide text-text-2">
-          {terminal.ticker}
+        <span className="text-text-1">
+          {terminal.name}
         </span>
         <span className="text-text-3">·</span>
         <span className="text-text-0">Modules</span>

--- a/apps/web/src/app/p/[ticker]/settings/page.tsx
+++ b/apps/web/src/app/p/[ticker]/settings/page.tsx
@@ -1,6 +1,7 @@
 import { notFound, redirect } from "next/navigation";
 import Link from "next/link";
 import { createClient } from "@/lib/supabase/server";
+import { resolveTerminalBySegment } from "@/lib/resolve-terminal";
 import { TopBar } from "@/components/TopBar";
 import { SettingsHistorySection } from "@/components/SettingsHistorySection";
 import { TerminalSettingsForm } from "./TerminalSettingsForm";
@@ -20,7 +21,6 @@ interface Props {
  */
 export default async function TerminalSettingsPage({ params }: Props) {
   const { ticker } = await params;
-  const tickerUpper = ticker.toUpperCase();
 
   const supabase = await createClient();
   const {
@@ -28,17 +28,23 @@ export default async function TerminalSettingsPage({ params }: Props) {
   } = await supabase.auth.getUser();
   if (!user) redirect("/login");
 
+  // The URL segment is named `ticker` historically but now carries
+  // the slug. Resolve handles slug-or-ticker so both new and legacy
+  // URLs work.
+  const resolved = await resolveTerminalBySegment(supabase, ticker);
+  if (!resolved) notFound();
   const { data: t } = await supabase
     .from("terminals")
     .select(
-      "id, space_id, ticker, name, description, type, status, metadata, archived_at",
+      "id, space_id, slug, ticker, name, description, type, status, metadata, archived_at",
     )
-    .eq("ticker", tickerUpper)
+    .eq("id", resolved.id)
     .maybeSingle();
   if (!t) notFound();
   const terminal = t as {
     id: string;
     space_id: string;
+    slug: string;
     ticker: string;
     name: string;
     description: string | null;
@@ -130,7 +136,7 @@ export default async function TerminalSettingsPage({ params }: Props) {
         ) : null}
         <span className="text-text-3">/</span>
         <Link
-          href={`/p/${terminal.ticker}`}
+          href={`/p/${terminal.slug}`}
           className="text-text-1 hover:text-text-0"
         >
           {terminal.name}
@@ -140,16 +146,13 @@ export default async function TerminalSettingsPage({ params }: Props) {
       </TopBar>
       <main className="mx-auto w-full max-w-3xl flex-1 overflow-y-auto p-6">
         <header className="mb-6">
-          <div className="mb-1 flex items-center gap-2">
-            <span className="font-mono text-xs font-semibold uppercase tracking-wide text-accent">
-              {terminal.ticker}
-            </span>
-            {terminal.archived_at ? (
+          {terminal.archived_at ? (
+            <div className="mb-1">
               <span className="rounded-sm border border-border bg-bg-2 px-1.5 py-0.5 text-[10px] uppercase text-text-3">
                 archived
               </span>
-            ) : null}
-          </div>
+            </div>
+          ) : null}
           <h1 className="text-xl font-semibold text-text-0">{terminal.name}</h1>
           <p className="mt-1 text-xs text-text-3">
             Rename, change status, archive, and manage members.

--- a/apps/web/src/app/p/[ticker]/task/[seq]/page.tsx
+++ b/apps/web/src/app/p/[ticker]/task/[seq]/page.tsx
@@ -1,6 +1,7 @@
 import { redirect, notFound } from "next/navigation";
 import Link from "next/link";
 import { createClient } from "@/lib/supabase/server";
+import { resolveTerminalBySegment } from "@/lib/resolve-terminal";
 import { TopBar } from "@/components/TopBar";
 import { TaskDetail } from "@/components/task-detail/TaskDetail";
 
@@ -25,14 +26,7 @@ export default async function TaskDetailPage({ params }: Props) {
   } = await supabase.auth.getUser();
   if (!user) redirect("/login");
 
-  const { data: termData } = await supabase
-    .from("terminals")
-    .select("id, ticker, name, space_id")
-    .eq("ticker", ticker.toUpperCase())
-    .maybeSingle();
-  const term = termData as
-    | { id: string; ticker: string; name: string; space_id: string }
-    | null;
+  const term = await resolveTerminalBySegment(supabase, ticker);
   if (!term) notFound();
 
   const { data: taskRow } = await supabase
@@ -95,14 +89,14 @@ export default async function TaskDetailPage({ params }: Props) {
         </Link>
         <span className="text-text-3">·</span>
         <Link
-          href={`/p/${term.ticker}`}
+          href={`/p/${term.slug}`}
           className="text-text-3 hover:text-text-1"
         >
           {term.name}
         </Link>
         <span className="text-text-3">·</span>
         <span className="font-mono text-text-0">
-          {term.ticker}-{(taskRow as { ticker_seq: number }).ticker_seq}
+          #{(taskRow as { ticker_seq: number }).ticker_seq}
         </span>
       </TopBar>
       <main className="mx-auto w-full max-w-5xl flex-1 overflow-y-auto p-6">
@@ -123,7 +117,7 @@ export default async function TaskDetailPage({ params }: Props) {
               created_by: string;
             }
           }
-          terminal={{ id: term.id, ticker: term.ticker, name: term.name }}
+          terminal={{ id: term.id, ticker: term.slug, name: term.name }}
           members={members}
           siblings={siblings}
           currentUserId={user.id}

--- a/apps/web/src/app/p/[ticker]/tasks/page.tsx
+++ b/apps/web/src/app/p/[ticker]/tasks/page.tsx
@@ -1,5 +1,6 @@
 import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
+import { resolveTerminalBySegment } from "@/lib/resolve-terminal";
 import { ScopedModuleShell } from "@/components/pane/ScopedModuleShell";
 import { ScopedTaskList } from "@/components/modules/ScopedTaskList";
 import { loadTasksForTerminal } from "@/lib/modules/tasks-queries";
@@ -25,13 +26,7 @@ export default async function TerminalTasksPage({ params }: Props) {
   } = await supabase.auth.getUser();
   if (!user) redirect("/login");
 
-  const { data: terminalRow } = await supabase
-    .from("terminals")
-    .select("id, name")
-    .eq("ticker", ticker.toUpperCase())
-    .is("archived_at", null)
-    .maybeSingle();
-  const terminal = terminalRow as { id: string; name: string } | null;
+  const terminal = await resolveTerminalBySegment(supabase, ticker);
   if (!terminal) redirect("/");
 
   const tasks = await loadTasksForTerminal(supabase, terminal.id);

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -97,10 +97,14 @@ export default async function DashboardPage({ searchParams }: Props) {
 
   // Build the ticker/name maps once at the page level — shared by
   // ExplorerRail (in DashboardClient) and TasksCardServer below.
+  // `tickerById` is the historical name; the values now hold each
+  // terminal's slug (URL-friendly identifier) so /p/<value> generates
+  // the slug-form URL. The internal name didn't change to avoid a
+  // bigger rename across TasksCard / WeekCard / tests.
   const tickerById: Record<string, string> = {};
   const terminalNameById: Record<string, string> = {};
   for (const t of terminals) {
-    tickerById[t.id] = t.ticker;
+    tickerById[t.id] = t.slug;
     terminalNameById[t.id] = t.name;
   }
 

--- a/apps/web/src/app/tasks/delegated/page.tsx
+++ b/apps/web/src/app/tasks/delegated/page.tsx
@@ -21,7 +21,8 @@ export default async function DelegatedTasksPage() {
     loadDelegatedTasks(supabase, user.id),
     loadDashTerminals(supabase),
   ]);
-  const tickerById = Object.fromEntries(terminals.map((t) => [t.id, t.ticker]));
+  // Values are slugs (URL-friendly), prop name stays for legacy parity.
+  const tickerById = Object.fromEntries(terminals.map((t) => [t.id, t.slug]));
   const terminalNameById = Object.fromEntries(
     terminals.map((t) => [t.id, t.name]),
   );

--- a/apps/web/src/app/tasks/mine/page.tsx
+++ b/apps/web/src/app/tasks/mine/page.tsx
@@ -21,7 +21,8 @@ export default async function MyTasksPage() {
     loadDelegatedTasks(supabase, user.id),
     loadDashTerminals(supabase),
   ]);
-  const tickerById = Object.fromEntries(terminals.map((t) => [t.id, t.ticker]));
+  // Values are slugs (URL-friendly), prop name stays for legacy parity.
+  const tickerById = Object.fromEntries(terminals.map((t) => [t.id, t.slug]));
   const terminalNameById = Object.fromEntries(
     terminals.map((t) => [t.id, t.name]),
   );

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -30,6 +30,7 @@ import {
   HeartPulse,
   CheckSquare,
   FileText,
+  Layers,
   MessageSquare,
   Terminal as TerminalIcon,
 } from "lucide-react";
@@ -38,6 +39,9 @@ import { createClient } from "@/lib/supabase/client";
 
 interface ProjectHit {
   id: string;
+  /** URL-friendly slug — primary identifier for `/p/<slug>` links. */
+  slug: string;
+  /** Legacy ticker, retained for fallback display only. */
   ticker: string;
   name: string;
 }
@@ -167,19 +171,25 @@ export function CommandPalette({ children }: { children: ReactNode }) {
         onRun: go("/help"),
       },
     ];
-    const projectNav: Command[] = projects.map((p) => ({
-      id: `go/p/${p.ticker}`,
-      title: p.name,
-      subtitle: p.ticker,
-      category: "navigation",
-      keywords: [p.ticker.toLowerCase(), p.name.toLowerCase()],
-      icon: (
-        <span className="font-mono text-[11px] font-semibold text-accent">
-          {p.ticker}
-        </span>
-      ),
-      onRun: go(`/p/${p.ticker}`),
-    }));
+    const projectNav: Command[] = projects.map((p) => {
+      const segment = p.slug || p.ticker;
+      return {
+        id: `go/p/${segment}`,
+        title: p.name,
+        // Subtitle is the slug for at-a-glance disambiguation between
+        // similarly-named terminals; the legacy ticker is in keywords
+        // so old-muscle-memory searches ("FFRDBL") still match.
+        subtitle: segment,
+        category: "navigation",
+        keywords: [
+          segment.toLowerCase(),
+          p.ticker.toLowerCase(),
+          p.name.toLowerCase(),
+        ],
+        icon: <Layers className="h-3.5 w-3.5 text-text-3" />,
+        onRun: go(`/p/${segment}`),
+      };
+    });
     const create: Command[] = [
       {
         id: "create/task",

--- a/apps/web/src/components/CreateProjectDialog.tsx
+++ b/apps/web/src/components/CreateProjectDialog.tsx
@@ -72,7 +72,7 @@ export function CreateProjectDialog({
       }),
     });
     const body = (await res.json()) as {
-      data?: { ticker: string };
+      data?: { slug?: string; ticker: string };
       errors?: { message: string }[];
     };
     if (!res.ok || !body.data) {
@@ -81,7 +81,10 @@ export function CreateProjectDialog({
       return;
     }
     onClose();
-    router.push(`/p/${body.data.ticker}`);
+    // Prefer the slug for the post-create URL (clean, name-derived).
+    // Fall back to the legacy ticker if the server response doesn't
+    // include slug — the route resolver accepts either.
+    router.push(`/p/${body.data.slug ?? body.data.ticker}`);
   }
 
   return (

--- a/apps/web/src/components/calendar/CalendarClient.tsx
+++ b/apps/web/src/components/calendar/CalendarClient.tsx
@@ -949,14 +949,14 @@ function DetailMeta({ item }: { item: CalendarItem }) {
           {dateLabel} · {timeLabel}
         </span>
       </p>
-      {item.terminal_ticker ? (
+      {item.terminal_slug || item.terminal_ticker ? (
         <p>
           <span className="font-mono text-[10px] uppercase tracking-wide text-text-3">
             Terminal
           </span>
           <span className="ml-2">
             <Link
-              href={`/p/${item.terminal_ticker}`}
+              href={`/p/${item.terminal_slug ?? item.terminal_ticker}`}
               className="text-accent hover:underline"
             >
               Open terminal
@@ -1002,9 +1002,10 @@ function EventBody({ item }: { item: CalendarItem }) {
 }
 
 function DueBody({ item }: { item: CalendarItem }) {
+  const segment = item.terminal_slug ?? item.terminal_ticker;
   const href =
-    item.terminal_ticker && item.ticker_seq != null
-      ? `/p/${item.terminal_ticker}/task/${item.ticker_seq}`
+    segment && item.ticker_seq != null
+      ? `/p/${segment}/task/${item.ticker_seq}`
       : null;
   return (
     <div className="mt-4 flex flex-col gap-3 text-sm text-text-1">

--- a/apps/web/src/components/dashboard/ExplorerRail.tsx
+++ b/apps/web/src/components/dashboard/ExplorerRail.tsx
@@ -76,7 +76,7 @@ export function ExplorerRail({
       const matches = list.filter(
         (t) =>
           t.name.toLowerCase().includes(filterLower) ||
-          t.ticker.toLowerCase().includes(filterLower),
+          t.slug.toLowerCase().includes(filterLower),
       );
       if (matches.length > 0) next.set(spaceId, matches);
     }
@@ -144,13 +144,18 @@ export function ExplorerRail({
 
   const liveRecents = useMemo(() => {
     if (recents.length === 0) return [];
+    // localStorage may hold either a slug (new) or a legacy ticker
+    // (old recents written before the slug column existed). Match
+    // against both so old recents keep working until they fall off
+    // the ring.
+    const bySlug = new Map(terminals.map((t) => [t.slug, t]));
     const byTicker = new Map(terminals.map((t) => [t.ticker, t]));
     return recents
       .map((r) => {
-        const live = byTicker.get(r.ticker);
-        return live ? { ticker: live.ticker, name: live.name } : null;
+        const live = bySlug.get(r.ticker) ?? byTicker.get(r.ticker);
+        return live ? { slug: live.slug, name: live.name } : null;
       })
-      .filter((r): r is { ticker: string; name: string } => r !== null);
+      .filter((r): r is { slug: string; name: string } => r !== null);
   }, [recents, terminals]);
 
   const filterRef = useRef<HTMLInputElement>(null);
@@ -244,9 +249,9 @@ export function ExplorerRail({
               </p>
               <ul className="space-y-0.5">
                 {liveRecents.map((r) => (
-                  <li key={r.ticker}>
+                  <li key={r.slug}>
                     <Link
-                      href={`/p/${r.ticker}`}
+                      href={`/p/${r.slug}`}
                       className="flex items-center gap-2 rounded-sm px-2 py-0.5 text-text-1 hover:bg-bg-2 hover:text-text-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-focus"
                     >
                       <Clock className="h-3 w-3 flex-shrink-0 text-text-3" />
@@ -328,7 +333,7 @@ export function ExplorerRail({
                         {children.map((t) => (
                           <li key={t.id}>
                             <Link
-                              href={`/p/${t.ticker}`}
+                              href={`/p/${t.slug}`}
                               // pl-5 gives terminals a clear "child of"
                               // indent under the space row's chevron
                               // (chevron sits at px-1 + 14px = ~18px;

--- a/apps/web/src/components/dashboard/WeekCard.tsx
+++ b/apps/web/src/components/dashboard/WeekCard.tsx
@@ -328,9 +328,14 @@ function SourceFilter({
 /* ----------------------------------------------------------------- */
 
 function WeekRow({ item }: { item: WeekItem }) {
-  const href = item.terminal_ticker
-    ? `/p/${item.terminal_ticker}`
-    : undefined;
+  // Prefer the slug for navigation; fall back to legacy ticker if
+  // slug isn't populated (older WeekItems streamed in before the
+  // slug migration ran). The route resolver accepts either.
+  const href = item.terminal_slug
+    ? `/p/${item.terminal_slug}`
+    : item.terminal_ticker
+      ? `/p/${item.terminal_ticker}`
+      : undefined;
   const content = (
     <div className="flex items-center gap-3 px-3 py-1.5 hover:bg-bg-2">
       <span className="flex h-4 w-12 flex-shrink-0 items-center justify-center font-mono text-[10px] text-text-3">

--- a/apps/web/src/lib/calendar-queries.ts
+++ b/apps/web/src/lib/calendar-queries.ts
@@ -38,7 +38,9 @@ export interface CalendarItem {
   source_id: string;
   /** Optional terminal_id (events with `terminal_id` set, all tasks). */
   terminal_id: string | null;
-  /** Optional terminal ticker — for deep links from the task path. */
+  /** URL-friendly terminal identifier — primary source for /p/<slug> links. */
+  terminal_slug: string | null;
+  /** Legacy ticker, kept for fallback rendering only — prefer terminal_slug. */
   terminal_ticker: string | null;
   /** Task only — for the detail link. */
   ticker_seq?: number;
@@ -177,7 +179,7 @@ async function fetchEvents(
   const { data: rows } = await supabase
     .from("calendar_events")
     .select(
-      "id, connection_id, title, description, location, starts_at, ends_at, all_day, html_link, terminal_id, terminals(ticker)",
+      "id, connection_id, title, description, location, starts_at, ends_at, all_day, html_link, terminal_id, terminals(slug, ticker)",
     )
     .in("connection_id", visibleConnIds)
     .gte("starts_at", range.startIso)
@@ -196,8 +198,8 @@ async function fetchEvents(
     html_link: string | null;
     terminal_id: string | null;
     terminals:
-      | { ticker: string }
-      | { ticker: string }[]
+      | { slug: string; ticker: string }
+      | { slug: string; ticker: string }[]
       | null;
   };
   return ((rows ?? []) as EventRow[]).map((r) => ({
@@ -209,7 +211,8 @@ async function fetchEvents(
     all_day: r.all_day,
     source_id: r.connection_id,
     terminal_id: r.terminal_id,
-    terminal_ticker: extractTicker(r.terminals),
+    terminal_slug: extractField(r.terminals, "slug"),
+    terminal_ticker: extractField(r.terminals, "ticker"),
     ticker_seq: undefined,
     ends_at: r.ends_at,
     description: r.description,
@@ -229,7 +232,7 @@ async function fetchDueTasks(
   const { data: rows } = await supabase
     .from("task_assignees")
     .select(
-      "tasks!task_assignees_task_id_fkey(id, title, due_date, ticker_seq, terminal_id, terminals(ticker))",
+      "tasks!task_assignees_task_id_fkey(id, title, due_date, ticker_seq, terminal_id, terminals(slug, ticker))",
     )
     .eq("user_id", userId);
   type AssignedRow = {
@@ -240,8 +243,8 @@ async function fetchDueTasks(
       ticker_seq: number;
       terminal_id: string;
       terminals:
-        | { ticker: string }
-        | { ticker: string }[]
+        | { slug: string; ticker: string }
+        | { slug: string; ticker: string }[]
         | null;
     } | null;
   };
@@ -262,15 +265,23 @@ async function fetchDueTasks(
       all_day: true,
       source_id: "tasks",
       terminal_id: t.terminal_id,
-      terminal_ticker: extractTicker(t.terminals),
+      terminal_slug: extractField(t.terminals, "slug"),
+      terminal_ticker: extractField(t.terminals, "ticker"),
       ticker_seq: t.ticker_seq,
     }));
 }
 
-function extractTicker(
-  rel: { ticker: string } | { ticker: string }[] | null,
+/**
+ * Pull a field off a PostgREST embedded relation that may come back
+ * as an object OR a single-element array depending on the query
+ * shape. Generic helper so we can extract `slug` and `ticker` from
+ * `terminals(...)` selects without duplicating the unwrap logic.
+ */
+function extractField<K extends string>(
+  rel: Record<K, string> | Record<K, string>[] | null,
+  field: K,
 ): string | null {
   if (!rel) return null;
-  if (Array.isArray(rel)) return rel[0]?.ticker ?? null;
-  return rel.ticker ?? null;
+  if (Array.isArray(rel)) return rel[0]?.[field] ?? null;
+  return rel[field] ?? null;
 }

--- a/apps/web/src/lib/dashboard-queries.ts
+++ b/apps/web/src/lib/dashboard-queries.ts
@@ -25,6 +25,18 @@ export interface DashSpace {
 export interface DashTerminal {
   id: string;
   space_id: string;
+  /**
+   * URL-friendly identifier (lowercase, dashed). The /p/<slug> route
+   * resolves by this. Stable across renames so old links never break.
+   * Backfilled from the terminal's name via the rokki_slugify SQL
+   * helper; see the 20260526010000_terminal_slug migration.
+   */
+  slug: string;
+  /**
+   * Legacy Bloomberg-style ticker (uppercase, e.g. "FFRDBL"). Still
+   * stored so old /p/FFRDBL URLs keep resolving via fallback lookup,
+   * but no longer rendered anywhere in the UI.
+   */
   ticker: string;
   name: string;
   status: string;
@@ -52,6 +64,12 @@ export interface WeekItem {
   title: string;
   when: string; // ISO date (full datetime for event, date-only for due)
   terminal_id: string | null;
+  /**
+   * URL-friendly terminal identifier. Used for `/p/<slug>` links from
+   * Week-card rows. Null when the item isn't tied to a terminal (e.g.
+   * raw calendar events with no terminal_id).
+   */
+  terminal_slug: string | null;
   terminal_ticker: string | null;
   /**
    * Source-id for the source filter chip in the Week card. Either a
@@ -129,7 +147,7 @@ export async function loadDashTerminals(
       // RLS filters this to terminals the caller can see.
       const { data } = await supabase
         .from("terminals")
-        .select("id, space_id, ticker, name, status, archived_at")
+        .select("id, space_id, slug, ticker, name, status, archived_at")
         .is("archived_at", null)
         .order("updated_at", { ascending: false });
       return (data ?? []) as DashTerminal[];
@@ -348,10 +366,13 @@ export async function loadWeekItems(
       const { data: terminals } = terminalIds.size
         ? await supabase
             .from("terminals")
-            .select("id, ticker")
+            .select("id, slug, ticker")
             .in("id", Array.from(terminalIds))
         : { data: [] };
-      type Tx = { id: string; ticker: string };
+      type Tx = { id: string; slug: string; ticker: string };
+      const slugById = new Map(
+        ((terminals ?? []) as Tx[]).map((t) => [t.id, t.slug]),
+      );
       const tickerById = new Map(
         ((terminals ?? []) as Tx[]).map((t) => [t.id, t.ticker]),
       );
@@ -362,6 +383,9 @@ export async function loadWeekItems(
         title: e.title,
         when: e.starts_at,
         terminal_id: e.terminal_id,
+        terminal_slug: e.terminal_id
+          ? (slugById.get(e.terminal_id) ?? null)
+          : null,
         terminal_ticker: e.terminal_id
           ? (tickerById.get(e.terminal_id) ?? null)
           : null,

--- a/apps/web/src/lib/resolve-terminal.ts
+++ b/apps/web/src/lib/resolve-terminal.ts
@@ -18,7 +18,7 @@
 
 // Loose `any` because the SSR-cookie and admin Supabase clients have
 // slightly different generic shapes and we only touch `.from()`.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+// eslint-disable-next-line
 type AnySupabaseClient = any;
 
 const TICKER_PATTERN = /^[A-Z][A-Z0-9]{1,9}$/;

--- a/apps/web/src/lib/resolve-terminal.ts
+++ b/apps/web/src/lib/resolve-terminal.ts
@@ -1,0 +1,85 @@
+/**
+ * Look up a terminal by either its slug (new, lowercase-dashed) or
+ * its legacy ticker (uppercase abbreviation). All `/p/<segment>`
+ * routes and the matching `/api/v1/projects/<segment>/...` endpoints
+ * funnel through here so:
+ *
+ *   1. New links generate slug URLs.
+ *   2. Old shared/bookmarked `/p/FFRDBL` URLs still resolve.
+ *   3. Lookup logic lives in one place — no scattered drift between
+ *      a dozen API routes.
+ *
+ * RLS narrows the visible terminals to the caller, so this returns
+ * whatever the caller is allowed to see, which is the same behaviour
+ * the per-route lookups had before centralisation.
+ *
+ * Returns `null` when no terminal matches (caller should 404).
+ */
+
+// Loose `any` because the SSR-cookie and admin Supabase clients have
+// slightly different generic shapes and we only touch `.from()`.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnySupabaseClient = any;
+
+const TICKER_PATTERN = /^[A-Z][A-Z0-9]{1,9}$/;
+
+/**
+ * If the segment matches the legacy ticker shape (uppercase alnum,
+ * 2-10 chars) we try the ticker column too. Lowercase/dashed inputs
+ * are assumed to be slugs and skip the ticker probe — saves a
+ * round-trip + avoids accidentally matching a slug like "API" against
+ * a real "API" ticker on someone else's terminal.
+ */
+function looksLikeLegacyTicker(segment: string): boolean {
+  return TICKER_PATTERN.test(segment);
+}
+
+export interface ResolvedTerminal {
+  id: string;
+  space_id: string;
+  slug: string;
+  ticker: string;
+  name: string;
+}
+
+/**
+ * Resolve a `/p/<segment>` URL fragment to a terminal row.
+ *
+ *   - Tries `slug = segment` first (the new common case).
+ *   - Falls back to `ticker = segment.toUpperCase()` only when the
+ *     segment is shaped like a legacy ticker.
+ *   - Selects only the columns most callers need (id, space_id,
+ *     slug, ticker, name). If a caller needs more they should run a
+ *     follow-up SELECT using the returned `id`.
+ */
+export async function resolveTerminalBySegment(
+  supabase: AnySupabaseClient,
+  segment: string,
+): Promise<ResolvedTerminal | null> {
+  if (!segment) return null;
+
+  // Slug lookup — the common case for any link generated since the
+  // 20260526010000_terminal_slug migration shipped.
+  {
+    const { data } = await supabase
+      .from("terminals")
+      .select("id, space_id, slug, ticker, name")
+      .eq("slug", segment)
+      .is("archived_at", null)
+      .maybeSingle();
+    if (data) return data as ResolvedTerminal;
+  }
+
+  // Fallback for shared URLs minted before the slug column existed.
+  if (looksLikeLegacyTicker(segment)) {
+    const { data } = await supabase
+      .from("terminals")
+      .select("id, space_id, slug, ticker, name")
+      .eq("ticker", segment.toUpperCase())
+      .is("archived_at", null)
+      .maybeSingle();
+    if (data) return data as ResolvedTerminal;
+  }
+
+  return null;
+}

--- a/apps/web/src/lib/space-queries.ts
+++ b/apps/web/src/lib/space-queries.ts
@@ -196,12 +196,14 @@ export async function loadSpaceTasks(
       // handles the per-row read check.
       const { data: terminals } = await supabase
         .from("terminals")
-        .select("id, ticker")
+        .select("id, slug, ticker")
         .eq("space_id", spaceId)
         .is("archived_at", null);
-      type TRow = { id: string; ticker: string };
+      type TRow = { id: string; slug: string; ticker: string };
       const tList = (terminals ?? []) as TRow[];
-      const tickerById = new Map(tList.map((t) => [t.id, t.ticker]));
+      // Values are slugs (URL-friendly), variable name stays
+      // `tickerById` for legacy parity across the codebase.
+      const tickerById = new Map(tList.map((t) => [t.id, t.slug]));
       const ids = tList.map((t) => t.id);
       if (ids.length === 0) {
         return {

--- a/supabase/migrations/20260526010000_terminal_slug.sql
+++ b/supabase/migrations/20260526010000_terminal_slug.sql
@@ -1,0 +1,131 @@
+-- Terminals get a `slug` column derived from the name. The URL bar
+-- on /p/<...> now reads the slug (e.g. "fairfield-river-debt") instead
+-- of the Bloomberg-style ticker abbreviation ("FFRDBL"), matching how
+-- spaces already work (/s/<slug>).
+--
+-- The `ticker` column stays so old shared URLs keep resolving — the
+-- route handler tries `slug` first and falls back to `ticker`. We can
+-- drop the column in a future cleanup once we're sure nobody is
+-- relying on the old URLs.
+--
+-- Slug behavior:
+--   - Set ONCE at INSERT time (sticky). Renaming a terminal does NOT
+--     change its slug, so existing links never break. If the user
+--     wants to change the slug they can edit it in settings later
+--     (manual edit path is a follow-up; for now slug is read-only
+--     after create).
+--   - Unique per space, scoped to non-archived rows so a deleted
+--     terminal's slug can be reused.
+--   - On collision we append `-2`, `-3`, … until a unique value is
+--     found, matching the way GitHub renames a fork.
+
+-- ---------------------------------------------------------------------------
+-- 1. Slugify helper (reusable from any trigger / view).
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION rokki_slugify(input TEXT)
+RETURNS TEXT
+LANGUAGE plpgsql
+IMMUTABLE
+AS $$
+DECLARE
+  s TEXT;
+BEGIN
+  IF input IS NULL THEN RETURN 'untitled'; END IF;
+  s := LOWER(input);
+  -- Drop everything that isn't a lowercase letter or digit; collapse
+  -- the resulting runs of separators into single hyphens.
+  s := REGEXP_REPLACE(s, '[^a-z0-9]+', '-', 'g');
+  -- Trim leading/trailing hyphens.
+  s := REGEXP_REPLACE(s, '^-+|-+$', '', 'g');
+  -- Cap length so the URL stays reasonable.
+  s := SUBSTRING(s FROM 1 FOR 80);
+  IF s IS NULL OR s = '' THEN s := 'untitled'; END IF;
+  RETURN s;
+END;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 2. Column + backfill.
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE terminals ADD COLUMN slug TEXT;
+
+-- Backfill with collision-suffix per space. RANK + the suffix logic
+-- mirrors what the BEFORE INSERT trigger below will do for new rows,
+-- so a terminal created today and a terminal backfilled today produce
+-- the same slug shape.
+WITH ranked AS (
+  SELECT
+    id,
+    rokki_slugify(name) AS base_slug,
+    ROW_NUMBER() OVER (
+      PARTITION BY space_id, rokki_slugify(name)
+      ORDER BY created_at, id
+    ) AS rn
+  FROM terminals
+)
+UPDATE terminals t
+SET slug = CASE
+  WHEN ranked.rn = 1 THEN ranked.base_slug
+  ELSE ranked.base_slug || '-' || (ranked.rn)::TEXT
+END
+FROM ranked
+WHERE t.id = ranked.id;
+
+ALTER TABLE terminals ALTER COLUMN slug SET NOT NULL;
+
+-- Unique per space, only enforced while the terminal is live. An
+-- archived terminal's slug is free to be reused by a new one.
+CREATE UNIQUE INDEX terminals_space_id_slug_key
+  ON terminals (space_id, slug)
+  WHERE archived_at IS NULL;
+
+-- Lookups by slug (no space scope yet — the route resolves by slug
+-- across all terminals the caller can see, then RLS narrows it).
+CREATE INDEX terminals_slug_idx ON terminals (slug) WHERE archived_at IS NULL;
+
+-- ---------------------------------------------------------------------------
+-- 3. BEFORE INSERT trigger — derive slug from name if the caller
+--    didn't pass one. Sticky: never fires on UPDATE.
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION terminals_default_slug()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  base_slug TEXT;
+  candidate TEXT;
+  n INT := 1;
+BEGIN
+  -- Caller may pass an explicit slug (e.g. settings rename path); only
+  -- compute one if they didn't.
+  IF NEW.slug IS NOT NULL AND NEW.slug <> '' THEN
+    NEW.slug := rokki_slugify(NEW.slug);
+    base_slug := NEW.slug;
+  ELSE
+    base_slug := rokki_slugify(NEW.name);
+  END IF;
+
+  candidate := base_slug;
+  -- Walk -2, -3, … until we find an unused slug in this space.
+  WHILE EXISTS (
+    SELECT 1 FROM terminals
+    WHERE space_id = NEW.space_id
+      AND slug = candidate
+      AND id <> NEW.id
+      AND archived_at IS NULL
+  ) LOOP
+    n := n + 1;
+    candidate := base_slug || '-' || n::TEXT;
+  END LOOP;
+  NEW.slug := candidate;
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trg_terminals_default_slug
+  BEFORE INSERT ON terminals
+  FOR EACH ROW
+  EXECUTE FUNCTION terminals_default_slug();


### PR DESCRIPTION
Zack: \"The URL should show the terminal name, not the abbreviation.
I don't want the abbreviation anywhere.\"

This adds a \`slug\` column on terminals derived from the name and flips
every visible URL (and most UI ticker references) over to it. Old
\`/p/FFRDBL\` URLs still resolve via a fallback so existing bookmarks
keep working.

## Migration (\`20260526010000_terminal_slug.sql\`)

- \`terminals.slug TEXT NOT NULL\` with \`UNIQUE (space_id, slug)\` where
  \`archived_at IS NULL\` (so archived slugs can be re-used).
- \`rokki_slugify(text)\` helper: lowercase → \`[^a-z0-9]+\` → \`-\` →
  trim → cap at 80 chars; falls back to \`untitled\` when input
  collapses to empty.
- Backfill: \`slug = slugify(name)\` per row, with \`-2, -3, …\` suffix
  for collisions per space (matches the runtime trigger).
- BEFORE INSERT trigger derives slug for new rows. **Sticky** — never
  fires on UPDATE, so renaming a terminal doesn't break links. (Manual
  slug edit in settings is a follow-up.)

## Centralised resolver (\`lib/resolve-terminal.ts\`)

\`resolveTerminalBySegment(supabase, segment)\` tries slug first, then
ticker — only when the segment matches the legacy uppercase shape
\`[A-Z][A-Z0-9]{1,9}\`. Replaces ~13 inline \`.eq(\"ticker\",
ticker.toUpperCase())\` resolvers across the API + page routes.

## What now generates slug URLs

- Explorer rail (tree + Recent ring)
- Dashboard Tasks card + Week card
- Calendar event drawer + due-task deep links
- Command palette quick-switch + post-create redirect
- Every \`/p/[ticker]/\*\` subpage (settings, task detail, files, goals,
  schedule, permits, drawings, budget, messages, print, OG image)

## Old URLs still work

The \`terminals.ticker\` column is kept (not dropped). The resolver's
ticker fallback only fires when the segment looks like the legacy
uppercase shape, so a bookmark of \`/p/FFRDBL\` resolves the same row
that's now also reachable as \`/p/fairfield-river-debt\`.

## Visible ticker chips also removed

- Print page: dropped \"FFRDBL\" prefix on h1 + footer + per-task
  \"FFRDBL-N\" → \"#N\".
- Settings page header: dropped the accent-colored ticker badge.
- Task detail TopBar: \"TICKER-N\" → \"#N\".

## Test plan

- [ ] Click any terminal in the explorer → URL bar shows
      \`/p/<slug>\`, no uppercase abbreviation
- [ ] Click an old bookmark like \`https://rokki.ai/p/FFRDBL\` → page
      loads, lookup falls through to ticker
- [ ] Rename a terminal in Settings → URL stays the same
      afterward (sticky slug)
- [ ] Create a new terminal → post-create redirect lands on
      \`/p/<slugified-name>\`
- [ ] Sub-tabs (Settings, Tasks, Files, Schedule, Permits,
      Budget) all load from a slug URL
- [ ] CI: migration applies cleanly + RLS tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)