### PR TITLE
Explorer rail: breathing room + aligned tree indentation

### DIFF
--- a/apps/web/src/components/dashboard/ExplorerRail.tsx
+++ b/apps/web/src/components/dashboard/ExplorerRail.tsx
@@ -285,7 +285,7 @@ export function ExplorerRail({
 
   return (
     <div className="flex h-full flex-col bg-bg-0">
-      <div className="flex h-9 flex-shrink-0 items-center border-b border-border px-3">
+      <div className="flex h-11 flex-shrink-0 items-center border-b border-border px-3">
         <span className="text-xs font-semibold uppercase tracking-wide text-text-3">
           Explorer
         </span>
@@ -300,7 +300,7 @@ export function ExplorerRail({
         {/* Filter input is sticky to the top of the scroll region so it
             stays in view as the tree scrolls. */}
         {spaces.length > 0 ? (
-          <div className="sticky top-0 z-10 flex-shrink-0 border-b border-border bg-bg-0 px-2 py-1.5">
+          <div className="sticky top-0 z-10 flex-shrink-0 border-b border-border bg-bg-0 px-2 py-2.5">
             <div className="relative">
               {/* The leading magnifying-glass icon was dropped per
                   Zack's report ("there is still a + in the filter").
@@ -317,7 +317,7 @@ export function ExplorerRail({
                 placeholder="Search…"
                 aria-label="Filter explorer"
                 title="Press / to focus"
-                className="h-7 w-full rounded-sm border border-border bg-bg-1 px-2 text-xs text-text-0 placeholder:text-text-3 focus:border-border-focus focus:outline-none focus-visible:ring-2 focus-visible:ring-border-focus"
+                className="h-8 w-full rounded-sm border border-border bg-bg-1 px-2 text-xs text-text-0 placeholder:text-text-3 focus:border-border-focus focus:outline-none focus-visible:ring-2 focus-visible:ring-border-focus"
               />
               {filter ? (
                 <button
@@ -341,7 +341,7 @@ export function ExplorerRail({
           <button
             type="button"
             onClick={() => toggleSection("spaces")}
-            className="flex w-full items-center gap-1.5 px-2 py-1 text-xs font-semibold uppercase tracking-wide text-text-3 hover:text-text-1"
+            className="flex w-full items-center gap-1 px-1 py-1 text-xs font-semibold uppercase tracking-wide text-text-3 hover:text-text-1"
           >
             {sectionsOpen.spaces ? (
               <ChevronDown className="h-3 w-3 flex-shrink-0" aria-hidden="true" />
@@ -362,7 +362,7 @@ export function ExplorerRail({
               .
             </p>
           ) : (
-            <ul className="space-y-0.5 text-xs">
+            <ul className="space-y-0.5 pl-3 text-xs">
               {orderedSpaces.map((s) => {
                 const children =
                   filteredTerminalsBySpace.get(s.id) ??
@@ -538,9 +538,10 @@ export function ExplorerRail({
                             <Link
                               href={`/p/${t.slug}`}
                               draggable={false}
-                              // pl-5 gives terminals a clear "child of"
-                              // indent under the space row's chevron.
-                              className="flex items-center gap-2 rounded-sm py-0.5 pl-5 pr-2 text-text-1 hover:bg-bg-2 hover:text-text-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-focus"
+                              // pl-8 indents terminals one step under the
+                              // space name, so the tree reads SPACES → space
+                              // → terminal at aligned, increasing depths.
+                              className="flex items-center gap-2 rounded-sm py-0.5 pl-8 pr-2 text-text-1 hover:bg-bg-2 hover:text-text-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-focus"
                               title={t.name}
                             >
                               <span className="flex-1 truncate text-xs">
@@ -561,7 +562,7 @@ export function ExplorerRail({
           <button
             type="button"
             onClick={() => toggleSection("modules")}
-            className="mt-3 flex w-full items-center gap-1.5 px-2 py-1 text-xs font-semibold uppercase tracking-wide text-text-3 hover:text-text-1"
+            className="mt-3 flex w-full items-center gap-1 px-1 py-1 text-xs font-semibold uppercase tracking-wide text-text-3 hover:text-text-1"
           >
             {sectionsOpen.modules ? (
               <ChevronDown className="h-3 w-3 flex-shrink-0" aria-hidden="true" />

--- a/apps/web/src/components/dashboard/RailModules.tsx
+++ b/apps/web/src/components/dashboard/RailModules.tsx
@@ -17,7 +17,7 @@ export function RailModules() {
   const vis = useModuleVisibility();
   if (!vis) return null;
   return (
-    <ul className="space-y-0.5 text-xs">
+    <ul className="space-y-0.5 pl-3 text-xs">
       {DASH_MODULES.map((m) => {
         const open = !vis.isMinimized(m.id);
         return (


### PR DESCRIPTION
From Zack's review of the left rail (screenshot): the **EXPLORER title + Search were cramped** at the top, and the **indentation didn't read as a tree** — section labels, spaces/modules, and terminals all sat at nearly the same indent (modules looked flush under MODULES; terminals were even slightly *left* of their space).

### Breathing room at the top
- EXPLORER header `h-9` → `h-11`
- Search row `py-1.5` → `py-2.5`, input `h-7` → `h-8`

### A proper, aligned indent staircase
Section header → item → child, consistent across **both** sections:
- Section headers (SPACES / MODULES) pulled left (`px-2`→`px-1`) so they're the clear **level-0** anchor.
- Spaces list **and** Modules list both indented one step (`pl-3`) → a space name and a module name now sit at the **same depth**, one level under their header.
- Terminals indented one step further (`pl-5`→`pl-8`) → clearly nested under their space.

Net: `EXPLORER ▸ SPACES ▸ space ▸ terminal` (and `MODULES ▸ module`) read as increasing, aligned depths instead of a flat row.

Styling only · typecheck ✅ · lint ✅ · build 92/92 ✅ · 351/351 tests ✅ · **sandbox only**. Indent steps (`pl-3`/`pl-8`) and header heights are easy to nudge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)