### PR TITLE
feat(dashboard): drag-resize splitter between Week and Tasks

### DIFF
--- a/apps/web/src/components/DashboardClient.tsx
+++ b/apps/web/src/components/DashboardClient.tsx
@@ -9,6 +9,7 @@ import { Focus, X } from "lucide-react";
 import { DashboardShell } from "./dashboard/DashboardShell";
 import { ExplorerRail } from "./dashboard/ExplorerRail";
 import { MessagesCard } from "./dashboard/MessagesCard";
+import { ResizableCenterStack } from "./dashboard/ResizableCenterStack";
 import { TerminalScopeFilter } from "./dashboard/TerminalScopeFilter";
 import { TopBar } from "./TopBar";
 import { DensityProvider, type Density } from "@/lib/density";
@@ -198,21 +199,25 @@ export function DashboardClient({
           />
         }
         center={
-          <div className="card-stack flex flex-col gap-3 p-2 sm:p-3">
-            {focused ? (
-              <FocusBanner
-                ticker={focused.ticker}
-                name={focused.name}
-                searchParams={searchParams}
+          <ResizableCenterStack
+            focus={
+              focused ? (
+                <FocusBanner
+                  ticker={focused.ticker}
+                  name={focused.name}
+                  searchParams={searchParams}
+                />
+              ) : null
+            }
+            briefing={
+              <BriefingCard
+                userName={userName}
+                dismissedOn={briefingDismissedOn}
               />
-            ) : null}
-            <BriefingCard
-              userName={userName}
-              dismissedOn={briefingDismissedOn}
-            />
-            {weekSlot}
-            {tasksSlot}
-          </div>
+            }
+            week={weekSlot}
+            tasks={tasksSlot}
+          />
         }
         right={
           <div className="card-stack flex flex-col gap-3 p-2 sm:p-3">

--- a/apps/web/src/components/dashboard/ResizableCenterStack.tsx
+++ b/apps/web/src/components/dashboard/ResizableCenterStack.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { useEffect, useState, type ReactNode } from "react";
+import { ResizeHandle, useResizable } from "@/components/ResizeHandle";
+
+interface ResizableCenterStackProps {
+  /** Optional focus banner (only when a terminal scope is active). */
+  focus?: ReactNode;
+  /** Dismissible greeting / briefing card. */
+  briefing: ReactNode;
+  /** Week calendar card — the top resizable pane. */
+  week: ReactNode;
+  /** Tasks card — the bottom pane, fills the remaining height. */
+  tasks: ReactNode;
+}
+
+/**
+ * Dashboard center column with a draggable splitter between the Week
+ * card and the Tasks card.
+ *
+ *  ┌───────────────────────────────┐
+ *  │ (focus banner)                │   ← natural height
+ *  │ (briefing)                    │
+ *  ├───────────────────────────────┤
+ *  │ Week                          │   ← user-resizable
+ *  │                               │
+ *  ╞═══════════════════════════════╡   ← drag handle (axis="y")
+ *  │ Tasks                         │   ← fills remaining
+ *  │                               │
+ *  └───────────────────────────────┘
+ *
+ * The handle uses the existing `useResizable` + `ResizeHandle`
+ * primitives (same ones that control the left/right rail widths) so
+ * the gesture, the cursor, the hit-area, and the localStorage
+ * persistence pattern all match what the user already learned from
+ * the horizontal rails.
+ *
+ * Default split: 50% Week / 50% Tasks. Stored as the Week pane's
+ * pixel height; Tasks fills the rest via `flex: 1`.
+ *
+ * Below `lg` the splitter is hidden and cards stack at natural
+ * height inside the page's scroll container — the resize gesture
+ * doesn't translate to phone/tablet.
+ */
+export function ResizableCenterStack({
+  focus,
+  briefing,
+  week,
+  tasks,
+}: ResizableCenterStackProps) {
+  // First mount: we don't have the available height yet (SSR has no
+  // window) so we render a "fluid" layout matching the old behaviour
+  // and only enable the splitter after hydration. Without this the
+  // initial paint would either jump (SSR vs client mismatch) or pick
+  // a wrong default size and resize on first render.
+  const [hydrated, setHydrated] = useState(false);
+  useEffect(() => {
+    setHydrated(true);
+  }, []);
+
+  const weekHeight = useResizable({
+    storageKey: "rokki:dash-week-height",
+    // Reasonable default — half a typical laptop viewport.
+    defaultSize: 360,
+    min: 160,
+    max: 800,
+  });
+
+  return (
+    <div className="flex h-full min-h-0 flex-col gap-3 p-2 sm:p-3">
+      {focus}
+      {briefing}
+      {/* Below lg: stack naturally and let the page scroll. The
+          resize splitter only makes sense when there's a fixed
+          viewport height to redistribute. */}
+      <div className="contents lg:hidden">
+        {week}
+        {tasks}
+      </div>
+      <div className="hidden min-h-0 flex-1 flex-col gap-2 lg:flex">
+        <div
+          className="min-h-0 flex-shrink-0"
+          style={hydrated ? { height: weekHeight.size } : undefined}
+        >
+          {week}
+        </div>
+        <ResizeHandle
+          orientation="horizontal"
+          ariaLabel="Resize Week vs Tasks"
+          onMouseDown={(e) =>
+            weekHeight.startDrag(e, { side: "before", axis: "y" })
+          }
+        />
+        <div className="min-h-0 flex-1">{tasks}</div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Zack: \"I like the ability to drag, to expand, and compress these
different sections to show more or less material.\"

## What's new
New \`ResizableCenterStack\` component wraps the dashboard's center
column. A draggable horizontal handle sits between the Week card
and the Tasks card — drag down to give Tasks more room, drag up
to give Week more room.

## Reuses existing primitives
\`useResizable\` + \`ResizeHandle\` already power the left/right rail
widths. This PR just uses them in the \`axis: \"y\"\` direction. So
the gesture, cursor, ~25px hit area, and localStorage persistence
all match what the user learned from the horizontal rails.

- Storage key: \`rokki:dash-week-height\`
- Defaults: 360px for Week, Tasks fills the rest
- Bounds: 160–800px so you can't collapse a pane to nothing

## Mobile
Below \`lg\` the splitter is hidden and cards stack at natural height
inside the page's scroll container — the resize gesture only makes
sense when there's a fixed viewport height to redistribute.

## Test plan
- [ ] Open the dashboard on desktop → see a thin separator with a grip
      between Week and Tasks
- [ ] Drag it up/down → both cards resize live
- [ ] Reload → the new ratio persists
- [ ] Resize to extremes → bounded at 160px (Week) / leaves Tasks
      bounded too
- [ ] Resize window narrower than lg → splitter hides; cards stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)