### PR TITLE
ui: card contrast + visible scrollbars + F5 Settings tab

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -309,7 +309,18 @@ kbd[data-active="true"] {
   box-shadow: 0 0 0 4px color-mix(in srgb, var(--accent) 18%, transparent);
 }
 
-/* Scrollbar */
+/* Scrollbar
+ *
+ * Visible enough to spot at a glance (Zack reported the previous
+ * thumb at --bg-3 blended into the page in both modes) while staying
+ * inside the dense-dark aesthetic. `--border-strong` reads as
+ * "subtle UI" in both themes; on hover we step up to `--text-3` so
+ * the affordance feels active without flashing color. Firefox/Edge
+ * pick up the `scrollbar-color` declaration; WebKit uses the
+ * pseudo-element rules. */
+* {
+  scrollbar-color: var(--border-strong) transparent;
+}
 ::-webkit-scrollbar {
   width: 10px;
   height: 10px;
@@ -318,11 +329,15 @@ kbd[data-active="true"] {
   background: transparent;
 }
 ::-webkit-scrollbar-thumb {
-  background: var(--bg-3);
+  background: var(--border-strong);
   border-radius: 5px;
+  border: 2px solid transparent;
+  background-clip: padding-box;
 }
 ::-webkit-scrollbar-thumb:hover {
-  background: var(--bg-4);
+  background: var(--text-3);
+  background-clip: padding-box;
+  border: 2px solid transparent;
 }
 
 /* Selection */

--- a/apps/web/src/app/p/[ticker]/page.tsx
+++ b/apps/web/src/app/p/[ticker]/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import Link from "next/link";
-import { CheckSquare, Settings, Users } from "lucide-react";
+import { CheckSquare, Users } from "lucide-react";
 import { createClient as createAdminClient } from "@supabase/supabase-js";
 import type { Database } from "@rokki/db";
 import { createClient } from "@/lib/supabase/server";
@@ -239,20 +239,10 @@ export default async function ProjectTerminalPage({ params }: Props) {
           ) : null}
           <span className="text-text-3">/</span>
           <span className="text-text-0 font-medium">{p.name}</span>
-          {/* Subtle settings cog right after the terminal name —
-              contextual access to per-terminal admin (rename, members,
-              archive) without re-introducing the redundant top-right
-              "Settings" link. The big top-right link was the
-              clutter; this small inline cog reads as "settings for
-              the thing the breadcrumb just named." */}
-          <Link
-            href={`/p/${p.slug}/settings`}
-            aria-label={`${p.name} settings`}
-            title="Terminal settings"
-            className="rounded-sm p-1 text-text-3 hover:bg-bg-2 hover:text-text-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-focus"
-          >
-            <Settings className="h-3 w-3" aria-hidden="true" />
-          </Link>
+          {/* The settings cog used to live here. Removed in favour of
+              the F5 Settings tab in the function-key bar, so Settings
+              now reads as a peer of Files / Tasks / Team instead of a
+              hidden cog tucked next to the breadcrumb. */}
           <span className="ml-auto flex items-center gap-3">
             <TerminalPresence
               terminalId={p.id}

