### PR TITLE
Halve the EXPLORER header increase (h-11 → h-10)

### DIFF
--- a/apps/web/src/components/dashboard/ExplorerRail.tsx
+++ b/apps/web/src/components/dashboard/ExplorerRail.tsx
@@ -285,7 +285,7 @@ export function ExplorerRail({
 
   return (
     <div className="flex h-full flex-col bg-bg-0">
-      <div className="flex h-11 flex-shrink-0 items-center border-b border-border px-3">
+      <div className="flex h-10 flex-shrink-0 items-center border-b border-border px-3">
         <span className="text-xs font-semibold uppercase tracking-wide text-text-3">
           Explorer
         </span>


### PR DESCRIPTION
Zack: the last rail change made the EXPLORER header too tall. It went h-9 → h-11 (+8px); this cuts the increase **50%** to h-10 (+4px). Search room and tree indentation unchanged.

Styling only · typecheck ✅ · lint ✅ · build 92/92 ✅ · **sandbox only**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)