### PR TITLE
feat(tasks): hide done toggle + uncap dashboard task list

### DIFF
--- a/apps/web/src/components/TasksPane.tsx
+++ b/apps/web/src/components/TasksPane.tsx
@@ -100,6 +100,10 @@ function groupStorageKey(projectId: string): string {
   return `rokki_tasks_group:${projectId}`;
 }
 
+function hideDoneStorageKey(projectId: string): string {
+  return `rokki_tasks_hide_done:${projectId}`;
+}
+
 interface TasksPaneProps {
   ticker: string;
   projectId: string;
@@ -140,6 +144,14 @@ export function TasksPane({ ticker, projectId, currentUserId }: TasksPaneProps) 
   const [mentionables, setMentionables] = useState<Mentionable[]>([]);
   const [sortMode, setSortMode] = useState<SortMode>("auto");
   const [groupMode, setGroupMode] = useState<GroupMode>("none");
+  /**
+   * When true, completed tasks are filtered out of the view. The
+   * server still returns them so the count of hidden rows can be
+   * displayed (so you remember they exist) and toggling back is
+   * instant — no refetch needed. Persisted per-terminal so each
+   * project remembers its own preference.
+   */
+  const [hideDone, setHideDone] = useState(false);
   /**
    * Client-side filter query. Matches against title + description +
    * labels + assignee names + `${ticker}-${seq}`. Empty string =
@@ -199,6 +211,27 @@ export function TasksPane({ ticker, projectId, currentUserId }: TasksPaneProps) 
       /* ignore */
     }
   }, [projectId, groupMode]);
+
+  // Hydrate + persist the hide-done preference per project.
+  useEffect(() => {
+    try {
+      const saved = window.localStorage.getItem(hideDoneStorageKey(projectId));
+      if (saved === "1") setHideDone(true);
+    } catch {
+      /* ignore */
+    }
+  }, [projectId]);
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(
+        hideDoneStorageKey(projectId),
+        hideDone ? "1" : "0",
+      );
+    } catch {
+      /* ignore */
+    }
+  }, [projectId, hideDone]);
 
   // Subtasks: lazily-loaded per parent. `null` = not yet fetched,
   // `[]` = fetched and empty. The expand toggle drives both
@@ -809,6 +842,36 @@ export function TasksPane({ ticker, projectId, currentUserId }: TasksPaneProps) 
               <option value="status">Status</option>
             </select>
           </label>
+          {/* Hide-done toggle. Shows the count of tasks being hidden
+              so the user remembers they exist (and can click to bring
+              them back). Persists per-project in localStorage. */}
+          {(() => {
+            const doneCount = tasks.filter((t) => t.status === "done").length;
+            if (doneCount === 0 && !hideDone) return null;
+            return (
+              <button
+                type="button"
+                onClick={() => setHideDone((v) => !v)}
+                aria-pressed={hideDone}
+                title={
+                  hideDone
+                    ? `Show ${doneCount} completed task${doneCount === 1 ? "" : "s"}`
+                    : `Hide ${doneCount} completed task${doneCount === 1 ? "" : "s"} from the list`
+                }
+                className={cn(
+                  "flex items-center gap-1 rounded-sm border px-2 py-0.5 font-mono text-[10px] uppercase tracking-wide transition-colors",
+                  hideDone
+                    ? "border-border bg-bg-2 text-text-2 hover:bg-bg-3"
+                    : "border-border bg-bg-1 text-text-3 hover:bg-bg-2 hover:text-text-1",
+                )}
+              >
+                {hideDone ? "Show done" : "Hide done"}
+                {doneCount > 0 ? (
+                  <span className="text-text-3">{doneCount}</span>
+                ) : null}
+              </button>
+            );
+          })()}
         </div>
         <div className="flex items-center gap-2">
           <TaskSearchInput
@@ -848,7 +911,12 @@ export function TasksPane({ ticker, projectId, currentUserId }: TasksPaneProps) 
             // bucket semantics — disable it when grouped OR filtered to
             // avoid a confusing "drag worked but the row didn't move"
             // UX.
