### PR TITLE
ci: build @rokki/sdk before the app build in e2e/visual/bundle jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,14 @@ jobs:
         if: steps.pw-cache.outputs.cache-hit == 'true'
         run: pnpm -C apps/web exec playwright install-deps chromium
 
+      - name: Build workspace dependencies
+        # @rokki/web imports @rokki/sdk, which ships compiled from dist/.
+        # The lint-typecheck-test job builds it transitively via `turbo
+        # run build`; this job builds the app directly, so without this
+        # the next build fails with: Can't resolve '@rokki/sdk'. `^...`
+        # selects web's workspace dependencies only (not the app itself).
+        run: pnpm turbo run build --filter='@rokki/web^...'
+
       - name: Build app
         run: pnpm -C apps/web build
         env:
@@ -231,6 +239,14 @@ jobs:
         if: steps.pw-cache-visual.outputs.cache-hit == 'true'
         run: pnpm -C apps/web exec playwright install-deps chromium
 
+      - name: Build workspace dependencies
+        # @rokki/web imports @rokki/sdk, which ships compiled from dist/.
+        # The lint-typecheck-test job builds it transitively via `turbo
+        # run build`; this job builds the app directly, so without this
+        # the next build fails with: Can't resolve '@rokki/sdk'. `^...`
+        # selects web's workspace dependencies only (not the app itself).
+        run: pnpm turbo run build --filter='@rokki/web^...'
+
       - name: Build app
         run: pnpm -C apps/web build
         env:
@@ -287,6 +303,13 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Build workspace dependencies
+        # @rokki/web imports @rokki/sdk, which ships compiled from dist/.
+        # bundle:analyze runs `next build` directly, so without this the
+        # build fails with: Can't resolve '@rokki/sdk'. `^...` selects
+        # web's workspace dependencies only (not the app itself).
+        run: pnpm turbo run build --filter='@rokki/web^...'
 
       - name: Build with bundle analyzer
         run: pnpm -C apps/web bundle:analyze

--- a/.github/workflows/update-visual-baselines.yml
+++ b/.github/workflows/update-visual-baselines.yml
@@ -69,6 +69,13 @@ jobs:
         if: steps.pw-cache.outputs.cache-hit == 'true'
         run: pnpm -C apps/web exec playwright install-deps chromium
 
+      - name: Build workspace dependencies
+        # @rokki/web imports @rokki/sdk, which ships compiled from dist/.
+        # This job builds the app directly, so without this the next
+        # build fails with: Can't resolve '@rokki/sdk'. `^...` selects
+        # web's workspace dependencies only (not the app itself).
+        run: pnpm turbo run build --filter='@rokki/web^...'
+
       - name: Build app
         run: pnpm -C apps/web build
         env:


### PR DESCRIPTION
## Problem

The **E2E**, **Visual regression**, and **Bundle-size** jobs build the web app directly (`pnpm -C apps/web build` / `bundle:analyze`), which runs `next build` **without first building the workspace packages it imports**. `@rokki/sdk` ships compiled from `dist/` (`main: ./dist/index.js`), so on a fresh CI checkout those jobs died at the **Build app** step on every PR with:

```
Module not found: Can't resolve '@rokki/sdk'
> import { listManifestsForScope } from "@rokki/sdk";
Build failed because of webpack errors
```

They're non-required (`continue-on-error: true`), so they didn't block merges — but they were red on every PR, which is noise and risks masking a real failure.

The **Lint, Typecheck, Test** job is green because it builds via `turbo run build`, which respects the dependency graph (`build` `dependsOn: ["^build"]`) and compiles `@rokki/sdk` first.

## Fix

Add a **Build workspace dependencies** step before each app build:

```yaml
- name: Build workspace dependencies
  run: pnpm turbo run build --filter='@rokki/web^...'
```

`@rokki/web^...` selects web's workspace **dependencies only** (`@rokki/db` — a source-only no-op — and `@rokki/sdk`), not the app itself, which the existing step still builds. Future-proof: any new workspace dep is covered automatically.

Applied to all four affected jobs: `ci.yml` (e2e, visual-regression, bundle-budget) + `update-visual-baselines.yml`.

## Verification

Locally reproduced + fixed:
1. `rm -rf packages/sdk/dist` (simulate fresh checkout)
2. `pnpm turbo run build --filter='@rokki/web^...'` → regenerated `dist/index.js`
3. `pnpm -C apps/web build` → **`✓ Compiled successfully` (92/92 pages)**, no `@rokki/sdk` error

After this lands, the three jobs should reach their actual test phase instead of dying at "Build app".

🤖 Generated with [Claude Code](https://claude.com/claude-code)