### PR TITLE
Fix React #418 hydration error from DueChip relative dates

### DIFF
--- a/apps/web/src/components/primitives.tsx
+++ b/apps/web/src/components/primitives.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { cn } from "@/lib/utils";
 
 /**
@@ -122,6 +123,25 @@ export function DueChip({
   date: string;
   className?: string;
 }) {
+  // Relative labels ("3d ago", "today") are derived from the CURRENT time,
+  // which differs between the server (UTC) and the client (the user's
+  // timezone). For a task ~23–24 days overdue, the UTC vs local midnight
+  // boundary makes the server render "24d ago" and the client "23d ago"
+  // → a React #418 hydration mismatch (the same reason WeekCard defers its
+  // date grouping to mount). Render an empty, width-stable placeholder
+  // during SSR + the first client paint, then the real label after mount.
+  // The enclosing fixed-width column already reserves space, so there is
+  // no layout shift.
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+  if (!mounted) {
+    return (
+      <span
+        className={cn("font-mono text-2xs", className)}
+        aria-hidden="true"
+      />
+    );
+  }
   const d = new Date(date);
   const today = new Date();
   today.setHours(0, 0, 0, 0);


### PR DESCRIPTION
Found by the 300-assertion live test battery: the dashboard logged **React #418** (hydration mismatch) on load.

**Cause:** `DueChip` derives "23d ago"/"today" from the current time on each render. Server (UTC) vs client (Miami, UTC-4) cross the local-midnight boundary differently, so a ~23–24-day-overdue task renders "24d ago" on the server and "23d ago" on the client → mismatch. Same class WeekCard already guards.

**Fix:** mount-gate `DueChip` — empty width-stable placeholder during SSR + first client paint (identical both sides → no mismatch), real label after mount. The fixed-width column reserves the space, so no layout shift.

typecheck ✅ · lint ✅ · build 92/92 ✅ · 351/351 tests ✅. I'll reload sandbox after deploy to confirm the console error is gone. Sandbox → production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)