### PR TITLE
Personal Space follow-ups: remove explorer glyph + fix terminal-create 404

### DIFF
--- a/apps/web/src/components/dashboard/ExplorerRail.tsx
+++ b/apps/web/src/components/dashboard/ExplorerRail.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { ChevronDown, ChevronRight, Settings, User, X } from "lucide-react";
+import { ChevronDown, ChevronRight, Settings, X } from "lucide-react";
 import type { DashSpace, DashTerminal } from "@/lib/dashboard-queries";
 import { cn } from "@/lib/utils";
 import { AccountBlock } from "@/components/AccountBlock";
@@ -454,24 +454,11 @@ export function ExplorerRail({
                           <ChevronDown className="h-3 w-3" />
                         )}
                       </button>
-                      {/* The personal space gets a person glyph so it
-                          reads as "yours / private" at a glance, set apart
-                          from the shared spaces below it. */}
-                      {s.is_personal ? (
-                        <User
-                          className="h-3 w-3 flex-shrink-0 text-text-3"
-                          aria-hidden="true"
-                        />
-                      ) : null}
                       <Link
                         href={`/s/${s.slug}`}
                         draggable={false}
                         className="flex-1 truncate text-text-1 hover:text-text-0"
-                        title={
-                          s.is_personal
-                            ? "Your private space"
-                            : `Open ${s.name}`
-                        }
+                        title={`Open ${s.name}`}
                       >
                         {s.name}
                       </Link>

--- a/apps/web/src/lib/resolve-terminal.ts
+++ b/apps/web/src/lib/resolve-terminal.ts
@@ -60,14 +60,24 @@ export async function resolveTerminalBySegment(
 
   // Slug lookup — the common case for any link generated since the
   // 20260526010000_terminal_slug migration shipped.
+  //
+  // Slugs are unique only PER SPACE (the unique index is on
+  // (space_id, slug)), so a caller who belongs to two spaces can have two
+  // terminals with the same slug — common now that everyone has a Personal
+  // space alongside shared ones. We must NOT use `.maybeSingle()` here: it
+  // throws on >1 row, which surfaced as a 404 ("page doesn't exist") right
+  // after creating a same-named terminal. Take the most recently created
+  // match instead, so a just-created terminal resolves to itself.
   {
     const { data } = await supabase
       .from("terminals")
       .select("id, space_id, slug, ticker, name")
       .eq("slug", segment)
       .is("archived_at", null)
-      .maybeSingle();
-    if (data) return data as ResolvedTerminal;
+      .order("created_at", { ascending: false })
+      .limit(1);
+    const row = ((data ?? []) as ResolvedTerminal[])[0];
+    if (row) return row;
   }
 
   // Fallback for shared URLs minted before the slug column existed.
@@ -77,8 +87,10 @@ export async function resolveTerminalBySegment(
       .select("id, space_id, slug, ticker, name")
       .eq("ticker", segment.toUpperCase())
       .is("archived_at", null)
-      .maybeSingle();
-    if (data) return data as ResolvedTerminal;
+      .order("created_at", { ascending: false })
+      .limit(1);
+    const row = ((data ?? []) as ResolvedTerminal[])[0];
+    if (row) return row;
   }
 
   return null;


### PR DESCRIPTION
Two fixes on the Personal Space feature, both reported by Zack:

### 1. Remove the person glyph in the explorer
Drops the little person icon next to the Personal space. The personal-first pin and the rename-only settings stay; just the icon goes.

### 2. Fix the 404 after creating a terminal in the Personal space
Creating a terminal in Personal navigated to a 404 ("This page doesn't exist or was moved").

**Root cause:** the terminal *was* created (the insert succeeded and the user is a member), but `resolveTerminalBySegment` did a `.maybeSingle()` slug lookup. Terminal slugs are unique only **per space** (unique index on `(space_id, slug)`), so a user who belongs to two spaces can have two terminals with the same slug — now common since everyone has a Personal space alongside shared ones. `.maybeSingle()` **throws on >1 row** → returns `null` → `notFound()` → 404.

**Fix:** take the most-recently-created match (`order created_at desc`, `limit 1`) instead of `.maybeSingle()`, so a just-created terminal resolves to itself and the resolver never crashes on a slug collision.

### Known follow-up (not in this PR)
`/p/<slug>` is still ambiguous across same-slug terminals in different spaces. The proper fix is globally-unique terminal slugs (or space-scoped terminal URLs). Filed separately; this PR stops the crash.

Verified: typecheck ✓, lint ✓, 351 unit tests ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)