### PR TITLE
Fix module/space text alignment + task column widths (broken Tailwind scale)

### DIFF
--- a/apps/web/src/components/TaskRow.tsx
+++ b/apps/web/src/components/TaskRow.tsx
@@ -304,10 +304,11 @@ export function TaskRow({
         </button>
       ) : null}
       {/* Right-side fixed-width column cells so dates / priority / status
-          align in vertical columns across rows. Empty cells render a
-          placeholder of the same width so absent values don't shift the
-          downstream columns. */}
-      <span className="flex w-14 flex-shrink-0 items-center justify-end">
+          align in vertical columns across rows. Empty cells hold the same
+          width so absent values don't shift the downstream columns.
+          NOTE: arbitrary w-[56px] — NOT w-14 — because this project's
+          Tailwind spacing scale omits the 14 step, so w-14 is a no-op. */}
+      <span className="flex w-[56px] flex-shrink-0 items-center justify-end">
         {task.due_date ? <DueChip date={task.due_date} /> : null}
       </span>
       {task.recurrence_rule ? (
@@ -319,7 +320,7 @@ export function TaskRow({
           {recurrenceShortLabel(task.recurrence_rule)}
         </span>
       ) : null}
-      <span className="flex w-14 flex-shrink-0 items-center justify-end">
+      <span className="flex w-[56px] flex-shrink-0 items-center justify-end">
         <PriorityDots priority={task.priority} />
       </span>
       {/* Status pill: hide "todo" — every row in this list is by definition

--- a/apps/web/src/components/dashboard/RailModules.tsx
+++ b/apps/web/src/components/dashboard/RailModules.tsx
@@ -29,8 +29,13 @@ export function RailModules() {
               title={open ? `Minimize ${m.label}` : `Open ${m.label}`}
               className="group flex w-full items-center gap-1 rounded-sm px-1 py-0.5 text-left text-text-1 hover:bg-bg-2 hover:text-text-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-focus"
             >
-              {/* empty chevron column → module names line up with space names */}
-              <span className="h-3.5 w-3.5 flex-shrink-0" aria-hidden="true" />
+              {/* Empty chevron column so module names line up with space
+                  names (not the space arrows). MUST use w-3, not w-3.5 —
+                  this project's Tailwind config has a custom spacing scale
+                  with NO 3.5 step, so w-3.5 generates no CSS and the spacer
+                  collapses to 0, pulling the label left to the arrow column.
+                  w-3 (12px) matches the space chevron's rendered width. */}
+              <span className="h-3 w-3 flex-shrink-0" aria-hidden="true" />
               <span className="flex-1 truncate text-xs">{m.label}</span>
               {/* far-right open indicator — the only color in the list */}
               <span


### PR DESCRIPTION
You were right — the Module names lined up with the space **arrows**, not the space **names**. I measured the live DOM: the module's chevron spacer had computed width **0px**.

## Root cause
`tailwind.config.ts` **replaces** `theme.spacing` with a hand-picked scale: `{0, 0.5, 1, 2, 3, 4, 5, 6, 8, 10, 12, 16, 20, 24}`. Anything not on that list — **every** half-step (`1.5`, `2.5`, `3.5`) and many odd integers (`7`, `9`, `11`, `14`) — generates **no CSS**. So `w-3.5` on the spacer did nothing → it collapsed to 0 → "Schedule/Tasks/Messages" slid left to the arrow column. (The space chevron only looked fine because its icon gives it intrinsic width.)

## Fixes (scale-safe values)
- **RailModules**: spacer `w-3.5` → `w-3` (12px). Re-measured live: module label left = **36px** == space name left = **36px**. ✅ aligned.
- **TaskRow**: the right-side due/priority "columns" I added last round used `w-14` — also not in the scale, so they were never actually fixed-width. Switched to `w-[56px]` so the date and priority columns line up across rows.

typecheck ✅ · lint ✅ · build 92/92 ✅

## ⚠️ The bigger finding
~20 component files use other no-op classes (`py-1.5`, `gap-1.5`, `px-2.5`, `w-7/9/11`, `h-3.5`, etc.) that silently produce zero spacing. This is almost certainly behind a chunk of the "spacing feels off" friction. Restoring the full scale is the real root fix, **but** it would make a lot of currently-collapsed padding/gaps appear at once — i.e. loosen the whole app, which fights the density you've been tuning toward. So I'm NOT bundling it here; it deserves its own reviewed pass (ideally with before/after). Flagging it so we do it deliberately.

## Deploy
Sandbox → production (this is one of the changes you asked to ship to prod).

🤖 Generated with [Claude Code](https://claude.com/claude-code)