### PR TITLE
Match the task-filter input height to the toolbar controls

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -149,7 +149,10 @@
   --rk-search-fs: 12px;
   --rk-search-px: 8px;
   --rk-filter-w: 176px;
-  --rk-filter-h: 28px;
+  /* Matches the Auto/Manual sort toggle + Group/Starred controls
+     (py-0.5 text-2xs ≈ 20px) so every control in the strip is one height.
+     Still tunable via Design Mode. */
+  --rk-filter-h: 20px;
   --rk-filter-fs: 12px;
 }
 html[data-density="cozy"] {

--- a/apps/web/src/components/TaskListToolbar.tsx
+++ b/apps/web/src/components/TaskListToolbar.tsx
@@ -329,7 +329,7 @@ function TaskFilterInput({
           height: "var(--rk-filter-h)",
           fontSize: "var(--rk-filter-fs)",
         }}
-        className="rounded-sm border border-border bg-bg-1 px-2 py-1 pr-6 text-text-0 placeholder:text-text-3 outline-none focus:border-border-focus"
+        className="rounded-sm border border-border bg-bg-1 px-2 pr-6 text-text-0 placeholder:text-text-3 outline-none focus:border-border-focus"
       />
       {value ? (
         <button


### PR DESCRIPTION
The Filter-tasks input had an explicit `--rk-filter-h: 28px` while the Auto/Manual toggle + Group/Starred controls are content-sized (~20px) — so it looked taller. Set `--rk-filter-h` to 20px (matches; still Design-Mode tunable) and drop the `py-1` that would clip the text at the shorter fixed height. Sandbox-bound. typecheck ✅ · lint ✅ · build 92/92 ✅.