### PR TITLE
Mute the dark theme + unify the three card headers

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -17,10 +17,17 @@
   --bg-4: #2d2d32;
 
   --border: #2a2a2f;
-  --border-strong: #3a3a42;
+  /* Softened from #3a3a42 — card/section outlines were reading as harsh
+     bright lines on the dark bg; this still defines surfaces without
+     shouting. The faintest dividers use --border (or its /40 alpha). */
+  --border-strong: #34343b;
   --border-focus: #f5a623;
 
-  --text-0: #f5f5f7;
+  /* text-0 dampened from #f5f5f7 → softer off-white. Pure-white primary
+     text read as "blinding" against the near-black bg; this is a clear
+     step down while staying well above text-1 so content hierarchy
+     holds. Token-level, so it calms primary text app-wide. Tunable. */
+  --text-0: #dadadf;
   --text-1: #c8c8cd;
   --text-2: #8a8a92;
   /* text-3 was #5a5a62 — failed WCAG-AA at 2.74-2.90:1 against bg-0/bg-1.

--- a/apps/web/src/components/TaskListToolbar.tsx
+++ b/apps/web/src/components/TaskListToolbar.tsx
@@ -73,157 +73,171 @@ export function TaskListToolbar({
   const maximize = usePanelMaximize();
   const minimize = usePanelMinimize();
   return (
-    <div className="flex flex-shrink-0 flex-wrap items-center justify-between gap-y-2 border-b border-border-strong px-3 py-2">
-      <div className="flex flex-wrap items-center gap-2">
-        {handle}
-        <h2 className="text-xs font-semibold uppercase tracking-wide text-text-2">
-          {title}
-        </h2>
-        <span className="font-mono text-2xs text-text-3">{count}</span>
-
-        {/* Sort toggle. Auto = triage order (incomplete, priority, due,
-            created). Manual = drag-to-reorder (terminal only). */}
-        <span
-          role="tablist"
-          aria-label="Task sort order"
-          className="flex items-center gap-0 overflow-hidden rounded-sm border border-border text-2xs"
-        >
-          <button
-            type="button"
-            role="tab"
-            aria-selected={sortMode === "auto"}
-            onClick={() => onSortMode("auto")}
-            className={cn(
-              "px-2 py-0.5 font-mono uppercase tracking-wide",
-              sortMode === "auto"
-                ? "bg-bg-3 text-text-0"
-                : "text-text-3 hover:bg-bg-2 hover:text-text-1",
-            )}
-          >
-            Auto
-          </button>
-          <button
-            type="button"
-            role="tab"
-            aria-selected={sortMode === "manual"}
-            disabled={!allowManual}
-            title={
-              allowManual
-                ? undefined
-                : "Manual drag-to-reorder is available inside a terminal"
-            }
-            onClick={() => allowManual && onSortMode("manual")}
-            className={cn(
-              "px-2 py-0.5 font-mono uppercase tracking-wide",
-              sortMode === "manual" && allowManual
-                ? "bg-bg-3 text-text-0"
-                : "text-text-3 hover:bg-bg-2 hover:text-text-1",
-              !allowManual && "cursor-not-allowed opacity-40 hover:bg-transparent",
-            )}
-          >
-            Manual
-          </button>
-        </span>
-
-        {/* Group-by selector — sections the list with sticky headers. */}
-        <label className="flex items-center gap-1 text-2xs">
-          <span className="font-mono uppercase tracking-wide text-text-3">
-            Group
-          </span>
-          <select
-            value={groupMode}
-            onChange={(e) => onGroupMode(e.target.value)}
-            className="rounded-sm border border-border bg-bg-1 px-1 py-0.5 font-mono text-2xs uppercase tracking-wide text-text-1 outline-none hover:border-border-focus focus:border-border-focus"
-            aria-label="Group tasks by"
-          >
-            {groupOptions.map((o) => (
-              <option key={o.value} value={o.value}>
-                {o.label}
-              </option>
-            ))}
-          </select>
-        </label>
-
-        {/* Hide-done toggle. Appears only when there are done tasks to
-            hide (or the filter is already on), with a count so the
-            hidden work isn't forgotten. */}
-        {doneCount > 0 || hideDone ? (
-          <button
-            type="button"
-            onClick={onHideDone}
-            aria-pressed={hideDone}
-            title={
-              hideDone
-                ? `Show ${doneCount} completed task${doneCount === 1 ? "" : "s"}`
-                : `Hide ${doneCount} completed task${doneCount === 1 ? "" : "s"} from the list`
-            }
-            className={cn(
-              "flex items-center gap-1 rounded-sm border px-2 py-0.5 font-mono text-2xs uppercase tracking-wide transition-colors",
-              hideDone
-                ? "border-border bg-bg-2 text-text-2 hover:bg-bg-3"
-                : "border-border bg-bg-1 text-text-3 hover:bg-bg-2 hover:text-text-1",
-            )}
-          >
-            {hideDone ? "Show done" : "Hide done"}
-            {doneCount > 0 ? <span className="text-text-3">{doneCount}</span> : null}
-          </button>
-        ) : null}
+    <>
+      {/* Row 1 — the title bar. Identical to DashboardCard's header
+          (h-9, same padding, divider, and title treatment) so the Tasks
+          box lines up header-for-header with Schedule and Messages. The
+          list controls live in the compact strip below (row 2). */}
+      <div className="flex h-9 flex-shrink-0 items-center justify-between border-b border-border px-3">
+        <div className="flex items-center gap-2">
+          {handle}
+          <h2 className="text-xs font-semibold uppercase tracking-wide text-text-2">
+            {title}
+          </h2>
+          <span className="font-mono text-2xs text-text-3">{count}</span>
+        </div>
+        <div className="flex items-center gap-2">
+          {minimize}
+          {/* Hosted in DashboardPanels → maximize/restore toggle.
+              Otherwise the original full-page expand link. */}
+          {maximize ? (
+            maximize
+          ) : expandHref ? (
+            <Link
+              href={expandHref}
+              aria-label="Open full task list"
+              className="rounded-sm p-1 text-text-3 hover:bg-bg-2 hover:text-text-0"
+            >
+              <Maximize2 className="h-3 w-3" />
+            </Link>
+          ) : null}
+        </div>
       </div>
 