--- a/apps/web/src/components/ProjectTerminal.tsx
+++ b/apps/web/src/components/ProjectTerminal.tsx
@@ -57,10 +57,23 @@ export function ProjectTerminal({
   const router = useRouter();
   const [activeKey, setActiveKey] = useState("F3");
 
+  // F5 (Settings) is a navigation tab, not an in-place pane. Clicking
+  // it routes to the per-terminal settings page (the gear icon that
+  // lived in the TopBar was removed in favour of this tab so Settings
+  // sits next to Files / Tasks / Team where the rest of the terminal
+  // surface lives).
+  const handleFunctionKey = (key: string) => {
+    if (key === "F5") {
+      router.push(`/p/${project.ticker}/settings`);
+      return;
+    }
+    setActiveKey(key);
+  };
+
   // Register a per-terminal "Terminal settings" command so ⌘K →
   // "settings" surfaces a route into the current terminal's admin
-  // (rename, members, archive). The breadcrumb cog covers the
-  // mouse path; this covers the keyboard one.
+  // (rename, members, archive). The F5 tab covers the mouse path;
+  // this covers the keyboard one.
   const terminalCommands = useMemo(
     () => [
       {
@@ -98,7 +111,7 @@ export function ProjectTerminal({
       topBar={topBar}
       functionKeys={CORE_FUNCTION_KEYS}
       activeKey={activeKey}
-      onFunctionKey={setActiveKey}
+      onFunctionKey={handleFunctionKey}
       tickerItems={tickerItems}
       tickerProjectId={project.id}
       leftRail={leftRail}

--- a/apps/web/src/components/dashboard/DashboardCard.tsx
+++ b/apps/web/src/components/dashboard/DashboardCard.tsx
@@ -41,12 +41,18 @@ export function DashboardCard({
 }: DashboardCardProps) {
   return (
     <section
+      // Stronger border + subtle ring/shadow so cards separate from the
+      // page background without shouting. `border-border-strong` is one
+      // tier darker than `border-border`; the `shadow-sm` adds a hair of
+      // depth that's just enough to read as a contained surface in both
+      // dark and light mode. Zack's feedback: the previous border was
+      // too thin to differentiate sections.
       className={cn(
-        "flex min-h-0 flex-col overflow-hidden rounded border border-border bg-bg-1",
+        "flex min-h-0 flex-col overflow-hidden rounded border border-border-strong bg-bg-1 shadow-sm",
         className,
       )}
     >
-      <header className="flex h-9 flex-shrink-0 items-center justify-between border-b border-border px-3">
+      <header className="flex h-9 flex-shrink-0 items-center justify-between border-b border-border-strong px-3">
         <div className="flex items-center gap-2">
           <h2 className="text-xs font-semibold uppercase tracking-wide text-text-2">
             {title}

--- a/apps/web/src/lib/project-templates.ts
+++ b/apps/web/src/lib/project-templates.ts
@@ -18,6 +18,7 @@ export const CORE_FUNCTION_KEYS: FunctionKey[] = [
   { key: "F2", label: "Files" },
   { key: "F3", label: "Tasks" },
   { key: "F4", label: "Team" },
+  { key: "F5", label: "Settings" },
 ];
 
 export interface ModuleCard {


### PR DESCRIPTION
Three of Zack's polish asks in one PR.

## 1. Card sections were too hard to differentiate
\`DashboardCard\`'s \`border-border\` + \`bg-bg-1\` blended into the page
in both modes. Bumped to \`border-border-strong\` (one tier darker)
and added \`shadow-sm\`. Each card now reads as a contained surface
without shouting. The header divider also moves to
\`border-border-strong\`.

## 2. Scrollbars were nearly invisible in dark mode
Thumb was \`--bg-3\` (#232327) against \`--bg-0\` (#0a0a0b) — almost
unreadable. Re-tuned:
- Default thumb → \`--border-strong\` (the \"subtle UI\" tier)
- Hover thumb → \`--text-3\`
- Added \`scrollbar-color\` so Firefox/Edge follow suit
- 2px transparent border on the thumb so it has air inside the
  10px track instead of butting up against content.

## 3. Gear removed; F5 \"Settings\" tab added
The cog next to the terminal name was a \"hidden tab\". F5 now sits
in the function-key bar next to Files / Tasks / Team, so Settings
reads as a peer of those surfaces. Clicking F5 (or pressing the F5
key) navigates to the existing \`/p/<slug>/settings\` page; F2/F3/F4
still switch panes in place.

## Still on the queue (separate PRs)
- ⭐ Star tasks (DB migration + sort starred to top)
- ↔️ Drag-resize between dashboard sections
- 📜 Scrollable dashboard Tasks card showing every task without
  the 10-row cap

🤖 Generated with [Claude Code](https://claude.com/claude-code)