### PR TITLE
Task row aligned columns + starred filter + drag full-width

### DIFF
--- a/apps/web/src/components/TaskListToolbar.tsx
+++ b/apps/web/src/components/TaskListToolbar.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useEffect, useRef } from "react";
-import { Plus, Maximize2 } from "lucide-react";
+import { Plus, Maximize2, Star } from "lucide-react";
 import { cn } from "@/lib/utils";
 import {
   usePanelHandle,
@@ -37,6 +37,8 @@ export function TaskListToolbar({
   hideDone,
   onHideDone,
   doneCount,
+  starredOnly = false,
+  onStarredOnly,
   query,
   onQuery,
   newTaskHref,
@@ -56,6 +58,9 @@ export function TaskListToolbar({
   hideDone: boolean;
   onHideDone: () => void;
   doneCount: number;
+  /** Starred-only filter. Omit `onStarredOnly` to hide the control. */
+  starredOnly?: boolean;
+  onStarredOnly?: () => void;
   query: string;
   onQuery: (q: string) => void;
   /** New-task destination. Provide a href OR an onClick, not both. */
@@ -193,6 +198,34 @@ export function TaskListToolbar({
             >
               {hideDone ? "Show done" : "Hide done"}
               {doneCount > 0 ? <span className="text-text-3">{doneCount}</span> : null}
+            </button>
+          ) : null}
+
+          {/* Starred-only filter. A pressed amber star shows just the tasks
+              you've starred (pinned to the top of the list). */}
+          {onStarredOnly ? (
+            <button
+              type="button"
+              onClick={onStarredOnly}
+              aria-pressed={starredOnly}
+              title={
+                starredOnly
+                  ? "Showing only starred tasks — click to show all"
+                  : "Show only starred tasks"
+              }
+              className={cn(
+                "flex items-center gap-1 rounded-sm border px-2 py-0.5 font-mono text-2xs uppercase tracking-wide transition-colors",
+                starredOnly
+                  ? "border-warning/50 bg-warning-subtle text-warning"
+                  : "border-border bg-bg-1 text-text-3 hover:bg-bg-2 hover:text-text-1",
+              )}
+            >
+              <Star
+                className="h-3 w-3"
+                fill={starredOnly ? "currentColor" : "none"}
+                aria-hidden="true"
+              />
+              Starred
             </button>
           ) : null}
         </div>

--- a/apps/web/src/components/TaskRow.tsx
+++ b/apps/web/src/components/TaskRow.tsx
@@ -238,20 +238,8 @@ export function TaskRow({
           </span>
         ) : null}
       </div>
-      {/* Dashboard-only terminal label (the list spans terminals). Fixed
-          width + right alignment so the terminal-name column lines up
-          across rows regardless of label length. */}
-      {terminalName ? (
-        <span
-          className="hidden w-20 flex-shrink-0 truncate text-right text-xs text-text-3 md:inline"
-          title={terminalName}
-        >
-          {terminalName}
-        </span>
-      ) : null}
-      {/* Subtask roll-up — surfaces the count without expanding. The
-          list endpoint already returns subtask_total/subtask_done
-          aggregates, so this is free. */}
+      {/* ---- metadata chips (variable; sit LEFT of the aligned columns) ---- */}
+      {/* Subtask roll-up — surfaces the count without expanding. */}
       {subtaskTotal > 0 ? (
         <span
           className="flex-shrink-0 rounded-sm bg-bg-3 px-1 font-mono text-2xs text-text-2"
@@ -268,6 +256,21 @@ export function TaskRow({
           @+{externalCount}
         </span>
       ) : null}
+      {task.recurrence_rule ? (
+        <span
+          className="flex flex-shrink-0 items-center gap-0.5 rounded-sm border border-border bg-bg-2 px-1 py-0.5 text-2xs uppercase tracking-wide text-text-2"
+          title={`Repeats ${recurrenceLabel(task.recurrence_rule)}`}
+        >
+          <Repeat className="h-3 w-3" aria-hidden="true" />
+          {recurrenceShortLabel(task.recurrence_rule)}
+        </span>
+      ) : null}
+      {/* Status pill: hidden when "todo" (every row here IS a to-do, so the
+          pill is redundant). Other statuses (in_progress / blocked / review
+          / done) still render. */}
+      {task.status !== "todo" ? <StatusPill status={task.status} /> : null}
+
+      {/* ---- hover row-actions (always reserve their space; fade in) ---- */}
       <Link
         href={href}
         onClick={(e) => e.stopPropagation()}
@@ -303,30 +306,34 @@ export function TaskRow({
           <Send className="h-3 w-3" />
         </button>
       ) : null}
-      {/* Right-side fixed-width column cells so dates / priority / status
-          align in vertical columns across rows. Empty cells hold the same
-          width so absent values don't shift the downstream columns.
-          NOTE: arbitrary w-[56px] — NOT w-14 — because this project's
-          Tailwind spacing scale omits the 14 step, so w-14 is a no-op. */}
+
+      {/* =====================================================================
+          Aligned category columns — fixed-width, right-aligned cells so they
+          form clean vertical columns across every row. Order, left → right:
+            LATE/DUE  →  PRIORITY  →  TERMINAL (far right, per Zack's spec).
+          Each cell keeps its width even when its value is empty, so a missing
+          value never shifts the neighbouring columns. Widths use arbitrary
+          values (w-[56px]) because this project's Tailwind spacing scale
+          omits the 14 step, so w-14 would be a no-op.
+          =================================================================== */}
+      {/* Late / due day */}
       <span className="flex w-[56px] flex-shrink-0 items-center justify-end">
         {task.due_date ? <DueChip date={task.due_date} /> : null}
       </span>
-      {task.recurrence_rule ? (
-        <span
-          className="flex flex-shrink-0 items-center gap-0.5 rounded-sm border border-border bg-bg-2 px-1 py-0.5 text-2xs uppercase tracking-wide text-text-2"
-          title={`Repeats ${recurrenceLabel(task.recurrence_rule)}`}
-        >
-          <Repeat className="h-2.5 w-2.5" aria-hidden="true" />
-          {recurrenceShortLabel(task.recurrence_rule)}
-        </span>
-      ) : null}
+      {/* Priority */}
       <span className="flex w-[56px] flex-shrink-0 items-center justify-end">
         <PriorityDots priority={task.priority} />
       </span>
-      {/* Status pill: hide "todo" — every row in this list is by definition
-          a to-do, so the pill is redundant. Other statuses (in_progress,
-          blocked, review, done) still render their pill. */}
-      {task.status !== "todo" ? <StatusPill status={task.status} /> : null}
+      {/* Terminal (far right). md:block (not md:inline) so the fixed width
+          actually applies and the column aligns; hidden on mobile. */}
+      {terminalName ? (
+        <span
+          className="hidden w-20 flex-shrink-0 truncate text-right text-xs text-text-3 md:block"
+          title={terminalName}
+        >
+          {terminalName}
+        </span>
+      ) : null}
     </div>
   );
 }

--- a/apps/web/src/components/TasksPane.tsx
+++ b/apps/web/src/components/TasksPane.tsx
@@ -164,6 +164,8 @@ export function TasksPane({ ticker, projectId, currentUserId }: TasksPaneProps) 
    * project remembers its own preference.
    */
   const [hideDone, setHideDone] = useState(false);
+  // Starred-only filter — show just the tasks pinned with a star.
+  const [starredOnly, setStarredOnly] = useState(false);
   /**
    * Collapsed group keys, stored as `${groupMode}:${groupKey}` so a
    * collapse in one group-by mode doesn't bleed into another. Persisted
@@ -856,6 +858,8 @@ export function TasksPane({ ticker, projectId, currentUserId }: TasksPaneProps) 
         hideDone={hideDone}
         onHideDone={() => setHideDone((v) => !v)}
         doneCount={tasks.filter((t) => t.status === "done").length}
+        starredOnly={starredOnly}
+        onStarredOnly={() => setStarredOnly((v) => !v)}
         query={query}
         onQuery={setQuery}
         onNewTask={() => setCreating(true)}
@@ -889,7 +893,10 @@ export function TasksPane({ ticker, projectId, currentUserId }: TasksPaneProps) 
             const visibleSource = hideDone
               ? tasks.filter((t) => t.status !== "done")
               : tasks;
-            const filtered = filterTasks(visibleSource, query, ticker);
+            const starScoped = starredOnly
+              ? visibleSource.filter((t) => t.starred)
+              : visibleSource;
+            const filtered = filterTasks(starScoped, query, ticker);
             const dragEnabled =
               sortMode === "manual" && groupMode === "none" && !query.trim();
             const groups = groupTasks(filtered, groupMode);

--- a/apps/web/src/components/dashboard/DashboardPanels.tsx
+++ b/apps/web/src/components/dashboard/DashboardPanels.tsx
@@ -397,15 +397,12 @@ export function DashboardPanels({
     );
   }
 
-  // Keep the two-column grid visible on desktop whenever there are 2+
-  // non-minimized panels — this is the fix for "drag right-to-left
-  // collapses the layout into one column." Empty columns stay alive as
-  // drop targets so the user can put panels back. Below 2 panels (after
-  // minimizing) we collapse to a single column to give the lone panel
-  // the full width. Also forces two columns during an active drag so
-  // there's always somewhere to drop on the empty side.
-  const totalVisible = visibleInCol("center").length + visibleInCol("right").length;
-  const forceTwo = isDesktop && (totalVisible >= 2 || dragId != null);
+  // Two columns are forced only while a panel is mid-drag, so the emptied
+  // side stays a reachable drop target. When NOT dragging, an empty column
+  // collapses and the occupied column takes the FULL width (Zack: "if all
+  // the modules are in the same column, they should take up the full area,
+  // not just the column"). gridTemplate() handles the collapse.
+  const forceTwo = dragId != null;
   // Only the non-minimized panels affect the layout/collapse maths.
   const visLayout: DashLayout = {
     center: visibleInCol("center"),

--- a/apps/web/src/components/dashboard/TasksCard.tsx
+++ b/apps/web/src/components/dashboard/TasksCard.tsx
@@ -160,6 +160,9 @@ export function TasksCard({
   // today — but the control is wired identically to the terminal so
   // the interface matches, and it works the moment done tasks appear.
   const [hideDone, setHideDone] = useState(true);
+  // Starred-only filter — shows just the tasks pinned with a star.
+  // Persisted globally so the choice sticks across reloads.
+  const [starredOnly, setStarredOnly] = useState(false);
   // Default to grouping by due date so the dashboard task list opens in
   // the same sectioned view as the in-terminal pane (Overdue / Today /
   // This week / Later) instead of a flat list. Persisted globally so
@@ -195,6 +198,27 @@ export function TasksCard({
       /* ignore */
     }
   }, [groupBy]);
+
+  // Hydrate + persist the starred-only filter.
+  useEffect(() => {
+    try {
+      setStarredOnly(
+        window.localStorage.getItem("rokki_dash_tasks_starred") === "1",
+      );
+    } catch {
+      /* ignore */
+    }
+  }, []);
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(
+        "rokki_dash_tasks_starred",
+        starredOnly ? "1" : "0",
+      );
+    } catch {
+      /* ignore */
+    }
+  }, [starredOnly]);
 
   // Hydrate + persist collapsed groups, keyed by `${groupBy}:${key}`.
   useEffect(() => {
@@ -251,7 +275,7 @@ export function TasksCard({
     hideDone ? combined.filter((t) => t.status !== "done") : combined,
     query,
     terminalNameById,
-  );
+  ).filter((t) => (starredOnly ? t.starred === true : true));
 
   return (
     // Plain card shell — no DashboardCard wrapper. The header chrome now
@@ -272,6 +296,8 @@ export function TasksCard({
         hideDone={hideDone}
         onHideDone={() => setHideDone((v) => !v)}
         doneCount={doneCount}
+        starredOnly={starredOnly}
+        onStarredOnly={() => setStarredOnly((v) => !v)}
         query={query}
         onQuery={setQuery}
         newTaskHref={createHref ?? undefined}


### PR DESCRIPTION
Three dashboard asks.

## 1. Task rows — aligned category columns
Reordered the trailing cells into fixed-width, right-aligned columns that line up vertically across rows, in the order you asked: **LATE/DUE → PRIORITY → TERMINAL (far right)**.
- Terminal name → far right; `md:inline` → `md:block` so its `w-20` width actually applies (inline ignores width — that's why the column never aligned).
- Due/late + priority each in `w-[56px]` right-aligned cells that hold width even when empty, so a missing value never shifts a neighbour.
- Metadata chips (subtask/external/recurrence) + hover actions moved LEFT of the aligned columns so they can't disturb the alignment.

## 2. ★ Starred filter
New "Starred" toggle in the Tasks toolbar — filters to just the tasks you've starred. Wired into the dashboard **and** the in-terminal pane; the dashboard choice persists in localStorage.

## 3. Drag → single column fills the full area
Reverted the `forceTwo` guard that kept both columns alive permanently (why a single column of modules only took ~60% width). Now an empty column collapses and the occupied one takes **full width**; both columns still show mid-drag so the empty side stays a drop target.

typecheck ✅ · lint ✅ · build 92/92 ✅ · 351/351 tests ✅

Deploy: sandbox → production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)