### PR TITLE
Unify task list interface across dashboard and terminal

### DIFF
--- a/apps/web/src/components/TaskListToolbar.tsx
+++ b/apps/web/src/components/TaskListToolbar.tsx
@@ -1,0 +1,282 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useRef } from "react";
+import { Plus, Maximize2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export interface GroupOption {
+  value: string;
+  label: string;
+}
+
+/**
+ * The one task-list toolbar, shared by the in-terminal TasksPane and the
+ * dashboard TasksCard so the two surfaces present an identical interface:
+ *
+ *   Tasks  N   [Auto | Manual]   Group [▾]   [Hide done N]   Filter…   + New task
+ *
+ * Every control is driven by props so each surface wires its own state.
+ * `allowManual=false` greys the Manual sort (the dashboard has no
+ * per-task manual order — drag-to-reorder lives inside a terminal).
+ */
+export function TaskListToolbar({
+  title = "Tasks",
+  count,
+  sortMode,
+  onSortMode,
+  allowManual = true,
+  groupMode,
+  onGroupMode,
+  groupOptions,
+  hideDone,
+  onHideDone,
+  doneCount,
+  query,
+  onQuery,
+  newTaskHref,
+  onNewTask,
+  newTaskDisabled = false,
+  newTaskShortcut = "C",
+  expandHref,
+}: {
+  title?: string;
+  count: number;
+  sortMode: "auto" | "manual";
+  onSortMode: (m: "auto" | "manual") => void;
+  allowManual?: boolean;
+  groupMode: string;
+  onGroupMode: (m: string) => void;
+  groupOptions: GroupOption[];
+  hideDone: boolean;
+  onHideDone: () => void;
+  doneCount: number;
+  query: string;
+  onQuery: (q: string) => void;
+  /** New-task destination. Provide a href OR an onClick, not both. */
+  newTaskHref?: string;
+  onNewTask?: () => void;
+  newTaskDisabled?: boolean;
+  newTaskShortcut?: string;
+  /** Optional maximize/expand link (dashboard → full-page view). */
+  expandHref?: string;
+}) {
+  return (
+    <div className="flex flex-shrink-0 flex-wrap items-center justify-between gap-y-2 border-b border-border px-4 py-3">
+      <div className="flex flex-wrap items-center gap-3">
+        <h2 className="text-sm font-semibold text-text-0">{title}</h2>
+        <span className="font-mono text-xs text-text-3">{count}</span>
+
+        {/* Sort toggle. Auto = triage order (incomplete, priority, due,
+            created). Manual = drag-to-reorder (terminal only). */}
+        <span
+          role="tablist"
+          aria-label="Task sort order"
+          className="flex items-center gap-0 overflow-hidden rounded-sm border border-border text-[10px]"
+        >
+          <button
+            type="button"
+            role="tab"
+            aria-selected={sortMode === "auto"}
+            onClick={() => onSortMode("auto")}
+            className={cn(
+              "px-2 py-0.5 font-mono uppercase tracking-wide",
+              sortMode === "auto"
+                ? "bg-bg-3 text-text-0"
+                : "text-text-3 hover:bg-bg-2 hover:text-text-1",
+            )}
+          >
+            Auto
+          </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={sortMode === "manual"}
+            disabled={!allowManual}
+            title={
+              allowManual
+                ? undefined
+                : "Manual drag-to-reorder is available inside a terminal"
+            }
+            onClick={() => allowManual && onSortMode("manual")}
+            className={cn(
+              "px-2 py-0.5 font-mono uppercase tracking-wide",
+              sortMode === "manual" && allowManual
+                ? "bg-bg-3 text-text-0"
+                : "text-text-3 hover:bg-bg-2 hover:text-text-1",
+              !allowManual && "cursor-not-allowed opacity-40 hover:bg-transparent",
+            )}
+          >
+            Manual
+          </button>
+        </span>
+
+        {/* Group-by selector — sections the list with sticky headers. */}
+        <label className="flex items-center gap-1 text-[10px]">
+          <span className="font-mono uppercase tracking-wide text-text-3">
+            Group
+          </span>
+          <select
+            value={groupMode}
+            onChange={(e) => onGroupMode(e.target.value)}
+            className="rounded-sm border border-border bg-bg-1 px-1 py-0.5 font-mono text-[10px] uppercase tracking-wide text-text-1 outline-none hover:border-border-focus focus:border-border-focus"
+            aria-label="Group tasks by"
+          >
+            {groupOptions.map((o) => (
+              <option key={o.value} value={o.value}>
+                {o.label}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        {/* Hide-done toggle. Appears only when there are done tasks to
+            hide (or the filter is already on), with a count so the
+            hidden work isn't forgotten. */}
+        {doneCount > 0 || hideDone ? (
+          <button
+            type="button"
+            onClick={onHideDone}
+            aria-pressed={hideDone}
+            title={
+              hideDone
+                ? `Show ${doneCount} completed task${doneCount === 1 ? "" : "s"}`
+                : `Hide ${doneCount} completed task${doneCount === 1 ? "" : "s"} from the list`
+            }
+            className={cn(
+              "flex items-center gap-1 rounded-sm border px-2 py-0.5 font-mono text-[10px] uppercase tracking-wide transition-colors",
+              hideDone
+                ? "border-border bg-bg-2 text-text-2 hover:bg-bg-3"
+                : "border-border bg-bg-1 text-text-3 hover:bg-bg-2 hover:text-text-1",
+            )}
+          >
+            {hideDone ? "Show done" : "Hide done"}
+            {doneCount > 0 ? <span className="text-text-3">{doneCount}</span> : null}
+          </button>
+        ) : null}
+      </div>
+
+      <div className="flex items-center gap-2">
+        <TaskFilterInput value={query} onChange={onQuery} />
+        {newTaskHref ? (
+          newTaskDisabled ? (
+            <span
+              title="No terminals yet — create a terminal first"
+              aria-disabled="true"
+              className="flex cursor-not-allowed items-center gap-1 rounded-sm px-2 py-1 text-xs text-text-3 opacity-60"
+            >
+              <Plus className="h-3 w-3" /> New task
+            </span>
+          ) : (
+            <Link
+              href={newTaskHref}
+              className="flex items-center gap-1 rounded-sm px-2 py-1 text-xs text-text-2 hover:bg-bg-2 hover:text-text-0"
+            >
+              <Plus className="h-3 w-3" /> New task
+              <kbd className="ml-1 font-mono text-[10px] text-text-3">
+                {newTaskShortcut}
+              </kbd>
+            </Link>
+          )
+        ) : (
+          <button
+            type="button"
+            onClick={onNewTask}
+            disabled={newTaskDisabled}
+            className={cn(
+              "flex items-center gap-1 rounded-sm px-2 py-1 text-xs text-text-2 hover:bg-bg-2 hover:text-text-0",
+              newTaskDisabled && "cursor-not-allowed opacity-60",
+            )}
+          >
+            <Plus className="h-3 w-3" /> New task
+            <kbd className="ml-1 font-mono text-[10px] text-text-3">
+              {newTaskShortcut}
+            </kbd>
+          </button>
+        )}
+        {expandHref ? (
+          <Link
+            href={expandHref}
+            aria-label="Open full task list"
+            className="rounded-sm p-1 text-text-3 hover:bg-bg-2 hover:text-text-0"
+          >
+            <Maximize2 className="h-3 w-3" />
+          </Link>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Filter input shared by both surfaces. `f` (outside any field) focuses
+ * it; Escape clears + blurs.
+ */
+function TaskFilterInput({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (next: string) => void;
+}) {
+  const ref = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key !== "f") return;
+      if (e.metaKey || e.ctrlKey || e.altKey || e.shiftKey) return;
+      const t = e.target as HTMLElement | null;
+      if (
+        t?.tagName === "INPUT" ||
+        t?.tagName === "TEXTAREA" ||
+        t?.tagName === "SELECT" ||
+        t?.isContentEditable
+      ) {
+        return;
+      }
+      e.preventDefault();
+      ref.current?.focus();
+      ref.current?.select();
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
+
+  return (
+    <div className="relative flex items-center">
+      <input
+        ref={ref}
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Escape") {
+            e.preventDefault();
+            onChange("");
+            ref.current?.blur();
+          }
+        }}
+        placeholder="Filter tasks…"
+        aria-label="Filter tasks"
+        className="w-44 rounded-sm border border-border bg-bg-1 px-2 py-1 pr-6 text-xs text-text-0 placeholder:text-text-3 outline-none focus:border-border-focus"
+      />
+      {value ? (
+        <button
+          type="button"
+          onClick={() => {
+            onChange("");
+            ref.current?.focus();
+          }}
+          aria-label="Clear filter"
+          className="absolute right-1 rounded-sm p-0.5 text-text-3 hover:bg-bg-3 hover:text-text-0"
+        >
+          ×
+        </button>
+      ) : (
+        <kbd className="absolute right-1 font-mono text-[10px] text-text-3">
+          f
+        </kbd>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/TasksPane.tsx
+++ b/apps/web/src/components/TasksPane.tsx
@@ -44,7 +44,18 @@ import {
   groupTone,
   priorityEdge,
 } from "./TaskSectionHeader";
+import { TaskListToolbar, type GroupOption } from "./TaskListToolbar";
 import { groupTasks, type TaskGroupMode } from "@/lib/task-grouping";
+
+/** Group-by options for the in-terminal pane (no "Terminal" — you're
+ * already inside one). Shared toolbar renders these in the dropdown. */
+const TERMINAL_GROUP_OPTIONS: GroupOption[] = [
+  { value: "none", label: "None" },
+  { value: "due", label: "Due" },
+  { value: "priority", label: "Priority" },
+  { value: "status", label: "Status" },
+  { value: "assignee", label: "Assignee" },
+];
 import type { TaskRecurrenceRule, TaskStatus } from "@rokki/db";
 
 interface TaskAssignee {
@@ -847,114 +858,20 @@ export function TasksPane({ ticker, projectId, currentUserId }: TasksPaneProps) 
   return (
     <div className="flex h-full">
       <div className="flex h-full flex-1 flex-col">
-      <div className="flex items-center justify-between border-b border-border px-4 py-3">
-        <div className="flex items-center gap-3">
-          <h2 className="text-sm font-semibold text-text-0">Tasks</h2>
-          <span className="font-mono text-xs text-text-3">{tasks.length}</span>
-          {/* Sort toggle. "Auto" is the natural triage order
-              (incomplete first, then priority, due, created).
-              "Manual" loads `?sort=position` so drag-to-reorder
-              writes back to the position column. The current mode
-              persists per-project in localStorage. */}
-          <span
-            role="tablist"
-            aria-label="Task sort order"
-            className="flex items-center gap-0 overflow-hidden rounded-sm border border-border text-[10px]"
-          >
-            <button
-              type="button"
-              role="tab"
-              aria-selected={sortMode === "auto"}
-              onClick={() => setSortMode("auto")}
-              className={cn(
-                "px-2 py-0.5 font-mono uppercase tracking-wide",
-                sortMode === "auto"
-                  ? "bg-bg-3 text-text-0"
-                  : "text-text-3 hover:bg-bg-2 hover:text-text-1",
-              )}
-            >
-              Auto
-            </button>
-            <button
-              type="button"
-              role="tab"
-              aria-selected={sortMode === "manual"}
-              onClick={() => setSortMode("manual")}
-              className={cn(
-                "px-2 py-0.5 font-mono uppercase tracking-wide",
-                sortMode === "manual"
-                  ? "bg-bg-3 text-text-0"
-                  : "text-text-3 hover:bg-bg-2 hover:text-text-1",
-              )}
-            >
-              Manual
-            </button>
-          </span>
-          {/* Group-by selector. Buckets the list visually with section
-              headers; rows still sort by the active SortMode within
-              each bucket. Persists per-project. */}
-          <label className="flex items-center gap-1 text-[10px]">
-            <span className="font-mono uppercase tracking-wide text-text-3">
-              Group
-            </span>
-            <select
-              value={groupMode}
-              onChange={(e) => setGroupMode(e.target.value as GroupMode)}
-              className="rounded-sm border border-border bg-bg-1 px-1 py-0.5 font-mono text-[10px] uppercase tracking-wide text-text-1 outline-none hover:border-border-focus focus:border-border-focus"
-              aria-label="Group tasks by"
-            >
-              <option value="none">None</option>
-              <option value="assignee">Assignee</option>
-              <option value="due">Due</option>
-              <option value="priority">Priority</option>
-              <option value="status">Status</option>
-            </select>
-          </label>
-          {/* Hide-done toggle. Shows the count of tasks being hidden
-              so the user remembers they exist (and can click to bring
-              them back). Persists per-project in localStorage. */}
-          {(() => {
-            const doneCount = tasks.filter((t) => t.status === "done").length;
-            if (doneCount === 0 && !hideDone) return null;
-            return (
-              <button
-                type="button"
-                onClick={() => setHideDone((v) => !v)}
-                aria-pressed={hideDone}
-                title={
-                  hideDone
-                    ? `Show ${doneCount} completed task${doneCount === 1 ? "" : "s"}`
-                    : `Hide ${doneCount} completed task${doneCount === 1 ? "" : "s"} from the list`
-                }
-                className={cn(
-                  "flex items-center gap-1 rounded-sm border px-2 py-0.5 font-mono text-[10px] uppercase tracking-wide transition-colors",
-                  hideDone
-                    ? "border-border bg-bg-2 text-text-2 hover:bg-bg-3"
-                    : "border-border bg-bg-1 text-text-3 hover:bg-bg-2 hover:text-text-1",
-                )}
-              >
-                {hideDone ? "Show done" : "Hide done"}
-                {doneCount > 0 ? (
-                  <span className="text-text-3">{doneCount}</span>
-                ) : null}
-              </button>
-            );
-          })()}
-        </div>
-        <div className="flex items-center gap-2">
-          <TaskSearchInput
-            value={query}
-            onChange={setQuery}
-            placeholder="Filter tasks…"
-          />
-          <button
-            onClick={() => setCreating(true)}
-            className="flex items-center gap-1 rounded-sm px-2 py-1 text-xs text-text-2 hover:bg-bg-2 hover:text-text-0"
-          >
-            <Plus className="h-3 w-3" /> New task <kbd className="ml-1 font-mono text-[10px] text-text-3">C</kbd>
-          </button>
-        </div>
-      </div>
+      <TaskListToolbar
+        count={tasks.length}
+        sortMode={sortMode}
+        onSortMode={setSortMode}
+        groupMode={groupMode}
+        onGroupMode={(m) => setGroupMode(m as GroupMode)}
+        groupOptions={TERMINAL_GROUP_OPTIONS}
+        hideDone={hideDone}
+        onHideDone={() => setHideDone((v) => !v)}
+        doneCount={tasks.filter((t) => t.status === "done").length}
+        query={query}
+        onQuery={setQuery}
+        onNewTask={() => setCreating(true)}
+      />
 
       {error ? (
         <div className="border-b border-border bg-danger-subtle px-4 py-2 text-xs text-danger">
@@ -1667,81 +1584,3 @@ function filterTasks(tasks: Task[], query: string, ticker: string): Task[] {
   });
 }
 
-/**
- * Toolbar search input. Visible always so the affordance is
- * discoverable; `f` from anywhere outside an input focuses it.
- * `Escape` clears the query and blurs.
- */
-function TaskSearchInput({
-  value,
-  onChange,
-  placeholder,
-}: {
-  value: string;
-  onChange: (next: string) => void;
-  placeholder?: string;
-}) {
-  const ref = useRef<HTMLInputElement | null>(null);
-
-  // Window-level `f` shortcut to focus this input. Guards against
-  // firing while typing in another input/textarea so it doesn't
-  // steal a real keystroke.
-  useEffect(() => {
-    function onKey(e: KeyboardEvent) {
-      if (e.key !== "f") return;
-      if (e.metaKey || e.ctrlKey || e.altKey || e.shiftKey) return;
-      const t = e.target as HTMLElement | null;
-      if (
-        t?.tagName === "INPUT" ||
-        t?.tagName === "TEXTAREA" ||
-        t?.tagName === "SELECT" ||
-        t?.isContentEditable
-      ) {
-        return;
-      }
-      e.preventDefault();
-      ref.current?.focus();
-      ref.current?.select();
-    }
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, []);
-
-  return (
-    <div className="relative flex items-center">
-      <input
-        ref={ref}
-        type="text"
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        onKeyDown={(e) => {
-          if (e.key === "Escape") {
-            e.preventDefault();
-            onChange("");
-            ref.current?.blur();
-          }
-        }}
-        placeholder={placeholder ?? "Filter…"}
-        aria-label="Filter tasks"
-        className="w-44 rounded-sm border border-border bg-bg-1 px-2 py-1 pr-6 text-xs text-text-0 placeholder:text-text-3 outline-none focus:border-border-focus"
-      />
-      {value ? (
-        <button
-          type="button"
-          onClick={() => {
-            onChange("");
-            ref.current?.focus();
-          }}
-          aria-label="Clear filter"
-          className="absolute right-1 rounded-sm p-0.5 text-text-3 hover:bg-bg-3 hover:text-text-0"
-        >
-          ×
-        </button>
-      ) : (
-        <kbd className="absolute right-1 font-mono text-[10px] text-text-3">
-          f
-        </kbd>
-      )}
-    </div>
-  );
-}

--- a/apps/web/src/components/dashboard/TasksCard.tsx
+++ b/apps/web/src/components/dashboard/TasksCard.tsx
@@ -3,28 +3,47 @@
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import {
-  Check,
-  ArrowRight,
-  Plus,
-  AlertOctagon,
-  Clock,
-  Layers,
-  User as UserIcon,
-} from "lucide-react";
+import { Check } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { DashboardCard } from "./DashboardCard";
 import { PriorityDots, DueChip } from "@/components/primitives";
 import {
   TaskSectionHeader,
   groupTone,
   priorityEdge,
 } from "@/components/TaskSectionHeader";
+import { TaskListToolbar, type GroupOption } from "@/components/TaskListToolbar";
 import { useRealtimeTable } from "@/lib/supabase/realtime";
 import { bucketDashTasks } from "@/lib/task-grouping";
 import type { AssignedTask, DelegatedTask } from "@/lib/dashboard-queries";
 
 const DASH_COLLAPSED_KEY = "rokki_dash_tasks_collapsed_groups";
+
+/** Group-by options for the dashboard — same toolbar as the terminal,
+ * plus "Terminal" (the cross-terminal headline grouping). */
+const DASH_GROUP_OPTIONS: GroupOption[] = [
+  { value: "none", label: "None" },
+  { value: "due", label: "Due" },
+  { value: "priority", label: "Priority" },
+  { value: "status", label: "Status" },
+  { value: "terminal", label: "Terminal" },
+  { value: "assignee", label: "Assignee" },
+];
+
+/** Client-side filter for dashboard tasks: title + terminal name. */
+function filterDashTasks(
+  tasks: AssignedTask[],
+  query: string,
+  terminalNameById?: Record<string, string>,
+): AssignedTask[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return tasks;
+  return tasks.filter((t) => {
+    if (t.title.toLowerCase().includes(q)) return true;
+    const name = terminalNameById?.[t.terminal_id] ?? "";
+    if (name.toLowerCase().includes(q)) return true;
+    return false;
+  });
+}
 
 interface TasksCardProps {
   assigned: AssignedTask[];
@@ -57,17 +76,26 @@ interface TasksCardProps {
 }
 
 /**
- * One master card with two stacked sub-sections.
+ * The dashboard task card. Presents the *exact* same interface as the
+ * in-terminal `TasksPane` — same shared `TaskListToolbar` (Sort, Group,
+ * Hide-done, Filter, New task) and same `TaskSectionHeader` sections —
+ * so a user never has to relearn the list when moving between the
+ * dashboard and a terminal.
  *
- *   ┌ TASKS ─────────────────┐
- *   │ ASSIGNED TO ME (5)     │
- *   │   task rows …          │
- *   │ DELEGATED (3)          │
- *   │   task rows …          │
- *   └────────────────────────┘
+ *   ┌──────────────────────────────────────────────────────────┐
+ *   │ Tasks 12   [Auto|Manual]  Group[Due▾]  Filter…  + New task │
+ *   ├──────────────────────────────────────────────────────────┤
+ *   │ ▎● OVERDUE                                          ⟨2⟩    │
+ *   │   task rows …                                             │
+ *   │ ▎● THIS WEEK                                        ⟨5⟩    │
+ *   │   task rows …                                             │
+ *   └──────────────────────────────────────────────────────────┘
  *
- * Both lists visible at once so the user never has to tab-switch to see a
- * full picture. Overflow scrolls within the card body.
+ * The list spans terminals and merges everything relevant to you —
+ * tasks assigned to you plus tasks you've delegated, deduped. The old
+ * Mine/Delegated/Overdue/Week/All tabs are gone: Group→Due reproduces
+ * the Overdue/Week sections and Group→Assignee surfaces who owes what.
+ * Overflow scrolls within the card body.
  */
 export function TasksCard({
   assigned,
@@ -119,14 +147,26 @@ export function TasksCard({
     },
   );
 
-  // Filter chips per Zack's "filter between different items
-  // directly in tasks on the dashboard." Tabs replace the old
-  // two-section split (Assigned to me + I assigned to others)
-  // with five filter modes plus a default that preserves the old
-  // shape under the "Mine" + "Delegated" tabs.
-  type Tab = "mine" | "delegated" | "overdue" | "week" | "all";
-  type DashGroupBy = "none" | "terminal" | "priority" | "due" | "assignee";
-  const [tab, setTab] = useState<Tab>("mine");
+  // Same toolbar as the in-terminal pane: Sort + Group + Hide-done +
+  // Filter. The old Mine/Delegated/Overdue/Week/All tabs are gone —
+  // grouping by Due gives the Overdue/Week sections, and the list now
+  // shows everything relevant to you (assigned + delegated, deduped).
+  type DashGroupBy =
+    | "none"
+    | "terminal"
+    | "priority"
+    | "due"
+    | "assignee"
+    | "status";
+  // Sort is shown for parity; Manual (drag-reorder) is terminal-only,
+  // so it stays disabled here. Auto = priority/due triage order.
+  const [sortMode, setSortMode] = useState<"auto" | "manual">("auto");
+  void sortMode;
+  const [query, setQuery] = useState("");
+  // Done tasks aren't fetched for the dashboard, so this hides nothing
+  // today — but the control is wired identically to the terminal so
+  // the interface matches, and it works the moment done tasks appear.
+  const [hideDone, setHideDone] = useState(true);
   // Default to grouping by due date so the dashboard task list opens in
   // the same sectioned view as the in-terminal pane (Overdue / Today /
   // This week / Later) instead of a flat list. Persisted globally so
@@ -146,7 +186,8 @@ export function TasksCard({
         saved === "terminal" ||
         saved === "priority" ||
         saved === "due" ||
-        saved === "assignee"
+        saved === "assignee" ||
+        saved === "status"
       ) {
         setGroupBy(saved);
       }
@@ -198,286 +239,117 @@ export function TasksCard({
     });
   }, []);
 
-  const { mineList, delegatedList, overdueList, weekList, allList } =
-    useMemo(() => {
-      const today = new Date().toISOString().slice(0, 10);
-      const wk = new Date();
-      wk.setDate(wk.getDate() + 7);
-      const weekIso = wk.toISOString().slice(0, 10);
-
-      const mine = assigned.filter((t) => t.status !== "done");
-      const deleg = delegated.filter((t) => t.status !== "done");
-      // Combine + dedupe for cross-cutting tabs (overdue / week /
-      // all). A task assigned to me AND created by me lands in
-      // both source arrays; dedupe by id.
-      const seen = new Set<string>();
-      const combined: AssignedTask[] = [];
-      for (const t of [...mine, ...deleg]) {
-        if (seen.has(t.id)) continue;
-        seen.add(t.id);
-        combined.push(t);
-      }
-      return {
-        mineList: mine,
-        delegatedList: deleg,
-        overdueList: combined.filter(
-          (t) => t.due_date && t.due_date < today,
-        ),
-        weekList: combined.filter(
-          (t) =>
-            t.due_date && t.due_date >= today && t.due_date <= weekIso,
-        ),
-        allList: combined,
-      };
-    }, [assigned, delegated]);
-
-  const visibleAssigned: AssignedTask[] = (() => {
-    switch (tab) {
-      case "mine":
-        return mineList;
-      case "delegated":
-        return delegatedList;
-      case "overdue":
-        return overdueList;
-      case "week":
-        return weekList;
-      case "all":
-        return allList;
+  // All tasks relevant to you — assigned to me + delegated to others —
+  // deduped (a task both assigned to and created by me lands in both
+  // source arrays).
+  const combined = useMemo(() => {
+    const seen = new Set<string>();
+    const out: AssignedTask[] = [];
+    for (const t of [...assigned, ...delegated]) {
+      if (seen.has(t.id)) continue;
+      seen.add(t.id);
+      out.push(t);
     }
-  })();
+    return out;
+  }, [assigned, delegated]);
+
+  const doneCount = combined.filter((t) => t.status === "done").length;
+  const visibleAssigned: AssignedTask[] = filterDashTasks(
+    hideDone ? combined.filter((t) => t.status !== "done") : combined,
+    query,
+    terminalNameById,
+  );
 
   return (
-    <DashboardCard
-      title="Tasks"
-      count={assigned.length + delegated.length}
-      expandHref="/tasks/mine"
-      headerRight={
-        createHref ? (
-          createDisabled ? (
-            <span
-              title="No terminals yet — create a terminal first"
-              className="flex cursor-not-allowed items-center gap-1 rounded-sm border border-border bg-bg-2 px-2 py-0.5 text-[10px] uppercase tracking-wide text-text-3 opacity-60"
-              aria-disabled="true"
-            >
-              <Plus className="h-3 w-3" aria-hidden="true" />
-              <span>New task</span>
-            </span>
-          ) : (
-            <Link
-              href={createHref}
-              title="New task (⌘N)"
-              className="flex items-center gap-1 rounded-sm border border-border bg-bg-2 px-2 py-0.5 text-[10px] uppercase tracking-wide text-text-1 hover:border-accent/40 hover:bg-bg-3"
-            >
-              <Plus className="h-3 w-3" aria-hidden="true" />
-              <span>New task</span>
-              <kbd className="ml-1 hidden font-mono text-[9px] text-text-3 sm:inline">
-                ⌘N
-              </kbd>
-            </Link>
-          )
-        ) : null
-      }
-    >
-      <div className="flex flex-wrap items-center gap-1 border-b border-border/60 px-3 py-1.5">
-        <FilterChip
-          active={tab === "mine"}
-          onClick={() => setTab("mine")}
-          icon={<UserIcon className="h-3 w-3" />}
-          label="Mine"
-          count={mineList.length}
-        />
-        <FilterChip
-          active={tab === "delegated"}
-          onClick={() => setTab("delegated")}
-          icon={<ArrowRight className="h-3 w-3" />}
-          label="Delegated"
-          count={delegatedList.length}
-        />
-        <FilterChip
-          active={tab === "overdue"}
-          onClick={() => setTab("overdue")}
-          icon={<AlertOctagon className="h-3 w-3" />}
-          label="Overdue"
-          count={overdueList.length}
-          tone={overdueList.length > 0 ? "danger" : "neutral"}
-        />
-        <FilterChip
-          active={tab === "week"}
-          onClick={() => setTab("week")}
-          icon={<Clock className="h-3 w-3" />}
-          label="Week"
-          count={weekList.length}
-        />
-        <FilterChip
-          active={tab === "all"}
-          onClick={() => setTab("all")}
-          icon={<Layers className="h-3 w-3" />}
-          label="All"
-          count={allList.length}
-        />
-        {/* Group-by selector. "Terminal" is the headline value here
-            since the dashboard list spans terminals — bucketing per
-            terminal turns the firehose into per-project micro-lists. */}
-        <label className="ml-auto flex items-center gap-1 text-[10px]">
-          <span className="font-mono uppercase tracking-wide text-text-3">
-            Group
-          </span>
-          <select
-            value={groupBy}
-            onChange={(e) => setGroupBy(e.target.value as DashGroupBy)}
-            className="rounded-sm border border-border bg-bg-2 px-1 py-0.5 font-mono text-[10px] uppercase tracking-wide text-text-1 outline-none hover:border-border-focus focus:border-border-focus"
-            aria-label="Group tasks by"
-          >
-            <option value="none">None</option>
-            <option value="terminal">Terminal</option>
-            <option value="priority">Priority</option>
-            <option value="due">Due</option>
-            {tab === "delegated" || tab === "all" ? (
-              <option value="assignee">Assignee</option>
-            ) : null}
-          </select>
-        </label>
-      </div>
-      {visibleAssigned.length === 0 ? (
-        <p className="px-3 py-4 text-center text-[11px] text-text-3">
-          {emptyForTab(tab)}
-        </p>
-      ) : groupBy === "none" ? (
-        <ul className="divide-y divide-border/40">
-          {visibleAssigned.slice(0, ROW_LIMIT).map((t) =>
-            tab === "delegated" ? (
-              <DelegatedRow
-                key={t.id}
-                task={t as DelegatedTask}
-                ticker={tickerById[t.terminal_id]}
-                terminalName={terminalNameById?.[t.terminal_id]}
-              />
-            ) : (
+    // Plain card shell — no DashboardCard wrapper. The header chrome now
+    // lives entirely in the shared TaskListToolbar so this surface is
+    // byte-for-byte the same interface as the in-terminal TasksPane.
+    <section className="flex h-full min-h-0 flex-col overflow-hidden rounded border border-border-strong bg-bg-1 shadow-sm">
+      <TaskListToolbar
+        count={visibleAssigned.length}
+        sortMode={sortMode}
+        onSortMode={setSortMode}
+        // Manual drag-to-reorder is a single-terminal concept; the
+        // dashboard spans terminals, so the control shows for parity
+        // but stays disabled.
+        allowManual={false}
+        groupMode={groupBy}
+        onGroupMode={(m) => setGroupBy(m as DashGroupBy)}
+        groupOptions={DASH_GROUP_OPTIONS}
+        hideDone={hideDone}
+        onHideDone={() => setHideDone((v) => !v)}
+        doneCount={doneCount}
+        query={query}
+        onQuery={setQuery}
+        newTaskHref={createHref ?? undefined}
+        newTaskDisabled={createDisabled}
+        newTaskShortcut="⌘N"
+        expandHref="/tasks/mine"
+      />
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        {visibleAssigned.length === 0 ? (
+          <p className="px-3 py-4 text-center text-[11px] text-text-3">
+            {query.trim()
+              ? "No tasks match your filter."
+              : "No open tasks. Nice."}
+          </p>
+        ) : groupBy === "none" ? (
+          <ul className="divide-y divide-border">
+            {visibleAssigned.slice(0, ROW_LIMIT).map((t) => (
               <AssignedRow
                 key={t.id}
                 task={t}
                 ticker={tickerById[t.terminal_id]}
                 terminalName={terminalNameById?.[t.terminal_id]}
               />
-            ),
-          )}
-        </ul>
-      ) : (
-        // Grouped — same sectioned treatment as the in-terminal pane:
-        // sticky semantic headers, count pills, collapse, 2px dividers.
-        (() => {
-          const buckets = bucketDashTasks(
-            visibleAssigned,
-            groupBy,
-            tickerById,
-            terminalNameById,
-          );
-          return (
-            <div className="divide-y-2 divide-border-strong">
-              {buckets.map((b) => {
-                const collapseKey = `${groupBy}:${b.key}`;
-                const collapsed = collapsedGroups.has(collapseKey);
-                return (
-                  <section key={b.key}>
-                    <TaskSectionHeader
-                      label={b.label}
-                      count={b.tasks.length}
-                      tone={groupTone(groupBy, b.key)}
-                      collapsed={collapsed}
-                      onToggle={() => toggleGroupCollapsed(collapseKey)}
-                    />
-                    {!collapsed ? (
-                      <ul className="divide-y divide-border/40">
-                        {b.tasks.map((t) =>
-                          tab === "delegated" ? (
-                            <DelegatedRow
-                              key={`${b.key}:${t.id}`}
-                              task={t as DelegatedTask}
-                              ticker={tickerById[t.terminal_id]}
-                              terminalName={terminalNameById?.[t.terminal_id]}
-                            />
-                          ) : (
+            ))}
+          </ul>
+        ) : (
+          // Grouped — same sectioned treatment as the in-terminal pane:
+          // sticky semantic headers, count pills, collapse, 2px dividers.
+          (() => {
+            const buckets = bucketDashTasks(
+              visibleAssigned,
+              groupBy,
+              tickerById,
+              terminalNameById,
+            );
+            return (
+              <div className="divide-y-2 divide-border-strong">
+                {buckets.map((b) => {
+                  const collapseKey = `${groupBy}:${b.key}`;
+                  const collapsed = collapsedGroups.has(collapseKey);
+                  return (
+                    <section key={b.key}>
+                      <TaskSectionHeader
+                        label={b.label}
+                        count={b.tasks.length}
+                        tone={groupTone(groupBy, b.key)}
+                        collapsed={collapsed}
+                        onToggle={() => toggleGroupCollapsed(collapseKey)}
+                      />
+                      {!collapsed ? (
+                        <ul className="divide-y divide-border">
+                          {b.tasks.map((t) => (
                             <AssignedRow
                               key={`${b.key}:${t.id}`}
                               task={t}
                               ticker={tickerById[t.terminal_id]}
                               terminalName={terminalNameById?.[t.terminal_id]}
                             />
-                          ),
-                        )}
-                      </ul>
-                    ) : null}
-                  </section>
-                );
-              })}
-            </div>
-          );
-        })()
-      )}
-      {/* The "X more — open the full list" footer is gone. All rows
-          now render and the user scrolls inside the card; the
-          Maximize icon in the card header is still a one-click route
-          to the full-page view for a roomier surface. */}
-    </DashboardCard>
-  );
-}
-
-function FilterChip({
-  active,
-  onClick,
-  icon,
-  label,
-  count,
-  tone = "neutral",
-}: {
-  active: boolean;
-  onClick: () => void;
-  icon: React.ReactNode;
-  label: string;
-  count: number;
-  tone?: "neutral" | "danger";
-}) {
-  return (
-    <button
-      type="button"
-      role="tab"
-      aria-selected={active}
-      onClick={onClick}
-      className={cn(
-        "inline-flex items-center gap-1 rounded-sm border px-1.5 py-0.5 text-[10px] uppercase tracking-wide",
-        active
-          ? "border-accent/40 bg-bg-3 text-text-0"
-          : "border-border bg-bg-2 text-text-2 hover:bg-bg-3",
-      )}
-    >
-      {icon}
-      <span>{label}</span>
-      <span
-        className={cn(
-          "ml-0.5 font-mono text-[10px]",
-          active ? "text-text-1" : "text-text-3",
-          tone === "danger" && count > 0 && "text-danger",
+                          ))}
+                        </ul>
+                      ) : null}
+                    </section>
+                  );
+                })}
+              </div>
+            );
+          })()
         )}
-      >
-        {count}
-      </span>
-    </button>
+      </div>
+    </section>
   );
-}
-
-function emptyForTab(tab: "mine" | "delegated" | "overdue" | "week" | "all"): string {
-  switch (tab) {
-    case "mine":
-      return "Nothing assigned to you. Nice.";
-    case "delegated":
-      return "Nothing waiting on others.";
-    case "overdue":
-      return "Nothing overdue. Well done.";
-    case "week":
-      return "Nothing due this week.";
-    case "all":
-      return "No open tasks anywhere.";
-  }
 }
 
 function AssignedRow({
@@ -598,59 +470,4 @@ function AssignedRow({
     </li>
   );
 }
-
-function DelegatedRow({
-  task,
-  ticker,
-  terminalName,
-}: {
-  task: DelegatedTask;
-  ticker?: string;
-  terminalName?: string;
-}) {
-  const href = ticker ? `/p/${ticker}/task/${task.ticker_seq}` : undefined;
-  const assigneeLabel = task.assignees
-    .map((a) => a.full_name ?? "someone")
-    .join(", ");
-  const body = (
-    <div
-      data-row
-      className={cn(
-        "flex items-center gap-2 border-l-2 px-3 py-1 pl-[10px] text-xs hover:bg-bg-2",
-        priorityEdge(task.priority),
-      )}
-    >
-      <ArrowRight className="h-3 w-3 flex-shrink-0 text-text-3" />
-      <span className="flex-1 truncate text-text-0">{task.title}</span>
-      <span
-        className="hidden truncate text-text-2 md:inline max-w-[14ch]"
-        title={assigneeLabel}
-      >
-        {assigneeLabel}
-      </span>
-      {terminalName ? (
-        <span
-          className="hidden truncate text-text-3 lg:inline max-w-[10ch]"
-          title={terminalName}
-        >
-          {terminalName}
-        </span>
-      ) : null}
-      <PriorityDots priority={task.priority} />
-      {task.due_date ? <DueChip date={task.due_date} /> : null}
-    </div>
-  );
-  return href ? (
-    <li>
-      <Link href={href} className="block">
-        {body}
-      </Link>
-    </li>
-  ) : (
-    <li>{body}</li>
-  );
-}
-
-// EmptyAssigned / EmptyDelegated removed — `emptyForTab` covers
-// the per-filter empty state inline.
 

--- a/apps/web/src/lib/task-grouping.test.ts
+++ b/apps/web/src/lib/task-grouping.test.ts
@@ -181,6 +181,20 @@ describe("bucketDashTasks", () => {
     expect(out.map((g) => g.key)).toEqual(["high", "none"]);
   });
 
+  it("supports status mode (toolbar parity with the in-terminal pane)", () => {
+    const out = bucketDashTasks(
+      [
+        dt({ id: "a", terminal_id: "t1", status: "done" }),
+        dt({ id: "b", terminal_id: "t2", status: "todo" }),
+        dt({ id: "c", terminal_id: "t1", status: "in_progress" }),
+      ],
+      "status",
+      tickerById,
+      nameById,
+    );
+    expect(out.map((g) => g.key)).toEqual(["todo", "in_progress", "done"]);
+  });
+
   it("none mode returns flat single group", () => {
     const out = bucketDashTasks(
       [dt({ id: "a", terminal_id: "t1" })],

--- a/apps/web/src/lib/task-grouping.ts
+++ b/apps/web/src/lib/task-grouping.ts
@@ -5,9 +5,10 @@
  *
  *   - In-terminal `TasksPane` — groups by assignee / due / priority /
  *     status (terminal context already pins the space + project).
- *   - Dashboard `TasksCard` — groups by terminal / priority / due /
- *     assignee (cross-cutting view, terminal-grouping is the headline
- *     value here since the dashboard list spans terminals).
+ *   - Dashboard `TasksCard` — same modes plus `terminal` (the headline
+ *     value here, since the dashboard list spans terminals). The two
+ *     surfaces share one toolbar, so the dashboard offers every
+ *     in-terminal mode too — due / priority / status / assignee.
  *
  * Both surfaces render the result as section headers + a count chip.
  * Empty buckets are dropped so the layout doesn't waste vertical
@@ -71,7 +72,8 @@ export type DashGroupMode =
   | "terminal"
   | "priority"
   | "due"
-  | "assignee";
+  | "assignee"
+  | "status";
 
 export interface DashGroupableTask extends GroupableTask {
   terminal_id: string;


### PR DESCRIPTION
## What & why

The dashboard task card and the in-terminal task pane presented two different interfaces — the dashboard had **Mine / Delegated / Overdue / Week / All** tabs while the terminal had a **Sort + Group + Hide-done + Filter** toolbar. Zack: *"i want them to have the same interface whether they're in the dashboard or the terminal. please make them match."*

This makes them identical by extracting the shared chrome into one component and stripping the dashboard down to the terminal toolbar.

## Changes

- **New `TaskListToolbar`** — the single toolbar both surfaces render: title + count, Auto/Manual sort, Group select, Hide-done, Filter (`f` to focus, Esc to clear), New task, optional Maximize. Driven entirely by props so each surface wires its own state. Manual sort is disabled on the dashboard (drag-reorder is a single-terminal concept).
- **`TasksPane` (terminal)** now renders `TaskListToolbar` instead of its inline toolbar; dropped its local search input.
- **`TasksCard` (dashboard)** stripped down to the terminal toolbar — the five tabs are gone. The list now shows everything relevant to you (assigned + delegated, deduped). `Group→Due` reproduces the old Overdue/Week sections; `Group→Assignee` surfaces who owes what. Removed the `FilterChip` / `DelegatedRow` / `emptyForTab` dead code and the `DashboardCard` wrapper.
- **`task-grouping`** — `DashGroupMode` gains `"status"` so the dashboard offers every in-terminal group mode (the bucket logic already lived in `groupTasks`). Added a parity unit test.

Both surfaces already share `TaskSectionHeader` (sticky semantic group headers) and `priorityEdge` (priority left-tick), so sectioning and row treatment are pixel-identical.

**Net −328 lines.**

## Verification

- `pnpm --filter @rokki/web typecheck` ✅
- `eslint` on changed files ✅
- `vitest run` → **315/315** (added 1 status-parity test) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)