### PR TITLE
fix(login): cosmos video paints first, card fades in only after

### DIFF
--- a/apps/web/src/app/login/LoginBackground.tsx
+++ b/apps/web/src/app/login/LoginBackground.tsx
@@ -23,10 +23,19 @@ import { useEffect, useRef, useState } from "react";
  *     `playing`, OR a 1500ms safety timer. This stops the video sitting at
  *     `opacity-0` indefinitely on slow dev servers where `loadeddata`
  *     doesn't fire promptly for a 32MB MP4.
+ *
+ * `onReady` fires exactly once when the video first reaches a paintable
+ * state (or when the safety timer trips). The parent uses it to gate
+ * the login card's fade-in so the user sees the cosmos *before* the
+ * form lands — per Zack: "the first thing the person sees is the
+ * cosmos video. then the other items."
  */
-export function LoginBackground() {
+export function LoginBackground({ onReady }: { onReady?: () => void }) {
   const videoRef = useRef<HTMLVideoElement>(null);
   const [ready, setReady] = useState(false);
+  // Guards against `onReady` firing more than once when several video
+  // events (`loadeddata`, `canplay`, `playing`) race to flip ready.
+  const firedRef = useRef(false);
 
   useEffect(() => {
     const v = videoRef.current;
@@ -38,7 +47,10 @@ export function LoginBackground() {
 
     let cancelled = false;
     const flip = () => {
-      if (!cancelled) setReady(true);
+      if (cancelled || firedRef.current) return;
+      firedRef.current = true;
+      setReady(true);
+      onReady?.();
     };
 
     v.addEventListener("loadeddata", flip);
@@ -70,7 +82,7 @@ export function LoginBackground() {
       v.removeEventListener("canplay", flip);
       v.removeEventListener("playing", flip);
     };
-  }, []);
+  }, [onReady]);
 
   return (
     <>

--- a/apps/web/src/app/login/LoginCanvas.tsx
+++ b/apps/web/src/app/login/LoginCanvas.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { Suspense, useCallback, useState } from "react";
+import { Wordmark } from "@/components/Wordmark";
+import { LoginForm } from "./LoginForm";
+import { LoginBackground } from "./LoginBackground";
+
+/**
+ * Client wrapper for the login surface. Owns the "video is playing"
+ * signal so the content card (wordmark + form + footer) stays hidden
+ * until the cosmos has paint.
+ *
+ * Behaviour:
+ *   1. Page paints solid black.
+ *   2. <video> starts loading + autoplays.
+ *   3. As soon as the video has a paintable frame (or the 1.5s
+ *      safety timer in LoginBackground trips), we flip `ready`.
+ *   4. The card fades in over 700ms.
+ *
+ * Until `ready` flips, the card is `opacity-0`, `pointer-events-none`,
+ * and `aria-hidden` so it doesn't catch focus or get announced by
+ * screen readers. The DOM is still mounted so the form is reachable
+ * for keyboard users the moment ready flips.
+ *
+ * Per Zack: "I want the first thing the person sees is the cosmos
+ * video. Then the other items. Don't load the page until the cosmos
+ * is playing."
+ */
+export function LoginCanvas() {
+  const [ready, setReady] = useState(false);
+
+  // `useCallback` so LoginBackground's effect doesn't re-run on every
+  // parent render (the callback is in its dep array).
+  const handleReady = useCallback(() => setReady(true), []);
+
+  return (
+    <div className="relative flex min-h-[100dvh] items-center justify-center overflow-hidden bg-black px-4">
+      <LoginBackground onReady={handleReady} />
+
+      {/* Single content card — wordmark, tagline, form, footer all
+          inside one solid panel so every text element has a backing.
+          Held at opacity-0 until the nebula is playing; transitions
+          to opacity-100 with a soft 700ms fade. */}
+      <div
+        aria-hidden={!ready}
+        className={`relative z-10 w-full max-w-sm rounded-lg border border-border bg-bg-1 p-6 shadow-2xl ring-1 ring-black/40 transition-opacity duration-700 ${
+          ready ? "opacity-100" : "pointer-events-none opacity-0"
+        }`}
+      >
+        <div className="mb-5 flex flex-col items-center gap-1.5">
+          <Wordmark size="lg" />
+          <p className="text-[11px] text-text-2">
+            The terminal for your projects.
+          </p>
+        </div>
+
+        <Suspense fallback={null}>
+          <LoginForm />
+        </Suspense>
+
+        <p className="mt-5 border-t border-border pt-3 text-center text-[11px] leading-snug text-text-3">
+          Sign in with the email or username your administrator
+          provisioned. Lost access?{" "}
+          <a
+            href="mailto:support@rokki.ai?subject=Lost%20access%20to%20Rokki"
+            className="text-text-2 underline-offset-2 hover:text-text-1 hover:underline"
+          >
+            Contact support
+          </a>
+          .
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -1,7 +1,4 @@
-import { Suspense } from "react";
-import { Wordmark } from "@/components/Wordmark";
-import { LoginForm } from "./LoginForm";
-import { LoginBackground } from "./LoginBackground";
+import { LoginCanvas } from "./LoginCanvas";
 
 export const metadata = {
   title: "Sign in · Rokki",
@@ -10,43 +7,11 @@ export const metadata = {
 /**
  * Login page.
  *
- * 4K space-nebula video fills the viewport, autoplays muted on loop. A
- * two-layer overlay (top-to-bottom gradient + radial vignette) keeps the
- * content card at WCAG-AA contrast without washing out the nebula. The
- * card itself is a single solid panel containing wordmark, tagline,
- * form, and footer copy — no see-through text.
+ * Cosmos-first paint order: a 4K space-nebula video fills the viewport
+ * and starts playing on mount; the wordmark + sign-in form fade in
+ * only after the video has a paintable frame. See `LoginCanvas` for
+ * the ready-state plumbing.
  */
 export default function LoginPage() {
-  return (
-    <div className="relative flex min-h-[100dvh] items-center justify-center overflow-hidden bg-black px-4">
-      <LoginBackground />
-
-      {/* Single content card — wordmark, tagline, form, footer all
-          inside one solid panel so every text element has a backing. */}
-      <div className="relative z-10 w-full max-w-sm rounded-lg border border-border bg-bg-1 p-6 shadow-2xl ring-1 ring-black/40">
-        <div className="mb-5 flex flex-col items-center gap-1.5">
-          <Wordmark size="lg" />
-          <p className="text-[11px] text-text-2">
-            The terminal for your projects.
-          </p>
-        </div>
-
-        <Suspense fallback={null}>
-          <LoginForm />
-        </Suspense>
-
-        <p className="mt-5 border-t border-border pt-3 text-center text-[11px] leading-snug text-text-3">
-          Sign in with the email or username your administrator
-          provisioned. Lost access?{" "}
-          <a
-            href="mailto:support@rokki.ai?subject=Lost%20access%20to%20Rokki"
-            className="text-text-2 underline-offset-2 hover:text-text-1 hover:underline"
-          >
-            Contact support
-          </a>
-          .
-        </p>
-      </div>
-    </div>
-  );
+  return <LoginCanvas />;
 }


### PR DESCRIPTION
Zack: \"I want the first thing the person sees is the cosmos video.
Then the other items. Don't load the page until the cosmos is
playing.\"

## Behaviour

1. Page paints solid black.
2. \`<video>\` starts loading + autoplays.
3. As soon as the video has a paintable frame (or the 1.5s safety
   timer in \`LoginBackground\` trips), we flip \`ready\`.
4. The card fades in over 700ms.

## Implementation

- \`LoginBackground\` now accepts \`onReady?: () => void\`. It fires
  exactly once when the video first reaches a paintable state
  (\`loadeddata\` / \`canplay\` / \`playing\`) or when the safety timer
  trips — guarded with a \`firedRef\` so multi-event races don't
  call it twice.

- New \`LoginCanvas\` client wrapper owns the \`ready\` state. The
  card is mounted in the DOM from first render so the form is
  reachable for keyboard users the moment ready flips, but is held
  at \`opacity-0 pointer-events-none aria-hidden\` until then.

- \`page.tsx\` slims to a thin Server Component that exports
  \`metadata\` and renders \`<LoginCanvas />\`.

## Test plan
- [ ] Open rokki.ai/login in a cold incognito window → see solid
      black, then cosmos, then card fades in (~700ms after the
      video paints)
- [ ] Throttle to Slow 3G in DevTools → at most 1.5s of black, then
      card appears (the safety timer)
- [ ] Keyboard tab once card is visible → focus lands on the email
      input
- [ ] \`prefers-reduced-motion: reduce\` → video paused on first
      frame, card still fades in

🤖 Generated with [Claude Code](https://claude.com/claude-code)