### PR TITLE
Personal spaces: one private auto-provisioned space per user

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,22 @@
+title = "Rokki gitleaks config"
+
+# Keep gitleaks' full default ruleset...
+[extend]
+useDefault = true
+
+# ...but do not flag the well-known PUBLIC local-Supabase demo JWTs. These
+# anon + service_role keys ship with the Supabase CLI for every local stack
+# (JWT header alg HS256, issuer "supabase-demo", exp 2033). They are not
+# secrets, are identical on every developer machine, never touch
+# staging/prod, and are required by the tests/rls integration suite to mint
+# local sessions. Allowlisted by token value (covers every test file that
+# uses them) and, belt-and-suspenders, by the RLS test path.
+[allowlist]
+description = "Public local-Supabase demo JWTs (anon + service_role) used only by local RLS integration tests"
+regexTarget = "match"
+regexes = [
+  '''eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9\.eyJpc3MiOiJzdXBhYmFzZS1kZW1v[A-Za-z0-9_.\-]+''',
+]
+paths = [
+  '''apps/web/tests/rls/.*\.test\.ts''',
+]

--- a/apps/web/src/app/api/v1/orgs/route.ts
+++ b/apps/web/src/app/api/v1/orgs/route.ts
@@ -17,7 +17,7 @@ async function handleGet() {
 
   const { data, error } = await supabase
     .from("space_members")
-    .select("role, spaces(id, slug, name, created_at)")
+    .select("role, spaces(id, slug, name, created_at, is_personal)")
     .eq("user_id", user.id);
 
   if (error) return internal(error.message);

--- a/apps/web/src/app/s/[slug]/settings/SpaceSettingsForm.tsx
+++ b/apps/web/src/app/s/[slug]/settings/SpaceSettingsForm.tsx
@@ -32,6 +32,7 @@ const ROLES: SpaceRole[] = ["owner", "admin", "member"];
  */
 export function SpaceSettingsForm({
   initial,
+  isPersonal = false,
   members: initialMembers,
   pendingInvites: initialInvites,
   canManage,
@@ -39,6 +40,13 @@ export function SpaceSettingsForm({
   myUserId,
 }: {
   initial: { slug: string; name: string };
+  /**
+   * The viewer's private Personal space. When true we show only the
+   * Identity (rename) card — a personal space is owner-only, can't be
+   * shared, and can't be deleted, so members/invites/danger-zone are
+   * hidden (and blocked at the database level regardless).
+   */
+  isPersonal?: boolean;
   members: SpaceMember[];
   pendingInvites: PendingInvite[];
   canManage: boolean;
@@ -57,6 +65,7 @@ export function SpaceSettingsForm({
         slug={slug}
         initial={initial}
         canManage={canManage}
+        isPersonal={isPersonal}
         onRenamed={(nextSlug) => {
           setSlug(nextSlug);
           router.push(`/s/${nextSlug}/settings`);
@@ -64,24 +73,47 @@ export function SpaceSettingsForm({
         }}
         onSaved={() => router.refresh()}
       />
-      <MembersCard
-        slug={slug}
-        members={members}
-        canManage={canManage}
-        myRole={myRole}
-        myUserId={myUserId}
-        onChange={setMembers}
-      />
-      <InvitesCard
-        slug={slug}
-        invites={invites}
-        canManage={canManage}
-        onAdd={(invite) => setInvites((prev) => [invite, ...prev])}
-      />
-      {myRole === "owner" ? (
-        <DangerZoneCard slug={slug} spaceName={initial.name} />
-      ) : null}
+      {isPersonal ? (
+        <PersonalNote />
+      ) : (
+        <>
+          <MembersCard
+            slug={slug}
+            members={members}
+            canManage={canManage}
+            myRole={myRole}
+            myUserId={myUserId}
+            onChange={setMembers}
+          />
+          <InvitesCard
+            slug={slug}
+            invites={invites}
+            canManage={canManage}
+            onAdd={(invite) => setInvites((prev) => [invite, ...prev])}
+          />
+          {myRole === "owner" ? (
+            <DangerZoneCard slug={slug} spaceName={initial.name} />
+          ) : null}
+        </>
+      )}
     </div>
+  );
+}
+
+/**
+ * Stand-in for the members/invites/danger cards on a personal space —
+ * explains why they're absent rather than leaving a bare page.
+ */
+function PersonalNote() {
+  return (
+    <Card title="Private">
+      <p className="px-4 py-3 text-xs text-text-2">
+        This is your personal space. It&apos;s private to you — no one else can
+        be added, and it can&apos;t be deleted. Create terminals, tasks, and
+        files inside it just like any other space. To collaborate with other
+        people, use or create a shared space instead.
+      </p>
+    </Card>
   );
 }
 
@@ -91,12 +123,14 @@ function IdentityCard({
   slug,
   initial,
   canManage,
+  isPersonal = false,
   onRenamed,
   onSaved,
 }: {
   slug: string;
   initial: { slug: string; name: string };
   canManage: boolean;
+  isPersonal?: boolean;
   onRenamed: (slug: string) => void;
   onSaved: () => void;
 }) {
@@ -156,14 +190,19 @@ function IdentityCard({
           disabled={!canManage}
           maxLength={120}
         />
-        <LabelledInput
-          label="Slug"
-          value={nextSlug}
-          onChange={(v) => setNextSlug(v.toLowerCase())}
-          disabled={!canManage}
-          maxLength={40}
-          hint={`Currently /s/${initial.slug} — renaming breaks existing URLs.`}
-        />
+        {/* A personal space has an auto-generated internal slug that's never
+            shown to the user, so we hide the Slug field — only the display
+            name is renamable here. */}
+        {isPersonal ? null : (
+          <LabelledInput
+            label="Slug"
+            value={nextSlug}
+            onChange={(v) => setNextSlug(v.toLowerCase())}
+            disabled={!canManage}
+            maxLength={40}
+            hint={`Currently /s/${initial.slug} — renaming breaks existing URLs.`}
+          />
+        )}
         <Footer
           saving={saving}
           savedAt={savedAt}

--- a/apps/web/src/app/s/[slug]/settings/page.tsx
+++ b/apps/web/src/app/s/[slug]/settings/page.tsx
@@ -29,7 +29,7 @@ export default async function SpaceSettingsPage({ params }: Props) {
 
   const { data: space } = await supabase
     .from("spaces")
-    .select("id, slug, name, created_at")
+    .select("id, slug, name, created_at, is_personal")
     .eq("slug", lower)
     .maybeSingle();
   if (!space) notFound();
@@ -38,6 +38,7 @@ export default async function SpaceSettingsPage({ params }: Props) {
     slug: string;
     name: string;
     created_at: string;
+    is_personal: boolean;
   };
 
   const { data: me } = await supabase
@@ -121,16 +122,19 @@ export default async function SpaceSettingsPage({ params }: Props) {
       <main className="mx-auto w-full max-w-3xl flex-1 p-6">
         <header className="mb-6">
           <div className="mb-1 flex items-center gap-2 text-[10px] uppercase tracking-wide text-text-3">
-            Space · {terminalCount ?? 0} terminal{terminalCount === 1 ? "" : "s"}
+            {s.is_personal ? "Personal space" : "Space"} · {terminalCount ?? 0}{" "}
+            terminal{terminalCount === 1 ? "" : "s"}
           </div>
           <h1 className="text-xl font-semibold text-text-0">{s.name}</h1>
           <p className="mt-1 text-xs text-text-3">
-            Rename, manage members, and invite new people. Terminal-level
-            membership is managed in each terminal&apos;s settings.
+            {s.is_personal
+              ? "Your private space — only you can see it. Rename it if you like; it can't be shared or deleted."
+              : "Rename, manage members, and invite new people. Terminal-level membership is managed in each terminal’s settings."}
           </p>
         </header>
         <SpaceSettingsForm
           initial={{ slug: s.slug, name: s.name }}
+          isPersonal={s.is_personal}
           members={members}
           pendingInvites={
             (invites ?? []) as {

--- a/apps/web/src/components/dashboard/ExplorerRail.tsx
+++ b/apps/web/src/components/dashboard/ExplorerRail.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { ChevronDown, ChevronRight, Settings, X } from "lucide-react";
+import { ChevronDown, ChevronRight, Settings, User, X } from "lucide-react";
 import type { DashSpace, DashTerminal } from "@/lib/dashboard-queries";
 import { cn } from "@/lib/utils";
 import { AccountBlock } from "@/components/AccountBlock";
@@ -198,12 +198,17 @@ export function ExplorerRail({
   const [overTermId, setOverTermId] = useState<string | null>(null);
 
   // Spaces in the user's saved order (server order until hydrated, to
-  // avoid an SSR/CSR mismatch on first paint).
-  const orderedSpaces = useMemo(
-    () =>
-      hydrated ? applyOrder(visibleSpaces, (s) => s.id, spaceOrder) : visibleSpaces,
-    [visibleSpaces, spaceOrder, hydrated],
-  );
+  // avoid an SSR/CSR mismatch on first paint). The personal space is then
+  // force-pinned to the very top regardless of saved drag order — it's the
+  // user's home and shouldn't get buried under shared spaces.
+  const orderedSpaces = useMemo(() => {
+    const base = hydrated
+      ? applyOrder(visibleSpaces, (s) => s.id, spaceOrder)
+      : visibleSpaces;
+    const personal = base.filter((s) => s.is_personal);
+    if (personal.length === 0) return base;
+    return [...personal, ...base.filter((s) => !s.is_personal)];
+  }, [visibleSpaces, spaceOrder, hydrated]);
 
   function handleSpaceDrop(targetSpaceId: string | null) {
     if (!dragSpaceId) return;
@@ -379,12 +384,15 @@ export function ExplorerRail({
                     : children;
                 const isCollapsed = isFiltering ? false : collapsed.has(s.id);
                 const canMakeTerminal = s.role === "owner" || s.role === "admin";
+                // The personal space is pinned, not reorderable — it stays
+                // at the top, so it can't be picked up and dragged.
+                const canDrag = dndEnabled && !s.is_personal;
                 return (
                   <li key={s.id}>
                     <div
-                      draggable={dndEnabled}
+                      draggable={canDrag}
                       onDragStart={
-                        dndEnabled
+                        canDrag
                           ? (e) => {
                               e.dataTransfer.effectAllowed = "move";
                               e.dataTransfer.setData("text/plain", s.id);
@@ -425,10 +433,10 @@ export function ExplorerRail({
                             }
                           : undefined
                       }
-                      title={dndEnabled ? "Drag to reorder" : undefined}
+                      title={canDrag ? "Drag to reorder" : undefined}
                       className={cn(
                         "group flex items-center gap-1 rounded-sm px-1 py-0.5 hover:bg-bg-2",
-                        dndEnabled && "cursor-grab active:cursor-grabbing",
+                        canDrag && "cursor-grab active:cursor-grabbing",
                         overSpaceId === s.id &&
                           dragSpaceId !== s.id &&
                           "outline outline-2 -outline-offset-2 outline-accent",
@@ -446,11 +454,24 @@ export function ExplorerRail({
                           <ChevronDown className="h-3 w-3" />
                         )}
                       </button>
+                      {/* The personal space gets a person glyph so it
+                          reads as "yours / private" at a glance, set apart
+                          from the shared spaces below it. */}
+                      {s.is_personal ? (
+                        <User
+                          className="h-3 w-3 flex-shrink-0 text-text-3"
+                          aria-hidden="true"
+                        />
+                      ) : null}
                       <Link
                         href={`/s/${s.slug}`}
                         draggable={false}
                         className="flex-1 truncate text-text-1 hover:text-text-0"
-                        title={`Open ${s.name}`}
+                        title={
+                          s.is_personal
+                            ? "Your private space"
+                            : `Open ${s.name}`
+                        }
                       >
                         {s.name}
                       </Link>

--- a/apps/web/src/lib/dashboard-queries.ts
+++ b/apps/web/src/lib/dashboard-queries.ts
@@ -20,6 +20,12 @@ export interface DashSpace {
   slug: string;
   name: string;
   role: "owner" | "admin" | "member";
+  /**
+   * The user's private "Personal" space — exactly one per user,
+   * owner-only, pinned to the top of the explorer. See the
+   * 20260614120000_personal_spaces migration.
+   */
+  is_personal: boolean;
 }
 
 export interface DashTerminal {
@@ -113,7 +119,7 @@ export async function loadDashSpaces(
       const { data } = await supabase
         .from("space_members")
         .select(
-          "role, spaces!space_members_space_id_fkey(id, slug, name, archived_at)",
+          "role, spaces!space_members_space_id_fkey(id, slug, name, archived_at, is_personal)",
         )
         .eq("user_id", userId);
       type Row = {
@@ -123,6 +129,7 @@ export async function loadDashSpaces(
           slug: string;
           name: string;
           archived_at: string | null;
+          is_personal: boolean;
         } | null;
       };
       return ((data ?? []) as unknown as Row[])
@@ -135,6 +142,7 @@ export async function loadDashSpaces(
           slug: r.spaces.slug,
           name: r.spaces.name,
           role: r.role,
+          is_personal: r.spaces.is_personal ?? false,
         }));
     },
   );

--- a/apps/web/tests/rls/personal-space.test.ts
+++ b/apps/web/tests/rls/personal-space.test.ts
@@ -1,0 +1,178 @@
+/**
+ * RLS + behaviour tests for Personal Spaces.
+ *
+ * Runs against the local Supabase stack (CI spins it up). Verifies the
+ * invariants from the 20260614120000_personal_spaces migration:
+ *
+ *   - every user is auto-provisioned exactly one personal space
+ *   - the owner can see their own personal space; nobody else can
+ *   - the owner CAN create terminals inside it (the headline requirement)
+ *   - no one can add a second member to a personal space
+ *   - a personal space can't be deleted
+ *
+ * Mirrors tests/rls/project-scope.test.ts for the auth/session plumbing.
+ */
+
+import { describe, it, expect, beforeAll } from "vitest";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+
+const SB_URL = process.env.SUPABASE_URL ?? "http://127.0.0.1:54321";
+const ANON =
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0";
+const SERVICE =
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU";
+
+const admin = createClient(SB_URL, SERVICE, {
+  auth: { autoRefreshToken: false, persistSession: false },
+});
+
+async function makeClientFor(email: string): Promise<SupabaseClient> {
+  const { data, error } = await admin.auth.admin.generateLink({
+    type: "magiclink",
+    email,
+  });
+  if (error || !data) throw new Error(`generateLink failed: ${error?.message}`);
+  const supabase = createClient(SB_URL, ANON, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+  const { data: verifyData, error: verifyErr } = await supabase.auth.verifyOtp({
+    type: "magiclink",
+    token_hash: data.properties.hashed_token,
+  });
+  if (verifyErr) throw new Error(`verifyOtp failed: ${verifyErr.message}`);
+  if (!verifyData.session) throw new Error("no session after verifyOtp");
+  await supabase.auth.setSession({
+    access_token: verifyData.session.access_token,
+    refresh_token: verifyData.session.refresh_token,
+  });
+  return supabase;
+}
+
+async function ensureUser(email: string): Promise<string> {
+  const { data: list } = await admin.auth.admin.listUsers();
+  const existing = list?.users.find((u) => u.email === email);
+  if (existing) return existing.id;
+  const { data, error } = await admin.auth.admin.createUser({
+    email,
+    email_confirm: true,
+  });
+  if (error || !data.user) throw new Error(`createUser ${email}: ${error?.message}`);
+  return data.user.id;
+}
+
+async function personalSpaceOf(userId: string): Promise<string> {
+  const { data, error } = await admin
+    .from("spaces")
+    .select("id")
+    .eq("personal_owner_id", userId)
+    .eq("is_personal", true);
+  if (error) throw new Error(`personalSpaceOf: ${error.message}`);
+  const rows = (data ?? []) as { id: string }[];
+  // Exactly one personal space per user — enforced by the partial unique index.
+  expect(rows.length).toBe(1);
+  return rows[0].id;
+}
+
+describe("RLS — personal spaces", () => {
+  let userA: string;
+  let userB: string;
+  let personalA: string;
+  let personalB: string;
+  let clientA: SupabaseClient;
+  let clientB: SupabaseClient;
+
+  beforeAll(async () => {
+    userA = await ensureUser("personal-a@rokki.local");
+    userB = await ensureUser("personal-b@rokki.local");
+    // The handle_new_user trigger provisions a personal space synchronously
+    // on insert, so by now both users have exactly one.
+    personalA = await personalSpaceOf(userA);
+    personalB = await personalSpaceOf(userB);
+    clientA = await makeClientFor("personal-a@rokki.local");
+    clientB = await makeClientFor("personal-b@rokki.local");
+  }, 30_000);
+
+  it("auto-provisions exactly one personal space per user, named Personal", async () => {
+    const { data } = await admin
+      .from("spaces")
+      .select("name, is_personal")
+      .eq("id", personalA)
+      .maybeSingle();
+    expect((data as { is_personal?: boolean } | null)?.is_personal).toBe(true);
+    expect((data as { name?: string } | null)?.name).toBe("Personal");
+    // personalSpaceOf already asserts the count is 1.
+    expect(personalA).not.toBe(personalB);
+  });
+
+  it("owner can see their own personal space", async () => {
+    const { data, error } = await clientA
+      .from("spaces")
+      .select("id, is_personal")
+      .eq("id", personalA)
+      .maybeSingle();
+    expect(error).toBeNull();
+    expect((data as { is_personal?: boolean } | null)?.is_personal).toBe(true);
+  });
+
+  it("another user cannot see someone else's personal space", async () => {
+    const { data } = await clientB
+      .from("spaces")
+      .select("id")
+      .eq("id", personalA)
+      .maybeSingle();
+    // RLS filters it out → null. (No leak of even its existence.)
+    expect(data).toBeNull();
+  });
+
+  it("owner CAN create a terminal inside their personal space", async () => {
+    const { data, error } = await clientA
+      .from("terminals")
+      .insert({
+        space_id: personalA,
+        ticker: "PERS",
+        name: "Notes",
+        created_by: userA,
+      })
+      .select("id, space_id")
+      .single();
+    expect(error).toBeNull();
+    expect((data as { space_id?: string } | null)?.space_id).toBe(personalA);
+  });
+
+  it("another user cannot create a terminal in someone else's personal space", async () => {
+    const { error } = await clientB.from("terminals").insert({
+      space_id: personalA,
+      ticker: "INTRUDE",
+      name: "Intruder",
+      created_by: userB,
+    });
+    expect(error).toBeTruthy();
+  });
+
+  it("nobody can add a second member to a personal space", async () => {
+    const { error } = await clientA.from("space_members").insert({
+      space_id: personalA,
+      user_id: userB,
+      role: "member",
+    });
+    expect(error).toBeTruthy();
+    // And it really didn't land.
+    const { data: members } = await admin
+      .from("space_members")
+      .select("user_id")
+      .eq("space_id", personalA);
+    expect((members ?? []).length).toBe(1);
+  });
+
+  it("a personal space cannot be deleted by its owner", async () => {
+    await clientA.from("spaces").delete().eq("id", personalA);
+    // RLS USING excludes personal spaces, so the DELETE matches 0 rows
+    // (it may not error). Confirm the space still exists.
+    const { data: still } = await admin
+      .from("spaces")
+      .select("id")
+      .eq("id", personalA)
+      .maybeSingle();
+    expect(still).toBeTruthy();
+  });
+});

--- a/docs/01_DATA_MODEL.md
+++ b/docs/01_DATA_MODEL.md
@@ -1259,3 +1259,69 @@ VALUES ('pane_shell_enabled', 'global', 'false'::jsonb, 0,
 Off (0% rollout) by default. Per-user overrides (scope = `user`,
 `scope_id = <uid>`, `value = true`) let staff dogfood without flipping
 for everyone.
+
+## 1.14 Personal spaces
+
+Migration: `20260614120000_personal_spaces.sql`. ADR: `docs/adr/0005-personal-spaces.md`.
+
+Every user gets exactly one private **Personal space** — an ordinary
+`spaces` row, auto-provisioned at signup, that holds personal terminals /
+tasks / files. It behaves like any space (the owner can create terminals
+inside it) but is private to the owner and can't be shared or deleted.
+
+### 1.14.1 Columns
+
+```sql
+ALTER TABLE spaces
+  ADD COLUMN is_personal BOOLEAN NOT NULL DEFAULT FALSE,
+  ADD COLUMN personal_owner_id UUID REFERENCES auth.users(id) ON DELETE CASCADE;
+
+-- A personal space names its owner; a shared space never does.
+ALTER TABLE spaces ADD CONSTRAINT spaces_personal_owner_consistency CHECK (
+  (is_personal AND personal_owner_id IS NOT NULL)
+  OR (NOT is_personal AND personal_owner_id IS NULL)
+);
+
+-- Exactly one personal space per user.
+CREATE UNIQUE INDEX spaces_personal_owner_key
+  ON spaces (personal_owner_id) WHERE is_personal;
+```
+
+### 1.14.2 Provisioning
+
+`provision_personal_space(uuid)` (SECURITY DEFINER, idempotent) inserts the
+row with slug `'p' || <32 hex of user id>` (33 chars, satisfies the spaces
+slug CHECK) and name `'Personal'`. It is called from the existing
+`handle_new_user()` trigger so it bypasses the platform-admin-only
+`spaces_insert` policy (same pattern as the profiles insert), and from a
+one-time backfill loop over `auth.users`. The existing
+`trg_space_creator → add_space_creator_as_owner` trigger seeds the owner's
+`space_members` row (role `owner`) automatically.
+
+### 1.14.3 Rules enforced at the DB (RLS)
+
+- **One per user** — partial unique index above.
+- **Owner-only / no invites** — `space_members_insert` (replaces
+  `org_members_insert`) adds `AND NOT EXISTS (SELECT 1 FROM spaces s WHERE
+  s.id = space_id AND s.is_personal)`. The provisioning trigger
+  (SECURITY DEFINER) still seeds the sole owner.
+- **Undeletable** — `spaces_delete` (replaces `orgs_delete`) adds
+  `AND NOT is_personal`.
+- **Isolation** — unchanged. The existing `orgs_select`
+  (`is_space_member OR created_by OR has_emergency_access`) already limits a
+  personal space to its owner.
+- **Admin visibility** — none added. Platform admins reach a personal space
+  exactly the way they reach every space: `has_emergency_access()`
+  (break-glass) or the service-role admin routes. No normal-session admin
+  read exists for any space, so personal spaces inherit that behaviour with
+  no special-casing.
+- **Terminal creation** — unchanged. `terminals_insert`
+  (`is_space_member(space_id) AND created_by = auth.uid()`) already lets the
+  sole owner create terminals inside their personal space.
+
+### 1.14.4 Surfacing
+
+`is_personal` is returned by `loadDashSpaces` and `GET /api/v1/orgs`. The
+explorer pins the personal space to the top with a person glyph and disables
+drag-reorder on it; its settings page hides the members / invites / danger
+cards (rename only).

--- a/docs/adr/0005-personal-spaces.md
+++ b/docs/adr/0005-personal-spaces.md
@@ -1,0 +1,89 @@
+# ADR 0005 — Personal spaces
+
+**Date:** 2026-06-14
+**Status:** Accepted
+
+## Context
+
+Rokki's tenancy model has one non-negotiable: **only platform admins can
+create spaces** (`CLAUDE.md`, enforced by the `spaces_insert` RLS policy).
+That's right for *shared* spaces (companies, families) — they're deliberate,
+admin-provisioned tenants.
+
+But a user has nowhere private to work. Every terminal lives in a shared
+space, visible to that space's members. Zack asked for a personal place to
+keep personal terminals/tasks that aren't tied to a company or family —
+private by default, but still a real space he can create terminals inside.
+
+The question is how to add a private per-user space without weakening the
+"admins create spaces" rule, and how privacy interacts with platform-admin
+oversight.
+
+## Decision
+
+Every user gets exactly **one** private **Personal space**: an ordinary
+`spaces` row flagged `is_personal = true` with a single `personal_owner_id`,
+auto-provisioned at signup and backfilled for existing users.
+
+It is **system-provisioned, not user-created.** Provisioning runs inside the
+existing `SECURITY DEFINER handle_new_user()` trigger, which bypasses
+`spaces_insert`. So the user-facing rule is unchanged — a *user* still can't
+call "create space"; the platform does it for them. The admin-only rule
+stands for shared spaces; personal spaces are an automatic, system carve-out.
+
+Rules, all enforced at the database (RLS), not just the UI:
+
+- **Exactly one per user** — partial unique index on `(personal_owner_id)`.
+- **Owner-only, no invites** — adding any other member is blocked.
+- **Undeletable** — so the user always has a home; the explorer is never
+  empty.
+- **Isolated** — only the owner can see it (existing select policy already
+  does this via membership).
+- **Renamable** — display name only; `is_personal` / owner are immutable.
+- **Works like any space** — the owner can create terminals, tasks, files,
+  and comments inside it (the existing `terminals_insert` policy already
+  permits the sole owner).
+
+**Admin access: same as every other space.** We deliberately did **not** add
+a privacy carve-out for admins, and we did **not** add new admin visibility.
+Today no space is readable by a platform admin in a normal session — admin
+reach to space/terminal/task data is only via `has_emergency_access()`
+(break-glass, requires the `app.emergency_access` GUC) or the service-role
+admin routes. Personal spaces inherit exactly that. So admins "see personal
+spaces like the others" — no more, no less — which is what Zack asked for,
+and it means zero new policy surface for admin access.
+
+The UI pins the personal space to the top of the explorer with a person
+glyph, disables drag-reorder on it, and hides the members/invites/danger-zone
+controls on its settings page. `is_personal` is exposed on `loadDashSpaces`
+and `GET /api/v1/orgs` for API + MCP parity.
+
+## Alternatives considered
+
+- **Privacy-first (hide contents from admins).** Rejected per Zack's call —
+  he wants the same oversight he has over every space. Also simpler: it
+  drops a whole special-case policy.
+- **Let users self-create personal spaces via an RLS carve-out**
+  (`WITH CHECK (is_personal AND personal_owner_id = auth.uid())`). Rejected —
+  auto-provisioning is invisible and guarantees the "exactly one, always
+  present" invariant without a user action that could create zero or many.
+- **A separate `personal_workspaces` table.** Rejected — it would fork every
+  terminal/task/file FK and RLS policy. Reusing `spaces` means terminals,
+  tasks, files, modules, and all existing tooling work unchanged.
+
+## Consequences
+
+- The `spaces_insert` "admins only" policy is untouched; the carve-out lives
+  entirely in `SECURITY DEFINER` provisioning.
+- Two existing policies are rewritten (renamed cleanly while at it):
+  `org_members_insert → space_members_insert` (+ no-invite-to-personal) and
+  `orgs_delete → spaces_delete` (+ not-personal).
+- A backfill creates one personal space for every existing user; the
+  provisioning function is idempotent, so re-runs are safe.
+- New users incur one extra row insert at signup (the personal space + its
+  owner membership via the existing trigger).
+- Open follow-ups (not built): per-user quota lane for personal spaces;
+  optional "upgrade to shared" path. Both are additive.
+
+See `docs/01_DATA_MODEL.md §1.14` for the schema and policy SQL and
+`supabase/migrations/20260614120000_personal_spaces.sql` for the migration.

--- a/supabase/migrations/20260614120000_personal_spaces.sql
+++ b/supabase/migrations/20260614120000_personal_spaces.sql
@@ -1,0 +1,181 @@
+-- Personal Space — every user gets exactly one private "Personal" space.
+--
+-- A personal space is an ordinary `spaces` row flagged is_personal=true with a
+-- single owner (personal_owner_id). It is auto-provisioned at signup and
+-- backfilled for existing users. It behaves like any space — the owner can
+-- create terminals, tasks, files, and comments inside it — but:
+--   * exactly one per user                    (partial unique index)
+--   * the owner is the sole member; nobody else can ever be added   (RLS)
+--   * it can't be deleted, so the dashboard always has a home        (RLS)
+--   * only the owner sees it; platform admins reach it EXACTLY the way they
+--     reach every other space (has_emergency_access break-glass /
+--     service-role admin routes) — no special-casing, so admins see personal
+--     spaces "like the others".
+--
+-- Provisioning runs inside the existing SECURITY DEFINER handle_new_user()
+-- trigger so it bypasses the platform-admin-only `spaces_insert` policy (the
+-- same pattern the codebase already uses for the profiles row). The existing
+-- AFTER INSERT ON spaces trigger (trg_space_creator -> add_space_creator_as_owner)
+-- seeds the owner's space_members row automatically, so this migration never
+-- touches space_members directly during provisioning.
+
+BEGIN;
+
+-- 1. Columns ----------------------------------------------------------------
+
+ALTER TABLE spaces
+  ADD COLUMN is_personal BOOLEAN NOT NULL DEFAULT FALSE,
+  ADD COLUMN personal_owner_id UUID REFERENCES auth.users(id) ON DELETE CASCADE;
+
+-- A personal space names its owner; a shared space never does. Keeps the two
+-- columns consistent and gives the unique index below its "one per user"
+-- meaning. Existing rows (is_personal=false, personal_owner_id=null) pass.
+ALTER TABLE spaces ADD CONSTRAINT spaces_personal_owner_consistency CHECK (
+  (is_personal AND personal_owner_id IS NOT NULL)
+  OR (NOT is_personal AND personal_owner_id IS NULL)
+);
+
+-- Exactly one personal space per user.
+CREATE UNIQUE INDEX spaces_personal_owner_key
+  ON spaces (personal_owner_id)
+  WHERE is_personal;
+
+-- 2. Provisioning helper ----------------------------------------------------
+-- Idempotent: returns the user's existing personal space if they already have
+-- one, otherwise creates it. SECURITY DEFINER so it bypasses the admin-only
+-- spaces_insert RLS. The slug must satisfy the spaces CHECK
+-- (^[a-z][a-z0-9-]{1,38}[a-z0-9]$, length 3-40): 'p' + the 32 hex chars of the
+-- user id = 33 chars, starts with a letter, ends alphanumeric, globally
+-- unique. The slug is never shown — the display name is "Personal".
+
+CREATE OR REPLACE FUNCTION provision_personal_space(p_user_id UUID)
+RETURNS UUID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_space_id UUID;
+BEGIN
+  SELECT id INTO v_space_id
+  FROM spaces
+  WHERE is_personal AND personal_owner_id = p_user_id;
+
+  IF v_space_id IS NOT NULL THEN
+    RETURN v_space_id;
+  END IF;
+
+  INSERT INTO spaces (slug, name, created_by, is_personal, personal_owner_id)
+  VALUES (
+    'p' || replace(p_user_id::text, '-', ''),
+    'Personal',
+    p_user_id,
+    TRUE,
+    p_user_id
+  )
+  RETURNING id INTO v_space_id;
+
+  RETURN v_space_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION provision_personal_space(UUID) TO authenticated, service_role;
+
+-- 3. Auto-provision on signup ----------------------------------------------
+-- Extend handle_new_user to give every new user their personal space. The
+-- profiles insert is kept verbatim from 20260419121000; we only append the
+-- space provisioning.
+
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  INSERT INTO public.profiles (user_id, full_name)
+  VALUES (
+    NEW.id,
+    COALESCE(NEW.raw_user_meta_data->>'full_name', split_part(NEW.email, '@', 1))
+  )
+  ON CONFLICT (user_id) DO NOTHING;
+
+  -- Give every new user their private Personal space.
+  PERFORM provision_personal_space(NEW.id);
+
+  RETURN NEW;
+END;
+$$;
+
+-- 4. No invites to a personal space ----------------------------------------
+-- A personal space is owner-only. The provisioning trigger seeds the owner
+-- (SECURITY DEFINER, bypasses RLS), but no one — not even the owner — can add
+-- a second member through normal RLS. Shared spaces are unaffected. This
+-- replaces the org_members_insert policy (renamed cleanly to
+-- space_members_insert while we're here).
+
+DROP POLICY IF EXISTS "org_members_insert" ON space_members;
+CREATE POLICY "space_members_insert" ON space_members FOR INSERT TO authenticated
+WITH CHECK (
+  is_space_admin(space_id)
+  AND NOT EXISTS (
+    SELECT 1 FROM spaces s WHERE s.id = space_id AND s.is_personal
+  )
+);
+
+-- 5. A personal space can't be deleted -------------------------------------
+-- Undeletable so the user always has a home. Shared-space owner-delete is
+-- unchanged (renamed cleanly orgs_delete -> spaces_delete).
+
+DROP POLICY IF EXISTS "orgs_delete" ON spaces;
+CREATE POLICY "spaces_delete" ON spaces FOR DELETE TO authenticated
+USING (
+  EXISTS (
+    SELECT 1 FROM space_members
+    WHERE space_id = spaces.id AND user_id = auth.uid() AND role = 'owner'
+  )
+  AND NOT is_personal
+);
+
+-- 6. Backfill ---------------------------------------------------------------
+-- Every existing user gets a personal space (idempotent via the helper). On a
+-- fresh `supabase db reset` auth.users is empty here, so this is a no-op and
+-- the seed users get provisioned by the trigger when they're inserted. On
+-- staging/prod (db push against a populated database) this gives every
+-- existing user their Personal space.
+
+DO $$
+DECLARE
+  r RECORD;
+BEGIN
+  FOR r IN SELECT id FROM auth.users LOOP
+    PERFORM provision_personal_space(r.id);
+  END LOOP;
+END $$;
+
+COMMIT;
+
+-- ROLLBACK:
+-- BEGIN;
+-- DROP POLICY IF EXISTS "spaces_delete" ON spaces;
+-- CREATE POLICY "orgs_delete" ON spaces FOR DELETE TO authenticated
+--   USING (EXISTS (SELECT 1 FROM space_members WHERE space_id = spaces.id AND user_id = auth.uid() AND role = 'owner'));
+-- DROP POLICY IF EXISTS "space_members_insert" ON space_members;
+-- CREATE POLICY "org_members_insert" ON space_members FOR INSERT TO authenticated
+--   WITH CHECK (is_space_admin(space_id));
+-- CREATE OR REPLACE FUNCTION public.handle_new_user()
+-- RETURNS TRIGGER LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $func$
+-- BEGIN
+--   INSERT INTO public.profiles (user_id, full_name)
+--   VALUES (NEW.id, COALESCE(NEW.raw_user_meta_data->>'full_name', split_part(NEW.email, '@', 1)))
+--   ON CONFLICT (user_id) DO NOTHING;
+--   RETURN NEW;
+-- END;
+-- $func$;
+-- DELETE FROM spaces WHERE is_personal;
+-- DROP FUNCTION IF EXISTS provision_personal_space(UUID);
+-- DROP INDEX IF EXISTS spaces_personal_owner_key;
+-- ALTER TABLE spaces DROP CONSTRAINT IF EXISTS spaces_personal_owner_consistency;
+-- ALTER TABLE spaces DROP COLUMN IF EXISTS personal_owner_id;
+-- ALTER TABLE spaces DROP COLUMN IF EXISTS is_personal;
+-- COMMIT;


### PR DESCRIPTION
Every user gets exactly **one** private **Personal** space — an ordinary `spaces` row flagged `is_personal=true` with a single owner, auto-provisioned at signup and backfilled for existing users. It behaves like any space (the owner can create terminals/tasks/files inside it) but is private to the owner, owner-only, and undeletable.

### Rules (all enforced at the DB — RLS, not just UI)
- **One per user** — partial unique index `(personal_owner_id) WHERE is_personal`.
- **Owner-only / no invites** — `space_members_insert` blocks adding members to a personal space.
- **Undeletable** — `spaces_delete` excludes personal spaces (self-healing home).
- **Isolated** — existing `orgs_select` already limits it to the owner.
- **Admin access = same as every space** — *no* new policy. Admins reach personal spaces only via `has_emergency_access()` (break-glass) or the service-role admin routes, exactly like every other space. This is what "admins see it like the others" means, and it's zero new admin surface.
- **Terminal creation works** — `terminals_insert` (`is_space_member AND created_by`) already lets the sole owner create terminals; locked in by an RLS test (the explicit requirement).

### How it's provisioned
Inside the existing `SECURITY DEFINER handle_new_user()` trigger, so the **admins-only `spaces_insert` rule is untouched** — a *user* still can't create a space; the platform provisions the personal one for them. The existing `trg_space_creator` seeds the owner's membership.

### UI / API
- Explorer: pinned to the top with a person glyph, not draggable.
- Settings page: rename only (members / invites / danger-zone hidden).
- `is_personal` surfaced on `loadDashSpaces` and `GET /api/v1/orgs` (API/MCP parity).

### Migration
`supabase/migrations/20260614120000_personal_spaces.sql` — adds `is_personal` + `personal_owner_id`, the unique index, `provision_personal_space()`, the trigger hook, the two policy rewrites, and an idempotent backfill. ADR: `docs/adr/0005-personal-spaces.md`; schema doc: `docs/01_DATA_MODEL.md §1.14`.

### Verification
- `typecheck` ✓ · `lint` ✓ (pre-existing warnings only) · `build` ✓ · `351` unit tests ✓ · `migrations:test` ✓ (0 broken).
- New RLS suite `tests/rls/personal-space.test.ts` covers: one-per-user, owner-sees / stranger-can't, **create-terminal-in-personal**, no-invite, undeletable — runs under the DB/RLS gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)