### PR TITLE
Design Mode v2: ~50 knobs, in-panel search, group collapse, font swap

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -133,6 +133,12 @@
   --rk-rail-header-h: 40px;
   --rk-rail-indent: 12px;
   --rk-rail-indent-child: 32px;
+  /* v2 additions — top-of-page chrome + element sizing. */
+  --rk-topbar-h: 44px;
+  --rk-ticker-h: 32px;
+  --rk-search-h: 32px;
+  --rk-section-head-h: 28px;
+  --rk-card-radius: 6px;
 }
 html[data-density="cozy"] {
   font-size: 16px;

--- a/apps/web/src/components/DesignMode.tsx
+++ b/apps/web/src/components/DesignMode.tsx
@@ -1,83 +1,160 @@
 "use client";
 
-import { useEffect, useRef, useState, type CSSProperties } from "react";
+import { useEffect, useMemo, useRef, useState, type CSSProperties } from "react";
 
 /**
- * Design Mode — a sandbox-only live tuner for the design system.
+ * Design Mode v2 — sandbox-only live tuner for the design system.
  *
- * Press Shift+D (or click the corner pill) on any non-production host and a
- * panel slides in over the REAL app. Every slider / swatch writes a CSS
- * custom property onto <html> at runtime, so the actual dashboard restyles
- * live — no mock, no deploy. Tweaks persist per-browser (localStorage) and
- * Export copies a summary of everything you changed so it can be baked into
- * the codebase permanently.
+ * Press Shift+D (or click the "✦ Design" pill) on any non-production host
+ * and a panel slides in over the REAL app. Every slider / swatch / select
+ * writes a CSS custom property (or attribute) onto <html> at runtime, so
+ * the actual UI restyles live — no mock, no deploy.
  *
- * It never renders on the production apex (rokki.ai / www.rokki.ai), and it
- * only mutates inline CSS variables — it touches no app state or data.
+ * v2 expands coverage from ~18 knobs to ~50:
+ *   - Type: all 8 font sizes (2xs..2xl) + 5 leading tiers + font family
+ *   - Color: 5 bg + 5 text + 3 border + 4 accent + 8 semantic = 25 swatches
+ *   - Layout: card header h, row py, ctrl py, search h, section head h,
+ *             card radius, topbar h, ticker h
+ *   - Rail: header h, item indent, terminal indent
  *
- * The two var families it drives:
- *   - existing design tokens: --text-0..3, --border, --border-strong,
- *     --accent, --text-2xs..base, --leading-sm   (defined in globals.css)
- *   - layout knobs: --rk-card-header-h, --rk-row-py, --rk-ctrl-py,
- *     --rk-rail-header-h, --rk-rail-indent, --rk-rail-indent-child
- *     (also in globals.css; consumed via Tailwind h-[var(...)] etc.)
+ * Plus in-panel features:
+ *   - Search/filter (find any knob fast)
+ *   - Collapsible groups
+ *   - "Show only changed" toggle (great for review before Export)
+ *   - Export copies a diff to the clipboard ready to paste back to Claude
+ *
+ * Tweaks persist per-browser. The panel never renders on rokki.ai /
+ * www.rokki.ai — only mutates inline CSS variables — no app state, no
+ * data, no DOM moves.
  */
 
 type Knob =
   | {
       id: string;
       label: string;
+      group: string;
       kind: "range";
       min: number;
       max: number;
       step: number;
       unit: string;
     }
-  | { id: string; label: string; kind: "color" };
+  | { id: string; label: string; group: string; kind: "color" }
+  | {
+      id: string;
+      label: string;
+      group: string;
+      kind: "select";
+      options: { value: string; label: string }[];
+      /** Non-CSS-var setters (e.g. font family, theme attribute). */
+      apply?: (v: string) => void;
+      read?: () => string;
+    };
 
-const GROUPS: { title: string; knobs: Knob[] }[] = [
+const KNOBS: Knob[] = [
+  // ---- Type — font size ----
+  { id: "--text-2xs", label: "Meta (counts, chips, times)", group: "Type — font size", kind: "range", min: 8, max: 16, step: 1, unit: "px" },
+  { id: "--text-xs", label: "Labels & nav", group: "Type — font size", kind: "range", min: 9, max: 18, step: 1, unit: "px" },
+  { id: "--text-sm", label: "Content (titles, events)", group: "Type — font size", kind: "range", min: 10, max: 20, step: 1, unit: "px" },
+  { id: "--text-base", label: "Base", group: "Type — font size", kind: "range", min: 12, max: 22, step: 1, unit: "px" },
+  { id: "--text-md", label: "Medium", group: "Type — font size", kind: "range", min: 12, max: 24, step: 1, unit: "px" },
+  { id: "--text-lg", label: "Large", group: "Type — font size", kind: "range", min: 14, max: 28, step: 1, unit: "px" },
+  { id: "--text-xl", label: "Extra large", group: "Type — font size", kind: "range", min: 16, max: 36, step: 1, unit: "px" },
+  { id: "--text-2xl", label: "2× extra large", group: "Type — font size", kind: "range", min: 18, max: 44, step: 1, unit: "px" },
+
+  // ---- Type — leading (line height) ----
+  { id: "--leading-2xs", label: "Meta line spacing", group: "Type — line spacing", kind: "range", min: 10, max: 22, step: 1, unit: "px" },
+  { id: "--leading-xs", label: "Labels line spacing", group: "Type — line spacing", kind: "range", min: 11, max: 24, step: 1, unit: "px" },
+  { id: "--leading-sm", label: "Content line spacing", group: "Type — line spacing", kind: "range", min: 12, max: 28, step: 1, unit: "px" },
+  { id: "--leading-base", label: "Base line spacing", group: "Type — line spacing", kind: "range", min: 14, max: 30, step: 1, unit: "px" },
+  { id: "--leading-md", label: "Medium line spacing", group: "Type — line spacing", kind: "range", min: 16, max: 32, step: 1, unit: "px" },
+
+  // ---- Type — family ----
   {
-    title: "Type — font size",
-    knobs: [
-      { id: "--text-2xs", label: "Meta (counts, chips, times)", kind: "range", min: 8, max: 14, step: 1, unit: "px" },
-      { id: "--text-xs", label: "Labels & nav", kind: "range", min: 9, max: 16, step: 1, unit: "px" },
-      { id: "--text-sm", label: "Content (titles, events)", kind: "range", min: 11, max: 18, step: 1, unit: "px" },
-      { id: "--text-base", label: "Base", kind: "range", min: 12, max: 20, step: 1, unit: "px" },
-      { id: "--leading-sm", label: "Content line spacing", kind: "range", min: 14, max: 28, step: 1, unit: "px" },
+    id: "font-family",
+    label: "Font family",
+    group: "Type — family",
+    kind: "select",
+    options: [
+      { value: "geist", label: "Geist (default)" },
+      { value: "system", label: "System UI" },
+      { value: "serif", label: "Serif" },
+      { value: "mono", label: "Geist Mono" },
     ],
+    apply: (v) => {
+      const map: Record<string, string> = {
+        geist: '"Geist", ui-sans-serif, system-ui, -apple-system, sans-serif',
+        system: 'ui-sans-serif, system-ui, -apple-system, sans-serif',
+        serif: '"GT Sectra", "Source Serif Pro", Georgia, serif',
+        mono: '"Geist Mono", ui-monospace, "SF Mono", Menlo, monospace',
+      };
+      document.documentElement.style.setProperty("--font-sans", map[v] ?? map.geist);
+    },
+    read: () => {
+      const v = getComputedStyle(document.documentElement).getPropertyValue("--font-sans");
+      if (v.includes("GT Sectra") || v.includes("Source Serif")) return "serif";
+      if (v.includes("Geist Mono")) return "mono";
+      if (v.includes("Geist")) return "geist";
+      return "system";
+    },
   },
-  {
-    title: "Color",
-    knobs: [
-      { id: "--text-0", label: "Text — brightest (the “white”)", kind: "color" },
-      { id: "--text-1", label: "Text — bright (body/nav)", kind: "color" },
-      { id: "--text-2", label: "Text — muted (titles/meta)", kind: "color" },
-      { id: "--text-3", label: "Text — dim (timestamps)", kind: "color" },
-      { id: "--border", label: "Border — soft (dividers)", kind: "color" },
-      { id: "--border-strong", label: "Border — strong (cards)", kind: "color" },
-      { id: "--accent", label: "Accent", kind: "color" },
-    ],
-  },
-  {
-    title: "Spacing & layout",
-    knobs: [
-      { id: "--rk-card-header-h", label: "Card header height", kind: "range", min: 28, max: 56, step: 1, unit: "px" },
-      { id: "--rk-row-py", label: "Row vertical padding", kind: "range", min: 2, max: 14, step: 1, unit: "px" },
-      { id: "--rk-ctrl-py", label: "Tasks controls-row padding", kind: "range", min: 2, max: 16, step: 1, unit: "px" },
-    ],
-  },
-  {
-    title: "Explorer rail",
-    knobs: [
-      { id: "--rk-rail-header-h", label: "Rail header height", kind: "range", min: 28, max: 56, step: 1, unit: "px" },
-      { id: "--rk-rail-indent", label: "Item indent", kind: "range", min: 0, max: 28, step: 1, unit: "px" },
-      { id: "--rk-rail-indent-child", label: "Terminal indent", kind: "range", min: 8, max: 48, step: 1, unit: "px" },
-    ],
-  },
+
+  // ---- Color — text ----
+  { id: "--text-0", label: "Text — brightest (the “white”)", group: "Color — text", kind: "color" },
+  { id: "--text-1", label: "Text — bright (body/nav)", group: "Color — text", kind: "color" },
+  { id: "--text-2", label: "Text — muted (titles/meta)", group: "Color — text", kind: "color" },
+  { id: "--text-3", label: "Text — dim (timestamps)", group: "Color — text", kind: "color" },
+  { id: "--text-disabled", label: "Text — disabled", group: "Color — text", kind: "color" },
+
+  // ---- Color — backgrounds ----
+  { id: "--bg-0", label: "Background — page", group: "Color — backgrounds", kind: "color" },
+  { id: "--bg-1", label: "Background — cards", group: "Color — backgrounds", kind: "color" },
+  { id: "--bg-2", label: "Background — hover", group: "Color — backgrounds", kind: "color" },
+  { id: "--bg-3", label: "Background — pressed / chip", group: "Color — backgrounds", kind: "color" },
+  { id: "--bg-4", label: "Background — emphasis", group: "Color — backgrounds", kind: "color" },
+
+  // ---- Color — borders ----
+  { id: "--border", label: "Border — soft", group: "Color — borders", kind: "color" },
+  { id: "--border-strong", label: "Border — strong", group: "Color — borders", kind: "color" },
+  { id: "--border-focus", label: "Border — focus ring", group: "Color — borders", kind: "color" },
+
+  // ---- Color — accent ----
+  { id: "--accent", label: "Accent", group: "Color — accent", kind: "color" },
+  { id: "--accent-hover", label: "Accent — hover", group: "Color — accent", kind: "color" },
+  { id: "--accent-active", label: "Accent — active", group: "Color — accent", kind: "color" },
+  { id: "--accent-subtle", label: "Accent — subtle bg", group: "Color — accent", kind: "color" },
+
+  // ---- Color — semantic ----
+  { id: "--success", label: "Success", group: "Color — semantic", kind: "color" },
+  { id: "--success-subtle", label: "Success — subtle bg", group: "Color — semantic", kind: "color" },
+  { id: "--warning", label: "Warning", group: "Color — semantic", kind: "color" },
+  { id: "--warning-subtle", label: "Warning — subtle bg", group: "Color — semantic", kind: "color" },
+  { id: "--danger", label: "Danger", group: "Color — semantic", kind: "color" },
+  { id: "--danger-subtle", label: "Danger — subtle bg", group: "Color — semantic", kind: "color" },
+  { id: "--info", label: "Info", group: "Color — semantic", kind: "color" },
+  { id: "--info-subtle", label: "Info — subtle bg", group: "Color — semantic", kind: "color" },
+
+  // ---- Spacing & layout — cards / rows ----
+  { id: "--rk-card-header-h", label: "Card header height", group: "Spacing — cards & rows", kind: "range", min: 24, max: 60, step: 1, unit: "px" },
+  { id: "--rk-row-py", label: "Row vertical padding", group: "Spacing — cards & rows", kind: "range", min: 1, max: 16, step: 1, unit: "px" },
+  { id: "--rk-ctrl-py", label: "Tasks controls-row padding", group: "Spacing — cards & rows", kind: "range", min: 1, max: 18, step: 1, unit: "px" },
+  { id: "--rk-section-head-h", label: "Section header height", group: "Spacing — cards & rows", kind: "range", min: 20, max: 44, step: 1, unit: "px" },
+  { id: "--rk-card-radius", label: "Card corner radius", group: "Spacing — cards & rows", kind: "range", min: 0, max: 16, step: 1, unit: "px" },
+
+  // ---- Spacing & layout — top chrome ----
+  { id: "--rk-topbar-h", label: "Top bar height", group: "Spacing — top chrome", kind: "range", min: 36, max: 64, step: 1, unit: "px" },
+  { id: "--rk-ticker-h", label: "Ticker tape height", group: "Spacing — top chrome", kind: "range", min: 24, max: 52, step: 1, unit: "px" },
+
+  // ---- Explorer rail ----
+  { id: "--rk-rail-header-h", label: "Rail header height", group: "Explorer rail", kind: "range", min: 24, max: 56, step: 1, unit: "px" },
+  { id: "--rk-search-h", label: "Search box height", group: "Explorer rail", kind: "range", min: 24, max: 44, step: 1, unit: "px" },
+  { id: "--rk-rail-indent", label: "Item indent", group: "Explorer rail", kind: "range", min: 0, max: 28, step: 1, unit: "px" },
+  { id: "--rk-rail-indent-child", label: "Terminal indent", group: "Explorer rail", kind: "range", min: 8, max: 56, step: 1, unit: "px" },
 ];
 
-const ALL: Knob[] = GROUPS.flatMap((g) => g.knobs);
+const GROUPS = Array.from(new Set(KNOBS.map((k) => k.group)));
 const STORE = "rokki:design-mode";
+const STORE_UI = "rokki:design-mode-ui";
 
 function isProdHost(h: string) {
   return h === "rokki.ai" || h === "www.rokki.ai";
@@ -88,6 +165,9 @@ function norm(s: string) {
 function toHex(v: string): string {
   const t = v.trim();
   if (/^#[0-9a-f]{6}$/i.test(t)) return t.toLowerCase();
+  if (/^#[0-9a-f]{3}$/i.test(t)) {
+    return ("#" + t.slice(1).split("").map((c) => c + c).join("")).toLowerCase();
+  }
   const m = t.match(/rgba?\(([^)]+)\)/i);
   if (m) {
     const [r, g, b] = m[1].split(",").map((x) => parseInt(x.trim(), 10));
@@ -105,46 +185,83 @@ function themeTargets(): HTMLElement[] {
   });
   return out;
 }
-function setVar(id: string, value: string) {
+function setCssVar(id: string, value: string) {
   themeTargets().forEach((el) => el.style.setProperty(id, value));
 }
-function clearVar(id: string) {
+function clearCssVar(id: string) {
   themeTargets().forEach((el) => el.style.removeProperty(id));
 }
 
 export function DesignMode() {
   const [enabled, setEnabled] = useState(false);
   const [open, setOpen] = useState(false);
-  // `vals` holds the input value for each knob: a number-as-string for
-  // ranges, a hex string for colors.
+
+  // Per-knob input values: numeric string for range, hex for color, raw value for select.
   const [vals, setVals] = useState<Record<string, string>>({});
+  // Per-knob baseline (computed from CSS at first mount). The diff vs. baseline is what Export produces.
   const baseline = useRef<Record<string, string>>({});
+
+  // Panel UI state — persisted so the user keeps their layout between visits.
+  const [query, setQuery] = useState("");
+  const [onlyChanged, setOnlyChanged] = useState(false);
+  const [collapsed, setCollapsed] = useState<Record<string, boolean>>({});
   const [exported, setExported] = useState<string | null>(null);
-  const [copied, setCopied] = useState(false);
+  const [copyState, setCopyState] = useState<"" | "copied" | "fallback">("");
 
   useEffect(() => {
     if (isProdHost(window.location.hostname)) return;
     setEnabled(true);
 
+    // 1. Read baseline values from CSS + the special select knobs' readers.
     const cs = getComputedStyle(document.documentElement);
     const base: Record<string, string> = {};
     const init: Record<string, string> = {};
+    for (const k of KNOBS) {
+      let raw = "";
+      if (k.kind === "select") raw = k.read ? k.read() : "";
+      else raw = cs.getPropertyValue(k.id).trim();
+      base[k.id] = raw;
+      if (k.kind === "color") init[k.id] = toHex(raw);
+      else if (k.kind === "range") init[k.id] = String(parseFloat(raw) || k.min);
+      else init[k.id] = raw;
+    }
+    baseline.current = base;
+
+    // 2. Replay any persisted overrides onto the page + into `init`.
     let stored: Record<string, string> = {};
     try {
       stored = JSON.parse(localStorage.getItem(STORE) || "{}") as Record<string, string>;
     } catch {
       stored = {};
     }
-    for (const k of ALL) {
-      const raw = cs.getPropertyValue(k.id).trim();
-      base[k.id] = raw;
-      const current = stored[k.id] ?? raw;
-      init[k.id] = k.kind === "color" ? toHex(current) : String(parseFloat(current) || 0);
-      if (stored[k.id]) setVar(k.id, stored[k.id]);
+    for (const k of KNOBS) {
+      if (!stored[k.id]) continue;
+      if (k.kind === "select") {
+        init[k.id] = stored[k.id];
+        k.apply?.(stored[k.id]);
+      } else if (k.kind === "color") {
+        init[k.id] = toHex(stored[k.id]);
+        setCssVar(k.id, stored[k.id]);
+      } else {
+        init[k.id] = String(parseFloat(stored[k.id]) || init[k.id]);
+        setCssVar(k.id, stored[k.id]);
+      }
     }
-    baseline.current = base;
     setVals(init);
 
+    // 3. UI state (groups collapsed, only-changed) persisted alongside.
+    try {
+      const ui = JSON.parse(localStorage.getItem(STORE_UI) || "{}") as {
+        collapsed?: Record<string, boolean>;
+        onlyChanged?: boolean;
+      };
+      if (ui.collapsed) setCollapsed(ui.collapsed);
+      if (typeof ui.onlyChanged === "boolean") setOnlyChanged(ui.onlyChanged);
+    } catch {
+      /* defaults */
+    }
+
+    // 4. Shift+D toggles the panel. Don't steal it while the user is typing.
     const onKey = (e: KeyboardEvent) => {
       if (e.key.toLowerCase() !== "d" || !e.shiftKey || e.metaKey || e.ctrlKey || e.altKey) return;
       const t = e.target as HTMLElement | null;
@@ -158,62 +275,127 @@ export function DesignMode() {
     return () => window.removeEventListener("keydown", onKey);
   }, []);
 
+  useEffect(() => {
+    try {
+      localStorage.setItem(STORE_UI, JSON.stringify({ collapsed, onlyChanged }));
+    } catch {
+      /* ignore */
+    }
+  }, [collapsed, onlyChanged]);
+
   function cssValue(k: Knob, input: string) {
-    return k.kind === "color" ? input : input + k.unit;
+    if (k.kind === "color") return input;
+    if (k.kind === "range") return input + k.unit;
+    return input;
   }
   function persist(next: Record<string, string>) {
     const map: Record<string, string> = {};
-    for (const k of ALL) {
-      const cv = cssValue(k, next[k.id]);
-      if (norm(cv) !== norm(baseline.current[k.id] ?? "")) map[k.id] = cv;
+    for (const k of KNOBS) {
+      const cv = cssValue(k, next[k.id] ?? "");
+      const base = baseline.current[k.id] ?? "";
+      if (norm(cv) !== norm(base) && next[k.id]) map[k.id] = cv;
     }
     try {
       localStorage.setItem(STORE, JSON.stringify(map));
     } catch {
-      /* ignore quota / privacy mode */
+      /* quota / private mode */
     }
   }
   function update(k: Knob, input: string) {
     setVals((v) => {
       const next = { ...v, [k.id]: input };
-      setVar(k.id, cssValue(k, input));
+      if (k.kind === "select") k.apply?.(input);
+      else setCssVar(k.id, cssValue(k, input));
       persist(next);
       return next;
     });
     setExported(null);
   }
-  function reset() {
-    for (const k of ALL) clearVar(k.id);
+  function resetAll() {
+    for (const k of KNOBS) {
+      if (k.kind === "select") k.apply?.(k.read ? k.read() : "");
+      else clearCssVar(k.id);
+    }
     try {
       localStorage.removeItem(STORE);
     } catch {
       /* ignore */
     }
+    // Re-read everything from CSS so the inputs land on the true baseline.
+    const cs = getComputedStyle(document.documentElement);
     const init: Record<string, string> = {};
-    for (const k of ALL) {
-      const raw = baseline.current[k.id] ?? "";
-      init[k.id] = k.kind === "color" ? toHex(raw) : String(parseFloat(raw) || 0);
+    for (const k of KNOBS) {
+      let raw = "";
+      if (k.kind === "select") raw = k.read ? k.read() : "";
+      else raw = cs.getPropertyValue(k.id).trim();
+      baseline.current[k.id] = raw;
+      if (k.kind === "color") init[k.id] = toHex(raw);
+      else if (k.kind === "range") init[k.id] = String(parseFloat(raw) || k.min);
+      else init[k.id] = raw;
     }
     setVals(init);
     setExported(null);
   }
+  function resetGroup(group: string) {
+    const next = { ...vals };
+    for (const k of KNOBS) {
+      if (k.group !== group) continue;
+      if (k.kind === "select") k.apply?.(baseline.current[k.id] ?? "");
+      else clearCssVar(k.id);
+      const raw = baseline.current[k.id] ?? "";
+      if (k.kind === "color") next[k.id] = toHex(raw);
+      else if (k.kind === "range") next[k.id] = String(parseFloat(raw) || k.min);
+      else next[k.id] = raw;
+    }
+    setVals(next);
+    persist(next);
+    setExported(null);
+  }
   function doExport() {
     const changed: string[] = [];
-    for (const k of ALL) {
+    for (const k of KNOBS) {
       const cv = cssValue(k, vals[k.id] ?? "");
       const base = baseline.current[k.id] ?? "";
-      if (norm(cv) !== norm(base)) changed.push(`  ${k.id}: ${cv}   (was ${base})  — ${k.label}`);
+      if (norm(cv) !== norm(base) && vals[k.id]) {
+        changed.push(`  ${k.id}: ${cv}   (was ${base || "—"})  — ${k.label}`);
+      }
     }
     const text = changed.length
       ? `ROKKI DESIGN MODE — apply these (${changed.length} changed):\n\n${changed.join("\n")}`
       : "No changes yet — everything matches the current app.";
     setExported(text);
-    setCopied(false);
+    setCopyState("");
     navigator.clipboard
       ?.writeText(text)
-      .then(() => setCopied(true))
-      .catch(() => setCopied(false));
+      .then(() => setCopyState("copied"))
+      .catch(() => setCopyState("fallback"));
   }
+
+  const visible = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return KNOBS.filter((k) => {
+      if (q) {
+        const hay = (k.label + " " + k.id + " " + k.group).toLowerCase();
+        if (!hay.includes(q)) return false;
+      }
+      if (onlyChanged) {
+        const cv = cssValue(k, vals[k.id] ?? "");
+        const base = baseline.current[k.id] ?? "";
+        if (norm(cv) === norm(base)) return false;
+      }
+      return true;
+    });
+  }, [query, onlyChanged, vals]);
+
+  const changedCount = useMemo(() => {
+    let c = 0;
+    for (const k of KNOBS) {
+      const cv = cssValue(k, vals[k.id] ?? "");
+      const base = baseline.current[k.id] ?? "";
+      if (norm(cv) !== norm(base) && vals[k.id]) c++;
+    }
+    return c;
+  }, [vals]);
 
   if (!enabled) return null;
 
@@ -225,15 +407,17 @@ export function DesignMode() {
         title="Design Mode (Shift+D)"
         style={S.launcher}
       >
-        ✦ Design
+        ✦ Design{changedCount ? <span style={S.badge}>{changedCount}</span> : null}
       </button>
 
       {open ? (
         <aside style={S.panel} aria-label="Design Mode">
           <div style={S.head}>
             <div>
-              <div style={S.title}>Design Mode</div>
-              <div style={S.sub}>Sandbox only · live · ⇧D to toggle</div>
+              <div style={S.title}>Design Mode <span style={S.v2}>v2</span></div>
+              <div style={S.sub}>
+                Sandbox only · live · ⇧D to toggle · {changedCount} changed
+              </div>
             </div>
             <button type="button" onClick={() => setOpen(false)} style={S.x} aria-label="Close">
               ✕
@@ -244,77 +428,163 @@ export function DesignMode() {
             <button type="button" onClick={doExport} style={{ ...S.btn, ...S.primary }}>
               Export ↗
             </button>
-            <button type="button" onClick={reset} style={S.btn}>
-              Reset
+            <button type="button" onClick={resetAll} style={S.btn}>
+              Reset all
             </button>
+          </div>
+
+          <div style={S.filterRow}>
+            <input
+              type="text"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Find a knob…  (e.g. row, color, header)"
+              style={S.search}
+              spellCheck={false}
+            />
+            <label style={S.checkRow}>
+              <input
+                type="checkbox"
+                checked={onlyChanged}
+                onChange={(e) => setOnlyChanged(e.target.checked)}
+              />
+              <span>Only changed</span>
+            </label>
           </div>
 
           {exported ? (
             <div style={S.exportBox}>
               <div style={S.exportNote}>
-                {copied ? "Copied to clipboard ✓ — paste it to Claude." : "Select all and copy — paste it to Claude."}
+                {copyState === "copied"
+                  ? "Copied to clipboard ✓ — paste it to Claude."
+                  : copyState === "fallback"
+                    ? "Select all and copy — paste it to Claude."
+                    : "Ready — copying…"}
               </div>
-              <textarea readOnly value={exported} style={S.textarea} onFocus={(e) => e.currentTarget.select()} />
+              <textarea
+                readOnly
+                value={exported}
+                style={S.textarea}
+                onFocus={(e) => e.currentTarget.select()}
+              />
             </div>
           ) : null}
 
           <div style={S.scroll}>
-            {GROUPS.map((g) => (
-              <div key={g.title} style={S.group}>
-                <div style={S.groupTitle}>{g.title}</div>
-                {g.knobs.map((k) => (
-                  <div key={k.id} style={S.knob}>
-                    {k.kind === "color" ? (
-                      <>
-                        <div style={S.labRow}>
-                          <span style={S.lab}>{k.label}</span>
-                        </div>
-                        <div style={S.colorRow}>
-                          <input
-                            type="color"
-                            value={vals[k.id] ?? "#000000"}
-                            onChange={(e) => update(k, e.target.value)}
-                            style={S.colorPick}
-                          />
-                          <input
-                            type="text"
+            {GROUPS.map((g) => {
+              const items = visible.filter((k) => k.group === g);
+              if (!items.length) return null;
+              const isCollapsed = collapsed[g] === true;
+              return (
+                <div key={g} style={S.group}>
+                  <button
+                    type="button"
+                    onClick={() => setCollapsed((c) => ({ ...c, [g]: !isCollapsed }))}
+                    style={S.groupTitle}
+                  >
+                    <span>{isCollapsed ? "▸" : "▾"} {g}</span>
+                    <span style={S.groupActions}>
+                      <span
+                        role="button"
+                        tabIndex={0}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          resetGroup(g);
+                        }}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter" || e.key === " ") {
+                            e.preventDefault();
+                            e.stopPropagation();
+                            resetGroup(g);
+                          }
+                        }}
+                        style={S.groupReset}
+                        title={`Reset ${g}`}
+                      >
+                        reset
+                      </span>
+                    </span>
+                  </button>
+                  {isCollapsed ? null : items.map((k) => (
+                    <div key={k.id} style={S.knob}>
+                      {k.kind === "color" ? (
+                        <>
+                          <div style={S.labRow}>
+                            <span style={S.lab}>{k.label}</span>
+                          </div>
+                          <div style={S.colorRow}>
+                            <input
+                              type="color"
+                              value={vals[k.id] ?? "#000000"}
+                              onChange={(e) => update(k, e.target.value)}
+                              style={S.colorPick}
+                            />
+                            <input
+                              type="text"
+                              value={vals[k.id] ?? ""}
+                              onChange={(e) => {
+                                const t = e.target.value;
+                                if (/^#[0-9a-fA-F]{6}$/.test(t)) update(k, t.toLowerCase());
+                                else setVals((v) => ({ ...v, [k.id]: t }));
+                              }}
+                              style={S.hex}
+                              spellCheck={false}
+                            />
+                          </div>
+                        </>
+                      ) : k.kind === "select" ? (
+                        <>
+                          <div style={S.labRow}>
+                            <span style={S.lab}>{k.label}</span>
+                          </div>
+                          <select
                             value={vals[k.id] ?? ""}
-                            onChange={(e) => {
-                              const t = e.target.value;
-                              if (/^#[0-9a-fA-F]{6}$/.test(t)) update(k, t.toLowerCase());
-                              else setVals((v) => ({ ...v, [k.id]: t }));
-                            }}
-                            style={S.hex}
-                            spellCheck={false}
+                            onChange={(e) => update(k, e.target.value)}
+                            style={S.select}
+                          >
+                            {k.options.map((o) => (
+                              <option key={o.value} value={o.value}>
+                                {o.label}
+                              </option>
+                            ))}
+                          </select>
+                        </>
+                      ) : (
+                        <>
+                          <div style={S.labRow}>
+                            <span style={S.lab}>{k.label}</span>
+                            <span style={S.val}>
+                              {vals[k.id]}
+                              {k.unit}
+                            </span>
+                          </div>
+                          <input
+                            type="range"
+                            min={k.min}
+                            max={k.max}
+                            step={k.step}
+                            value={vals[k.id] ?? k.min}
+                            onChange={(e) => update(k, e.target.value)}
+                            style={S.range}
                           />
-                        </div>
-                      </>
-                    ) : (
-                      <>
-                        <div style={S.labRow}>
-                          <span style={S.lab}>{k.label}</span>
-                          <span style={S.val}>
-                            {vals[k.id]}
-                            {k.unit}
-                          </span>
-                        </div>
-                        <input
-                          type="range"
-                          min={k.min}
-                          max={k.max}
-                          step={k.step}
-                          value={vals[k.id] ?? k.min}
-                          onChange={(e) => update(k, e.target.value)}
-                          style={S.range}
-                        />
-                      </>
-                    )}
-                  </div>
-                ))}
+                        </>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              );
+            })}
+            {visible.length === 0 ? (
+              <div style={S.empty}>
+                No knobs match{" "}
+                <span style={{ color: "#f5a623" }}>“{query}”</span>
+                {onlyChanged ? " in the changed set." : "."}
               </div>
-            ))}
+            ) : null}
             <div style={S.footer}>
-              Changes are saved in this browser only and never touch production. Hit Export when you like it.
+              Changes save in this browser only, never touch production. Hit{" "}
+              <strong style={{ color: "#e6e6ea" }}>Export</strong> when you like the look — paste it
+              to Claude and it gets baked into the app.
             </div>
           </div>
         </aside>
@@ -341,14 +611,25 @@ const S: Record<string, CSSProperties> = {
     fontFamily: "ui-sans-serif, system-ui, sans-serif",
     cursor: "pointer",
     boxShadow: "0 4px 14px rgba(0,0,0,.4)",
+    display: "inline-flex",
+    alignItems: "center",
+    gap: 6,
+  },
+  badge: {
+    background: "#f5a623",
+    color: "#0a0a0b",
+    borderRadius: 999,
+    fontSize: 10,
+    fontWeight: 700,
+    padding: "1px 6px",
   },
   panel: {
     position: "fixed",
     top: 0,
     right: 0,
     height: "100vh",
-    width: 348,
-    maxWidth: "92vw",
+    width: 360,
+    maxWidth: "95vw",
     zIndex: 2147483001,
     background: "#0f0f11",
     borderLeft: "1px solid #2a2a2f",
@@ -367,6 +648,16 @@ const S: Record<string, CSSProperties> = {
     borderBottom: "1px solid #1c1c20",
   },
   title: { fontSize: 14, fontWeight: 700 },
+  v2: {
+    fontSize: 10,
+    fontWeight: 600,
+    background: "#3d2e14",
+    color: "#f5a623",
+    padding: "1px 5px",
+    borderRadius: 3,
+    marginLeft: 6,
+    verticalAlign: 1,
+  },
   sub: { fontSize: 11, color: "#8a8a92", marginTop: 2 },
   x: { background: "none", border: "none", color: "#8a8a92", fontSize: 16, cursor: "pointer", lineHeight: 1 },
   actions: { display: "flex", gap: 8, padding: "10px 14px", borderBottom: "1px solid #1c1c20" },
@@ -382,11 +673,37 @@ const S: Record<string, CSSProperties> = {
     fontWeight: 600,
   },
   primary: { background: "#f5a623", borderColor: "#f5a623", color: "#0a0a0b" },
+  filterRow: {
+    display: "flex",
+    flexDirection: "column",
+    gap: 8,
+    padding: "10px 14px",
+    borderBottom: "1px solid #1c1c20",
+  },
+  search: {
+    width: "100%",
+    background: "#16161a",
+    border: "1px solid #34343b",
+    color: "#e6e6ea",
+    borderRadius: 5,
+    padding: "6px 9px",
+    fontSize: 12,
+    fontFamily: "inherit",
+  },
+  checkRow: {
+    display: "flex",
+    alignItems: "center",
+    gap: 7,
+    fontSize: 12,
+    color: "#cdd0d6",
+    cursor: "pointer",
+    userSelect: "none",
+  },
   exportBox: { padding: "10px 14px", borderBottom: "1px solid #1c1c20" },
   exportNote: { fontSize: 11.5, color: "#9aa0aa", marginBottom: 6 },
   textarea: {
     width: "100%",
-    height: 120,
+    height: 130,
     background: "#0a0a0b",
     border: "1px solid #2a2a2f",
     borderRadius: 6,
@@ -400,12 +717,34 @@ const S: Record<string, CSSProperties> = {
   scroll: { flex: 1, overflow: "auto", padding: "0 14px 24px" },
   group: { padding: "4px 0 8px", borderBottom: "1px solid #161619" },
   groupTitle: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "space-between",
+    width: "100%",
     margin: "12px 0 8px",
+    padding: "4px 0",
+    background: "none",
+    border: "none",
+    color: "#cdd0d6",
+    cursor: "pointer",
     fontSize: 11,
     fontWeight: 700,
     textTransform: "uppercase" as const,
     letterSpacing: ".08em",
+    textAlign: "left" as const,
+  },
+  groupActions: { display: "inline-flex", alignItems: "center", gap: 6 },
+  groupReset: {
+    fontSize: 10,
+    fontWeight: 600,
     color: "#8a8a92",
+    background: "#1a1a1d",
+    border: "1px solid #2a2a2f",
+    borderRadius: 3,
+    padding: "1px 6px",
+    cursor: "pointer",
+    textTransform: "none" as const,
+    letterSpacing: 0,
   },
   knob: { margin: "9px 0" },
   labRow: { display: "flex", justifyContent: "space-between", alignItems: "baseline", marginBottom: 4 },
@@ -432,5 +771,16 @@ const S: Record<string, CSSProperties> = {
     fontFamily: "ui-monospace, monospace",
     fontSize: 11,
   },
+  select: {
+    width: "100%",
+    background: "#16161a",
+    border: "1px solid #34343b",
+    color: "#e6e6ea",
+    borderRadius: 4,
+    padding: "5px 7px",
+    fontSize: 12,
+    fontFamily: "inherit",
+  },
+  empty: { padding: "16px 0", fontSize: 12, color: "#8a8a92" },
   footer: { fontSize: 11, color: "#6f7078", lineHeight: 1.5, paddingTop: 14 },
 };

--- a/apps/web/src/components/TaskSectionHeader.tsx
+++ b/apps/web/src/components/TaskSectionHeader.tsx
@@ -43,7 +43,7 @@ export function TaskSectionHeader({
           onToggle();
         }
       }}
-      className="sticky top-0 z-[2] flex h-7 cursor-pointer select-none items-center gap-2 border-b border-border bg-bg-2 pr-3 transition-colors hover:bg-bg-3 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-border-focus"
+      className="sticky top-0 z-[2] flex h-[var(--rk-section-head-h)] cursor-pointer select-none items-center gap-2 border-b border-border bg-bg-2 pr-3 transition-colors hover:bg-bg-3 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-border-focus"
     >
       {/* Colored left tick carrying the bucket's meaning. */}
       <span aria-hidden="true" className={cn("h-full w-[3px] flex-shrink-0", tone)} />

--- a/apps/web/src/components/TickerTape.tsx
+++ b/apps/web/src/components/TickerTape.tsx
@@ -146,7 +146,7 @@ export function TickerTape({
 
   if (combined.length === 0) {
     return (
-      <div className="flex h-8 flex-shrink-0 items-center gap-2 border-b border-border bg-bg-1 px-3 text-xs text-text-3">
+      <div className="flex h-[var(--rk-ticker-h)] flex-shrink-0 items-center gap-2 border-b border-border bg-bg-1 px-3 text-xs text-text-3">
         <span
           className={cn("h-1.5 w-1.5 flex-shrink-0 rounded-full", dotClass)}
           title={dotTitle}
@@ -171,7 +171,7 @@ export function TickerTape({
   const doubled = [...combined, ...combined];
 
   return (
-    <div className="flex h-8 flex-shrink-0 items-center gap-2 overflow-hidden border-b border-border bg-bg-1 px-3 text-xs text-text-2">
+    <div className="flex h-[var(--rk-ticker-h)] flex-shrink-0 items-center gap-2 overflow-hidden border-b border-border bg-bg-1 px-3 text-xs text-text-2">
       <span
         className={cn("h-1.5 w-1.5 flex-shrink-0 rounded-full", dotClass)}
         title={dotTitle}

--- a/apps/web/src/components/TopBar.tsx
+++ b/apps/web/src/components/TopBar.tsx
@@ -41,7 +41,7 @@ export function TopBar({ children }: TopBarProps) {
   const homeHref = pathname?.startsWith("/admin") ? "/admin" : "/";
   return (
     <header
-      className="flex h-11 flex-shrink-0 items-center border-b border-border bg-bg-1 px-4"
+      className="flex h-[var(--rk-topbar-h)] flex-shrink-0 items-center border-b border-border bg-bg-1 px-4"
       role="banner"
     >
       <Link

--- a/apps/web/src/components/dashboard/DashboardCard.tsx
+++ b/apps/web/src/components/dashboard/DashboardCard.tsx
@@ -59,7 +59,7 @@ export function DashboardCard({
       // dark and light mode. Zack's feedback: the previous border was
       // too thin to differentiate sections.
       className={cn(
-        "flex min-h-0 flex-col overflow-hidden rounded border border-border-strong bg-bg-1 shadow-sm",
+        "flex min-h-0 flex-col overflow-hidden rounded-[var(--rk-card-radius)] border border-border-strong bg-bg-1 shadow-sm",
         className,
       )}
     >

--- a/apps/web/src/components/dashboard/ExplorerRail.tsx
+++ b/apps/web/src/components/dashboard/ExplorerRail.tsx
@@ -317,7 +317,7 @@ export function ExplorerRail({
                 placeholder="Search…"
                 aria-label="Filter explorer"
                 title="Press / to focus"
-                className="h-8 w-full rounded-sm border border-border bg-bg-1 px-2 text-xs text-text-0 placeholder:text-text-3 focus:border-border-focus focus:outline-none focus-visible:ring-2 focus-visible:ring-border-focus"
+                className="h-[var(--rk-search-h)] w-full rounded-sm border border-border bg-bg-1 px-2 text-xs text-text-0 placeholder:text-text-3 focus:border-border-focus focus:outline-none focus-visible:ring-2 focus-visible:ring-border-focus"
               />
               {filter ? (
                 <button

--- a/apps/web/src/components/dashboard/TasksCard.tsx
+++ b/apps/web/src/components/dashboard/TasksCard.tsx
@@ -257,7 +257,7 @@ export function TasksCard({
     // Plain card shell — no DashboardCard wrapper. The header chrome now
     // lives entirely in the shared TaskListToolbar so this surface is
     // byte-for-byte the same interface as the in-terminal TasksPane.
-    <section className="flex h-full min-h-0 flex-col overflow-hidden rounded border border-border-strong bg-bg-1 shadow-sm">
+    <section className="flex h-full min-h-0 flex-col overflow-hidden rounded-[var(--rk-card-radius)] border border-border-strong bg-bg-1 shadow-sm">
       <TaskListToolbar
         count={visibleAssigned.length}
         sortMode={sortMode}


### PR DESCRIPTION
You called out the panel was missing a lot — this is the comprehensive build. Goes from ~18 knobs to ~50, with the in-panel features that make finding any knob fast.

### Every knob now available (Shift+D)
**Type**
- Font size — all 8 tiers (2xs · xs · sm · base · md · lg · xl · 2xl)
- Line spacing — 5 tiers (2xs · xs · sm · base · md)
- **Font family** — swap between Geist (default), System UI, Serif, Geist Mono

**Color** — 25 swatches
- Text — text-0 / 1 / 2 / 3 / disabled
- Backgrounds — bg-0 / 1 / 2 / 3 / 4
- Borders — border, border-strong, border-focus
- Accent — accent, hover, active, subtle bg
- Semantic — success / warning / danger / info, each + subtle bg

**Spacing — cards & rows**
- Card header height
- Row vertical padding
- Tasks controls-row padding
- Section header height *(new)*
- Card corner radius *(new)*

**Spacing — top chrome** *(new section)*
- Top bar height
- Ticker tape height

**Explorer rail**
- Rail header height
- **Search box height** *(new)*
- Item indent
- Terminal indent

### New CSS vars (so v2's new knobs can drive the real UI)
`--rk-topbar-h`, `--rk-ticker-h`, `--rk-search-h`, `--rk-section-head-h`, `--rk-card-radius` — added to `globals.css`. Wired through:
- `TopBar` (`h-11` → var)
- `TickerTape` (`h-8` → var, both states)
- `DashboardCard` + `TasksCard` (`rounded` → var)
- `ExplorerRail` search (`h-8` → var)
- `TaskSectionHeader` (`h-7` → var)

Defaults equal the current values, so **no visual change** until tuned.

### In-panel features (the big quality-of-life adds)
- 🔎 **Search** at top filters by label/group/id — type "row" → only row-related knobs visible.
- 📂 **Collapsible groups**, state persists per-browser.
- ✅ **"Only changed"** checkbox — review your diff before Export.
- ↺ **Per-group reset** chip (don't blow away the whole panel just because one group's off).
- 🔔 Launcher pill shows a **changed-count badge** so you can spot when localStorage has overrides applied.

### Still safe
Sandbox-only — gates on hostname. Runtime mutates inline CSS variables only — no app state, no data, no DOM moves.

typecheck ✅ · lint ✅ · build 92/92 ✅ · 351/351 tests ✅ · **sandbox only**.

### Position toggles?
Skipped here. The few useful ones ("put controls strip above title", "center the card title") are real DOM changes, not token changes — they need their own structural support. I'll add them as a follow-up if you want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)