### PR TITLE
Group → Terminal: show the terminal once, not "Name · Name"

### DIFF
--- a/apps/web/src/lib/task-grouping.test.ts
+++ b/apps/web/src/lib/task-grouping.test.ts
@@ -141,7 +141,7 @@ describe("bucketDashTasks", () => {
     ...over,
   });
 
-  it("terminal mode buckets per terminal_id with TICKER · Name labels", () => {
+  it("terminal mode dedupes identical ticker/name, keeps TICKER · Name when they differ", () => {
     const out = bucketDashTasks(
       [
         dt({ id: "a", terminal_id: "t1" }),
@@ -154,7 +154,10 @@ describe("bucketDashTasks", () => {
     );
     expect(out).toHaveLength(2);
     const labels = out.map((g) => g.label);
-    expect(labels).toContain("HELIOS · Helios");
+    // t1: ticker "HELIOS" equals name "Helios" (case-insensitive) → shown once.
+    expect(labels).toContain("Helios");
+    expect(labels).not.toContain("HELIOS · Helios");
+    // t2: ticker "CASA" genuinely differs from "Casablanca" → keep both.
     expect(labels).toContain("CASA · Casablanca");
   });
 

--- a/apps/web/src/lib/task-grouping.ts
+++ b/apps/web/src/lib/task-grouping.ts
@@ -97,13 +97,18 @@ export function bucketDashTasks<T extends DashGroupableTask>(
     }
     return Array.from(buckets.entries())
       .map(([key, list]) => {
-        const ticker = tickerById[key] ?? "";
-        const name = terminalNameById?.[key] ?? "";
-        const label = ticker
-          ? name
-            ? `${ticker} · ${name}`
-            : ticker
-          : name || "Terminal";
+        const ticker = (tickerById[key] ?? "").trim();
+        const name = (terminalNameById?.[key] ?? "").trim();
+        // When a terminal's ticker and display name are identical (common —
+        // many terminals use the code as the name), show it ONCE rather than
+        // "Casablanca · Casablanca". Keep "TICKER · Name" only when the two
+        // actually differ and the ticker adds information.
+        const label =
+          ticker && name
+            ? ticker.toLowerCase() === name.toLowerCase()
+              ? name
+              : `${ticker} · ${name}`
+            : name || ticker || "Terminal";
         return { key, label, tasks: list };
       })
       .sort((a, b) => a.label.localeCompare(b.label));


### PR DESCRIPTION
Grouping the task list by **Terminal** rendered the ticker *and* the display name in the section header — `Casablanca · Casablanca`, `Civic · Civic` — because those terminals use the code as their name.

Fix: show it **once** when ticker and name are identical (case-insensitive); keep `TICKER · Name` only when they genuinely differ. Grouping unit test updated to cover both.

typecheck ✅ · lint ✅ · build 92/92 ✅ · 351/351 tests ✅

Branched off `production` so it ships to prod **without** the still-pending icon/dot-sizing change.