-            const filtered = filterTasks(tasks, query, ticker);
+            // Hide-done step runs before the search filter so the "X
+            // tasks match" count reflects only what's visible.
+            const visibleSource = hideDone
+              ? tasks.filter((t) => t.status !== "done")
+              : tasks;
+            const filtered = filterTasks(visibleSource, query, ticker);
             const dragEnabled =
               sortMode === "manual" && groupMode === "none" && !query.trim();
             const groups = groupTasks(filtered, groupMode);

--- a/apps/web/src/components/dashboard/TasksCard.tsx
+++ b/apps/web/src/components/dashboard/TasksCard.tsx
@@ -71,11 +71,16 @@ export function TasksCard({
   createDisabled,
   expanded = false,
 }: TasksCardProps) {
-  // Dashboard caps at 10 to keep the card bounded; full-page views
-  // (/tasks/mine, /tasks/delegated) pass `expanded` and we lift the
-  // cap so the user sees everything, scrolling within the parent's
-  // height instead of clicking through a fake "open the full list".
-  const ROW_LIMIT = expanded ? Number.POSITIVE_INFINITY : 10;
+  // The cap is gone. Zack: "I could just keep on scrolling through
+  // the tasks on my dashboard and see tasks that may not be showing."
+  // The dashboard card already lives in a `flex-1 min-h-0
+  // overflow-y-auto` body, so all rows render and the user scrolls
+  // inside the card to reach the rest of the list. The
+  // `expandHref` Maximize button in the card header still takes them
+  // to the full-page view if they want more room.
+  const ROW_LIMIT = Number.POSITIVE_INFINITY;
+  // Kept for API back-compat with callers that still pass `expanded`.
+  void expanded;
 
   const router = useRouter();
   useRealtimeTable<{ id: string }>(
@@ -314,19 +319,10 @@ export function TasksCard({
           );
         })()
       )}
-      {!expanded && visibleAssigned.length > ROW_LIMIT ? (
-        // Dashboard footer: real Link to the full-page view for the
-        // active tab. The old <p> was decorative-only ("13 more —
-        // open the full list" but no href), which read as broken.
-        // overdue/week/all all live inside "Mine" so they route there;
-        // "delegated" has its own page.
-        <Link
-          href={tab === "delegated" ? "/tasks/delegated" : "/tasks/mine"}
-          className="block px-3 py-1 text-center text-[10px] text-text-3 hover:bg-bg-2 hover:text-text-1"
-        >
-          {visibleAssigned.length - ROW_LIMIT} more — open the full list
-        </Link>
-      ) : null}
+      {/* The "X more — open the full list" footer is gone. All rows
+          now render and the user scrolls inside the card; the
+          Maximize icon in the card header is still a one-click route
+          to the full-page view for a roomier surface. */}
     </DashboardCard>
   );
 }


### PR DESCRIPTION
Two related task-visibility asks.

## 1. Hide completed tasks
New \"Hide done\" toggle in the TasksPane toolbar. When on, completed
tasks drop out of the list so the user can focus on what's open.
- Button label shows the count of hidden tasks so they're not
  forgotten (\"Hide done 5\" / \"Show done 5\").
- Persists per-terminal in \`localStorage\` (same pattern as the
  existing sort/group preferences).
- Server still returns done tasks, so toggling back is instant
  — no refetch needed.

## 2. Uncap the dashboard task list
The \`TasksCard\` on the dashboard was hard-capped at 10 rows with
an \"X more — open the full list\" link. Zack: \"I could just keep on
scrolling through the tasks on my dashboard.\"

- Dropped the cap. All rows render.
- The card body already has \`min-h-0 flex-1 overflow-y-auto\`, so
  the user scrolls inside the card.
- Maximize icon in the card header is still a one-click route to
  the full-page \`/tasks/mine\` for a roomier surface.

## Test plan
- [ ] Open a terminal with both open and done tasks → \"Hide done N\"
      chip appears in toolbar
- [ ] Click it → done tasks disappear, chip becomes \"Show done N\"
- [ ] Refresh → preference persists
- [ ] Dashboard \"Tasks\" card with >10 tasks → scroll inside the
      card to see all of them, no \"X more\" footer
- [ ] Star a task → it floats to top above both starred and
      non-starred (combines with PR #189)

🤖 Generated with [Claude Code](https://claude.com/claude-code)