### PR TITLE
Restore icon/dot sizing (width/height fractional scale) — sandbox review

### DIFF
--- a/apps/web/src/components/dashboard/RailModules.tsx
+++ b/apps/web/src/components/dashboard/RailModules.tsx
@@ -29,13 +29,11 @@ export function RailModules() {
               title={open ? `Minimize ${m.label}` : `Open ${m.label}`}
               className="group flex w-full items-center gap-1 rounded-sm px-1 py-0.5 text-left text-text-1 hover:bg-bg-2 hover:text-text-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-focus"
             >
-              {/* Empty chevron column so module names line up with space
-                  names (not the space arrows). MUST use w-3, not w-3.5 —
-                  this project's Tailwind config has a custom spacing scale
-                  with NO 3.5 step, so w-3.5 generates no CSS and the spacer
-                  collapses to 0, pulling the label left to the arrow column.
-                  w-3 (12px) matches the space chevron's rendered width. */}
-              <span className="h-3 w-3 flex-shrink-0" aria-hidden="true" />
+              {/* Empty chevron column so module names line up with the
+                  space NAMES (not the arrows). h-3.5/w-3.5 = 14px to match
+                  the space chevron button, now that width/height carry the
+                  3.5 step (tailwind.config `extend`). */}
+              <span className="h-3.5 w-3.5 flex-shrink-0" aria-hidden="true" />
               <span className="flex-1 truncate text-xs">{m.label}</span>
               {/* far-right open indicator — the only color in the list */}
               <span

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -95,6 +95,16 @@ export default {
       full: "9999px",
     },
     extend: {
+      // The custom `spacing` scale above (which padding/margin/gap read
+      // from) intentionally omits half-steps to keep density tight. But
+      // width/height ALSO read from spacing, so icon/dot SIZING classes
+      // like h-3.5/w-3.5 (14px) and h-1.5/w-1.5 (6px) produced no CSS and
+      // collapsed — icons fell back to their 24px intrinsic size, and dots
+      // (priority / status / online / section) rendered at 0 and vanished.
+      // Re-add ONLY the fractional sizes to width + height so icons and
+      // dots size correctly, WITHOUT touching padding/gap (no loosening).
+      width: { 1.5: "6px", 2.5: "10px", 3.5: "14px" },
+      height: { 1.5: "6px", 2.5: "10px", 3.5: "14px" },
       transitionTimingFunction: {
         DEFAULT: "cubic-bezier(0.2, 0, 0, 1)",
       },


### PR DESCRIPTION
The custom Tailwind spacing scale drops half-steps to keep padding tight — but width/height read from the same scale, so `h-3.5`/`w-3.5` (14px icons) and `h-1.5`/`w-1.5` (6px dots) were no-ops: icons fell back to 24px (oversized, app-wide) and the **priority / status / online / section dots collapsed to 0px (invisible)**.

**Surgical fix:** re-add ONLY the fractional sizes (`1.5`/`2.5`/`3.5`) to `extend.width` + `extend.height`. Corrects icon/dot sizing everywhere **without** touching padding/gap/margin — the tight spacing you tuned stays exactly as-is.

**Visible deltas (dashboard):** colored priority dots + small status/online dots appear; explorer chevrons go 12→14px (intended), so space names shift ~2px and the Modules spacer is reverted to `w-3.5` to stay aligned. Oversized icons on admin/welcome/tools shrink to 14px.

Ships to **sandbox only** for your sign-off — production unchanged until you OK the look.

typecheck ✅ · lint ✅ · build 92/92 ✅ · 351/351 tests ✅.