### PR TITLE
Fix deploy-prod promote step (refusing to fetch into checked-out main)

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -87,14 +87,20 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          ref: main
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Fast-forward production to main HEAD
         run: |
           git config user.name "rokki-deploy[bot]"
           git config user.email "deploy@rokki.ai"
-          git fetch origin main:main
-          git push origin main:production
+          # `ref: main` above already checked out main at its HEAD, so push
+          # that commit straight to the production branch. The previous
+          # `git fetch origin main:main` failed every run with
+          # "refusing to fetch into branch 'refs/heads/main' checked out".
+          # A non-fast-forward (a diverged production branch) is rejected
+          # here by design — promote a single feature via cherry-pick then.
+          git push origin HEAD:production
           echo "Pushed main → production. Vercel will auto-build."
 
   smoke-test-prod:


### PR DESCRIPTION
The `promote-vercel` job in `deploy-prod.yml` failed **every** production deploy at the promotion step:

```
fatal: refusing to fetch into branch 'refs/heads/main' checked out at '/home/runner/work/rokki/rokki'
```

It ran `git fetch origin main:main` while `main` was already the checked-out branch — git refuses that. Because the step died there, the migrate + smoke-test never completed and `production` was never advanced. (Surfaced while shipping Personal Space #231 — I completed that promotion by hand.)

**Fix:** pin the checkout to `ref: main` and push the checked-out HEAD straight to the production branch — no fetch into the current branch:

```yaml
- uses: actions/checkout@v6
  with:
    ref: main
    fetch-depth: 0
    token: ${{ secrets.GITHUB_TOKEN }}
- run: |
    ...
    git push origin HEAD:production
```

A **diverged** production branch now rejects as a non-fast-forward — which is the correct, safe behavior: held PRs (e.g. #228 icon/dot sizing) are deliberately kept off prod and shipped via cherry-pick, and this prevents a blanket `main → production` from dragging them live.

Workflow-only change; no app code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)