### PR TITLE
Dashboard panels: maximize a module to fill the viewing area, restore back

### DIFF
--- a/apps/web/src/components/TaskListToolbar.tsx
+++ b/apps/web/src/components/TaskListToolbar.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { useEffect, useRef } from "react";
 import { Plus, Maximize2 } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { usePanelHandle } from "./dashboard/panel-handle";
+import { usePanelHandle, usePanelMaximize } from "./dashboard/panel-handle";
 
 export interface GroupOption {
   value: string;
@@ -62,9 +62,11 @@ export function TaskListToolbar({
   /** Optional maximize/expand link (dashboard → full-page view). */
   expandHref?: string;
 }) {
-  // Drag grip when hosted in a rearrangeable DashboardPanels; null (no
-  // grip) inside a terminal, where the toolbar isn't a movable panel.
+  // Drag grip + maximize toggle when hosted in a rearrangeable
+  // DashboardPanels; null inside a terminal, where the toolbar isn't a
+  // movable panel (the expand button stays its normal link there).
   const handle = usePanelHandle();
+  const maximize = usePanelMaximize();
   return (
     <div className="flex flex-shrink-0 flex-wrap items-center justify-between gap-y-2 border-b border-border px-4 py-3">
       <div className="flex flex-wrap items-center gap-3">
@@ -199,7 +201,11 @@ export function TaskListToolbar({
             </kbd>
           </button>
         )}
-        {expandHref ? (
+        {/* Hosted in DashboardPanels → maximize/restore toggle.
+            Otherwise the original full-page expand link. */}
+        {maximize ? (
+          maximize
+        ) : expandHref ? (
           <Link
             href={expandHref}
             aria-label="Open full task list"

--- a/apps/web/src/components/dashboard/DashboardCard.tsx
+++ b/apps/web/src/components/dashboard/DashboardCard.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { Maximize2 } from "lucide-react";
 import type { ReactNode } from "react";
 import { cn } from "@/lib/utils";
-import { usePanelHandle } from "./panel-handle";
+import { usePanelHandle, usePanelMaximize } from "./panel-handle";
 
 /**
  * Shared card primitive used across the dashboard. Always has:
@@ -40,9 +40,11 @@ export function DashboardCard({
   bodyClassName,
   children,
 }: DashboardCardProps) {
-  // When hosted inside a rearrangeable DashboardPanels, this is the
-  // panel's drag grip; everywhere else it's null and renders nothing.
+  // When hosted inside a rearrangeable DashboardPanels, these are the
+  // panel's drag grip and maximize/restore toggle; everywhere else they
+  // are null (no grip; the expand button stays a plain link).
   const handle = usePanelHandle();
+  const maximize = usePanelMaximize();
   return (
     <section
       // Stronger border + subtle ring/shadow so cards separate from the
@@ -68,7 +70,11 @@ export function DashboardCard({
         </div>
         <div className="flex items-center gap-2">
           {headerRight}
-          {expandHref ? (
+          {/* Hosted in DashboardPanels → maximize/restore toggle.
+              Otherwise the original full-page expand link. */}
+          {maximize ? (
+            maximize
+          ) : expandHref ? (
             <Link
               href={expandHref}
               aria-label={`Open ${title}`}

--- a/apps/web/src/components/dashboard/DashboardPanels.test.tsx
+++ b/apps/web/src/components/dashboard/DashboardPanels.test.tsx
@@ -1,8 +1,25 @@
 // @vitest-environment jsdom
 import { describe, it, expect, beforeAll, beforeEach, afterEach } from "vitest";
-import { render, screen, cleanup } from "@testing-library/react";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
 import { DashboardPanels } from "./DashboardPanels";
-import { usePanelHandle } from "./panel-handle";
+import { usePanelHandle, usePanelMaximize } from "./panel-handle";
+
+function setDesktop(matches: boolean) {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    configurable: true,
+    value: (query: string) => ({
+      matches,
+      media: query,
+      onchange: null,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      dispatchEvent: () => false,
+    }),
+  });
+}
 
 beforeAll(() => {
   // jsdom has no matchMedia; the component subscribes to the lg breakpoint.
@@ -23,6 +40,7 @@ beforeAll(() => {
 
 beforeEach(() => {
   window.localStorage.clear();
+  setDesktop(false);
 });
 
 afterEach(() => {
@@ -83,5 +101,34 @@ describe("DashboardPanels", () => {
     expect(screen.getByText("WEEK_PANEL")).toBeTruthy();
     expect(screen.getByText("TASKS_PANEL")).toBeTruthy();
     expect(screen.getByText("MESSAGES_PANEL")).toBeTruthy();
+  });
+
+  it("maximize fills the area and hides the other panels; restore brings them back", () => {
+    setDesktop(true);
+    function WeekProbe() {
+      return <div>WEEK{usePanelMaximize()}</div>;
+    }
+    render(
+      <DashboardPanels
+        briefing={null}
+        week={<WeekProbe />}
+        tasks={<div>t</div>}
+        messages={<div>m</div>}
+      />,
+    );
+    const tasksPanel = () =>
+      document.querySelector('[data-panel-id="tasks"]') as HTMLElement;
+
+    // Maximize Week → the other panels are hidden on desktop.
+    fireEvent.click(screen.getByLabelText("Maximize Week"));
+    expect(tasksPanel().className).toContain("lg:hidden");
+    // Button flips to Restore.
+    const restore = screen.getByLabelText("Restore Week");
+    expect(restore).toBeTruthy();
+
+    // Restore → the others come back.
+    fireEvent.click(restore);
+    expect(tasksPanel().className).not.toContain("lg:hidden");
+    expect(screen.getByLabelText("Maximize Week")).toBeTruthy();
   });
 });

--- a/apps/web/src/components/dashboard/DashboardPanels.tsx
+++ b/apps/web/src/components/dashboard/DashboardPanels.tsx
@@ -10,9 +10,9 @@ import {
   type PointerEvent,
   type ReactNode,
 } from "react";
-import { GripVertical } from "lucide-react";
+import { GripVertical, Maximize2, Minimize2 } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { PanelHandleProvider } from "./panel-handle";
+import { PanelControlsProvider } from "./panel-handle";
 import {
   DASH_LAYOUT_STORAGE_KEY,
   DEFAULT_DASH_LAYOUT,
@@ -74,6 +74,10 @@ export function DashboardPanels({
   const [centerFrac, setCenterFrac] = useState(0.6);
   const [dragId, setDragId] = useState<string | null>(null);
   const [hint, setHint] = useState<DropHint>(null);
+  // Which panel is maximized (fills the whole viewing area), or null.
+  // Deliberately NOT persisted — it's a transient view, not a saved
+  // preference, so a reload returns to the normal arrangement.
+  const [maximizedId, setMaximizedId] = useState<string | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
 
   // Track the lg breakpoint so the dynamic inline styles (panel flex,
@@ -261,14 +265,49 @@ export function DashboardPanels({
     );
   }
 
+  // Maximize / restore toggle. Replaces the card's expand link when the
+  // panel is hosted here (desktop only); clicking fills the viewing area
+  // with this module, clicking again restores the prior arrangement.
+  function panelMaxBtn(id: string): ReactNode {
+    const isMax = maximizedId === id;
+    return (
+      <button
+        type="button"
+        onClick={() => setMaximizedId(isMax ? null : id)}
+        aria-label={
+          isMax
+            ? `Restore ${TITLES[id] ?? "panel"}`
+            : `Maximize ${TITLES[id] ?? "panel"}`
+        }
+        title={isMax ? "Restore" : "Maximize"}
+        className="rounded-sm p-1 text-text-3 hover:bg-bg-2 hover:text-text-0"
+      >
+        {isMax ? (
+          <Minimize2 className="h-3 w-3" aria-hidden="true" />
+        ) : (
+          <Maximize2 className="h-3 w-3" aria-hidden="true" />
+        )}
+      </button>
+    );
+  }
+
   function renderPanel(id: string, col: DashColumn) {
     const before = hint?.kind === "panel" && hint.id === id && !hint.after;
     const after = hint?.kind === "panel" && hint.id === id && hint.after;
+    const isMax = maximizedId === id;
+    const hiddenByMax = maximizedId != null && !isMax;
     const style: CSSProperties = isDesktop
-      ? { flex: `${weights[id] ?? 1} 1 0` }
+      ? { flex: isMax ? "1 1 0" : `${weights[id] ?? 1} 1 0` }
       : {};
     return (
-      <PanelHandleProvider value={panelGrip(id)} key={id}>
+      <PanelControlsProvider
+        key={id}
+        value={{
+          // No drag grip while a panel is maximized.
+          handle: maximizedId ? null : panelGrip(id),
+          maximize: isDesktop ? panelMaxBtn(id) : null,
+        }}
+      >
         <div
           data-panel-id={id}
           style={style}
@@ -279,6 +318,8 @@ export function DashboardPanels({
           }
           className={cn(
             "relative min-h-0 flex-none overflow-hidden lg:flex-1 lg:[&>*]:h-full",
+            // Hide the other panels (desktop) while one is maximized.
+            hiddenByMax && "lg:hidden",
             dragId === id && "opacity-40",
             before && "shadow-[inset_0_3px_0_0_var(--accent)]",
             after && "shadow-[inset_0_-3px_0_0_var(--accent)]",
@@ -286,7 +327,7 @@ export function DashboardPanels({
         >
           {nodes[id]}
         </div>
-      </PanelHandleProvider>
+      </PanelControlsProvider>
     );
   }
 
@@ -307,7 +348,7 @@ export function DashboardPanels({
         {ids.map((id, i) => (
           <Fragment key={id}>
             {renderPanel(id, col)}
-            {isDesktop && i < ids.length - 1 ? (
+            {isDesktop && !maximizedId && i < ids.length - 1 ? (
               <div
                 role="separator"
                 aria-orientation="horizontal"
@@ -325,17 +366,34 @@ export function DashboardPanels({
   }
 
   const forceTwo = dragId != null;
-  const grid = gridTemplate(layout, centerFrac, forceTwo);
+  // Which column the maximized panel lives in (so the grid collapses the
+  // other column to 0 and the maximized one takes the full width).
+  const maxCol = maximizedId
+    ? layout.center.includes(maximizedId)
+      ? "center"
+      : "right"
+    : null;
+  const grid = maximizedId
+    ? maxCol === "center"
+      ? "1fr 0 0"
+      : "0 0 1fr"
+    : gridTemplate(layout, centerFrac, forceTwo);
   const showColSplit =
-    isDesktop && (forceTwo || (layout.center.length > 0 && layout.right.length > 0));
+    isDesktop &&
+    !maximizedId &&
+    (forceTwo || (layout.center.length > 0 && layout.right.length > 0));
 
   return (
     <div
       ref={containerRef}
       className="flex min-h-0 flex-col gap-2 p-2 sm:p-3 lg:h-full"
     >
-      {focus}
-      {briefing}
+      {/* Briefing + focus banners hide while a module is maximized so it
+          truly fills the viewing area. */}
+      <div className={cn("flex flex-col gap-2", maximizedId && "lg:hidden")}>
+        {focus}
+        {briefing}
+      </div>
       <div
         data-cols
         className="grid grid-cols-1 gap-2 lg:min-h-0 lg:flex-1 lg:grid-cols-[1.6fr_9px_1fr] lg:gap-0 lg:overflow-hidden"

--- a/apps/web/src/components/dashboard/panel-handle.tsx
+++ b/apps/web/src/components/dashboard/panel-handle.tsx
@@ -3,16 +3,27 @@
 import { createContext, useContext, type ReactNode } from "react";
 
 /**
- * Lets a card header render a drag handle supplied by its DashboardPanels
- * host, without the host having to clone the card element. DashboardPanels
- * wraps each panel in a `PanelHandleProvider` carrying that panel's grip;
- * `DashboardCard` / `TaskListToolbar` call `usePanelHandle()` and render it
- * (or nothing, when not hosted in a rearrangeable dashboard).
+ * Controls a DashboardPanels host injects into each panel's card header,
+ * so the card can render the host's chrome (drag grip, maximize/restore
+ * toggle) without the host cloning the card element. Outside a
+ * rearrangeable dashboard the context is null and the cards fall back to
+ * their own defaults (no grip; the expand button is a plain link).
  */
-const PanelHandleContext = createContext<ReactNode>(null);
+export interface PanelControls {
+  /** Drag grip for reordering / moving the panel. */
+  handle: ReactNode;
+  /** Maximize / restore toggle (replaces the card's expand link). */
+  maximize: ReactNode;
+}
 
-export const PanelHandleProvider = PanelHandleContext.Provider;
+const PanelControlsContext = createContext<PanelControls | null>(null);
+
+export const PanelControlsProvider = PanelControlsContext.Provider;
 
 export function usePanelHandle(): ReactNode {
-  return useContext(PanelHandleContext);
+  return useContext(PanelControlsContext)?.handle ?? null;
+}
+
+export function usePanelMaximize(): ReactNode {
+  return useContext(PanelControlsContext)?.maximize ?? null;
 }


### PR DESCRIPTION
## What

Zack: *"if I click the expand button I'd like the module to take the whole viewing panel; in reverse if you shrink it I'd like it to fit back like it was in relation to the other modules."*

The panel **expand (⤢) button** used to navigate to a full-page route. Inside the rearrangeable dashboard it now **maximizes the module in place**:
- Click → the module fills the whole viewing area; the other panels, splitters, and the briefing banner hide.
- The icon flips to **restore (⤡)**; click again → returns to the **exact prior arrangement** (column assignment, order, and sizes are preserved — they live in state).

## How

- `panel-handle`: the host context now carries both a drag `handle` and a `maximize` control (`usePanelMaximize()`). `DashboardCard` + `TaskListToolbar` render the maximize toggle when hosted; otherwise they keep their original full-page expand link (unchanged inside a terminal / on mobile).
- `DashboardPanels` owns a transient `maximizedId` (**not persisted** — a reload returns to the normal layout). When set: the maximized panel's column goes full-width, the other column collapses to 0, the other panels get `lg:hidden`, splitters are suppressed, and the briefing hides — all via **display toggling**, so every card stays mounted (no refetch / scroll-loss churn).
- **Desktop only** — on mobile the panels already stack full-width, so the expand button keeps its full-page navigation there.

## Verification
- typecheck ✅ · lint ✅ · production build **92/92 pages** ✅ · `vitest run` → **347/347** (added a maximize→restore interaction test) ✅

## Deploy
**Sandbox only** (merge to `main` → sandbox.rokki.ai). Production stays put pending Zack's sign-off on the dashboard work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)