-      <div className="flex items-center gap-2">
-        <TaskFilterInput value={query} onChange={onQuery} />
-        {newTaskHref ? (
-          newTaskDisabled ? (
-            <span
-              title="No terminals yet — create a terminal first"
-              aria-disabled="true"
-              className="flex cursor-not-allowed items-center gap-1 rounded-sm px-2 py-1 text-xs text-text-3 opacity-60"
+      {/* Row 2 — the controls strip: sort / group / hide-done on the
+          left, filter + new task on the right. Compact density. */}
+      <div className="flex flex-shrink-0 flex-wrap items-center justify-between gap-2 border-b border-border px-3 py-1.5">
+        <div className="flex flex-wrap items-center gap-2">
+          {/* Sort toggle. Auto = triage order (incomplete, priority, due,
+              created). Manual = drag-to-reorder (terminal only). */}
+          <span
+            role="tablist"
+            aria-label="Task sort order"
+            className="flex items-center gap-0 overflow-hidden rounded-sm border border-border text-2xs"
+          >
+            <button
+              type="button"
+              role="tab"
+              aria-selected={sortMode === "auto"}
+              onClick={() => onSortMode("auto")}
+              className={cn(
+                "px-2 py-0.5 font-mono uppercase tracking-wide",
+                sortMode === "auto"
+                  ? "bg-bg-3 text-text-0"
+                  : "text-text-3 hover:bg-bg-2 hover:text-text-1",
+              )}
             >
-              <Plus className="h-3 w-3" /> New task
+              Auto
+            </button>
+            <button
+              type="button"
+              role="tab"
+              aria-selected={sortMode === "manual"}
+              disabled={!allowManual}
+              title={
+                allowManual
+                  ? undefined
+                  : "Manual drag-to-reorder is available inside a terminal"
+              }
+              onClick={() => allowManual && onSortMode("manual")}
+              className={cn(
+                "px-2 py-0.5 font-mono uppercase tracking-wide",
+                sortMode === "manual" && allowManual
+                  ? "bg-bg-3 text-text-0"
+                  : "text-text-3 hover:bg-bg-2 hover:text-text-1",
+                !allowManual && "cursor-not-allowed opacity-40 hover:bg-transparent",
+              )}
+            >
+              Manual
+            </button>
+          </span>
+
+          {/* Group-by selector — sections the list with sticky headers. */}
+          <label className="flex items-center gap-1 text-2xs">
+            <span className="font-mono uppercase tracking-wide text-text-3">
+              Group
             </span>
+            <select
+              value={groupMode}
+              onChange={(e) => onGroupMode(e.target.value)}
+              className="rounded-sm border border-border bg-bg-1 px-1 py-0.5 font-mono text-2xs uppercase tracking-wide text-text-1 outline-none hover:border-border-focus focus:border-border-focus"
+              aria-label="Group tasks by"
+            >
+              {groupOptions.map((o) => (
+                <option key={o.value} value={o.value}>
+                  {o.label}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          {/* Hide-done toggle. Appears only when there are done tasks to
+              hide (or the filter is already on), with a count so the
+              hidden work isn't forgotten. */}
+          {doneCount > 0 || hideDone ? (
+            <button
+              type="button"
+              onClick={onHideDone}
+              aria-pressed={hideDone}
+              title={
+                hideDone
+                  ? `Show ${doneCount} completed task${doneCount === 1 ? "" : "s"}`
+                  : `Hide ${doneCount} completed task${doneCount === 1 ? "" : "s"} from the list`
+              }
+              className={cn(
+                "flex items-center gap-1 rounded-sm border px-2 py-0.5 font-mono text-2xs uppercase tracking-wide transition-colors",
+                hideDone
+                  ? "border-border bg-bg-2 text-text-2 hover:bg-bg-3"
+                  : "border-border bg-bg-1 text-text-3 hover:bg-bg-2 hover:text-text-1",
+              )}
+            >
+              {hideDone ? "Show done" : "Hide done"}
+              {doneCount > 0 ? <span className="text-text-3">{doneCount}</span> : null}
+            </button>
+          ) : null}
+        </div>
+
+        <div className="flex items-center gap-2">
+          <TaskFilterInput value={query} onChange={onQuery} />
+          {newTaskHref ? (
+            newTaskDisabled ? (
+              <span
+                title="No terminals yet — create a terminal first"
+                aria-disabled="true"
+                className="flex cursor-not-allowed items-center gap-1 rounded-sm px-2 py-1 text-xs text-text-3 opacity-60"
+              >
+                <Plus className="h-3 w-3" /> New task
+              </span>
+            ) : (
+              <Link
+                href={newTaskHref}
+                className="flex items-center gap-1 rounded-sm px-2 py-1 text-xs text-text-2 hover:bg-bg-2 hover:text-text-0"
+              >
+                <Plus className="h-3 w-3" /> New task
+                <kbd className="ml-1 font-mono text-2xs text-text-3">
+                  {newTaskShortcut}
+                </kbd>
+              </Link>
+            )
           ) : (
-            <Link
-              href={newTaskHref}
-              className="flex items-center gap-1 rounded-sm px-2 py-1 text-xs text-text-2 hover:bg-bg-2 hover:text-text-0"
+            <button
+              type="button"
+              onClick={onNewTask}
+              disabled={newTaskDisabled}
+              className={cn(
+                "flex items-center gap-1 rounded-sm px-2 py-1 text-xs text-text-2 hover:bg-bg-2 hover:text-text-0",
+                newTaskDisabled && "cursor-not-allowed opacity-60",
+              )}
             >
               <Plus className="h-3 w-3" /> New task
               <kbd className="ml-1 font-mono text-2xs text-text-3">
                 {newTaskShortcut}
               </kbd>
-            </Link>
-          )
-        ) : (
-          <button
-            type="button"
-            onClick={onNewTask}
-            disabled={newTaskDisabled}
-            className={cn(
-              "flex items-center gap-1 rounded-sm px-2 py-1 text-xs text-text-2 hover:bg-bg-2 hover:text-text-0",
-              newTaskDisabled && "cursor-not-allowed opacity-60",
-            )}
-          >
-            <Plus className="h-3 w-3" /> New task
-            <kbd className="ml-1 font-mono text-2xs text-text-3">
-              {newTaskShortcut}
-            </kbd>
-          </button>
-        )}
-        {minimize}
-        {/* Hosted in DashboardPanels → maximize/restore toggle.
-            Otherwise the original full-page expand link. */}
-        {maximize ? (
-          maximize
-        ) : expandHref ? (
-          <Link
-            href={expandHref}
-            aria-label="Open full task list"
-            className="rounded-sm p-1 text-text-3 hover:bg-bg-2 hover:text-text-0"
-          >
-            <Maximize2 className="h-3 w-3" />
-          </Link>
-        ) : null}
+            </button>
+          )}
+        </div>
       </div>
-    </div>
+    </>
   );
 }
 

--- a/apps/web/src/components/TaskSectionHeader.tsx
+++ b/apps/web/src/components/TaskSectionHeader.tsx
@@ -43,7 +43,7 @@ export function TaskSectionHeader({
           onToggle();
         }
       }}
