### PR TITLE
Explorer: Modules section + minimize panels to the rail

### DIFF
--- a/apps/web/src/components/DashboardClient.tsx
+++ b/apps/web/src/components/DashboardClient.tsx
@@ -10,6 +10,7 @@ import { DashboardShell } from "./dashboard/DashboardShell";
 import { ExplorerRail } from "./dashboard/ExplorerRail";
 import { MessagesCard } from "./dashboard/MessagesCard";
 import { DashboardPanels } from "./dashboard/DashboardPanels";
+import { ModuleVisibilityProvider } from "./dashboard/module-visibility";
 import { TerminalScopeFilter } from "./dashboard/TerminalScopeFilter";
 import { TopBar } from "./TopBar";
 import { DensityProvider, type Density } from "@/lib/density";
@@ -166,6 +167,7 @@ export function DashboardClient({
 
   return (
     <DensityProvider initial={initialDensity}>
+      <ModuleVisibilityProvider>
       <DashboardShell
         topBar={
           <TopBar>
@@ -230,6 +232,7 @@ export function DashboardClient({
           />
         }
       />
+      </ModuleVisibilityProvider>
       {/* Conditional mounting (not just open=false) — combined with
           the `dynamic()` imports above, the dialog code only ships
           to the client when the user actually opens one. Trims

--- a/apps/web/src/components/TaskListToolbar.tsx
+++ b/apps/web/src/components/TaskListToolbar.tsx
@@ -4,7 +4,11 @@ import Link from "next/link";
 import { useEffect, useRef } from "react";
 import { Plus, Maximize2 } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { usePanelHandle, usePanelMaximize } from "./dashboard/panel-handle";
+import {
+  usePanelHandle,
+  usePanelMaximize,
+  usePanelMinimize,
+} from "./dashboard/panel-handle";
 
 export interface GroupOption {
   value: string;
@@ -67,6 +71,7 @@ export function TaskListToolbar({
   // movable panel (the expand button stays its normal link there).
   const handle = usePanelHandle();
   const maximize = usePanelMaximize();
+  const minimize = usePanelMinimize();
   return (
     <div className="flex flex-shrink-0 flex-wrap items-center justify-between gap-y-2 border-b border-border px-4 py-3">
       <div className="flex flex-wrap items-center gap-3">
@@ -201,6 +206,7 @@ export function TaskListToolbar({
             </kbd>
           </button>
         )}
+        {minimize}
         {/* Hosted in DashboardPanels → maximize/restore toggle.
             Otherwise the original full-page expand link. */}
         {maximize ? (

--- a/apps/web/src/components/dashboard/DashboardCard.tsx
+++ b/apps/web/src/components/dashboard/DashboardCard.tsx
@@ -4,7 +4,11 @@ import Link from "next/link";
 import { Maximize2 } from "lucide-react";
 import type { ReactNode } from "react";
 import { cn } from "@/lib/utils";
-import { usePanelHandle, usePanelMaximize } from "./panel-handle";
+import {
+  usePanelHandle,
+  usePanelMaximize,
+  usePanelMinimize,
+} from "./panel-handle";
 
 /**
  * Shared card primitive used across the dashboard. Always has:
@@ -45,6 +49,7 @@ export function DashboardCard({
   // are null (no grip; the expand button stays a plain link).
   const handle = usePanelHandle();
   const maximize = usePanelMaximize();
+  const minimize = usePanelMinimize();
   return (
     <section
       // Stronger border + subtle ring/shadow so cards separate from the
@@ -70,6 +75,7 @@ export function DashboardCard({
         </div>
         <div className="flex items-center gap-2">
           {headerRight}
+          {minimize}
           {/* Hosted in DashboardPanels → maximize/restore toggle.
               Otherwise the original full-page expand link. */}
           {maximize ? (

--- a/apps/web/src/components/dashboard/DashboardPanels.test.tsx
+++ b/apps/web/src/components/dashboard/DashboardPanels.test.tsx
@@ -2,7 +2,12 @@
 import { describe, it, expect, beforeAll, beforeEach, afterEach } from "vitest";
 import { render, screen, cleanup, fireEvent } from "@testing-library/react";
 import { DashboardPanels } from "./DashboardPanels";
-import { usePanelHandle, usePanelMaximize } from "./panel-handle";
+import {
+  usePanelHandle,
+  usePanelMaximize,
+  usePanelMinimize,
+} from "./panel-handle";
+import { ModuleVisibilityProvider } from "./module-visibility";
 
 function setDesktop(matches: boolean) {
   Object.defineProperty(window, "matchMedia", {
@@ -130,5 +135,29 @@ describe("DashboardPanels", () => {
     fireEvent.click(restore);
     expect(tasksPanel().className).not.toContain("lg:hidden");
     expect(screen.getByLabelText("Maximize Week")).toBeTruthy();
+  });
+
+  it("minimize removes a panel from the viewing area (with provider)", () => {
+    setDesktop(true);
+    function WeekProbe() {
+      return <div>WEEK{usePanelMinimize()}</div>;
+    }
+    render(
+      <ModuleVisibilityProvider>
+        <DashboardPanels
+          briefing={null}
+          week={<WeekProbe />}
+          tasks={<div>TASKS_PANEL</div>}
+          messages={<div>m</div>}
+        />
+      </ModuleVisibilityProvider>,
+    );
+    // Week is in the viewing area initially.
+    expect(document.querySelector('[data-panel-id="week"]')).not.toBeNull();
+    // Minimize it → it leaves the viewing area.
+    fireEvent.click(screen.getByLabelText("Minimize Week"));
+    expect(document.querySelector('[data-panel-id="week"]')).toBeNull();
+    // Tasks is still there.
+    expect(document.querySelector('[data-panel-id="tasks"]')).not.toBeNull();
   });
 });

--- a/apps/web/src/components/dashboard/DashboardPanels.tsx
+++ b/apps/web/src/components/dashboard/DashboardPanels.tsx
@@ -10,9 +10,10 @@ import {
   type PointerEvent,
   type ReactNode,
 } from "react";
-import { GripVertical, Maximize2, Minimize2 } from "lucide-react";
+import { GripVertical, Maximize2, Minimize2, Minus } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { PanelControlsProvider } from "./panel-handle";
+import { useModuleVisibility } from "./module-visibility";
 import {
   DASH_LAYOUT_STORAGE_KEY,
   DEFAULT_DASH_LAYOUT,
@@ -79,6 +80,15 @@ export function DashboardPanels({
   // preference, so a reload returns to the normal arrangement.
   const [maximizedId, setMaximizedId] = useState<string | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
+
+  // Minimized modules (shared with the explorer rail's Modules list).
+  // A minimized panel is dropped from the viewing area but kept in
+  // `layout`, so restoring it from the rail puts it back in its slot.
+  const vis = useModuleVisibility();
+  function visibleInCol(col: DashColumn): string[] {
+    const m = vis?.minimized;
+    return m ? layout[col].filter((id) => !m.has(id)) : layout[col];
+  }
 
   // Track the lg breakpoint so the dynamic inline styles (panel flex,
   // grid template) only apply on desktop; mobile stays a natural stack.
@@ -291,6 +301,26 @@ export function DashboardPanels({
     );
   }
 
+  // Minimize — drops the panel out of the viewing area into the rail's
+  // Modules list (click it there to bring it back).
+  function panelMinBtn(id: string): ReactNode {
+    if (!vis) return null;
+    return (
+      <button
+        type="button"
+        onClick={() => {
+          if (maximizedId === id) setMaximizedId(null);
+          vis.toggle(id);
+        }}
+        aria-label={`Minimize ${TITLES[id] ?? "panel"}`}
+        title="Minimize"
+        className="rounded-sm p-1 text-text-3 hover:bg-bg-2 hover:text-text-0"
+      >
+        <Minus className="h-3 w-3" aria-hidden="true" />
+      </button>
+    );
+  }
+
   function renderPanel(id: string, col: DashColumn) {
     const before = hint?.kind === "panel" && hint.id === id && !hint.after;
     const after = hint?.kind === "panel" && hint.id === id && hint.after;
@@ -306,6 +336,8 @@ export function DashboardPanels({
           // No drag grip while a panel is maximized.
           handle: maximizedId ? null : panelGrip(id),
           maximize: isDesktop ? panelMaxBtn(id) : null,
+          // No minimize while maximized — restore first.
+          minimize: isDesktop && !maximizedId ? panelMinBtn(id) : null,
         }}
       >
         <div
@@ -332,7 +364,7 @@ export function DashboardPanels({
   }
 
   function renderColumn(col: DashColumn) {
-    const ids = layout[col];
+    const ids = visibleInCol(col);
     const emptyHighlight =
       hint?.kind === "col" && hint.col === col && ids.length === 0;
     return (
@@ -366,6 +398,11 @@ export function DashboardPanels({
   }
 
   const forceTwo = dragId != null;
+  // Only the non-minimized panels affect the layout/collapse maths.
+  const visLayout: DashLayout = {
+    center: visibleInCol("center"),
+    right: visibleInCol("right"),
+  };
   // Which column the maximized panel lives in (so the grid collapses the
   // other column to 0 and the maximized one takes the full width).
   const maxCol = maximizedId
@@ -377,11 +414,11 @@ export function DashboardPanels({
     ? maxCol === "center"
       ? "1fr 0 0"
       : "0 0 1fr"
-    : gridTemplate(layout, centerFrac, forceTwo);
+    : gridTemplate(visLayout, centerFrac, forceTwo);
   const showColSplit =
     isDesktop &&
     !maximizedId &&
-    (forceTwo || (layout.center.length > 0 && layout.right.length > 0));
+    (forceTwo || (visLayout.center.length > 0 && visLayout.right.length > 0));
 
   return (
     <div

--- a/apps/web/src/components/dashboard/ExplorerRail.tsx
+++ b/apps/web/src/components/dashboard/ExplorerRail.tsx
@@ -2,21 +2,12 @@
 
 import Link from "next/link";
 import { useEffect, useMemo, useRef, useState } from "react";
-import {
-  ChevronDown,
-  ChevronRight,
-  Clock,
-  Settings,
-  X,
-} from "lucide-react";
+import { ChevronDown, ChevronRight, Settings, X } from "lucide-react";
 import type { DashSpace, DashTerminal } from "@/lib/dashboard-queries";
 import { cn } from "@/lib/utils";
 import { AccountBlock } from "@/components/AccountBlock";
-import {
-  COLLAPSED_SPACES_KEY,
-  readRecentTerminals,
-  type RecentTerminal,
-} from "@/lib/recent-terminals";
+import { RailModules } from "./RailModules";
+import { COLLAPSED_SPACES_KEY } from "@/lib/recent-terminals";
 import {
   applyOrder,
   reorder,
@@ -234,32 +225,36 @@ export function ExplorerRail({
     setOverTermId(null);
   }
 
-  // Recently-viewed terminals. Hydrate on mount + listen for the
-  // custom event the tracker dispatches when a new terminal is opened.
-  const [recents, setRecents] = useState<RecentTerminal[]>([]);
+  // Collapse state for the two rail sections (Spaces / Modules),
+  // persisted per-device like the per-space collapse.
+  const [sectionsOpen, setSectionsOpen] = useState({
+    spaces: true,
+    modules: true,
+  });
   useEffect(() => {
-    setRecents(readRecentTerminals());
-    const onChange = () => setRecents(readRecentTerminals());
-    window.addEventListener("rokki:recent-terminals-changed", onChange);
-    return () =>
-      window.removeEventListener("rokki:recent-terminals-changed", onChange);
+    try {
+      const raw = window.localStorage.getItem("rokki:explorer-sections");
+      if (raw) {
+        const p = JSON.parse(raw) as Partial<typeof sectionsOpen>;
+        setSectionsOpen((s) => ({ ...s, ...p }));
+      }
+    } catch {
+      /* default: both open */
+    }
   }, []);
-
-  const liveRecents = useMemo(() => {
-    if (recents.length === 0) return [];
-    // localStorage may hold either a slug (new) or a legacy ticker
-    // (old recents written before the slug column existed). Match
-    // against both so old recents keep working until they fall off
-    // the ring.
-    const bySlug = new Map(terminals.map((t) => [t.slug, t]));
-    const byTicker = new Map(terminals.map((t) => [t.ticker, t]));
-    return recents
-      .map((r) => {
-        const live = bySlug.get(r.ticker) ?? byTicker.get(r.ticker);
-        return live ? { slug: live.slug, name: live.name } : null;
-      })
-      .filter((r): r is { slug: string; name: string } => r !== null);
-  }, [recents, terminals]);
+  useEffect(() => {
+    if (!hydrated) return;
+    try {
+      window.localStorage.setItem(
+        "rokki:explorer-sections",
+        JSON.stringify(sectionsOpen),
+      );
+    } catch {
+      /* non-fatal */
+    }
+  }, [sectionsOpen, hydrated]);
+  const toggleSection = (k: "spaces" | "modules") =>
+    setSectionsOpen((s) => ({ ...s, [k]: !s[k] }));
 
   const filterRef = useRef<HTMLInputElement>(null);
 
@@ -342,32 +337,21 @@ export function ExplorerRail({
         ) : null}
 
         <div className="px-1 py-2">
-          {/* Recently-viewed — only when not filtering, and only if
-              there's anything in the ring. Heading style now matches
-              the "Explorer" heading at the top — same density. */}
-          {!isFiltering && liveRecents.length > 0 ? (
-            <div className="mb-3">
-              <p className="px-3 pb-1 text-xs font-semibold uppercase tracking-wide text-text-3">
-                Recent
-              </p>
-              <ul className="space-y-0.5">
-                {liveRecents.map((r) => (
-                  <li key={r.slug}>
-                    <Link
-                      href={`/p/${r.slug}`}
-                      className="flex items-center gap-2 rounded-sm px-2 py-0.5 text-text-1 hover:bg-bg-2 hover:text-text-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-focus"
-                    >
-                      <Clock className="h-3 w-3 flex-shrink-0 text-text-3" />
-                      <span className="flex-1 truncate text-xs">{r.name}</span>
-                    </Link>
-                  </li>
-                ))}
-              </ul>
-              <div className="mx-2 mt-2 border-t border-border" />
-            </div>
-          ) : null}
+          {/* ---- SPACES section (collapsible) ---- */}
+          <button
+            type="button"
+            onClick={() => toggleSection("spaces")}
+            className="flex w-full items-center gap-1.5 px-2 py-1 text-xs font-semibold uppercase tracking-wide text-text-3 hover:text-text-1"
+          >
+            {sectionsOpen.spaces ? (
+              <ChevronDown className="h-3 w-3 flex-shrink-0" aria-hidden="true" />
+            ) : (
+              <ChevronRight className="h-3 w-3 flex-shrink-0" aria-hidden="true" />
+            )}
+            Spaces
+          </button>
 
-          {spaces.length === 0 ? (
+          {!sectionsOpen.spaces ? null : spaces.length === 0 ? (
             <p className="px-3 py-4 text-xs text-text-3">
               You&apos;re not in any spaces yet.
             </p>
@@ -573,10 +557,20 @@ export function ExplorerRail({
             </ul>
           )}
 
-          {/* The "Tools" tile lived here. Removed at Zack's request —
-              the marketplace is reachable from the command palette
-              ("tools") and the AccountBlock menu, and the tile was
-              eating rail real estate without earning the visit count. */}
+          {/* ---- MODULES section (collapsible) ---- */}
+          <button
+            type="button"
+            onClick={() => toggleSection("modules")}
+            className="mt-3 flex w-full items-center gap-1.5 px-2 py-1 text-xs font-semibold uppercase tracking-wide text-text-3 hover:text-text-1"
+          >
+            {sectionsOpen.modules ? (
+              <ChevronDown className="h-3 w-3 flex-shrink-0" aria-hidden="true" />
+            ) : (
+              <ChevronRight className="h-3 w-3 flex-shrink-0" aria-hidden="true" />
+            )}
+            Modules
+          </button>
+          {sectionsOpen.modules ? <RailModules /> : null}
         </div>
       </div>
 

--- a/apps/web/src/components/dashboard/RailModules.test.tsx
+++ b/apps/web/src/components/dashboard/RailModules.test.tsx
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import { ModuleVisibilityProvider } from "./module-visibility";
+import { RailModules } from "./RailModules";
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+afterEach(() => {
+  cleanup();
+});
+
+describe("RailModules", () => {
+  it("renders nothing outside a ModuleVisibility provider", () => {
+    const { container } = render(<RailModules />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("lists the three modules, all open by default", () => {
+    render(
+      <ModuleVisibilityProvider>
+        <RailModules />
+      </ModuleVisibilityProvider>,
+    );
+    for (const name of ["Schedule", "Tasks", "Messages"]) {
+      const btn = screen.getByText(name).closest("button")!;
+      expect(btn.getAttribute("aria-pressed")).toBe("true"); // open
+    }
+  });
+
+  it("clicking a module toggles it minimized and persists", () => {
+    render(
+      <ModuleVisibilityProvider>
+        <RailModules />
+      </ModuleVisibilityProvider>,
+    );
+    const tasks = screen.getByText("Tasks").closest("button")!;
+    expect(tasks.getAttribute("aria-pressed")).toBe("true");
+
+    fireEvent.click(tasks);
+    expect(tasks.getAttribute("aria-pressed")).toBe("false"); // minimized
+
+    const raw = window.localStorage.getItem("rokki:dash-minimized-modules");
+    expect(raw ? JSON.parse(raw) : []).toContain("tasks");
+
+    fireEvent.click(tasks); // back open
+    expect(tasks.getAttribute("aria-pressed")).toBe("true");
+  });
+});

--- a/apps/web/src/components/dashboard/RailModules.tsx
+++ b/apps/web/src/components/dashboard/RailModules.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { useModuleVisibility, DASH_MODULES } from "./module-visibility";
+
+/**
+ * The explorer rail's "Modules" list. Minimal by design: each module is
+ * just its name, conforming to the spaces rows (same indent/padding), and
+ * the ONLY adornment is a far-right accent bar marking an *open* module.
+ * No icon, no count, no bold — the bar is the single signal. Clicking a
+ * row toggles the module open/minimized in the dashboard viewing area.
+ *
+ * Renders nothing when there's no dashboard host (no ModuleVisibility
+ * provider) — e.g. the rail shown inside a terminal.
+ */
+export function RailModules() {
+  const vis = useModuleVisibility();
+  if (!vis) return null;
+  return (
+    <ul className="space-y-0.5 text-sm">
+      {DASH_MODULES.map((m) => {
+        const open = !vis.isMinimized(m.id);
+        return (
+          <li key={m.id}>
+            <button
+              type="button"
+              onClick={() => vis.toggle(m.id)}
+              aria-pressed={open}
+              title={open ? `Minimize ${m.label}` : `Open ${m.label}`}
+              className="group flex w-full items-center gap-1 rounded-sm px-1 py-0.5 text-left text-text-1 hover:bg-bg-2 hover:text-text-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-focus"
+            >
+              {/* empty chevron column → module names line up with space names */}
+              <span className="h-3.5 w-3.5 flex-shrink-0" aria-hidden="true" />
+              <span className="flex-1 truncate text-xs">{m.label}</span>
+              {/* far-right open indicator — the only color in the list */}
+              <span
+                aria-hidden="true"
+                className={cn(
+                  "h-3 w-[3px] flex-shrink-0 rounded",
+                  open ? "bg-accent" : "bg-transparent",
+                )}
+              />
+            </button>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/apps/web/src/components/dashboard/module-visibility.tsx
+++ b/apps/web/src/components/dashboard/module-visibility.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from "react";
+
+/**
+ * Shared "which dashboard modules are minimized" state, so the explorer
+ * rail's Modules list and the DashboardPanels viewing area stay in sync:
+ *
+ *   - Minimize a panel (the – in its header) → it leaves the viewing
+ *     area and shows un-barred (minimized) in the rail's Modules list.
+ *   - Click a module in the rail → it toggles back open into the panels.
+ *
+ * Persisted per-device, like the rest of the dashboard layout. The
+ * context is null outside the provider so the rail can hide its Modules
+ * section when it isn't hosting a dashboard (e.g. inside a terminal).
+ */
+const KEY = "rokki:dash-minimized-modules";
+
+export interface ModuleVisibility {
+  minimized: Set<string>;
+  toggle: (id: string) => void;
+  isMinimized: (id: string) => boolean;
+}
+
+const ModuleVisibilityContext = createContext<ModuleVisibility | null>(null);
+
+export function ModuleVisibilityProvider({ children }: { children: ReactNode }) {
+  const [minimized, setMinimized] = useState<Set<string>>(() => new Set());
+  const [hydrated, setHydrated] = useState(false);
+
+  useEffect(() => {
+    try {
+      const raw = window.localStorage.getItem(KEY);
+      if (raw) {
+        const parsed = JSON.parse(raw) as unknown;
+        if (Array.isArray(parsed)) {
+          setMinimized(
+            new Set(parsed.filter((v): v is string => typeof v === "string")),
+          );
+        }
+      }
+    } catch {
+      /* default: nothing minimized */
+    }
+    setHydrated(true);
+  }, []);
+
+  useEffect(() => {
+    if (!hydrated) return;
+    try {
+      window.localStorage.setItem(KEY, JSON.stringify([...minimized]));
+    } catch {
+      /* non-fatal */
+    }
+  }, [minimized, hydrated]);
+
+  const value: ModuleVisibility = {
+    minimized,
+    isMinimized: (id) => minimized.has(id),
+    toggle: (id) =>
+      setMinimized((prev) => {
+        const next = new Set(prev);
+        next.has(id) ? next.delete(id) : next.add(id);
+        return next;
+      }),
+  };
+
+  return (
+    <ModuleVisibilityContext.Provider value={value}>
+      {children}
+    </ModuleVisibilityContext.Provider>
+  );
+}
+
+/** Returns the shared visibility controls, or null when not inside a
+ *  ModuleVisibilityProvider (e.g. the rail rendered outside a dashboard). */
+export function useModuleVisibility(): ModuleVisibility | null {
+  return useContext(ModuleVisibilityContext);
+}
+
+/** The dashboard's modules, in rail display order. id matches the
+ *  DashboardPanels panel id; label is what the rail shows. */
+export const DASH_MODULES: { id: string; label: string }[] = [
+  { id: "week", label: "Schedule" },
+  { id: "tasks", label: "Tasks" },
+  { id: "messages", label: "Messages" },
+];

--- a/apps/web/src/components/dashboard/panel-handle.tsx
+++ b/apps/web/src/components/dashboard/panel-handle.tsx
@@ -14,6 +14,8 @@ export interface PanelControls {
   handle: ReactNode;
   /** Maximize / restore toggle (replaces the card's expand link). */
   maximize: ReactNode;
+  /** Minimize button — sends the panel to the rail's Modules list. */
+  minimize: ReactNode;
 }
 
 const PanelControlsContext = createContext<PanelControls | null>(null);
@@ -26,4 +28,8 @@ export function usePanelHandle(): ReactNode {
 
 export function usePanelMaximize(): ReactNode {
   return useContext(PanelControlsContext)?.maximize ?? null;
+}
+
+export function usePanelMinimize(): ReactNode {
+  return useContext(PanelControlsContext)?.minimize ?? null;
 }


### PR DESCRIPTION
## What

Reworks the explorer rail per the approved minimal mockup and wires it to the dashboard panels, so modules behave like desktop windows (open / minimized to the rail).

**Rail**
- Removed the **Recent** section.
- **SPACES** and **MODULES** are collapsible sections (chevron headers, persisted per-device).
- **MODULES** lists Schedule / Tasks / Messages, conforming exactly to the space rows (same indent, padding, height). The only adornment is a **far-right accent bar = open** — no icon, no count, no bold; the bar is the single signal. Click a row to open/minimize that module.

**Panels**
- Each panel header gains a **minimize (–)** button next to maximize. Minimizing drops the panel out of the viewing area (remaining panels reflow; an emptied column collapses to full width) and shows it un-barred in the rail's Modules list. Click it there to restore it to its slot.

**Plumbing**
- New `ModuleVisibilityProvider` (shared minimized-set, persisted) wraps the dashboard so rail + panels stay in sync; `useModuleVisibility()` returns null outside it, so the rail hides its Modules section when not hosting a dashboard.
- `panel-handle` context gains a `minimize` control; `DashboardCard` + `TaskListToolbar` render it. `DashboardPanels` filters minimized panels out of the rendered columns (kept in `layout` for restore) and bases the grid/collapse maths on the visible set.

## Verification
- typecheck ✅ · lint ✅ · production build **92/92 pages** ✅ · `vitest run` → **351/351** (added `RailModules` + panel-minimize tests) ✅

## Deploy
**Sandbox only** (merge to `main` → sandbox.rokki.ai). Production stays put.

🤖 Generated with [Claude Code](https://claude.com/claude-code)