### PR TITLE
More top-header room in dashboard modules

### DIFF
--- a/apps/web/src/components/TaskListToolbar.tsx
+++ b/apps/web/src/components/TaskListToolbar.tsx
@@ -78,7 +78,7 @@ export function TaskListToolbar({
           (h-9, same padding, divider, and title treatment) so the Tasks
           box lines up header-for-header with Schedule and Messages. The
           list controls live in the compact strip below (row 2). */}
-      <div className="flex h-9 flex-shrink-0 items-center justify-between border-b border-border px-3">
+      <div className="flex h-10 flex-shrink-0 items-center justify-between border-b border-border px-3">
         <div className="flex items-center gap-2">
           {handle}
           <h2 className="text-xs font-semibold uppercase tracking-wide text-text-2">
@@ -106,7 +106,7 @@ export function TaskListToolbar({
 
       {/* Row 2 — the controls strip: sort / group / hide-done on the
           left, filter + new task on the right. Compact density. */}
-      <div className="flex flex-shrink-0 flex-wrap items-center justify-between gap-2 border-b border-border px-3 py-1.5">
+      <div className="flex flex-shrink-0 flex-wrap items-center justify-between gap-2 border-b border-border px-3 py-2">
         <div className="flex flex-wrap items-center gap-2">
           {/* Sort toggle. Auto = triage order (incomplete, priority, due,
               created). Manual = drag-to-reorder (terminal only). */}

--- a/apps/web/src/components/dashboard/DashboardCard.tsx
+++ b/apps/web/src/components/dashboard/DashboardCard.tsx
@@ -63,7 +63,7 @@ export function DashboardCard({
         className,
       )}
     >
-      <header className="flex h-9 flex-shrink-0 items-center justify-between border-b border-border px-3">
+      <header className="flex h-10 flex-shrink-0 items-center justify-between border-b border-border px-3">
         <div className="flex items-center gap-2">
           {handle}
           <h2 className="text-xs font-semibold uppercase tracking-wide text-text-2">


### PR DESCRIPTION
Follow-up to Zack's note: *"a little more space inside each box… really only in the first two pieces of the top"* — not the sides, not between rows.

So this adds vertical breathing room to the **header area only**:
- **Title bar** `h-9` → `h-10` on all three boxes (kept identical so they still line up).
- **Tasks controls strip** (the second top piece) `py-1.5` → `py-2` to match.

Left/right padding and row-to-row spacing are unchanged.

Styling only · typecheck ✅ · lint ✅ · build 92/92 ✅ · 351/351 tests ✅ · **sandbox only**. `h-10` / `py-2` are easy to nudge if you want more.

🤖 Generated with [Claude Code](https://claude.com/claude-code)