### PR TITLE
Module settings: gear on the MODULES shelf (settings #1-8) + 223 tests

### DIFF
--- a/apps/web/src/components/dashboard/DashboardPanels.tsx
+++ b/apps/web/src/components/dashboard/DashboardPanels.tsx
@@ -3,6 +3,7 @@
 import {
   Fragment,
   useEffect,
+  useMemo,
   useRef,
   useState,
   type CSSProperties,
@@ -13,9 +14,10 @@ import {
 import { GripVertical, Maximize2, Minimize2, Minus } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { PanelControlsProvider } from "./panel-handle";
-import { useModuleVisibility } from "./module-visibility";
+import { useModulePrefs } from "./module-visibility";
 import {
   DASH_LAYOUT_STORAGE_KEY,
+  DASH_PANEL_IDS,
   DEFAULT_DASH_LAYOUT,
   gridTemplate,
   movePanel,
@@ -23,6 +25,7 @@ import {
   type DashColumn,
   type DashLayout,
 } from "@/lib/dashboard-layout";
+import { presetToDashLayout, type DashLayoutPreset } from "@/lib/module-prefs";
 
 const TITLES: Record<string, string> = {
   week: "Week",
@@ -81,13 +84,23 @@ export function DashboardPanels({
   const [maximizedId, setMaximizedId] = useState<string | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
 
-  // Minimized modules (shared with the explorer rail's Modules list).
-  // A minimized panel is dropped from the viewing area but kept in
-  // `layout`, so restoring it from the rail puts it back in its slot.
-  const vis = useModuleVisibility();
+  // Module prefs (shared with the explorer rail's Modules list + the
+  // settings gear). A minimized panel is dropped from the viewing area but
+  // kept in `layout`, so restoring it puts it back in its slot; a hidden
+  // module (#1) is dropped entirely until it's shown again.
+  const mods = useModulePrefs();
+  const activeIds = useMemo(
+    () =>
+      new Set<string>(
+        mods ? mods.visibleModules.map((m) => m.id) : [...DASH_PANEL_IDS],
+      ),
+    [mods],
+  );
   function visibleInCol(col: DashColumn): string[] {
-    const m = vis?.minimized;
-    return m ? layout[col].filter((id) => !m.has(id)) : layout[col];
+    const min = mods?.minimized;
+    return layout[col].filter(
+      (id) => activeIds.has(id) && !(min ? min.has(id) : false),
+    );
   }
 
   // Track the lg breakpoint so the dynamic inline styles (panel flex,
@@ -134,6 +147,27 @@ export function DashboardPanels({
       /* non-fatal */
     }
   }, [layout, weights, centerFrac, hydrated]);
+
+  // Apply the default-layout preset (#5) when the user changes it in the
+  // module settings gear. The first observed value is skipped so the saved
+  // drag arrangement wins on load — only an explicit preset change in
+  // settings rearranges the columns into the stacked/split shape.
+  const lastPreset = useRef<DashLayoutPreset | null>(null);
+  useEffect(() => {
+    if (!hydrated) return;
+    const preset = mods?.prefs.layout;
+    if (!preset) return;
+    if (lastPreset.current === null) {
+      lastPreset.current = preset;
+      return;
+    }
+    if (lastPreset.current !== preset) {
+      lastPreset.current = preset;
+      const order = mods?.prefs.order ?? [...DASH_PANEL_IDS];
+      setLayout(presetToDashLayout(preset, order));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mods?.prefs.layout, hydrated]);
 
   /* ---------------- drag-and-drop (rearrange) ---------------- */
   function endDrag() {
@@ -308,13 +342,13 @@ export function DashboardPanels({
   // Minimize — drops the panel out of the viewing area into the rail's
   // Modules list (click it there to bring it back).
   function panelMinBtn(id: string): ReactNode {
-    if (!vis) return null;
+    if (!mods) return null;
     return (
       <button
         type="button"
         onClick={() => {
           if (maximizedId === id) setMaximizedId(null);
-          vis.toggle(id);
+          mods.toggle(id);
         }}
         aria-label={`Minimize ${TITLES[id] ?? "panel"}`}
         title="Minimize"

--- a/apps/web/src/components/dashboard/ExplorerRail.tsx
+++ b/apps/web/src/components/dashboard/ExplorerRail.tsx
@@ -7,6 +7,8 @@ import type { DashSpace, DashTerminal } from "@/lib/dashboard-queries";
 import { cn } from "@/lib/utils";
 import { AccountBlock } from "@/components/AccountBlock";
 import { RailModules } from "./RailModules";
+import { ModuleSettings } from "./ModuleSettings";
+import { useModulePrefs } from "./module-visibility";
 import { COLLAPSED_SPACES_KEY } from "@/lib/recent-terminals";
 import {
   applyOrder,
@@ -260,6 +262,22 @@ export function ExplorerRail({
   }, [sectionsOpen, hydrated]);
   const toggleSection = (k: "spaces" | "modules") =>
     setSectionsOpen((s) => ({ ...s, [k]: !s[k] }));
+
+  // The MODULES section collapse is driven by module prefs when the
+  // dashboard provider is present, so the chevron stays in sync with the
+  // gear's "Collapse on load" setting (#6). Falls back to the local
+  // per-rail state on pages without modules (terminal / space).
+  const modulePrefs = useModulePrefs();
+  const modulesOpen = modulePrefs
+    ? !modulePrefs.prefs.sectionCollapsed
+    : sectionsOpen.modules;
+  const toggleModules = () => {
+    if (modulePrefs) {
+      modulePrefs.setSectionCollapsed(!modulePrefs.prefs.sectionCollapsed);
+    } else {
+      toggleSection("modules");
+    }
+  };
 
   const filterRef = useRef<HTMLInputElement>(null);
 
@@ -572,19 +590,24 @@ export function ExplorerRail({
           )}
 
           {/* ---- MODULES section (collapsible) ---- */}
-          <button
-            type="button"
-            onClick={() => toggleSection("modules")}
-            className="mt-3 flex w-full items-center gap-1 px-1 py-1 text-xs font-semibold uppercase tracking-wide text-text-3 hover:text-text-1"
-          >
-            {sectionsOpen.modules ? (
-              <ChevronDown className="h-3 w-3 flex-shrink-0" aria-hidden="true" />
-            ) : (
-              <ChevronRight className="h-3 w-3 flex-shrink-0" aria-hidden="true" />
-            )}
-            Modules
-          </button>
-          {sectionsOpen.modules ? <RailModules /> : null}
+          <div className="mt-3 flex items-center gap-1 px-1 py-1">
+            <button
+              type="button"
+              onClick={toggleModules}
+              className="flex flex-1 items-center gap-1 text-xs font-semibold uppercase tracking-wide text-text-3 hover:text-text-1"
+            >
+              {modulesOpen ? (
+                <ChevronDown className="h-3 w-3 flex-shrink-0" aria-hidden="true" />
+              ) : (
+                <ChevronRight className="h-3 w-3 flex-shrink-0" aria-hidden="true" />
+              )}
+              Modules
+            </button>
+            {/* The gear — per-user settings for the whole module shelf.
+                Renders nothing on pages without a module provider. */}
+            <ModuleSettings />
+          </div>
+          {modulesOpen ? <RailModules /> : null}
         </div>
       </div>
 

--- a/apps/web/src/components/dashboard/ModuleSettings.test.tsx
+++ b/apps/web/src/components/dashboard/ModuleSettings.test.tsx
@@ -1,0 +1,282 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup, fireEvent, within } from "@testing-library/react";
+import { ModuleVisibilityProvider } from "./module-visibility";
+import { ModuleSettings } from "./ModuleSettings";
+import {
+  MODULE_PREFS_STORAGE_KEY,
+  defaultModulePrefs,
+  type ModulePrefs,
+} from "@/lib/module-prefs";
+
+function readPrefs(): ModulePrefs | null {
+  const raw = window.localStorage.getItem(MODULE_PREFS_STORAGE_KEY);
+  return raw ? (JSON.parse(raw) as ModulePrefs) : null;
+}
+
+function renderSettings() {
+  return render(
+    <ModuleVisibilityProvider>
+      <ModuleSettings />
+    </ModuleVisibilityProvider>,
+  );
+}
+
+function openPanel() {
+  fireEvent.click(screen.getByRole("button", { name: /module settings/i }));
+  return screen.getByRole("dialog", { name: /module settings/i });
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+afterEach(() => {
+  cleanup();
+});
+
+describe("ModuleSettings — gear + popover", () => {
+  it("renders nothing outside a provider", () => {
+    const { container } = render(<ModuleSettings />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("shows the gear button inside a provider", () => {
+    renderSettings();
+    expect(screen.getByRole("button", { name: /module settings/i })).toBeTruthy();
+  });
+
+  it("popover is closed initially", () => {
+    renderSettings();
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("clicking the gear opens the popover", () => {
+    renderSettings();
+    expect(openPanel()).toBeTruthy();
+  });
+
+  it("clicking the gear again closes the popover", () => {
+    renderSettings();
+    const gear = screen.getByRole("button", { name: /module settings/i });
+    fireEvent.click(gear);
+    expect(screen.queryByRole("dialog")).toBeTruthy();
+    fireEvent.click(gear);
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("Escape closes the popover", () => {
+    renderSettings();
+    openPanel();
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("gear reflects expanded state via aria-expanded", () => {
+    renderSettings();
+    const gear = screen.getByRole("button", { name: /module settings/i });
+    expect(gear.getAttribute("aria-expanded")).toBe("false");
+    fireEvent.click(gear);
+    expect(gear.getAttribute("aria-expanded")).toBe("true");
+  });
+
+  it("lists the three modules", () => {
+    renderSettings();
+    const panel = openPanel();
+    expect(within(panel).getByText("Schedule")).toBeTruthy();
+    expect(within(panel).getByText("Tasks")).toBeTruthy();
+    expect(within(panel).getByText("Messages")).toBeTruthy();
+  });
+});
+
+describe("ModuleSettings — reorder (#2)", () => {
+  it("moves a module up and persists", () => {
+    renderSettings();
+    openPanel();
+    fireEvent.click(screen.getByRole("button", { name: "Move Tasks up" }));
+    expect(readPrefs()!.order).toEqual(["tasks", "week", "messages"]);
+  });
+
+  it("moves a module down and persists", () => {
+    renderSettings();
+    openPanel();
+    fireEvent.click(screen.getByRole("button", { name: "Move Schedule down" }));
+    expect(readPrefs()!.order).toEqual(["tasks", "week", "messages"]);
+  });
+
+  it("disables Move up on the first module", () => {
+    renderSettings();
+    openPanel();
+    expect(
+      (screen.getByRole("button", { name: "Move Schedule up" }) as HTMLButtonElement).disabled,
+    ).toBe(true);
+  });
+
+  it("disables Move down on the last module", () => {
+    renderSettings();
+    openPanel();
+    expect(
+      (screen.getByRole("button", { name: "Move Messages down" }) as HTMLButtonElement).disabled,
+    ).toBe(true);
+  });
+
+  it("reorder updates the rendered row order", () => {
+    renderSettings();
+    const panel = openPanel();
+    fireEvent.click(screen.getByRole("button", { name: "Move Messages up" }));
+    const names = within(panel)
+      .getAllByText(/^(Schedule|Tasks|Messages)$/)
+      .map((n) => n.textContent);
+    expect(names).toEqual(["Schedule", "Messages", "Tasks"]);
+  });
+});
+
+describe("ModuleSettings — show / hide (#1/#8)", () => {
+  it("hiding a module persists it to hidden", () => {
+    renderSettings();
+    openPanel();
+    fireEvent.click(screen.getByRole("button", { name: "Hide Tasks" }));
+    expect(readPrefs()!.hidden).toEqual(["tasks"]);
+  });
+
+  it("hidden module appears in the Hidden tray with an Add control", () => {
+    renderSettings();
+    openPanel();
+    fireEvent.click(screen.getByRole("button", { name: "Hide Tasks" }));
+    expect(screen.getByRole("button", { name: "Show Tasks" })).toBeTruthy();
+  });
+
+  it("hidden module is removed from the active list", () => {
+    renderSettings();
+    openPanel();
+    fireEvent.click(screen.getByRole("button", { name: "Hide Tasks" }));
+    expect(screen.queryByRole("button", { name: "Hide Tasks" })).toBeNull();
+  });
+
+  it("showing a hidden module returns it to the shelf", () => {
+    renderSettings();
+    openPanel();
+    fireEvent.click(screen.getByRole("button", { name: "Hide Tasks" }));
+    fireEvent.click(screen.getByRole("button", { name: "Show Tasks" }));
+    expect(readPrefs()!.hidden).toEqual([]);
+    expect(screen.getByRole("button", { name: "Hide Tasks" })).toBeTruthy();
+  });
+
+  it("shows the all-hidden message when everything is hidden", () => {
+    renderSettings();
+    openPanel();
+    fireEvent.click(screen.getByRole("button", { name: "Hide Schedule" }));
+    fireEvent.click(screen.getByRole("button", { name: "Hide Tasks" }));
+    fireEvent.click(screen.getByRole("button", { name: "Hide Messages" }));
+    expect(screen.getByText(/All modules hidden/i)).toBeTruthy();
+  });
+});
+
+describe("ModuleSettings — open by default (#3)", () => {
+  it("modules are open by default (checkbox checked)", () => {
+    renderSettings();
+    openPanel();
+    const cb = screen.getByRole("checkbox", { name: "Open Tasks by default" }) as HTMLInputElement;
+    expect(cb.checked).toBe(true);
+  });
+
+  it("unchecking minimizes the module on load", () => {
+    renderSettings();
+    openPanel();
+    fireEvent.click(screen.getByRole("checkbox", { name: "Open Tasks by default" }));
+    expect(readPrefs()!.minimized).toContain("tasks");
+  });
+
+  it("re-checking opens it again", () => {
+    renderSettings();
+    openPanel();
+    const cb = screen.getByRole("checkbox", { name: "Open Tasks by default" });
+    fireEvent.click(cb);
+    fireEvent.click(cb);
+    expect(readPrefs()!.minimized).not.toContain("tasks");
+  });
+});
+
+describe("ModuleSettings — layout (#5)", () => {
+  it("defaults to split", () => {
+    renderSettings();
+    openPanel();
+    expect(
+      screen.getByRole("button", { name: "Split" }).getAttribute("aria-pressed"),
+    ).toBe("true");
+  });
+
+  it("choosing Stacked persists the preset", () => {
+    renderSettings();
+    openPanel();
+    fireEvent.click(screen.getByRole("button", { name: "Stacked" }));
+    expect(readPrefs()!.layout).toBe("stacked");
+  });
+
+  it("choosing Stacked updates aria-pressed", () => {
+    renderSettings();
+    openPanel();
+    fireEvent.click(screen.getByRole("button", { name: "Stacked" }));
+    expect(
+      screen.getByRole("button", { name: "Stacked" }).getAttribute("aria-pressed"),
+    ).toBe("true");
+    expect(
+      screen.getByRole("button", { name: "Split" }).getAttribute("aria-pressed"),
+    ).toBe("false");
+  });
+});
+
+describe("ModuleSettings — collapse (#6) + sync (#7)", () => {
+  it("Collapse on load persists", () => {
+    renderSettings();
+    openPanel();
+    fireEvent.click(screen.getByRole("checkbox", { name: "Collapse on load" }));
+    expect(readPrefs()!.sectionCollapsed).toBe(true);
+  });
+
+  it("Collapse on load is off by default", () => {
+    renderSettings();
+    openPanel();
+    expect(
+      (screen.getByRole("checkbox", { name: "Collapse on load" }) as HTMLInputElement).checked,
+    ).toBe(false);
+  });
+
+  it("Sync across devices persists", () => {
+    renderSettings();
+    openPanel();
+    fireEvent.click(screen.getByRole("checkbox", { name: "Sync across devices" }));
+    expect(readPrefs()!.sync).toBe(true);
+  });
+
+  it("Sync is off by default", () => {
+    renderSettings();
+    openPanel();
+    expect(
+      (screen.getByRole("checkbox", { name: "Sync across devices" }) as HTMLInputElement).checked,
+    ).toBe(false);
+  });
+});
+
+describe("ModuleSettings — reset (#4)", () => {
+  it("reset restores defaults after changes", () => {
+    renderSettings();
+    openPanel();
+    fireEvent.click(screen.getByRole("button", { name: "Hide Tasks" }));
+    fireEvent.click(screen.getByRole("button", { name: "Stacked" }));
+    fireEvent.click(screen.getByRole("checkbox", { name: "Collapse on load" }));
+    fireEvent.click(screen.getByRole("button", { name: /reset modules/i }));
+    const p = readPrefs()!;
+    expect(p.hidden).toEqual([]);
+    expect(p.layout).toBe("split");
+    expect(p.sectionCollapsed).toBe(false);
+    expect(p.order).toEqual(defaultModulePrefs().order);
+  });
+
+  it("reset preserves the sync choice", () => {
+    renderSettings();
+    openPanel();
+    fireEvent.click(screen.getByRole("checkbox", { name: "Sync across devices" }));
+    fireEvent.click(screen.getByRole("button", { name: /reset modules/i }));
+    expect(readPrefs()!.sync).toBe(true);
+  });
+});

--- a/apps/web/src/components/dashboard/ModuleSettings.tsx
+++ b/apps/web/src/components/dashboard/ModuleSettings.tsx
@@ -1,0 +1,280 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import {
+  Settings,
+  ChevronUp,
+  ChevronDown,
+  EyeOff,
+  Plus,
+  RotateCcw,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import { useModulePrefs } from "./module-visibility";
+import {
+  isOpenByDefault,
+  LAYOUT_PRESETS,
+  type DashLayoutPreset,
+} from "@/lib/module-prefs";
+
+const LAYOUT_LABELS: Record<DashLayoutPreset, string> = {
+  stacked: "Stacked",
+  split: "Split",
+};
+
+/**
+ * The gear on the explorer rail's MODULES header → a popover of per-user
+ * settings for the whole module shelf (settings #1-8). Renders nothing when
+ * there's no ModulePrefs provider (e.g. the rail inside a terminal), so the
+ * gear only appears where modules actually live — the dashboard.
+ */
+export function ModuleSettings() {
+  const ctx = useModulePrefs();
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    function onDown(e: MouseEvent) {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") setOpen(false);
+    }
+    window.addEventListener("mousedown", onDown);
+    window.addEventListener("keydown", onKey);
+    return () => {
+      window.removeEventListener("mousedown", onDown);
+      window.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  if (!ctx) return null;
+
+  const {
+    prefs,
+    visibleModules,
+    hiddenModules,
+    moveBy,
+    setOpenByDefault,
+    setHidden,
+    setLayout,
+    setSectionCollapsed,
+    setSync,
+    reset,
+  } = ctx;
+
+  return (
+    <div ref={rootRef} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        aria-label="Module settings"
+        title="Module settings"
+        className={cn(
+          "rounded-sm p-0.5 text-text-3 hover:bg-bg-3 hover:text-text-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-focus",
+          open && "bg-bg-3 text-text-1",
+        )}
+      >
+        <Settings className="h-3 w-3" aria-hidden="true" />
+      </button>
+
+      {open ? (
+        <div
+          role="dialog"
+          aria-label="Module settings"
+          className="absolute right-0 z-30 mt-1 w-64 rounded-md border border-border bg-bg-1 py-2 text-xs shadow-lg shadow-black/30"
+        >
+          {/* ---- Modules: show/hide (#1/#8), reorder (#2), open default (#3) ---- */}
+          <SectionLabel>Modules</SectionLabel>
+          <ul className="px-1">
+            {visibleModules.map((m, i) => {
+              const openByDefault = isOpenByDefault(prefs, m.id);
+              return (
+                <li
+                  key={m.id}
+                  className="flex items-center gap-1 rounded-sm px-1 py-0.5 hover:bg-bg-2"
+                >
+                  <span className="flex flex-shrink-0 flex-col">
+                    <button
+                      type="button"
+                      onClick={() => moveBy(m.id, -1)}
+                      disabled={i === 0}
+                      aria-label={`Move ${m.label} up`}
+                      className="text-text-3 hover:text-text-0 disabled:opacity-30"
+                    >
+                      <ChevronUp className="h-2.5 w-2.5" aria-hidden="true" />
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => moveBy(m.id, 1)}
+                      disabled={i === visibleModules.length - 1}
+                      aria-label={`Move ${m.label} down`}
+                      className="text-text-3 hover:text-text-0 disabled:opacity-30"
+                    >
+                      <ChevronDown className="h-2.5 w-2.5" aria-hidden="true" />
+                    </button>
+                  </span>
+                  <span className="flex-1 truncate text-text-1">{m.label}</span>
+                  <label
+                    className="flex flex-shrink-0 items-center gap-1 text-2xs text-text-3"
+                    title="Open this module on load (uncheck to start minimized)"
+                  >
+                    <input
+                      type="checkbox"
+                      checked={openByDefault}
+                      onChange={(e) => setOpenByDefault(m.id, e.target.checked)}
+                      aria-label={`Open ${m.label} by default`}
+                      className="h-3 w-3 accent-accent"
+                    />
+                    open
+                  </label>
+                  <button
+                    type="button"
+                    onClick={() => setHidden(m.id, true)}
+                    aria-label={`Hide ${m.label}`}
+                    title="Hide this module"
+                    className="rounded-sm p-0.5 text-text-3 hover:bg-bg-3 hover:text-danger"
+                  >
+                    <EyeOff className="h-3 w-3" aria-hidden="true" />
+                  </button>
+                </li>
+              );
+            })}
+            {visibleModules.length === 0 ? (
+              <li className="px-1 py-1 text-2xs text-text-3">
+                All modules hidden.
+              </li>
+            ) : null}
+          </ul>
+
+          {/* ---- Hidden tray — add back (#8) ---- */}
+          {hiddenModules.length > 0 ? (
+            <>
+              <SectionLabel>Hidden</SectionLabel>
+              <ul className="px-1">
+                {hiddenModules.map((m) => (
+                  <li
+                    key={m.id}
+                    className="flex items-center gap-1 rounded-sm px-1 py-0.5 hover:bg-bg-2"
+                  >
+                    <span className="flex-1 truncate text-text-3">{m.label}</span>
+                    <button
+                      type="button"
+                      onClick={() => setHidden(m.id, false)}
+                      aria-label={`Show ${m.label}`}
+                      title="Add back to the shelf"
+                      className="flex items-center gap-1 rounded-sm px-1 py-0.5 text-2xs text-text-2 hover:bg-bg-3 hover:text-text-0"
+                    >
+                      <Plus className="h-3 w-3" aria-hidden="true" /> Add
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            </>
+          ) : null}
+
+          <Divider />
+
+          {/* ---- Layout (#5) ---- */}
+          <SectionLabel>Layout</SectionLabel>
+          <div
+            role="group"
+            aria-label="Default layout"
+            className="flex gap-1 px-2 pb-1"
+          >
+            {LAYOUT_PRESETS.map((preset) => (
+              <button
+                key={preset}
+                type="button"
+                onClick={() => setLayout(preset)}
+                aria-pressed={prefs.layout === preset}
+                className={cn(
+                  "flex-1 rounded-sm border px-2 py-1 font-mono text-2xs uppercase tracking-wide",
+                  prefs.layout === preset
+                    ? "border-accent/50 bg-accent-subtle text-accent"
+                    : "border-border bg-bg-1 text-text-3 hover:bg-bg-2 hover:text-text-1",
+                )}
+              >
+                {LAYOUT_LABELS[preset]}
+              </button>
+            ))}
+          </div>
+
+          <Divider />
+
+          {/* ---- Behavior (#6) + Sync (#7) ---- */}
+          <ToggleRow
+            label="Collapse on load"
+            title="Start the MODULES section collapsed"
+            checked={prefs.sectionCollapsed}
+            onChange={(v) => setSectionCollapsed(v)}
+          />
+          <ToggleRow
+            label="Sync across devices"
+            title="Save these settings to your account so they follow you to other devices"
+            checked={prefs.sync}
+            onChange={(v) => setSync(v)}
+          />
+
+          <Divider />
+
+          {/* ---- Reset (#4) ---- */}
+          <div className="px-2 pt-1">
+            <button
+              type="button"
+              onClick={reset}
+              className="flex w-full items-center justify-center gap-1 rounded-sm border border-border bg-bg-1 px-2 py-1 font-mono text-2xs uppercase tracking-wide text-text-3 hover:bg-bg-2 hover:text-text-1"
+            >
+              <RotateCcw className="h-3 w-3" aria-hidden="true" /> Reset modules
+            </button>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function SectionLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="px-2 pb-0.5 pt-1 font-mono text-[10px] uppercase tracking-wide text-text-3">
+      {children}
+    </div>
+  );
+}
+
+function Divider() {
+  return <div className="my-1 border-t border-border" aria-hidden="true" />;
+}
+
+function ToggleRow({
+  label,
+  title,
+  checked,
+  onChange,
+}: {
+  label: string;
+  title: string;
+  checked: boolean;
+  onChange: (v: boolean) => void;
+}) {
+  return (
+    <label
+      title={title}
+      className="flex cursor-pointer items-center gap-2 px-2 py-1 hover:bg-bg-2"
+    >
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={(e) => onChange(e.target.checked)}
+        aria-label={label}
+        className="h-3 w-3 accent-accent"
+      />
+      <span className="text-text-1">{label}</span>
+    </label>
+  );
+}

--- a/apps/web/src/components/dashboard/RailModules.test.tsx
+++ b/apps/web/src/components/dashboard/RailModules.test.tsx
@@ -3,6 +3,22 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { render, screen, cleanup, fireEvent } from "@testing-library/react";
 import { ModuleVisibilityProvider } from "./module-visibility";
 import { RailModules } from "./RailModules";
+import {
+  MODULE_PREFS_STORAGE_KEY,
+  defaultModulePrefs,
+  type ModulePrefs,
+} from "@/lib/module-prefs";
+
+function seed(over: Partial<ModulePrefs>) {
+  window.localStorage.setItem(
+    MODULE_PREFS_STORAGE_KEY,
+    JSON.stringify({ ...defaultModulePrefs(), ...over }),
+  );
+}
+
+function readPrefs(): ModulePrefs {
+  return JSON.parse(window.localStorage.getItem(MODULE_PREFS_STORAGE_KEY)!);
+}
 
 beforeEach(() => {
   window.localStorage.clear();
@@ -12,7 +28,7 @@ afterEach(() => {
 });
 
 describe("RailModules", () => {
-  it("renders nothing outside a ModuleVisibility provider", () => {
+  it("renders nothing outside a ModulePrefs provider", () => {
     const { container } = render(<RailModules />);
     expect(container.firstChild).toBeNull();
   });
@@ -29,7 +45,55 @@ describe("RailModules", () => {
     }
   });
 
-  it("clicking a module toggles it minimized and persists", () => {
+  it("renders modules in the stored order", () => {
+    seed({ order: ["messages", "tasks", "week"] });
+    render(
+      <ModuleVisibilityProvider>
+        <RailModules />
+      </ModuleVisibilityProvider>,
+    );
+    const labels = screen.getAllByRole("button").map((b) => b.textContent);
+    expect(labels).toEqual(["Messages", "Tasks", "Schedule"]);
+  });
+
+  it("does not render hidden modules", () => {
+    seed({ hidden: ["tasks"] });
+    render(
+      <ModuleVisibilityProvider>
+        <RailModules />
+      </ModuleVisibilityProvider>,
+    );
+    expect(screen.queryByText("Tasks")).toBeNull();
+    expect(screen.getByText("Schedule")).toBeTruthy();
+    expect(screen.getByText("Messages")).toBeTruthy();
+  });
+
+  it("shows minimized modules as not-pressed (un-barred)", () => {
+    seed({ minimized: ["tasks"] });
+    render(
+      <ModuleVisibilityProvider>
+        <RailModules />
+      </ModuleVisibilityProvider>,
+    );
+    expect(
+      screen.getByText("Tasks").closest("button")!.getAttribute("aria-pressed"),
+    ).toBe("false");
+    expect(
+      screen.getByText("Schedule").closest("button")!.getAttribute("aria-pressed"),
+    ).toBe("true");
+  });
+
+  it("renders the all-hidden hint when every module is hidden", () => {
+    seed({ hidden: ["week", "tasks", "messages"] });
+    render(
+      <ModuleVisibilityProvider>
+        <RailModules />
+      </ModuleVisibilityProvider>,
+    );
+    expect(screen.getByText(/All modules hidden/i)).toBeTruthy();
+  });
+
+  it("clicking a module toggles it minimized and persists to module prefs", () => {
     render(
       <ModuleVisibilityProvider>
         <RailModules />
@@ -40,11 +104,25 @@ describe("RailModules", () => {
 
     fireEvent.click(tasks);
     expect(tasks.getAttribute("aria-pressed")).toBe("false"); // minimized
-
-    const raw = window.localStorage.getItem("rokki:dash-minimized-modules");
-    expect(raw ? JSON.parse(raw) : []).toContain("tasks");
+    expect(readPrefs().minimized).toContain("tasks");
 
     fireEvent.click(tasks); // back open
     expect(tasks.getAttribute("aria-pressed")).toBe("true");
+    expect(readPrefs().minimized).not.toContain("tasks");
+  });
+
+  it("migrates legacy minimized storage on first load", () => {
+    window.localStorage.setItem(
+      "rokki:dash-minimized-modules",
+      JSON.stringify(["messages"]),
+    );
+    render(
+      <ModuleVisibilityProvider>
+        <RailModules />
+      </ModuleVisibilityProvider>,
+    );
+    expect(
+      screen.getByText("Messages").closest("button")!.getAttribute("aria-pressed"),
+    ).toBe("false");
   });
 });

--- a/apps/web/src/components/dashboard/RailModules.tsx
+++ b/apps/web/src/components/dashboard/RailModules.tsx
@@ -1,38 +1,40 @@
 "use client";
 
 import { cn } from "@/lib/utils";
-import { useModuleVisibility, DASH_MODULES } from "./module-visibility";
+import { useModulePrefs } from "./module-visibility";
 
 /**
  * The explorer rail's "Modules" list. Minimal by design: each module is
  * just its name, conforming to the spaces rows (same indent/padding), and
  * the ONLY adornment is a far-right accent bar marking an *open* module.
- * No icon, no count, no bold — the bar is the single signal. Clicking a
- * row toggles the module open/minimized in the dashboard viewing area.
+ * Clicking a row toggles the module open/minimized in the dashboard.
  *
- * Renders nothing when there's no dashboard host (no ModuleVisibility
- * provider) — e.g. the rail shown inside a terminal.
+ * The list, its order, and which modules appear are all driven by the
+ * user's module prefs (the gear in the MODULES header) — `visibleModules`
+ * is already ordered (#2) and excludes hidden ones (#1/#8).
+ *
+ * Renders nothing when there's no ModulePrefs provider (e.g. the rail
+ * shown inside a terminal).
  */
 export function RailModules() {
-  const vis = useModuleVisibility();
-  if (!vis) return null;
+  const ctx = useModulePrefs();
+  if (!ctx) return null;
+  const { visibleModules, isMinimized, toggle } = ctx;
   return (
     <ul className="space-y-0.5 pl-[var(--rk-rail-indent)] text-xs">
-      {DASH_MODULES.map((m) => {
-        const open = !vis.isMinimized(m.id);
+      {visibleModules.map((m) => {
+        const open = !isMinimized(m.id);
         return (
           <li key={m.id}>
             <button
               type="button"
-              onClick={() => vis.toggle(m.id)}
+              onClick={() => toggle(m.id)}
               aria-pressed={open}
               title={open ? `Minimize ${m.label}` : `Open ${m.label}`}
               className="group flex w-full items-center gap-1 rounded-sm px-1 py-0.5 text-left text-text-1 hover:bg-bg-2 hover:text-text-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-focus"
             >
               {/* Empty chevron column so module names line up with the
-                  space NAMES (not the arrows). h-3.5/w-3.5 = 14px to match
-                  the space chevron button, now that width/height carry the
-                  3.5 step (tailwind.config `extend`). */}
+                  space NAMES (not the arrows). */}
               <span className="h-3.5 w-3.5 flex-shrink-0" aria-hidden="true" />
               <span className="flex-1 truncate text-xs">{m.label}</span>
               {/* far-right open indicator — the only color in the list */}
@@ -47,6 +49,11 @@ export function RailModules() {
           </li>
         );
       })}
+      {visibleModules.length === 0 ? (
+        <li className="px-1 py-1 text-2xs text-text-3">
+          All modules hidden — add them back in module settings.
+        </li>
+      ) : null}
     </ul>
   );
 }

--- a/apps/web/src/components/dashboard/module-visibility.test.tsx
+++ b/apps/web/src/components/dashboard/module-visibility.test.tsx
@@ -1,0 +1,216 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  render,
+  screen,
+  cleanup,
+  fireEvent,
+  waitFor,
+} from "@testing-library/react";
+import {
+  ModuleVisibilityProvider,
+  useModulePrefs,
+  useModuleVisibility,
+} from "./module-visibility";
+import {
+  MODULE_PREFS_STORAGE_KEY,
+  LEGACY_MINIMIZED_KEY,
+  defaultModulePrefs,
+  type ModulePrefs,
+} from "@/lib/module-prefs";
+
+function seed(over: Partial<ModulePrefs>) {
+  window.localStorage.setItem(
+    MODULE_PREFS_STORAGE_KEY,
+    JSON.stringify({ ...defaultModulePrefs(), ...over }),
+  );
+}
+function readPrefs(): ModulePrefs {
+  return JSON.parse(window.localStorage.getItem(MODULE_PREFS_STORAGE_KEY)!);
+}
+
+function Probe() {
+  const ctx = useModulePrefs();
+  if (!ctx) return <div data-testid="no-ctx" />;
+  return (
+    <div>
+      <div data-testid="order">{ctx.prefs.order.join(",")}</div>
+      <div data-testid="hidden">{ctx.prefs.hidden.join(",")}</div>
+      <div data-testid="minimized">{ctx.prefs.minimized.join(",")}</div>
+      <div data-testid="layout">{ctx.prefs.layout}</div>
+      <div data-testid="collapsed">{String(ctx.prefs.sectionCollapsed)}</div>
+      <div data-testid="sync">{String(ctx.prefs.sync)}</div>
+      <button onClick={() => ctx.toggleHidden("tasks")}>hide</button>
+      <button onClick={() => ctx.move("messages", 0)}>move</button>
+      <button onClick={() => ctx.setSync(true)}>sync-on</button>
+      <button onClick={() => ctx.reset()}>reset</button>
+    </div>
+  );
+}
+
+function VisProbe() {
+  const vis = useModuleVisibility();
+  return <div data-testid="vis">{vis ? "has-vis" : "no-vis"}</div>;
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("ModulePrefs provider", () => {
+  it("useModulePrefs is null outside a provider", () => {
+    render(<Probe />);
+    expect(screen.getByTestId("no-ctx")).toBeTruthy();
+  });
+
+  it("useModuleVisibility is null outside a provider", () => {
+    render(<VisProbe />);
+    expect(screen.getByTestId("vis").textContent).toBe("no-vis");
+  });
+
+  it("useModuleVisibility is available inside a provider", () => {
+    render(
+      <ModuleVisibilityProvider>
+        <VisProbe />
+      </ModuleVisibilityProvider>,
+    );
+    expect(screen.getByTestId("vis").textContent).toBe("has-vis");
+  });
+
+  it("renders defaults with no stored prefs", () => {
+    render(
+      <ModuleVisibilityProvider>
+        <Probe />
+      </ModuleVisibilityProvider>,
+    );
+    expect(screen.getByTestId("order").textContent).toBe("week,tasks,messages");
+    expect(screen.getByTestId("layout").textContent).toBe("split");
+    expect(screen.getByTestId("sync").textContent).toBe("false");
+  });
+
+  it("hydrates from stored prefs", async () => {
+    seed({ order: ["messages", "tasks", "week"], layout: "stacked" });
+    render(
+      <ModuleVisibilityProvider>
+        <Probe />
+      </ModuleVisibilityProvider>,
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("order").textContent).toBe("messages,tasks,week"),
+    );
+    expect(screen.getByTestId("layout").textContent).toBe("stacked");
+  });
+
+  it("migrates the legacy minimized key", async () => {
+    window.localStorage.setItem(
+      LEGACY_MINIMIZED_KEY,
+      JSON.stringify(["tasks"]),
+    );
+    render(
+      <ModuleVisibilityProvider>
+        <Probe />
+      </ModuleVisibilityProvider>,
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("minimized").textContent).toBe("tasks"),
+    );
+  });
+
+  it("persists a hide to localStorage", () => {
+    render(
+      <ModuleVisibilityProvider>
+        <Probe />
+      </ModuleVisibilityProvider>,
+    );
+    fireEvent.click(screen.getByText("hide"));
+    expect(readPrefs().hidden).toEqual(["tasks"]);
+  });
+
+  it("persists a reorder to localStorage", () => {
+    render(
+      <ModuleVisibilityProvider>
+        <Probe />
+      </ModuleVisibilityProvider>,
+    );
+    fireEvent.click(screen.getByText("move"));
+    expect(readPrefs().order).toEqual(["messages", "week", "tasks"]);
+  });
+
+  it("reset restores defaults but keeps sync", async () => {
+    seed({ hidden: ["tasks"], layout: "stacked", sync: true });
+    render(
+      <ModuleVisibilityProvider>
+        <Probe />
+      </ModuleVisibilityProvider>,
+    );
+    await waitFor(() => expect(screen.getByTestId("hidden").textContent).toBe("tasks"));
+    fireEvent.click(screen.getByText("reset"));
+    expect(screen.getByTestId("hidden").textContent).toBe("");
+    expect(screen.getByTestId("layout").textContent).toBe("split");
+    expect(screen.getByTestId("sync").textContent).toBe("true");
+  });
+
+  it("pulls server prefs when sync is on (GET /api/v1/me)", async () => {
+    seed({ sync: true });
+    const fetchMock = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            data: {
+              preferences: {
+                modules: {
+                  order: ["tasks", "week", "messages"],
+                  hidden: [],
+                  minimized: [],
+                  layout: "stacked",
+                  sectionCollapsed: false,
+                  sync: true,
+                },
+              },
+            },
+          }),
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    render(
+      <ModuleVisibilityProvider>
+        <Probe />
+      </ModuleVisibilityProvider>,
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("layout").textContent).toBe("stacked"),
+    );
+    expect(fetchMock).toHaveBeenCalled();
+    expect((fetchMock.mock.calls[0][0] as string)).toContain("/api/v1/me");
+  });
+
+  it("pushes prefs to the server when sync is enabled (PATCH /api/v1/me)", async () => {
+    const fetchMock = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ data: { preferences: {} } }),
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    render(
+      <ModuleVisibilityProvider>
+        <Probe />
+      </ModuleVisibilityProvider>,
+    );
+    fireEvent.click(screen.getByText("sync-on"));
+    await waitFor(
+      () =>
+        expect(
+          fetchMock.mock.calls.some(
+            (c) => (c[1] as RequestInit | undefined)?.method === "PATCH",
+          ),
+        ).toBe(true),
+      { timeout: 2000 },
+    );
+  });
+});

--- a/apps/web/src/components/dashboard/module-visibility.test.tsx
+++ b/apps/web/src/components/dashboard/module-visibility.test.tsx
@@ -156,7 +156,7 @@ describe("ModulePrefs provider", () => {
 
   it("pulls server prefs when sync is on (GET /api/v1/me)", async () => {
     seed({ sync: true });
-    const fetchMock = vi.fn(() =>
+    const fetchMock = vi.fn((_url: string, _opts?: RequestInit) =>
       Promise.resolve({
         ok: true,
         json: () =>
@@ -190,7 +190,7 @@ describe("ModulePrefs provider", () => {
   });
 
   it("pushes prefs to the server when sync is enabled (PATCH /api/v1/me)", async () => {
-    const fetchMock = vi.fn(() =>
+    const fetchMock = vi.fn((_url: string, _opts?: RequestInit) =>
       Promise.resolve({
         ok: true,
         json: () => Promise.resolve({ data: { preferences: {} } }),

--- a/apps/web/src/components/dashboard/module-visibility.tsx
+++ b/apps/web/src/components/dashboard/module-visibility.tsx
@@ -2,25 +2,208 @@
 
 import {
   createContext,
+  useCallback,
   useContext,
   useEffect,
+  useMemo,
+  useRef,
   useState,
   type ReactNode,
 } from "react";
+import {
+  MODULE_CATALOG,
+  MODULE_PREFS_STORAGE_KEY,
+  LEGACY_MINIMIZED_KEY,
+  defaultModulePrefs,
+  normalizeModulePrefs,
+  parseModulePrefs,
+  migrateLegacyMinimized,
+  serializeModulePrefs,
+  modulePrefsEqual,
+  orderedVisibleModules,
+  hiddenModules as selectHiddenModules,
+  hideModule as pHide,
+  showModule as pShow,
+  setModuleHidden as pSetHidden,
+  toggleModuleHidden as pToggleHidden,
+  moveModule as pMove,
+  moveModuleBy as pMoveBy,
+  toggleModuleMinimized as pToggleMin,
+  setModuleOpenByDefault as pSetOpen,
+  setLayoutPreset as pSetLayout,
+  setSectionCollapsed as pSetCollapsed,
+  setSync as pSetSync,
+  resetModulePrefs as pReset,
+  type ModulePrefs,
+  type ModuleCatalogItem,
+  type DashLayoutPreset,
+} from "@/lib/module-prefs";
 
 /**
- * Shared "which dashboard modules are minimized" state, so the explorer
- * rail's Modules list and the DashboardPanels viewing area stay in sync:
+ * Provider for the dashboard's MODULES shelf preferences — what the
+ * "Modules settings" gear edits, plus the live minimized/open state shared
+ * between the explorer rail's Modules list and the DashboardPanels viewing
+ * area. The pure model lives in `lib/module-prefs.ts`; this file is the
+ * React + persistence wiring.
  *
- *   - Minimize a panel (the – in its header) → it leaves the viewing
- *     area and shows un-barred (minimized) in the rail's Modules list.
- *   - Click a module in the rail → it toggles back open into the panels.
+ * Persistence: per-device in localStorage by default. When the user turns
+ * on "Sync across devices" (#7), prefs also round-trip through
+ * `profiles.preferences.modules` via `PATCH /api/v1/me` (no migration — the
+ * preferences jsonb + deep-merge already exist).
  *
- * Persisted per-device, like the rest of the dashboard layout. The
- * context is null outside the provider so the rail can hide its Modules
+ * The context is null outside the provider so the rail can hide its Modules
  * section when it isn't hosting a dashboard (e.g. inside a terminal).
  */
-const KEY = "rokki:dash-minimized-modules";
+export interface ModulePrefsContextValue {
+  prefs: ModulePrefs;
+
+  /* visibility — back-compat surface used by RailModules + DashboardPanels */
+  minimized: Set<string>;
+  isMinimized: (id: string) => boolean;
+  toggle: (id: string) => void;
+
+  /* rich setters (the settings panel) */
+  setHidden: (id: string, hidden: boolean) => void;
+  toggleHidden: (id: string) => void;
+  move: (id: string, toIndex: number) => void;
+  moveBy: (id: string, delta: number) => void;
+  setOpenByDefault: (id: string, open: boolean) => void;
+  setLayout: (layout: DashLayoutPreset) => void;
+  setSectionCollapsed: (collapsed: boolean) => void;
+  setSync: (sync: boolean) => void;
+  reset: () => void;
+
+  /* derived selectors */
+  visibleModules: ModuleCatalogItem[];
+  hiddenModules: ModuleCatalogItem[];
+}
+
+const Ctx = createContext<ModulePrefsContextValue | null>(null);
+
+export function ModulePrefsProvider({ children }: { children: ReactNode }) {
+  const [prefs, setPrefs] = useState<ModulePrefs>(() => defaultModulePrefs());
+  const [hydrated, setHydrated] = useState(false);
+  const pulledFromServer = useRef(false);
+  const lastPushed = useRef<string>("");
+
+  // Hydrate from localStorage (with one-time migration off the legacy
+  // minimized-only key) after mount, SSR-safe.
+  useEffect(() => {
+    let next: ModulePrefs | null = null;
+    try {
+      const raw = window.localStorage.getItem(MODULE_PREFS_STORAGE_KEY);
+      if (raw) {
+        next = parseModulePrefs(JSON.parse(raw));
+      } else {
+        const legacy = window.localStorage.getItem(LEGACY_MINIMIZED_KEY);
+        if (legacy) {
+          next = normalizeModulePrefs(migrateLegacyMinimized(JSON.parse(legacy)));
+        }
+      }
+    } catch {
+      /* fall back to defaults */
+    }
+    if (next) setPrefs(next);
+    setHydrated(true);
+  }, []);
+
+  // Persist to localStorage on every change (also the offline cache when
+  // sync is on).
+  useEffect(() => {
+    if (!hydrated) return;
+    try {
+      window.localStorage.setItem(
+        MODULE_PREFS_STORAGE_KEY,
+        JSON.stringify(serializeModulePrefs(prefs)),
+      );
+    } catch {
+      /* non-fatal */
+    }
+  }, [prefs, hydrated]);
+
+  // Sync ON → pull the server copy once, and treat it as authoritative.
+  useEffect(() => {
+    if (!hydrated || !prefs.sync || pulledFromServer.current) return;
+    pulledFromServer.current = true;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const res = await fetch("/api/v1/me", { credentials: "include" });
+        if (!res.ok) return;
+        const body = (await res.json()) as {
+          data?: { preferences?: { modules?: unknown } };
+        };
+        const remote = body.data?.preferences?.modules;
+        if (remote && !cancelled) {
+          const server = { ...parseModulePrefs(remote), sync: true };
+          setPrefs((cur) => (modulePrefsEqual(cur, server) ? cur : server));
+        }
+      } catch {
+        /* offline — keep local */
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [hydrated, prefs.sync]);
+
+  // Sync ON → push prefs to the server (debounced) on change.
+  useEffect(() => {
+    if (!hydrated || !prefs.sync) return;
+    const payload = JSON.stringify(serializeModulePrefs(prefs));
+    if (payload === lastPushed.current) return;
+    const t = setTimeout(() => {
+      lastPushed.current = payload;
+      void fetch("/api/v1/me", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({ preferences: { modules: JSON.parse(payload) } }),
+      }).catch(() => {
+        // Reset so a later change retries the push.
+        lastPushed.current = "";
+      });
+    }, 600);
+    return () => clearTimeout(t);
+  }, [prefs, hydrated]);
+
+  const toggle = useCallback(
+    (id: string) => setPrefs((p) => pToggleMin(p, id)),
+    [],
+  );
+
+  const minimized = useMemo(() => new Set(prefs.minimized), [prefs.minimized]);
+
+  const value = useMemo<ModulePrefsContextValue>(
+    () => ({
+      prefs,
+      minimized,
+      isMinimized: (id) => minimized.has(id),
+      toggle,
+      setHidden: (id, hidden) => setPrefs((p) => pSetHidden(p, id, hidden)),
+      toggleHidden: (id) => setPrefs((p) => pToggleHidden(p, id)),
+      move: (id, toIndex) => setPrefs((p) => pMove(p, id, toIndex)),
+      moveBy: (id, delta) => setPrefs((p) => pMoveBy(p, id, delta)),
+      setOpenByDefault: (id, open) => setPrefs((p) => pSetOpen(p, id, open)),
+      setLayout: (layout) => setPrefs((p) => pSetLayout(p, layout)),
+      setSectionCollapsed: (c) => setPrefs((p) => pSetCollapsed(p, c)),
+      setSync: (s) => setPrefs((p) => pSetSync(p, s)),
+      reset: () => setPrefs((p) => pReset(p)),
+      visibleModules: orderedVisibleModules(prefs),
+      hiddenModules: selectHiddenModules(prefs),
+    }),
+    [prefs, minimized, toggle],
+  );
+
+  return <Ctx.Provider value={value}>{children}</Ctx.Provider>;
+}
+
+/** Full prefs context, or null outside a provider. */
+export function useModulePrefs(): ModulePrefsContextValue | null {
+  return useContext(Ctx);
+}
+
+/* ---- back-compat: the original visibility surface ------------------ */
 
 export interface ModuleVisibility {
   minimized: Set<string>;
@@ -28,66 +211,25 @@ export interface ModuleVisibility {
   isMinimized: (id: string) => boolean;
 }
 
-const ModuleVisibilityContext = createContext<ModuleVisibility | null>(null);
-
-export function ModuleVisibilityProvider({ children }: { children: ReactNode }) {
-  const [minimized, setMinimized] = useState<Set<string>>(() => new Set());
-  const [hydrated, setHydrated] = useState(false);
-
-  useEffect(() => {
-    try {
-      const raw = window.localStorage.getItem(KEY);
-      if (raw) {
-        const parsed = JSON.parse(raw) as unknown;
-        if (Array.isArray(parsed)) {
-          setMinimized(
-            new Set(parsed.filter((v): v is string => typeof v === "string")),
-          );
-        }
-      }
-    } catch {
-      /* default: nothing minimized */
-    }
-    setHydrated(true);
-  }, []);
-
-  useEffect(() => {
-    if (!hydrated) return;
-    try {
-      window.localStorage.setItem(KEY, JSON.stringify([...minimized]));
-    } catch {
-      /* non-fatal */
-    }
-  }, [minimized, hydrated]);
-
-  const value: ModuleVisibility = {
-    minimized,
-    isMinimized: (id) => minimized.has(id),
-    toggle: (id) =>
-      setMinimized((prev) => {
-        const next = new Set(prev);
-        next.has(id) ? next.delete(id) : next.add(id);
-        return next;
-      }),
-  };
-
-  return (
-    <ModuleVisibilityContext.Provider value={value}>
-      {children}
-    </ModuleVisibilityContext.Provider>
-  );
-}
-
-/** Returns the shared visibility controls, or null when not inside a
- *  ModuleVisibilityProvider (e.g. the rail rendered outside a dashboard). */
+/** Returns just the open/minimized controls, or null outside the provider.
+ *  Kept so DashboardPanels and existing tests don't need rewiring. */
 export function useModuleVisibility(): ModuleVisibility | null {
-  return useContext(ModuleVisibilityContext);
+  const ctx = useContext(Ctx);
+  if (!ctx) return null;
+  return {
+    minimized: ctx.minimized,
+    toggle: ctx.toggle,
+    isMinimized: ctx.isMinimized,
+  };
 }
 
-/** The dashboard's modules, in rail display order. id matches the
- *  DashboardPanels panel id; label is what the rail shows. */
-export const DASH_MODULES: { id: string; label: string }[] = [
-  { id: "week", label: "Schedule" },
-  { id: "tasks", label: "Tasks" },
-  { id: "messages", label: "Messages" },
-];
+/** Back-compat alias — the provider grew from "visibility" into full prefs,
+ *  but the mounted name in DashboardClient is unchanged. */
+export const ModuleVisibilityProvider = ModulePrefsProvider;
+
+/** The dashboard's modules, in catalog order. Retained for any consumer
+ *  that imported the old constant; prefer `useModulePrefs().visibleModules`
+ *  for the ordered, non-hidden list. */
+export const DASH_MODULES: { id: string; label: string }[] = MODULE_CATALOG.map(
+  (m) => ({ id: m.id, label: m.label }),
+);

--- a/apps/web/src/components/dashboard/module-visibility.tsx
+++ b/apps/web/src/components/dashboard/module-visibility.tsx
@@ -22,8 +22,6 @@ import {
   modulePrefsEqual,
   orderedVisibleModules,
   hiddenModules as selectHiddenModules,
-  hideModule as pHide,
-  showModule as pShow,
   setModuleHidden as pSetHidden,
   toggleModuleHidden as pToggleHidden,
   moveModule as pMove,

--- a/apps/web/src/lib/module-prefs.test.ts
+++ b/apps/web/src/lib/module-prefs.test.ts
@@ -1,0 +1,876 @@
+import { describe, it, expect } from "vitest";
+import {
+  MODULE_CATALOG,
+  MODULE_IDS,
+  MODULE_LABELS,
+  LAYOUT_PRESETS,
+  DEFAULT_LAYOUT,
+  defaultModulePrefs,
+  normalizeModulePrefs,
+  parseModulePrefs,
+  migrateLegacyMinimized,
+  activeModuleIds,
+  orderedVisibleModules,
+  hiddenModules,
+  isHidden,
+  isMinimized,
+  isOpenByDefault,
+  initialMinimized,
+  hideModule,
+  showModule,
+  setModuleHidden,
+  toggleModuleHidden,
+  moveModule,
+  moveModuleBy,
+  setModuleMinimized,
+  toggleModuleMinimized,
+  setModuleOpenByDefault,
+  setLayoutPreset,
+  setSectionCollapsed,
+  setSync,
+  resetModulePrefs,
+  presetToDashLayout,
+  dashLayoutForPrefs,
+  serializeModulePrefs,
+  modulePrefsEqual,
+  type ModulePrefs,
+} from "./module-prefs";
+
+const ID = { week: "week", tasks: "tasks", messages: "messages" } as const;
+
+function prefs(over: Partial<ModulePrefs> = {}): ModulePrefs {
+  return { ...defaultModulePrefs(), ...over };
+}
+
+/* ================================================================== */
+/* Catalog constants                                                   */
+/* ================================================================== */
+describe("module catalog constants", () => {
+  it("catalog has the three dashboard modules", () => {
+    expect(MODULE_CATALOG.map((m) => m.id)).toEqual(["week", "tasks", "messages"]);
+  });
+  it("MODULE_IDS mirrors the catalog ids", () => {
+    expect(MODULE_IDS).toEqual(["week", "tasks", "messages"]);
+  });
+  it("week is labelled Schedule", () => {
+    expect(MODULE_LABELS.week).toBe("Schedule");
+  });
+  it("tasks is labelled Tasks", () => {
+    expect(MODULE_LABELS.tasks).toBe("Tasks");
+  });
+  it("messages is labelled Messages", () => {
+    expect(MODULE_LABELS.messages).toBe("Messages");
+  });
+  it("layout presets are stacked + split", () => {
+    expect(LAYOUT_PRESETS).toEqual(["stacked", "split"]);
+  });
+  it("default layout is split", () => {
+    expect(DEFAULT_LAYOUT).toBe("split");
+  });
+});
+
+/* ================================================================== */
+/* defaultModulePrefs                                                  */
+/* ================================================================== */
+describe("defaultModulePrefs", () => {
+  it("order is the full catalog", () => {
+    expect(defaultModulePrefs().order).toEqual(["week", "tasks", "messages"]);
+  });
+  it("nothing hidden by default", () => {
+    expect(defaultModulePrefs().hidden).toEqual([]);
+  });
+  it("nothing minimized by default", () => {
+    expect(defaultModulePrefs().minimized).toEqual([]);
+  });
+  it("layout defaults to split", () => {
+    expect(defaultModulePrefs().layout).toBe("split");
+  });
+  it("section not collapsed by default", () => {
+    expect(defaultModulePrefs().sectionCollapsed).toBe(false);
+  });
+  it("sync off by default", () => {
+    expect(defaultModulePrefs().sync).toBe(false);
+  });
+  it("returns a fresh instance each call", () => {
+    expect(defaultModulePrefs()).not.toBe(defaultModulePrefs());
+  });
+  it("order array is not shared between instances", () => {
+    const a = defaultModulePrefs();
+    a.order.push("x");
+    expect(defaultModulePrefs().order).toEqual(["week", "tasks", "messages"]);
+  });
+});
+
+/* ================================================================== */
+/* normalizeModulePrefs                                                */
+/* ================================================================== */
+describe("normalizeModulePrefs", () => {
+  it("null → defaults", () => {
+    expect(normalizeModulePrefs(null)).toEqual(defaultModulePrefs());
+  });
+  it("undefined → defaults", () => {
+    expect(normalizeModulePrefs(undefined)).toEqual(defaultModulePrefs());
+  });
+  it("empty object → defaults", () => {
+    expect(normalizeModulePrefs({})).toEqual(defaultModulePrefs());
+  });
+  it("keeps a valid full order", () => {
+    expect(normalizeModulePrefs({ order: ["messages", "week", "tasks"] }).order).toEqual([
+      "messages",
+      "week",
+      "tasks",
+    ]);
+  });
+  it("appends missing ids in catalog order", () => {
+    expect(normalizeModulePrefs({ order: ["tasks"] }).order).toEqual([
+      "tasks",
+      "week",
+      "messages",
+    ]);
+  });
+  it("drops unknown ids from order", () => {
+    expect(normalizeModulePrefs({ order: ["tasks", "bogus", "week"] }).order).toEqual([
+      "tasks",
+      "week",
+      "messages",
+    ]);
+  });
+  it("dedupes order", () => {
+    expect(normalizeModulePrefs({ order: ["tasks", "tasks", "week"] }).order).toEqual([
+      "tasks",
+      "week",
+      "messages",
+    ]);
+  });
+  it("non-array order → default order", () => {
+    expect(normalizeModulePrefs({ order: "tasks" as never }).order).toEqual([
+      "week",
+      "tasks",
+      "messages",
+    ]);
+  });
+  it("non-string order entries are dropped", () => {
+    expect(normalizeModulePrefs({ order: [1, "tasks", null] as never }).order).toEqual([
+      "tasks",
+      "week",
+      "messages",
+    ]);
+  });
+  it("keeps known hidden ids", () => {
+    expect(normalizeModulePrefs({ hidden: ["messages"] }).hidden).toEqual(["messages"]);
+  });
+  it("drops unknown hidden ids", () => {
+    expect(normalizeModulePrefs({ hidden: ["bogus", "tasks"] }).hidden).toEqual(["tasks"]);
+  });
+  it("dedupes hidden", () => {
+    expect(normalizeModulePrefs({ hidden: ["tasks", "tasks"] }).hidden).toEqual(["tasks"]);
+  });
+  it("non-array hidden → empty", () => {
+    expect(normalizeModulePrefs({ hidden: 7 as never }).hidden).toEqual([]);
+  });
+  it("keeps known minimized ids", () => {
+    expect(normalizeModulePrefs({ minimized: ["week"] }).minimized).toEqual(["week"]);
+  });
+  it("strips minimized ids that are also hidden", () => {
+    const p = normalizeModulePrefs({ hidden: ["tasks"], minimized: ["tasks", "week"] });
+    expect(p.minimized).toEqual(["week"]);
+  });
+  it("drops unknown minimized ids", () => {
+    expect(normalizeModulePrefs({ minimized: ["nope", "week"] }).minimized).toEqual(["week"]);
+  });
+  it("accepts stacked layout", () => {
+    expect(normalizeModulePrefs({ layout: "stacked" }).layout).toBe("stacked");
+  });
+  it("accepts split layout", () => {
+    expect(normalizeModulePrefs({ layout: "split" }).layout).toBe("split");
+  });
+  it("invalid layout → default split", () => {
+    expect(normalizeModulePrefs({ layout: "grid" as never }).layout).toBe("split");
+  });
+  it("coerces sectionCollapsed truthy-but-not-true to false", () => {
+    expect(normalizeModulePrefs({ sectionCollapsed: 1 as never }).sectionCollapsed).toBe(false);
+  });
+  it("keeps sectionCollapsed true", () => {
+    expect(normalizeModulePrefs({ sectionCollapsed: true }).sectionCollapsed).toBe(true);
+  });
+  it("coerces sync non-true to false", () => {
+    expect(normalizeModulePrefs({ sync: "yes" as never }).sync).toBe(false);
+  });
+  it("keeps sync true", () => {
+    expect(normalizeModulePrefs({ sync: true }).sync).toBe(true);
+  });
+  it("is idempotent", () => {
+    const once = normalizeModulePrefs({ order: ["tasks"], hidden: ["week"] });
+    expect(normalizeModulePrefs(once)).toEqual(once);
+  });
+  it("custom id set restricts known ids", () => {
+    expect(normalizeModulePrefs({ order: ["a", "b"] }, ["a", "b"]).order).toEqual(["a", "b"]);
+  });
+  it("custom id set drops ids outside it", () => {
+    expect(normalizeModulePrefs({ order: ["a", "tasks"] }, ["a"]).order).toEqual(["a"]);
+  });
+});
+
+/* ================================================================== */
+/* parseModulePrefs / migrateLegacyMinimized                           */
+/* ================================================================== */
+describe("parseModulePrefs", () => {
+  it("parses a valid object", () => {
+    expect(parseModulePrefs({ layout: "stacked" }).layout).toBe("stacked");
+  });
+  it("array input → defaults", () => {
+    expect(parseModulePrefs(["week"])).toEqual(defaultModulePrefs());
+  });
+  it("null → defaults", () => {
+    expect(parseModulePrefs(null)).toEqual(defaultModulePrefs());
+  });
+  it("string → defaults", () => {
+    expect(parseModulePrefs("hi")).toEqual(defaultModulePrefs());
+  });
+  it("number → defaults", () => {
+    expect(parseModulePrefs(42)).toEqual(defaultModulePrefs());
+  });
+  it("normalizes while parsing", () => {
+    expect(parseModulePrefs({ order: ["tasks"] }).order).toEqual(["tasks", "week", "messages"]);
+  });
+});
+
+describe("migrateLegacyMinimized", () => {
+  it("array of ids → minimized patch", () => {
+    expect(migrateLegacyMinimized(["tasks", "week"])).toEqual({ minimized: ["tasks", "week"] });
+  });
+  it("filters non-strings", () => {
+    expect(migrateLegacyMinimized(["tasks", 3, null])).toEqual({ minimized: ["tasks"] });
+  });
+  it("empty array → empty minimized", () => {
+    expect(migrateLegacyMinimized([])).toEqual({ minimized: [] });
+  });
+  it("non-array → empty patch", () => {
+    expect(migrateLegacyMinimized(null)).toEqual({});
+  });
+  it("object → empty patch", () => {
+    expect(migrateLegacyMinimized({ minimized: ["x"] })).toEqual({});
+  });
+  it("migrated patch normalizes into valid prefs", () => {
+    const patch = migrateLegacyMinimized(["tasks", "ghost"]);
+    expect(normalizeModulePrefs(patch).minimized).toEqual(["tasks"]);
+  });
+});
+
+/* ================================================================== */
+/* activeModuleIds / orderedVisibleModules / hiddenModules             */
+/* ================================================================== */
+describe("activeModuleIds", () => {
+  it("all three by default", () => {
+    expect(activeModuleIds(defaultModulePrefs())).toEqual(["week", "tasks", "messages"]);
+  });
+  it("respects order", () => {
+    expect(activeModuleIds(prefs({ order: ["messages", "tasks", "week"] }))).toEqual([
+      "messages",
+      "tasks",
+      "week",
+    ]);
+  });
+  it("excludes hidden", () => {
+    expect(activeModuleIds(prefs({ hidden: ["tasks"] }))).toEqual(["week", "messages"]);
+  });
+  it("excludes multiple hidden", () => {
+    expect(activeModuleIds(prefs({ hidden: ["week", "messages"] }))).toEqual(["tasks"]);
+  });
+  it("all hidden → empty", () => {
+    expect(activeModuleIds(prefs({ hidden: ["week", "tasks", "messages"] }))).toEqual([]);
+  });
+  it("hidden + reordered", () => {
+    expect(
+      activeModuleIds(prefs({ order: ["messages", "tasks", "week"], hidden: ["tasks"] })),
+    ).toEqual(["messages", "week"]);
+  });
+  it("ignores unknown ids in order", () => {
+    expect(activeModuleIds(prefs({ order: ["tasks", "x", "week", "messages"] }))).toEqual([
+      "tasks",
+      "week",
+      "messages",
+    ]);
+  });
+});
+
+describe("orderedVisibleModules", () => {
+  it("returns catalog items in order", () => {
+    expect(orderedVisibleModules(defaultModulePrefs()).map((m) => m.id)).toEqual([
+      "week",
+      "tasks",
+      "messages",
+    ]);
+  });
+  it("carries labels", () => {
+    expect(orderedVisibleModules(defaultModulePrefs())[0].label).toBe("Schedule");
+  });
+  it("drops hidden modules", () => {
+    expect(orderedVisibleModules(prefs({ hidden: ["week"] })).map((m) => m.id)).toEqual([
+      "tasks",
+      "messages",
+    ]);
+  });
+  it("reorders", () => {
+    expect(
+      orderedVisibleModules(prefs({ order: ["tasks", "messages", "week"] })).map((m) => m.id),
+    ).toEqual(["tasks", "messages", "week"]);
+  });
+  it("empty when all hidden", () => {
+    expect(orderedVisibleModules(prefs({ hidden: ["week", "tasks", "messages"] }))).toEqual([]);
+  });
+});
+
+describe("hiddenModules", () => {
+  it("empty by default", () => {
+    expect(hiddenModules(defaultModulePrefs())).toEqual([]);
+  });
+  it("lists hidden items", () => {
+    expect(hiddenModules(prefs({ hidden: ["tasks"] })).map((m) => m.id)).toEqual(["tasks"]);
+  });
+  it("uses catalog order, not pref order", () => {
+    expect(
+      hiddenModules(prefs({ order: ["messages", "tasks", "week"], hidden: ["messages", "week"] })).map(
+        (m) => m.id,
+      ),
+    ).toEqual(["week", "messages"]);
+  });
+  it("all when everything hidden", () => {
+    expect(hiddenModules(prefs({ hidden: ["week", "tasks", "messages"] })).length).toBe(3);
+  });
+});
+
+/* ================================================================== */
+/* predicates                                                          */
+/* ================================================================== */
+describe("isHidden / isMinimized / isOpenByDefault", () => {
+  it("isHidden false by default", () => {
+    expect(isHidden(defaultModulePrefs(), "tasks")).toBe(false);
+  });
+  it("isHidden true when hidden", () => {
+    expect(isHidden(prefs({ hidden: ["tasks"] }), "tasks")).toBe(true);
+  });
+  it("isMinimized false by default", () => {
+    expect(isMinimized(defaultModulePrefs(), "tasks")).toBe(false);
+  });
+  it("isMinimized true when minimized", () => {
+    expect(isMinimized(prefs({ minimized: ["tasks"] }), "tasks")).toBe(true);
+  });
+  it("isOpenByDefault true by default", () => {
+    expect(isOpenByDefault(defaultModulePrefs(), "tasks")).toBe(true);
+  });
+  it("isOpenByDefault false when minimized", () => {
+    expect(isOpenByDefault(prefs({ minimized: ["tasks"] }), "tasks")).toBe(false);
+  });
+  it("isOpenByDefault false when hidden", () => {
+    expect(isOpenByDefault(prefs({ hidden: ["tasks"] }), "tasks")).toBe(false);
+  });
+  it("isOpenByDefault false when hidden and minimized", () => {
+    expect(isOpenByDefault(prefs({ hidden: ["tasks"], minimized: ["tasks"] }), "tasks")).toBe(false);
+  });
+});
+
+describe("initialMinimized", () => {
+  it("empty by default", () => {
+    expect(initialMinimized(defaultModulePrefs())).toEqual([]);
+  });
+  it("returns minimized active ids", () => {
+    expect(initialMinimized(prefs({ minimized: ["week", "tasks"] }))).toEqual(["week", "tasks"]);
+  });
+  it("excludes minimized ids that are hidden", () => {
+    // normalize first to mimic real state; even unnormalized, hidden wins.
+    expect(initialMinimized(prefs({ hidden: ["week"], minimized: ["week", "tasks"] }))).toEqual([
+      "tasks",
+    ]);
+  });
+  it("excludes unknown ids", () => {
+    expect(initialMinimized(prefs({ minimized: ["ghost", "tasks"] }))).toEqual(["tasks"]);
+  });
+});
+
+/* ================================================================== */
+/* hide / show                                                         */
+/* ================================================================== */
+describe("hideModule / showModule / setModuleHidden / toggleModuleHidden", () => {
+  it("hideModule adds to hidden", () => {
+    expect(hideModule(defaultModulePrefs(), "tasks").hidden).toEqual(["tasks"]);
+  });
+  it("hideModule is a no-op when already hidden", () => {
+    const p = prefs({ hidden: ["tasks"] });
+    expect(hideModule(p, "tasks")).toBe(p);
+  });
+  it("hideModule clears the module's minimized flag", () => {
+    const p = prefs({ minimized: ["tasks", "week"] });
+    expect(hideModule(p, "tasks").minimized).toEqual(["week"]);
+  });
+  it("hideModule ignores unknown ids", () => {
+    const p = defaultModulePrefs();
+    expect(hideModule(p, "ghost")).toBe(p);
+  });
+  it("hideModule does not mutate input", () => {
+    const p = defaultModulePrefs();
+    hideModule(p, "tasks");
+    expect(p.hidden).toEqual([]);
+  });
+  it("hideModule preserves order", () => {
+    expect(hideModule(prefs({ order: ["messages", "week", "tasks"] }), "week").order).toEqual([
+      "messages",
+      "week",
+      "tasks",
+    ]);
+  });
+  it("showModule removes from hidden", () => {
+    expect(showModule(prefs({ hidden: ["tasks"] }), "tasks").hidden).toEqual([]);
+  });
+  it("showModule no-op when not hidden", () => {
+    const p = defaultModulePrefs();
+    expect(showModule(p, "tasks")).toBe(p);
+  });
+  it("showModule leaves other hidden intact", () => {
+    expect(showModule(prefs({ hidden: ["tasks", "week"] }), "tasks").hidden).toEqual(["week"]);
+  });
+  it("setModuleHidden(true) hides", () => {
+    expect(isHidden(setModuleHidden(defaultModulePrefs(), "week", true), "week")).toBe(true);
+  });
+  it("setModuleHidden(false) shows", () => {
+    expect(isHidden(setModuleHidden(prefs({ hidden: ["week"] }), "week", false), "week")).toBe(false);
+  });
+  it("toggleModuleHidden flips false→true", () => {
+    expect(isHidden(toggleModuleHidden(defaultModulePrefs(), "week"), "week")).toBe(true);
+  });
+  it("toggleModuleHidden flips true→false", () => {
+    expect(isHidden(toggleModuleHidden(prefs({ hidden: ["week"] }), "week"), "week")).toBe(false);
+  });
+  it("toggle twice returns to start", () => {
+    const once = toggleModuleHidden(defaultModulePrefs(), "tasks");
+    expect(toggleModuleHidden(once, "tasks").hidden).toEqual([]);
+  });
+});
+
+/* ================================================================== */
+/* reorder                                                             */
+/* ================================================================== */
+describe("moveModule", () => {
+  it("moves to the front", () => {
+    expect(moveModule(defaultModulePrefs(), "messages", 0).order).toEqual([
+      "messages",
+      "week",
+      "tasks",
+    ]);
+  });
+  it("moves to the end", () => {
+    expect(moveModule(defaultModulePrefs(), "week", 2).order).toEqual(["tasks", "messages", "week"]);
+  });
+  it("moves to the middle", () => {
+    expect(moveModule(defaultModulePrefs(), "week", 1).order).toEqual(["tasks", "week", "messages"]);
+  });
+  it("clamps a negative index to 0", () => {
+    expect(moveModule(defaultModulePrefs(), "messages", -5).order).toEqual([
+      "messages",
+      "week",
+      "tasks",
+    ]);
+  });
+  it("clamps an over-large index to the end", () => {
+    expect(moveModule(defaultModulePrefs(), "week", 99).order).toEqual(["tasks", "messages", "week"]);
+  });
+  it("truncates fractional indices", () => {
+    expect(moveModule(defaultModulePrefs(), "messages", 0.9).order).toEqual([
+      "messages",
+      "week",
+      "tasks",
+    ]);
+  });
+  it("unknown id is a no-op (same reference)", () => {
+    const p = defaultModulePrefs();
+    expect(moveModule(p, "ghost", 0)).toBe(p);
+  });
+  it("moving to its own position is a no-op (same reference)", () => {
+    const p = defaultModulePrefs();
+    expect(moveModule(p, "week", 0)).toBe(p);
+  });
+  it("does not mutate the input order", () => {
+    const p = defaultModulePrefs();
+    moveModule(p, "week", 2);
+    expect(p.order).toEqual(["week", "tasks", "messages"]);
+  });
+  it("preserves hidden/minimized/layout", () => {
+    const p = prefs({ hidden: ["tasks"], minimized: ["week"], layout: "stacked" });
+    const moved = moveModule(p, "messages", 0);
+    expect(moved.hidden).toEqual(["tasks"]);
+    expect(moved.minimized).toEqual(["week"]);
+    expect(moved.layout).toBe("stacked");
+  });
+});
+
+describe("moveModuleBy", () => {
+  it("moves down by one", () => {
+    expect(moveModuleBy(defaultModulePrefs(), "week", 1).order).toEqual([
+      "tasks",
+      "week",
+      "messages",
+    ]);
+  });
+  it("moves up by one", () => {
+    expect(moveModuleBy(defaultModulePrefs(), "messages", -1).order).toEqual([
+      "week",
+      "messages",
+      "tasks",
+    ]);
+  });
+  it("moves down by two", () => {
+    expect(moveModuleBy(defaultModulePrefs(), "week", 2).order).toEqual([
+      "tasks",
+      "messages",
+      "week",
+    ]);
+  });
+  it("moving the first up is a no-op", () => {
+    const p = defaultModulePrefs();
+    expect(moveModuleBy(p, "week", -1)).toBe(p);
+  });
+  it("moving the last down is a no-op", () => {
+    const p = defaultModulePrefs();
+    expect(moveModuleBy(p, "messages", 1)).toBe(p);
+  });
+  it("over-shooting down clamps to no-op", () => {
+    const p = defaultModulePrefs();
+    expect(moveModuleBy(p, "tasks", 5)).toBe(p);
+  });
+  it("over-shooting up clamps to no-op", () => {
+    const p = defaultModulePrefs();
+    expect(moveModuleBy(p, "tasks", -5)).toBe(p);
+  });
+  it("delta 0 is a no-op", () => {
+    const p = defaultModulePrefs();
+    expect(moveModuleBy(p, "tasks", 0)).toBe(p);
+  });
+  it("unknown id is a no-op", () => {
+    const p = defaultModulePrefs();
+    expect(moveModuleBy(p, "ghost", 1)).toBe(p);
+  });
+  it("up then down returns to start", () => {
+    const down = moveModuleBy(defaultModulePrefs(), "week", 1);
+    expect(moveModuleBy(down, "week", -1).order).toEqual(["week", "tasks", "messages"]);
+  });
+});
+
+/* ================================================================== */
+/* minimize / open-by-default                                          */
+/* ================================================================== */
+describe("setModuleMinimized / toggle / openByDefault", () => {
+  it("minimizes a module", () => {
+    expect(setModuleMinimized(defaultModulePrefs(), "tasks", true).minimized).toEqual(["tasks"]);
+  });
+  it("un-minimizes a module", () => {
+    expect(setModuleMinimized(prefs({ minimized: ["tasks"] }), "tasks", false).minimized).toEqual([]);
+  });
+  it("minimize is a no-op when already minimized", () => {
+    const p = prefs({ minimized: ["tasks"] });
+    expect(setModuleMinimized(p, "tasks", true)).toBe(p);
+  });
+  it("un-minimize is a no-op when already open", () => {
+    const p = defaultModulePrefs();
+    expect(setModuleMinimized(p, "tasks", false)).toBe(p);
+  });
+  it("minimize is a no-op for a hidden module", () => {
+    const p = prefs({ hidden: ["tasks"] });
+    expect(setModuleMinimized(p, "tasks", true)).toBe(p);
+  });
+  it("minimize ignores unknown ids", () => {
+    const p = defaultModulePrefs();
+    expect(setModuleMinimized(p, "ghost", true)).toBe(p);
+  });
+  it("does not mutate input", () => {
+    const p = defaultModulePrefs();
+    setModuleMinimized(p, "tasks", true);
+    expect(p.minimized).toEqual([]);
+  });
+  it("toggle minimizes an open module", () => {
+    expect(toggleModuleMinimized(defaultModulePrefs(), "week").minimized).toEqual(["week"]);
+  });
+  it("toggle opens a minimized module", () => {
+    expect(toggleModuleMinimized(prefs({ minimized: ["week"] }), "week").minimized).toEqual([]);
+  });
+  it("toggle twice is identity on contents", () => {
+    const once = toggleModuleMinimized(defaultModulePrefs(), "messages");
+    expect(toggleModuleMinimized(once, "messages").minimized).toEqual([]);
+  });
+  it("setModuleOpenByDefault(false) minimizes", () => {
+    expect(isMinimized(setModuleOpenByDefault(defaultModulePrefs(), "tasks", false), "tasks")).toBe(
+      true,
+    );
+  });
+  it("setModuleOpenByDefault(true) un-minimizes", () => {
+    expect(
+      isMinimized(setModuleOpenByDefault(prefs({ minimized: ["tasks"] }), "tasks", true), "tasks"),
+    ).toBe(false);
+  });
+  it("open-by-default is consistent with predicate", () => {
+    const p = setModuleOpenByDefault(defaultModulePrefs(), "tasks", false);
+    expect(isOpenByDefault(p, "tasks")).toBe(false);
+  });
+});
+
+/* ================================================================== */
+/* layout / section / sync                                             */
+/* ================================================================== */
+describe("setLayoutPreset", () => {
+  it("sets stacked", () => {
+    expect(setLayoutPreset(defaultModulePrefs(), "stacked").layout).toBe("stacked");
+  });
+  it("sets split", () => {
+    expect(setLayoutPreset(prefs({ layout: "stacked" }), "split").layout).toBe("split");
+  });
+  it("same value is a no-op (same reference)", () => {
+    const p = defaultModulePrefs();
+    expect(setLayoutPreset(p, "split")).toBe(p);
+  });
+  it("invalid value is a no-op", () => {
+    const p = defaultModulePrefs();
+    expect(setLayoutPreset(p, "grid" as never)).toBe(p);
+  });
+  it("does not mutate input", () => {
+    const p = defaultModulePrefs();
+    setLayoutPreset(p, "stacked");
+    expect(p.layout).toBe("split");
+  });
+});
+
+describe("setSectionCollapsed", () => {
+  it("collapses", () => {
+    expect(setSectionCollapsed(defaultModulePrefs(), true).sectionCollapsed).toBe(true);
+  });
+  it("expands", () => {
+    expect(setSectionCollapsed(prefs({ sectionCollapsed: true }), false).sectionCollapsed).toBe(false);
+  });
+  it("no-op when unchanged", () => {
+    const p = defaultModulePrefs();
+    expect(setSectionCollapsed(p, false)).toBe(p);
+  });
+});
+
+describe("setSync", () => {
+  it("enables sync", () => {
+    expect(setSync(defaultModulePrefs(), true).sync).toBe(true);
+  });
+  it("disables sync", () => {
+    expect(setSync(prefs({ sync: true }), false).sync).toBe(false);
+  });
+  it("no-op when unchanged", () => {
+    const p = defaultModulePrefs();
+    expect(setSync(p, false)).toBe(p);
+  });
+});
+
+/* ================================================================== */
+/* reset                                                               */
+/* ================================================================== */
+describe("resetModulePrefs", () => {
+  it("with no arg returns defaults", () => {
+    expect(resetModulePrefs()).toEqual(defaultModulePrefs());
+  });
+  it("clears order/hidden/minimized/layout/collapse", () => {
+    const messy = prefs({
+      order: ["messages", "tasks", "week"],
+      hidden: ["tasks"],
+      minimized: ["week"],
+      layout: "stacked",
+      sectionCollapsed: true,
+    });
+    const reset = resetModulePrefs(messy);
+    expect(reset.order).toEqual(["week", "tasks", "messages"]);
+    expect(reset.hidden).toEqual([]);
+    expect(reset.minimized).toEqual([]);
+    expect(reset.layout).toBe("split");
+    expect(reset.sectionCollapsed).toBe(false);
+  });
+  it("preserves sync by default", () => {
+    expect(resetModulePrefs(prefs({ sync: true })).sync).toBe(true);
+  });
+  it("can drop sync when keepSync=false", () => {
+    expect(resetModulePrefs(prefs({ sync: true }), { keepSync: false }).sync).toBe(false);
+  });
+  it("does not mutate the previous prefs", () => {
+    const messy = prefs({ hidden: ["tasks"] });
+    resetModulePrefs(messy);
+    expect(messy.hidden).toEqual(["tasks"]);
+  });
+});
+
+/* ================================================================== */
+/* layout mapping                                                      */
+/* ================================================================== */
+describe("presetToDashLayout", () => {
+  it("stacked puts everything in center", () => {
+    expect(presetToDashLayout("stacked", ["week", "tasks", "messages"])).toEqual({
+      center: ["week", "tasks", "messages"],
+      right: [],
+    });
+  });
+  it("stacked of one", () => {
+    expect(presetToDashLayout("stacked", ["tasks"])).toEqual({ center: ["tasks"], right: [] });
+  });
+  it("stacked of none", () => {
+    expect(presetToDashLayout("stacked", [])).toEqual({ center: [], right: [] });
+  });
+  it("split of three matches the default layout", () => {
+    expect(presetToDashLayout("split", ["week", "tasks", "messages"])).toEqual({
+      center: ["week", "tasks"],
+      right: ["messages"],
+    });
+  });
+  it("split of two", () => {
+    expect(presetToDashLayout("split", ["week", "tasks"])).toEqual({
+      center: ["week"],
+      right: ["tasks"],
+    });
+  });
+  it("split of four", () => {
+    expect(presetToDashLayout("split", ["a", "b", "c", "d"])).toEqual({
+      center: ["a", "b"],
+      right: ["c", "d"],
+    });
+  });
+  it("split of one keeps it in center", () => {
+    expect(presetToDashLayout("split", ["tasks"])).toEqual({ center: ["tasks"], right: [] });
+  });
+  it("split of none", () => {
+    expect(presetToDashLayout("split", [])).toEqual({ center: [], right: [] });
+  });
+  it("does not share the input array", () => {
+    const ids = ["week", "tasks"];
+    const out = presetToDashLayout("stacked", ids);
+    out.center.push("x");
+    expect(ids).toEqual(["week", "tasks"]);
+  });
+});
+
+describe("dashLayoutForPrefs", () => {
+  it("default prefs → split of all three", () => {
+    expect(dashLayoutForPrefs(defaultModulePrefs())).toEqual({
+      center: ["week", "tasks"],
+      right: ["messages"],
+    });
+  });
+  it("stacked layout", () => {
+    expect(dashLayoutForPrefs(prefs({ layout: "stacked" }))).toEqual({
+      center: ["week", "tasks", "messages"],
+      right: [],
+    });
+  });
+  it("hidden module drops out of the layout", () => {
+    expect(dashLayoutForPrefs(prefs({ hidden: ["messages"] }))).toEqual({
+      center: ["week"],
+      right: ["tasks"],
+    });
+  });
+  it("reorder changes the columns", () => {
+    expect(dashLayoutForPrefs(prefs({ order: ["messages", "tasks", "week"] }))).toEqual({
+      center: ["messages", "tasks"],
+      right: ["week"],
+    });
+  });
+});
+
+/* ================================================================== */
+/* serialize / equality                                                */
+/* ================================================================== */
+describe("serializeModulePrefs", () => {
+  it("returns a normalized object", () => {
+    expect(serializeModulePrefs(prefs({ order: ["tasks"] })).order).toEqual([
+      "tasks",
+      "week",
+      "messages",
+    ]);
+  });
+  it("round-trips through JSON", () => {
+    const p = prefs({ hidden: ["tasks"], minimized: ["week"], layout: "stacked", sync: true });
+    const round = parseModulePrefs(JSON.parse(JSON.stringify(serializeModulePrefs(p))));
+    expect(modulePrefsEqual(round, p)).toBe(true);
+  });
+});
+
+describe("modulePrefsEqual", () => {
+  it("equal defaults", () => {
+    expect(modulePrefsEqual(defaultModulePrefs(), defaultModulePrefs())).toBe(true);
+  });
+  it("different order → not equal", () => {
+    expect(modulePrefsEqual(defaultModulePrefs(), prefs({ order: ["tasks", "week", "messages"] }))).toBe(
+      false,
+    );
+  });
+  it("hidden compared as a set (order-insensitive)", () => {
+    expect(
+      modulePrefsEqual(prefs({ hidden: ["week", "tasks"] }), prefs({ hidden: ["tasks", "week"] })),
+    ).toBe(true);
+  });
+  it("different hidden contents → not equal", () => {
+    expect(modulePrefsEqual(prefs({ hidden: ["week"] }), prefs({ hidden: ["tasks"] }))).toBe(false);
+  });
+  it("minimized order matters", () => {
+    expect(
+      modulePrefsEqual(prefs({ minimized: ["week", "tasks"] }), prefs({ minimized: ["tasks", "week"] })),
+    ).toBe(false);
+  });
+  it("different layout → not equal", () => {
+    expect(modulePrefsEqual(defaultModulePrefs(), prefs({ layout: "stacked" }))).toBe(false);
+  });
+  it("different sectionCollapsed → not equal", () => {
+    expect(modulePrefsEqual(defaultModulePrefs(), prefs({ sectionCollapsed: true }))).toBe(false);
+  });
+  it("different sync → not equal", () => {
+    expect(modulePrefsEqual(defaultModulePrefs(), prefs({ sync: true }))).toBe(false);
+  });
+  it("different hidden length → not equal", () => {
+    expect(modulePrefsEqual(prefs({ hidden: [] }), prefs({ hidden: ["week"] }))).toBe(false);
+  });
+});
+
+/* ================================================================== */
+/* integration-ish: realistic sequences                                */
+/* ================================================================== */
+describe("realistic sequences", () => {
+  it("hide then show restores active set", () => {
+    let p = defaultModulePrefs();
+    p = hideModule(p, "messages");
+    expect(activeModuleIds(p)).toEqual(["week", "tasks"]);
+    p = showModule(p, "messages");
+    expect(activeModuleIds(p)).toEqual(["week", "tasks", "messages"]);
+  });
+  it("reorder then hide keeps the new order on the rest", () => {
+    let p = moveModule(defaultModulePrefs(), "messages", 0);
+    p = hideModule(p, "week");
+    expect(activeModuleIds(p)).toEqual(["messages", "tasks"]);
+  });
+  it("minimize survives a reorder", () => {
+    let p = setModuleMinimized(defaultModulePrefs(), "tasks", true);
+    p = moveModule(p, "tasks", 0);
+    expect(isMinimized(p, "tasks")).toBe(true);
+    expect(p.order[0]).toBe("tasks");
+  });
+  it("hiding a minimized module clears minimized, showing it starts open", () => {
+    let p = setModuleMinimized(defaultModulePrefs(), "tasks", true);
+    p = hideModule(p, "tasks");
+    expect(isMinimized(p, "tasks")).toBe(false);
+    p = showModule(p, "tasks");
+    expect(isOpenByDefault(p, "tasks")).toBe(true);
+  });
+  it("reset after heavy customization returns to stock (keeping sync)", () => {
+    let p = defaultModulePrefs();
+    p = setSync(p, true);
+    p = hideModule(p, "messages");
+    p = moveModule(p, "tasks", 0);
+    p = setModuleMinimized(p, "week", true);
+    p = setLayoutPreset(p, "stacked");
+    p = setSectionCollapsed(p, true);
+    const reset = resetModulePrefs(p);
+    expect(reset).toEqual({ ...defaultModulePrefs(), sync: true });
+  });
+  it("layout reflects a hide + reorder + stacked sequence", () => {
+    let p = defaultModulePrefs();
+    p = setLayoutPreset(p, "stacked");
+    p = hideModule(p, "week");
+    expect(dashLayoutForPrefs(p)).toEqual({ center: ["tasks", "messages"], right: [] });
+  });
+});

--- a/apps/web/src/lib/module-prefs.test.ts
+++ b/apps/web/src/lib/module-prefs.test.ts
@@ -36,8 +36,6 @@ import {
   type ModulePrefs,
 } from "./module-prefs";
 
-const ID = { week: "week", tasks: "tasks", messages: "messages" } as const;
-
 function prefs(over: Partial<ModulePrefs> = {}): ModulePrefs {
   return { ...defaultModulePrefs(), ...over };
 }

--- a/apps/web/src/lib/module-prefs.ts
+++ b/apps/web/src/lib/module-prefs.ts
@@ -1,0 +1,434 @@
+/**
+ * Pure preferences model for the dashboard's MODULES shelf — the thing the
+ * "Modules settings" gear (in the explorer rail's MODULES header) edits.
+ *
+ * DOM-free and side-effect-free so it's exhaustively unit-testable; the
+ * React wiring (provider, localStorage, server sync) lives in
+ * components/dashboard/module-prefs.tsx, and the UI in ModuleSettings.tsx.
+ *
+ * The eight settings this model backs:
+ *   1. Show / hide each module          → `hidden`
+ *   2. Reorder modules                  → `order`
+ *   3. Open vs. minimized by default    → `minimized`
+ *   4. Reset to defaults                → resetModulePrefs()
+ *   5. Default layout (stacked/split)   → `layout` (+ presetToDashLayout)
+ *   6. Collapse MODULES section default → `sectionCollapsed`
+ *   7. Sync across devices              → `sync`
+ *   8. Add / remove from the catalog    → same `hidden` mechanism (a removed
+ *                                          module is hidden; re-add = un-hide)
+ */
+
+export interface ModuleCatalogItem {
+  id: string;
+  label: string;
+}
+
+/**
+ * The catalog of dashboard modules. The `id` matches the DashboardPanels
+ * panel id and the dashboard-layout panel id; `label` is what the rail and
+ * settings show. Grows over time (Goals, Files, …) — every consumer derives
+ * from this list, so adding one here is the only change needed.
+ */
+export const MODULE_CATALOG: readonly ModuleCatalogItem[] = [
+  { id: "week", label: "Schedule" },
+  { id: "tasks", label: "Tasks" },
+  { id: "messages", label: "Messages" },
+];
+
+export const MODULE_IDS: readonly string[] = MODULE_CATALOG.map((m) => m.id);
+
+export const MODULE_LABELS: Readonly<Record<string, string>> = Object.fromEntries(
+  MODULE_CATALOG.map((m) => [m.id, m.label]),
+);
+
+/** Default panel arrangement applied on load (setting #5). */
+export type DashLayoutPreset = "stacked" | "split";
+export const LAYOUT_PRESETS: readonly DashLayoutPreset[] = ["stacked", "split"];
+
+export interface ModulePrefs {
+  /** Display order — drives the rail list and the default panel order (#2). */
+  order: string[];
+  /** Modules removed from the shelf: not in the rail or the panels (#1/#8). */
+  hidden: string[];
+  /** Modules that start minimized (parked in the rail) rather than open (#3).
+   *  Also the live minimized state — toggling persists, so it *is* the
+   *  per-device default for the next load. */
+  minimized: string[];
+  /** Default two-column arrangement (#5). */
+  layout: DashLayoutPreset;
+  /** Start the rail's MODULES section collapsed (#6). */
+  sectionCollapsed: boolean;
+  /** Persist server-side (profiles.preferences.modules) vs. per-device (#7). */
+  sync: boolean;
+}
+
+export const MODULE_PREFS_STORAGE_KEY = "rokki:module-prefs";
+/** Pre-#43 key: a bare array of minimized ids. Migrated on first load. */
+export const LEGACY_MINIMIZED_KEY = "rokki:dash-minimized-modules";
+
+export const DEFAULT_LAYOUT: DashLayoutPreset = "split";
+
+/** A fresh defaults object. Returns a new instance each call (no shared
+ *  mutable arrays), so callers can safely mutate the result. */
+export function defaultModulePrefs(): ModulePrefs {
+  return {
+    order: [...MODULE_IDS],
+    hidden: [],
+    minimized: [],
+    layout: DEFAULT_LAYOUT,
+    sectionCollapsed: false,
+    sync: false,
+  };
+}
+
+/* ------------------------------------------------------------------ */
+/* Normalization                                                       */
+/* ------------------------------------------------------------------ */
+
+function cleanIds(
+  input: unknown,
+  known: Set<string>,
+  seen: Set<string>,
+): string[] {
+  if (!Array.isArray(input)) return [];
+  const out: string[] = [];
+  for (const x of input) {
+    if (typeof x === "string" && known.has(x) && !seen.has(x)) {
+      seen.add(x);
+      out.push(x);
+    }
+  }
+  return out;
+}
+
+/**
+ * Coerce a possibly-stale / partial / untrusted prefs object into a valid
+ * one:
+ *   - `order` is deduped, stripped of unknown ids, and any known id that's
+ *     missing is appended in catalog order (a newly-added module never
+ *     silently disappears);
+ *   - `hidden` is the subset of known ids;
+ *   - `minimized` is the subset of known ids, minus anything hidden (a
+ *     hidden module isn't meaningfully "minimized");
+ *   - `layout` is a valid preset or the default;
+ *   - the booleans are real booleans.
+ */
+export function normalizeModulePrefs(
+  input: Partial<ModulePrefs> | null | undefined,
+  ids: readonly string[] = MODULE_IDS,
+): ModulePrefs {
+  const known = new Set(ids);
+
+  const orderSeen = new Set<string>();
+  const order = cleanIds(input?.order, known, orderSeen);
+  for (const id of ids) if (!orderSeen.has(id)) order.push(id);
+
+  const hidden = cleanIds(input?.hidden, known, new Set<string>());
+  const hiddenSet = new Set(hidden);
+
+  const minimized = cleanIds(input?.minimized, known, new Set<string>()).filter(
+    (id) => !hiddenSet.has(id),
+  );
+
+  const layout: DashLayoutPreset =
+    input?.layout === "stacked" || input?.layout === "split"
+      ? input.layout
+      : DEFAULT_LAYOUT;
+
+  return {
+    order,
+    hidden,
+    minimized,
+    layout,
+    sectionCollapsed: input?.sectionCollapsed === true,
+    sync: input?.sync === true,
+  };
+}
+
+/** Parse an unknown blob (localStorage / server JSON) into valid prefs. */
+export function parseModulePrefs(
+  raw: unknown,
+  ids: readonly string[] = MODULE_IDS,
+): ModulePrefs {
+  if (raw && typeof raw === "object" && !Array.isArray(raw)) {
+    return normalizeModulePrefs(raw as Partial<ModulePrefs>, ids);
+  }
+  return normalizeModulePrefs(null, ids);
+}
+
+/** Extract a partial prefs patch from the legacy minimized-only storage
+ *  (a bare array of ids), for one-time migration. */
+export function migrateLegacyMinimized(raw: unknown): Partial<ModulePrefs> {
+  if (Array.isArray(raw)) {
+    return {
+      minimized: raw.filter((x): x is string => typeof x === "string"),
+    };
+  }
+  return {};
+}
+
+/* ------------------------------------------------------------------ */
+/* Selectors                                                           */
+/* ------------------------------------------------------------------ */
+
+/** Ordered ids of modules that are NOT hidden — the rail/panel set. */
+export function activeModuleIds(
+  prefs: ModulePrefs,
+  ids: readonly string[] = MODULE_IDS,
+): string[] {
+  const known = new Set(ids);
+  const hidden = new Set(prefs.hidden);
+  return prefs.order.filter((id) => known.has(id) && !hidden.has(id));
+}
+
+/** Catalog items for the visible modules, in display order. */
+export function orderedVisibleModules(
+  prefs: ModulePrefs,
+  catalog: readonly ModuleCatalogItem[] = MODULE_CATALOG,
+): ModuleCatalogItem[] {
+  const byId = new Map(catalog.map((m) => [m.id, m]));
+  return activeModuleIds(
+    prefs,
+    catalog.map((m) => m.id),
+  )
+    .map((id) => byId.get(id))
+    .filter((m): m is ModuleCatalogItem => !!m);
+}
+
+/** Catalog items that are currently hidden — the "add back" tray (#8). */
+export function hiddenModules(
+  prefs: ModulePrefs,
+  catalog: readonly ModuleCatalogItem[] = MODULE_CATALOG,
+): ModuleCatalogItem[] {
+  const hidden = new Set(prefs.hidden);
+  // Catalog order, not `order`, so the tray is stable.
+  return catalog.filter((m) => hidden.has(m.id));
+}
+
+export function isHidden(prefs: ModulePrefs, id: string): boolean {
+  return prefs.hidden.includes(id);
+}
+
+export function isMinimized(prefs: ModulePrefs, id: string): boolean {
+  return prefs.minimized.includes(id);
+}
+
+/** A module is "open by default" when it's neither hidden nor minimized. */
+export function isOpenByDefault(prefs: ModulePrefs, id: string): boolean {
+  return !prefs.hidden.includes(id) && !prefs.minimized.includes(id);
+}
+
+/** Ids that should be minimized on load — the live minimized set, scoped to
+ *  modules that are actually active (a hidden module isn't minimized). */
+export function initialMinimized(
+  prefs: ModulePrefs,
+  ids: readonly string[] = MODULE_IDS,
+): string[] {
+  const active = new Set(activeModuleIds(prefs, ids));
+  return prefs.minimized.filter((id) => active.has(id));
+}
+
+/* ------------------------------------------------------------------ */
+/* Mutators (pure — each returns a new prefs object)                   */
+/* ------------------------------------------------------------------ */
+
+/** #1/#8 — hide a module (remove from the shelf). Also clears its minimized
+ *  flag, since a hidden module has no live state. No-op if already hidden. */
+export function hideModule(prefs: ModulePrefs, id: string): ModulePrefs {
+  if (!MODULE_IDS.includes(id) || prefs.hidden.includes(id)) return prefs;
+  return {
+    ...prefs,
+    hidden: [...prefs.hidden, id],
+    minimized: prefs.minimized.filter((m) => m !== id),
+  };
+}
+
+/** #1/#8 — show a module (return it to the shelf). No-op if already shown. */
+export function showModule(prefs: ModulePrefs, id: string): ModulePrefs {
+  if (!prefs.hidden.includes(id)) return prefs;
+  return { ...prefs, hidden: prefs.hidden.filter((h) => h !== id) };
+}
+
+export function setModuleHidden(
+  prefs: ModulePrefs,
+  id: string,
+  hidden: boolean,
+): ModulePrefs {
+  return hidden ? hideModule(prefs, id) : showModule(prefs, id);
+}
+
+export function toggleModuleHidden(prefs: ModulePrefs, id: string): ModulePrefs {
+  return setModuleHidden(prefs, id, !isHidden(prefs, id));
+}
+
+/**
+ * #2 — move `id` so it lands at `toIndex` among the other modules (i.e. the
+ * insertion index AFTER the module has been pulled out of its current spot).
+ * Index is clamped to the valid range. No-op for an unknown id.
+ */
+export function moveModule(
+  prefs: ModulePrefs,
+  id: string,
+  toIndex: number,
+): ModulePrefs {
+  const cur = prefs.order.indexOf(id);
+  if (cur < 0) return prefs;
+  const order = [...prefs.order];
+  order.splice(cur, 1);
+  const idx = Math.max(0, Math.min(Math.trunc(toIndex), order.length));
+  order.splice(idx, 0, id);
+  // No-op guard: if nothing changed, keep the same reference.
+  if (order.every((v, i) => v === prefs.order[i])) return prefs;
+  return { ...prefs, order };
+}
+
+/** #2 — nudge a module up (delta<0) or down (delta>0) by N slots. Clamped:
+ *  nudging the first module up (or the last down) is a no-op. */
+export function moveModuleBy(
+  prefs: ModulePrefs,
+  id: string,
+  delta: number,
+): ModulePrefs {
+  const cur = prefs.order.indexOf(id);
+  if (cur < 0) return prefs;
+  const target = cur + Math.trunc(delta);
+  if (target < 0 || target >= prefs.order.length) return prefs;
+  return moveModule(prefs, id, target);
+}
+
+/** #3 — set a module's minimized (parked) state. No-op for hidden ids. */
+export function setModuleMinimized(
+  prefs: ModulePrefs,
+  id: string,
+  minimized: boolean,
+): ModulePrefs {
+  if (!MODULE_IDS.includes(id) || prefs.hidden.includes(id)) return prefs;
+  const has = prefs.minimized.includes(id);
+  if (minimized && !has) {
+    return { ...prefs, minimized: [...prefs.minimized, id] };
+  }
+  if (!minimized && has) {
+    return { ...prefs, minimized: prefs.minimized.filter((m) => m !== id) };
+  }
+  return prefs;
+}
+
+export function toggleModuleMinimized(
+  prefs: ModulePrefs,
+  id: string,
+): ModulePrefs {
+  return setModuleMinimized(prefs, id, !isMinimized(prefs, id));
+}
+
+/** #3 — "open by default" is the inverse of minimized. */
+export function setModuleOpenByDefault(
+  prefs: ModulePrefs,
+  id: string,
+  open: boolean,
+): ModulePrefs {
+  return setModuleMinimized(prefs, id, !open);
+}
+
+/** #5 — choose the default layout preset. */
+export function setLayoutPreset(
+  prefs: ModulePrefs,
+  layout: DashLayoutPreset,
+): ModulePrefs {
+  if (layout !== "stacked" && layout !== "split") return prefs;
+  if (prefs.layout === layout) return prefs;
+  return { ...prefs, layout };
+}
+
+/** #6 — collapse/expand the MODULES rail section by default. */
+export function setSectionCollapsed(
+  prefs: ModulePrefs,
+  collapsed: boolean,
+): ModulePrefs {
+  if (prefs.sectionCollapsed === collapsed) return prefs;
+  return { ...prefs, sectionCollapsed: collapsed };
+}
+
+/** #7 — toggle cross-device sync. */
+export function setSync(prefs: ModulePrefs, sync: boolean): ModulePrefs {
+  if (prefs.sync === sync) return prefs;
+  return { ...prefs, sync };
+}
+
+/** #4 — reset to defaults. Preserves the sync choice by default (resetting
+ *  your layout shouldn't silently disconnect you from your other devices). */
+export function resetModulePrefs(
+  prev?: ModulePrefs,
+  opts: { keepSync?: boolean } = { keepSync: true },
+): ModulePrefs {
+  const base = defaultModulePrefs();
+  if (prev && opts.keepSync) base.sync = prev.sync;
+  return base;
+}
+
+/* ------------------------------------------------------------------ */
+/* Layout mapping (#5)                                                 */
+/* ------------------------------------------------------------------ */
+
+export interface DashLayoutColumns {
+  center: string[];
+  right: string[];
+}
+
+/**
+ * Map a layout preset + the active (ordered, visible) module ids to the
+ * two-column DashLayout the panels consume.
+ *   - "stacked" → everything in one (center) column, full width;
+ *   - "split"   → first half (rounded up) in center, the rest in the right
+ *                 column. For the default 3 modules that's
+ *                 center:[week,tasks], right:[messages].
+ */
+export function presetToDashLayout(
+  layout: DashLayoutPreset,
+  activeIds: string[],
+): DashLayoutColumns {
+  if (layout === "stacked") {
+    return { center: [...activeIds], right: [] };
+  }
+  const cut = Math.ceil(activeIds.length / 2);
+  return { center: activeIds.slice(0, cut), right: activeIds.slice(cut) };
+}
+
+/** Convenience: the DashLayout for a whole prefs object (#5 applied to the
+ *  current active set). */
+export function dashLayoutForPrefs(
+  prefs: ModulePrefs,
+  ids: readonly string[] = MODULE_IDS,
+): DashLayoutColumns {
+  return presetToDashLayout(prefs.layout, activeModuleIds(prefs, ids));
+}
+
+/* ------------------------------------------------------------------ */
+/* Serialization / sync helpers (#7)                                   */
+/* ------------------------------------------------------------------ */
+
+/** A normalized plain object safe to JSON-stringify for localStorage or the
+ *  server (profiles.preferences.modules). */
+export function serializeModulePrefs(prefs: ModulePrefs): ModulePrefs {
+  return normalizeModulePrefs(prefs);
+}
+
+/** True when two prefs objects are value-equal (order matters for `order`
+ *  and `minimized`, set-equality for `hidden`). Used to skip redundant
+ *  writes. */
+export function modulePrefsEqual(a: ModulePrefs, b: ModulePrefs): boolean {
+  const arrEq = (x: string[], y: string[]) =>
+    x.length === y.length && x.every((v, i) => v === y[i]);
+  const setEq = (x: string[], y: string[]) => {
+    if (x.length !== y.length) return false;
+    const s = new Set(x);
+    return y.every((v) => s.has(v));
+  };
+  return (
+    arrEq(a.order, b.order) &&
+    setEq(a.hidden, b.hidden) &&
+    arrEq(a.minimized, b.minimized) &&
+    a.layout === b.layout &&
+    a.sectionCollapsed === b.sectionCollapsed &&
+    a.sync === b.sync
+  );
+}


### PR DESCRIPTION
Adds a settings **gear** to the explorer rail's **MODULES** header (mirroring the per-space gear) → a per-user popover for the whole module shelf, with all eight settings you picked:

| # | Setting | |
|---|---|---|
| 1 | **Show / hide** each module | per-module eye-off + a "Hidden" tray to add back |
| 2 | **Reorder** | ↑/↓ per module (drives rail + default panel order) |
| 3 | **Open by default** | per-module "open" checkbox (unchecked = starts minimized) |
| 4 | **Reset to defaults** | one button (keeps your sync choice) |
| 5 | **Default layout** | Stacked / Split |
| 6 | **Collapse on load** | the MODULES section starts collapsed |
| 7 | **Sync across devices** | saves to your account |
| 8 | **Add / remove from catalog** | same show/hide mechanism; grows as modules are added |

### Architecture
- **Pure model** `lib/module-prefs.ts` — DOM-free, side-effect-free, exhaustively unit-tested.
- **Provider** — the existing `module-visibility.tsx` grown into the full prefs provider. Keeps every current import and the `useModuleVisibility` surface; adds `useModulePrefs`.
- **Sync (#7) needs no migration** — prefs round-trip through `profiles.preferences.modules` via the existing `PATCH /api/v1/me` deep-merge. Per-device localStorage otherwise; legacy minimized storage migrates on first load.
- `RailModules` renders the ordered, non-hidden list; `DashboardPanels` drops hidden modules and applies the layout preset on change; the section collapse is driven by prefs so the chevron and "Collapse on load" stay in sync.

### Tests — 223 for this feature
- **174** pure-model cases (normalize, reorder, hide/show, minimize, layout mapping, reset, serialize/equality, realistic sequences).
- Component tests: RailModules (order/hidden/minimize/migration), the settings popover (**every control**), and the provider (persistence, legacy migration, sync **GET + PATCH** round-trip).
- Full web suite **571 green**; typecheck / lint / build clean.

Per-user UI prefs only — no DB migration, no new API, no RLS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)