### PR TITLE
Smooth "New task" open — no navigation flash, no lazy-load delay

### DIFF
--- a/apps/web/src/components/DashboardClient.tsx
+++ b/apps/web/src/components/DashboardClient.tsx
@@ -165,6 +165,36 @@ export function DashboardClient({
     return () => window.removeEventListener("keydown", onKey);
   }, [terminals.length]);
 
+  // "New task" buttons (dashboard TasksCard) dispatch this cancelable event
+  // instead of navigating to `/?new=task`. Opening the dialog in place
+  // avoids an App Router searchParams navigation that would refetch every
+  // streamed slot (Tasks / Week / Ticker) — the visible flash + delay Zack
+  // reported. preventDefault() tells the dispatcher we handled it so it
+  // skips its URL fallback.
+  useEffect(() => {
+    function onOpen(e: Event) {
+      if (terminals.length === 0) return;
+      e.preventDefault();
+      setTaskDialog(true);
+    }
+    window.addEventListener("rokki:open-new-task", onOpen);
+    return () => window.removeEventListener("rokki:open-new-task", onOpen);
+  }, [terminals.length]);
+
+  // Warm the quick-task dialog chunk once the dashboard is idle so the
+  // FIRST open is instant rather than waiting on its lazy import.
+  useEffect(() => {
+    const warm = () => {
+      void import("./QuickTaskDialog");
+    };
+    if (typeof window.requestIdleCallback === "function") {
+      const id = window.requestIdleCallback(warm);
+      return () => window.cancelIdleCallback(id);
+    }
+    const t = setTimeout(warm, 1200);
+    return () => clearTimeout(t);
+  }, []);
+
   return (
     <DensityProvider initial={initialDensity}>
       <ModuleVisibilityProvider>

--- a/apps/web/src/components/dashboard/TasksCard.tsx
+++ b/apps/web/src/components/dashboard/TasksCard.tsx
@@ -300,7 +300,25 @@ export function TasksCard({
         onStarredOnly={() => setStarredOnly((v) => !v)}
         query={query}
         onQuery={setQuery}
-        newTaskHref={createHref ?? undefined}
+        onNewTask={
+          createHref == null
+            ? undefined
+            : () => {
+                // Open the quick-task dialog IN PLACE via a cancelable event
+                // the dashboard listens for — instead of navigating to
+                // `/?new=task`. The navigation re-ran the page's server
+                // component and refetched every streamed slot (Tasks / Week /
+                // Ticker), which is the flash ("trippy") + delay Zack saw.
+                // If no host is listening (e.g. a full-page task list with no
+                // DashboardClient), fall back to the URL so the button still
+                // works everywhere.
+                const ev = new CustomEvent("rokki:open-new-task", {
+                  cancelable: true,
+                });
+                const handled = !window.dispatchEvent(ev);
+                if (!handled) router.push(createHref);
+              }
+        }
         newTaskDisabled={createDisabled}
         newTaskShortcut="⌘N"
         expandHref="/tasks/mine"


### PR DESCRIPTION
Clicking **New task** on the dashboard made the screen flash ("go trippy") and then, after a delay, the input appeared.

**Cause:** the button was a `<Link href="/?new=task">`. Clicking it (1) navigated → App Router refetched every streamed slot (Tasks/Week/Ticker) → fallbacks flashed + panels reflowed (the "trippy"); (2) opened the `dynamic()`-imported dialog → chunk load delay; (3) `router.replace("/")` → a *second* refetch.

`⌘N` already opened it in place with no navigation, so the button now does the same:
- **TasksCard** dispatches a cancelable `rokki:open-new-task` event instead of linking to `/?new=task` → no URL change → no slot refetch → no flash. Falls back to `router.push` where nothing listens.
- **DashboardClient** listens and opens the dialog directly.
- **DashboardClient** warms the dialog chunk on idle so the first open is instant.

typecheck ✅ · lint ✅ · build 92/92 ✅ · 351/351 tests ✅. Sandbox → production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)