-      className="sticky top-0 z-[2] flex h-7 cursor-pointer select-none items-center gap-2 border-b border-border-strong bg-bg-2 pr-3 transition-colors hover:bg-bg-3 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-border-focus"
+      className="sticky top-0 z-[2] flex h-7 cursor-pointer select-none items-center gap-2 border-b border-border bg-bg-2 pr-3 transition-colors hover:bg-bg-3 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-border-focus"
     >
       {/* Colored left tick carrying the bucket's meaning. */}
       <span aria-hidden="true" className={cn("h-full w-[3px] flex-shrink-0", tone)} />
@@ -56,10 +56,10 @@ export function TaskSectionHeader({
         aria-hidden="true"
         className={cn("h-1.5 w-1.5 flex-shrink-0 rounded-full", tone)}
       />
-      <span className="font-mono text-[10px] font-semibold uppercase tracking-wide text-text-1">
+      <span className="font-mono text-2xs font-semibold uppercase tracking-wide text-text-1">
         {label}
       </span>
-      <span className="ml-auto rounded-full bg-bg-3 px-1.5 py-0.5 font-mono text-[10px] leading-none text-text-2">
+      <span className="ml-auto rounded-full bg-bg-3 px-1.5 py-0.5 font-mono text-2xs leading-none text-text-2">
         {count}
       </span>
     </header>

--- a/apps/web/src/components/TasksPane.tsx
+++ b/apps/web/src/components/TasksPane.tsx
@@ -908,7 +908,7 @@ export function TasksPane({ ticker, projectId, currentUserId }: TasksPaneProps) 
               );
             }
             return (
-              <div className="divide-y-2 divide-border-strong">
+              <div className="divide-y divide-border">
                 {groups.map((group) => {
                   const hasHeader = group.label !== "";
                   const collapseKey = `${groupMode}:${group.key}`;

--- a/apps/web/src/components/dashboard/DashboardCard.tsx
+++ b/apps/web/src/components/dashboard/DashboardCard.tsx
@@ -63,7 +63,7 @@ export function DashboardCard({
         className,
       )}
     >
-      <header className="flex h-9 flex-shrink-0 items-center justify-between border-b border-border-strong px-3">
+      <header className="flex h-9 flex-shrink-0 items-center justify-between border-b border-border px-3">
         <div className="flex items-center gap-2">
           {handle}
           <h2 className="text-xs font-semibold uppercase tracking-wide text-text-2">

--- a/apps/web/src/components/dashboard/MessagesCard.tsx
+++ b/apps/web/src/components/dashboard/MessagesCard.tsx
@@ -57,7 +57,7 @@ export function MessagesCard() {
       ) : threads.length === 0 ? (
         <Empty />
       ) : (
-        <ul className="divide-y divide-border/60 text-sm">
+        <ul className="divide-y divide-border/40 text-sm">
           {threads.slice(0, 10).map((t) => (
             <li key={t.id}>
               <Link

--- a/apps/web/src/components/dashboard/TasksCard.tsx
+++ b/apps/web/src/components/dashboard/TasksCard.tsx
@@ -281,13 +281,13 @@ export function TasksCard({
       />
       <div className="min-h-0 flex-1 overflow-y-auto">
         {visibleAssigned.length === 0 ? (
-          <p className="px-3 py-4 text-center text-[11px] text-text-3">
+          <p className="px-3 py-4 text-center text-xs text-text-3">
             {query.trim()
               ? "No tasks match your filter."
               : "No open tasks. Nice."}
           </p>
         ) : groupBy === "none" ? (
-          <ul className="divide-y divide-border/60">
+          <ul className="divide-y divide-border/40">
             {visibleAssigned.slice(0, ROW_LIMIT).map((t) => (
               <DashboardTaskRow
                 key={t.id}
@@ -308,7 +308,7 @@ export function TasksCard({
               terminalNameById,
             );
             return (
-              <div className="divide-y-2 divide-border-strong">
+              <div className="divide-y divide-border">
                 {buckets.map((b) => {
                   const collapseKey = `${groupBy}:${b.key}`;
                   const collapsed = collapsedGroups.has(collapseKey);
@@ -322,7 +322,7 @@ export function TasksCard({
                         onToggle={() => toggleGroupCollapsed(collapseKey)}
                       />
                       {!collapsed ? (
-                        <ul className="divide-y divide-border/60">
+                        <ul className="divide-y divide-border/40">
                           {b.tasks.map((t) => (
                             <DashboardTaskRow
                               key={`${b.key}:${t.id}`}

--- a/apps/web/src/components/dashboard/WeekCard.tsx
+++ b/apps/web/src/components/dashboard/WeekCard.tsx
@@ -153,7 +153,7 @@ export function WeekCard({
       {items.length === 0 ? (
         <EmptyWeek range={range} filtered={hiddenSourceIds.length > 0} />
       ) : (
-        <ul className="divide-y divide-border/60 text-sm">
+        <ul className="divide-y divide-border/40 text-sm">
           {grouped.map((day) => (
             <li key={day.key}>
               <div className="flex items-center gap-2 bg-bg-1 px-3 py-1">
@@ -167,7 +167,7 @@ export function WeekCard({
               {day.items.length === 0 ? (
                 <div className="px-3 py-1.5 text-xs text-text-3">—</div>
               ) : (
-                <ul className="divide-y divide-border/60">
+                <ul className="divide-y divide-border/40">
                   {day.items.map((it) => (
                     <WeekRow key={it.id} item={it} />
                   ))}


### PR DESCRIPTION
Two comfort/consistency fixes from Zack's dashboard review — both **app-wide**, not just the three cards.

## 1. Muted, easier on the eyes (token-level → every surface)
The bright white was "blinding" and the lines read as harsh. Fixed at the token level so it propagates to the **file explorer, top bar, ticker, function keys, account block** — everything — not just the dashboard cards.

- `--text-0` `#f5f5f7` → **`#dadadf`** — pure-white primary text was the blinding element; a clear step softer, still well above `text-1` so hierarchy holds.
- `--border-strong` `#3a3a42` → **`#34343b`** — card/section outlines were the harsh bright lines; softened, still defines surfaces.

### Lines — one muted hierarchy (frame > section > row)
- Card **header dividers**: `border-strong` → `border` (gentler than the frame around the card).
- **Section dividers**: the 2px `divide-y-2 divide-border-strong` — the single harshest element, in both the dashboard *and* the in-terminal task pane — → 1px `divide-y divide-border`. `TaskSectionHeader` border likewise softened.
- **Row dividers** (tasks / schedule / messages): `divide-border/60` → **`divide-border/40`**, a clearly softer hairline.

## 2. The three box headers now line up
The **Tasks** header was one tall, wrapping bar (`px-3 py-2`, controls inline) while Schedule/Messages use `DashboardCard`'s fixed **h-9** title bar — so they never lined up. Split the Tasks toolbar into two rows:
- an **h-9 title bar identical to DashboardCard** (handle + title + count · minimize + maximize), and
- a compact **controls strip** beneath (sort / group / hide-done · filter + new task).

Because the toolbar is shared, the in-terminal task pane gets the same clean split.

## Verification
Styling only, no behaviour changes. typecheck ✅ · lint ✅ · build **92/92** ✅ · `vitest` **351/351** ✅

`text-0` and the divider opacity are single-knob **tunable** if you want it softer/stronger after seeing it.

## Deploy
**Sandbox only.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)