### PR TITLE
feat(tasks): star tasks; starred float to the top of the list

### DIFF
--- a/apps/web/src/app/api/v1/projects/[ticker]/tasks/route.ts
+++ b/apps/web/src/app/api/v1/projects/[ticker]/tasks/route.ts
@@ -47,11 +47,17 @@ async function handleGet(request: NextRequest, { params }: Props) {
   let query = supabase
     .from("tasks")
     .select(
-      "id, ticker_seq, title, description, status, priority, due_date, labels, position, latest_status_text, latest_status_author_id, latest_status_at, status_thread_id, external_assignee_emails, recurrence_rule, created_at, updated_at, completed_at",
+      "id, ticker_seq, title, description, status, priority, due_date, labels, position, starred, latest_status_text, latest_status_author_id, latest_status_at, status_thread_id, external_assignee_emails, recurrence_rule, created_at, updated_at, completed_at",
     )
     .eq("terminal_id", project.id);
 
   if (status) query = query.eq("status", status);
+
+  // Starred tasks always float to the top — that's the contract of
+  // the star ("highest priority of the day"). Within the starred and
+  // unstarred groups we keep the existing sort: by-position for
+  // manual mode, by status → priority → due → created for auto.
+  query = query.order("starred", { ascending: false });
 
   if (sortMode === "position") {
     query = query
@@ -234,7 +240,7 @@ async function handlePost(request: NextRequest, { params }: Props) {
     // freshly-created row and visibly differs from neighbouring rows
     // until the next refetch lands.
     .select(
-      "id, ticker_seq, title, description, status, priority, due_date, labels, position, latest_status_text, latest_status_author_id, latest_status_at, status_thread_id, external_assignee_emails, recurrence_rule, created_at, updated_at, completed_at",
+      "id, ticker_seq, title, description, status, priority, due_date, labels, position, starred, latest_status_text, latest_status_author_id, latest_status_at, status_thread_id, external_assignee_emails, recurrence_rule, created_at, updated_at, completed_at",
     )
     .single();
 

--- a/apps/web/src/app/api/v1/tasks/[id]/route.ts
+++ b/apps/web/src/app/api/v1/tasks/[id]/route.ts
@@ -71,6 +71,13 @@ async function handlePatch(request: NextRequest, { params }: Props) {
      */
     external_assignee_emails?: string[];
     /**
+     * "Highest priority of the day" flag. Starred tasks float to the
+     * top of every list (the GET endpoint orders by `starred DESC`
+     * before applying the regular sort). Toggle from the row's star
+     * button in TasksPane.
+     */
+    starred?: boolean;
+    /**
      * Optimistic-concurrency token. If supplied (either via this field or
      * the `If-Match` header) we 409 when the row's current `updated_at`
      * doesn't match what the client thought it was editing.
@@ -113,6 +120,9 @@ async function handlePatch(request: NextRequest, { params }: Props) {
     patch.status = body.status;
     patch.completed_at = body.status === "done" ? new Date().toISOString() : null;
   }
+  if (body.starred !== undefined) {
+    patch.starred = Boolean(body.starred);
+  }
   if (body.external_assignee_emails !== undefined) {
     const normalized = normalizeEmails(body.external_assignee_emails);
     if (normalized === "invalid") {
@@ -131,7 +141,7 @@ async function handlePatch(request: NextRequest, { params }: Props) {
     const { data: current } = await supabase
       .from("tasks")
       .select(
-        "id, terminal_id, ticker_seq, title, description, status, priority, due_date, labels, recurrence_rule, recurrence_parent_id, completed_at, updated_at",
+        "id, terminal_id, ticker_seq, title, description, status, priority, starred, due_date, labels, recurrence_rule, recurrence_parent_id, completed_at, updated_at",
       )
       .eq("id", id)
       .maybeSingle();
@@ -160,7 +170,7 @@ async function handlePatch(request: NextRequest, { params }: Props) {
     .update(patch)
     .eq("id", id)
     .select(
-      "id, terminal_id, ticker_seq, title, description, status, priority, due_date, labels, recurrence_rule, recurrence_parent_id, completed_at, updated_at",
+      "id, terminal_id, ticker_seq, title, description, status, priority, starred, due_date, labels, recurrence_rule, recurrence_parent_id, completed_at, updated_at",
     )
     .single();
 

--- a/apps/web/src/components/TasksPane.tsx
+++ b/apps/web/src/components/TasksPane.tsx
@@ -14,6 +14,7 @@ import {
   ListTodo,
   Repeat,
   Send,
+  Star,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { EmptyState } from "./EmptyState";
@@ -54,6 +55,12 @@ interface Task {
   status: TaskStatus;
   /** 1=High, 2=Medium, 3=Low, null=No priority. */
   priority: number | null;
+  /**
+   * "Highest priority of the day" flag. Starred tasks sort to the
+   * top of the list regardless of priority/due/position. Toggled
+   * inline from the star button on each row.
+   */
+  starred: boolean;
   due_date: string | null;
   labels: string[];
   latest_status_text?: string | null;
@@ -600,6 +607,32 @@ export function TasksPane({ ticker, projectId, currentUserId }: TasksPaneProps) 
     }
   }
 
+  /**
+   * Toggle the star on a task. Optimistically flips the flag locally
+   * (so the row jumps to/from the top immediately) and PATCHes the
+   * server. Rollback on failure via load().
+   */
+  async function toggleStar(task: Task) {
+    const next = !task.starred;
+    setTasks((prev) =>
+      sortTasks(
+        prev.map((t) => (t.id === task.id ? { ...t, starred: next } : t)),
+        sortMode,
+      ),
+    );
+    try {
+      const r = await offlineFetch(`/api/v1/tasks/${task.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ starred: next }),
+        label: next ? `Star "${task.title}"` : `Unstar "${task.title}"`,
+      });
+      if (!r.ok && r.status !== 202) await load();
+    } catch {
+      await load();
+    }
+  }
+
   async function toggleComplete(task: Task) {
     const nextStatus: TaskStatus = task.status === "done" ? "todo" : "done";
     // Optimistic update
@@ -919,6 +952,7 @@ export function TasksPane({ ticker, projectId, currentUserId }: TasksPaneProps) 
                               draggable={dragEnabled}
                               onClick={() => setSelectedIdx(i)}
                               onToggle={() => toggleComplete(t)}
+                              onToggleStar={() => toggleStar(t)}
                               onOpenComments={() =>
                                 setCommentTaskId((prev) =>
                                   prev === t.id ? null : t.id,
@@ -986,6 +1020,7 @@ function TaskRow({
   draggable,
   onClick,
   onToggle,
+  onToggleStar,
   onOpenComments,
   onToggleExpand,
   onRequestUpdate,
@@ -998,6 +1033,11 @@ function TaskRow({
   draggable: boolean;
   onClick: () => void;
   onToggle: () => void;
+  /**
+   * Flip the "highest priority of the day" star. Starred rows float
+   * to the top of the list regardless of priority/due/position.
+   */
+  onToggleStar: () => void;
   onOpenComments: () => void;
   onToggleExpand: () => void;
   onRequestUpdate: () => void;
@@ -1061,6 +1101,34 @@ function TaskRow({
         ) : (
           <ChevronRight className="h-3 w-3" aria-hidden="true" />
         )}
+      </button>
+      <button
+        type="button"
+        onClick={(e) => {
+          e.stopPropagation();
+          onToggleStar();
+        }}
+        aria-label={task.starred ? "Unstar (remove from top)" : "Star (pin to top)"}
+        aria-pressed={task.starred}
+        title={
+          task.starred
+            ? "Starred — highest priority. Click to unstar."
+            : "Star to pin to top of the list"
+        }
+        className={cn(
+          "flex h-4 w-4 flex-shrink-0 items-center justify-center rounded-sm transition-colors",
+          task.starred
+            ? "text-warning"
+            : "text-text-3 hover:text-warning opacity-0 group-hover:opacity-100",
+          // Starred state stays visible always — even when not hovered —
+          // because the star is the highest-priority signal on the row.
+        )}
+      >
+        <Star
+          className="h-3 w-3"
+          fill={task.starred ? "currentColor" : "none"}
+          aria-hidden="true"
+        />
       </button>
       <button
         onClick={(e) => {
@@ -1374,8 +1442,15 @@ function Empty({ onCreate }: { onCreate: () => void }) {
  * comparison the server uses keeps the visible list deterministic.
  */
 function sortTasks(tasks: Task[], mode: SortMode = "auto"): Task[] {
+  // Starred tasks float to the top of every sort mode — that's the
+  // contract of the star ("highest priority of the day"). Matches the
+  // server-side `ORDER BY starred DESC, …` so realtime + load() agree.
+  const starRank = (t: Task) => (t.starred ? 0 : 1);
+
   if (mode === "manual") {
     return [...tasks].sort((a, b) => {
+      const s = starRank(a) - starRank(b);
+      if (s !== 0) return s;
       const ap = a.position ?? Number.POSITIVE_INFINITY;
       const bp = b.position ?? Number.POSITIVE_INFINITY;
       if (ap !== bp) return ap - bp;
@@ -1393,8 +1468,10 @@ function sortTasks(tasks: Task[], mode: SortMode = "auto"): Task[] {
   const pkey = (p: number | null | undefined): number =>
     p == null ? Number.POSITIVE_INFINITY : p;
   return [...tasks].sort((a, b) => {
-    const s = rank[a.status] - rank[b.status];
+    const s = starRank(a) - starRank(b);
     if (s !== 0) return s;
+    const st = rank[a.status] - rank[b.status];
+    if (st !== 0) return st;
     const p = pkey(a.priority) - pkey(b.priority);
     if (p !== 0) return p;
     const da = a.due_date ? new Date(a.due_date).getTime() : Number.POSITIVE_INFINITY;

--- a/supabase/migrations/20260526020000_task_starred.sql
+++ b/supabase/migrations/20260526020000_task_starred.sql
@@ -1,0 +1,17 @@
+-- Tasks get a `starred` boolean so users can flag "this is the highest
+-- priority for today" independent of the priority field. Starred tasks
+-- sort to the top of every task list (auto + manual modes) so the
+-- user's day-of-day priorities float without losing the underlying
+-- priority/due/position ordering for everything else.
+--
+-- Shared (not per-user) for the first cut — most teams of 1-3 people
+-- effectively star the same critical task. If a per-user need shows
+-- up we'd add a `task_stars(task_id, user_id)` join table later.
+
+ALTER TABLE tasks ADD COLUMN starred BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- Partial index — only starred rows are interesting for the
+-- "show me what's starred" path. Keeps the index small.
+CREATE INDEX tasks_starred_idx
+  ON tasks (terminal_id, updated_at DESC)
+  WHERE starred = TRUE AND deleted_at IS NULL;


### PR DESCRIPTION
Zack: \"I'd like the ability to star tasks and order with stars at
the top. Essentially it's the highest priority task of the day.\"

## Migration
\`20260526020000_task_starred.sql\` — \`tasks.starred BOOLEAN NOT NULL
DEFAULT FALSE\` + a partial index on \`(terminal_id, updated_at DESC)
WHERE starred = TRUE\`.

## API
- \`GET /api/v1/projects/:ticker/tasks\` returns \`starred\` and orders
  by \`starred DESC\` before the existing auto/manual sort, so the
  list comes back from the server with starred tasks already at the
  top.
- \`POST\` returns \`starred\` so the optimistic-insert path doesn't
  fake the field.
- \`PATCH /api/v1/tasks/:id\` accepts \`starred?: boolean\`.

## UI
Star icon left of the checkbox on each TasksPane row.
- Filled gold when starred, hollow-on-hover when not.
- Click toggles + optimistically re-sorts so the row jumps to the
  top in the same frame.
- \`sortTasks()\` prepends a star-rank step so realtime + load()
  agree with the server's \`ORDER BY\`.

## Scope note
Shared star (not per-user) for the first cut — most small teams
star the same critical task. If a per-user need shows up later
we'd add a \`task_stars(task_id, user_id)\` join table.

## Test plan
- [ ] Click the star icon on a task → row jumps to top, icon fills gold
- [ ] Refresh → starred row is still at the top
- [ ] Star multiple → all starred at top, in their original auto/manual sort within the starred group
- [ ] Unstar → row drops back into its priority/due position
- [ ] In manual sort: starred tasks still at top; drag-reorder within unstarred works
- [ ] CI green (migration applies, RLS tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)