### PR TITLE
Signal integration Phase 0: spec + data model + bridge service scaffold

### DIFF
--- a/apps/signal-bridge/Dockerfile
+++ b/apps/signal-bridge/Dockerfile
@@ -1,0 +1,32 @@
+# Rokki Signal bridge — Node service + signal-cli (Java). Deploys standalone
+# (Fly.io). Build context is this directory; run `pnpm build` first locally OR
+# let the image build it. signal-cli is a Java app from AsamK/signal-cli.
+
+FROM node:20-bookworm-slim
+
+# Java runtime for signal-cli + tools to fetch it.
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends default-jre-headless ca-certificates wget \
+  && rm -rf /var/lib/apt/lists/*
+
+# Pin signal-cli. Bump as new releases land (it tracks the Signal protocol).
+ARG SIGNAL_CLI_VERSION=0.13.18
+RUN wget -q "https://github.com/AsamK/signal-cli/releases/download/v${SIGNAL_CLI_VERSION}/signal-cli-${SIGNAL_CLI_VERSION}.tar.gz" \
+  && tar xf "signal-cli-${SIGNAL_CLI_VERSION}.tar.gz" -C /opt \
+  && ln -sf "/opt/signal-cli-${SIGNAL_CLI_VERSION}/bin/signal-cli" /usr/local/bin/signal-cli \
+  && rm "signal-cli-${SIGNAL_CLI_VERSION}.tar.gz"
+
+WORKDIR /app
+RUN corepack enable && corepack prepare pnpm@9.12.0 --activate
+
+# Copy this package's manifests + source. (For a monorepo build you may prefer
+# to build dist/ in CI and COPY it in; this self-contained path keeps Phase-0
+# deploys simple.)
+COPY package.json tsconfig.json ./
+RUN pnpm install --no-frozen-lockfile
+COPY src ./src
+RUN pnpm build
+
+ENV PORT=8080
+EXPOSE 8080
+CMD ["node", "dist/index.js"]

--- a/apps/signal-bridge/README.md
+++ b/apps/signal-bridge/README.md
@@ -1,0 +1,66 @@
+# @rokki/signal-bridge
+
+Always-on service that bridges a user's **Signal** account into Rokki, via
+[`signal-cli`](https://github.com/AsamK/signal-cli). It links as a **secondary
+device** (like Signal Desktop), receives messages into Supabase
+(`signal_threads` / `signal_messages`), and sends on the user's behalf.
+
+> Messaging only. Signal **calls (audio/video) cannot be bridged** — there's no
+> API. See `docs/SIGNAL_INTEGRATION.md`. A/V/meetings are a separate
+> Rokki-native (LiveKit) track.
+
+This is the **Phase-0 skeleton**: structure + auth + DB writes are real; the
+exact `signal-cli` JSON envelope mapping (`toInbound`) gets validated against a
+live install during deploy.
+
+## Endpoints
+- `GET  /health` — liveness.
+- `POST /accounts/:userId/link` → `{ uri }` — start linking; render `uri` as a QR.
+- `POST /accounts/:userId/send` `{ signalNumber, signalId, kind, text }`.
+
+All non-health routes require header `x-bridge-secret: $BRIDGE_SECRET`.
+
+## Env
+| var | what |
+|---|---|
+| `BRIDGE_SECRET` | shared secret Rokki sends to authenticate to the bridge |
+| `SUPABASE_URL` | your Supabase project URL |
+| `SUPABASE_SERVICE_ROLE_KEY` | service role (bridge bypasses RLS to write on a user's behalf) |
+| `PORT` | default 8080 |
+| `SIGNAL_CLI_PATH` | default `signal-cli` |
+
+## Deploy to Fly.io (Zack — the one new account)
+```bash
+# 1. one-time: install flyctl + log in
+#    https://fly.io/docs/flyctl/install/
+fly auth login
+
+# 2. from apps/signal-bridge/
+fly launch --no-deploy            # creates the app from fly.toml (keep the name)
+fly volumes create signal_data --size 1 -r iad   # persistent signal-cli session
+
+# 3. secrets
+fly secrets set \
+  BRIDGE_SECRET="$(openssl rand -hex 32)" \
+  SUPABASE_URL="https://<prod-ref>.supabase.co" \
+  SUPABASE_SERVICE_ROLE_KEY="<service-role-key>"
+
+# 4. ship it
+fly deploy
+
+# 5. verify
+curl https://rokki-signal-bridge.fly.dev/health
+```
+
+Then Rokki (Messages → Connect Signal) calls `/accounts/:userId/link`, shows the
+QR, you scan it from **Signal app → Settings → Linked Devices**, and your
+threads start syncing.
+
+> Keep `BRIDGE_SECRET` and the service-role key in Fly secrets only — never in
+> the repo. The `signal-cli` session lives on the mounted volume; treat that host
+> as holding decrypted message plaintext (the inherent E2E-bridge tradeoff).
+
+## Local dev
+```bash
+pnpm --filter @rokki/signal-bridge dev   # needs signal-cli on PATH + the env vars
+```

--- a/apps/signal-bridge/fly.toml
+++ b/apps/signal-bridge/fly.toml
@@ -1,0 +1,23 @@
+app = "rokki-signal-bridge"
+primary_region = "iad"
+
+[build]
+  dockerfile = "Dockerfile"
+
+[env]
+  PORT = "8080"
+  SIGNAL_CLI_PATH = "signal-cli"
+
+# Always-on: the receive loop must keep running, so machines never auto-stop.
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = false
+  auto_start_machines = true
+  min_machines_running = 1
+
+# Persistent volume for signal-cli's account/session data so the linked device
+# survives restarts. Create with: fly volumes create signal_data --size 1
+[mounts]
+  source = "signal_data"
+  destination = "/root/.local/share/signal-cli"

--- a/apps/signal-bridge/package.json
+++ b/apps/signal-bridge/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@rokki/signal-bridge",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/index.js",
+    "typecheck": "tsc --noEmit",
+    "lint": "echo 'lint stub'",
+    "test": "echo 'tests pending'"
+  },
+  "dependencies": {
+    "@hono/node-server": "^1.13.1",
+    "@supabase/supabase-js": "^2.45.4",
+    "hono": "^4.6.3"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.0",
+    "tsx": "^4.19.1",
+    "typescript": "^5.6.3"
+  }
+}

--- a/apps/signal-bridge/src/index.ts
+++ b/apps/signal-bridge/src/index.ts
@@ -1,0 +1,217 @@
+import { serve } from "@hono/node-server";
+import { Hono } from "hono";
+import { spawn } from "node:child_process";
+import { createClient } from "@supabase/supabase-js";
+
+/**
+ * Rokki Signal bridge — Phase 0 skeleton. Wraps signal-cli to:
+ *   - link a user's Signal account as a secondary device,
+ *   - receive their messages into Supabase (signal_threads / signal_messages),
+ *   - send on their behalf.
+ *
+ * Deploys standalone on an always-on host (Fly.io), separate from the Vercel
+ * web app — see docs/SIGNAL_INTEGRATION.md and ./README.md. The structure,
+ * auth, and DB writes are real; the exact signal-cli JSON envelope mapping in
+ * `toInbound` is best-effort and gets validated against a live signal-cli as
+ * the Phase-0 acceptance step.
+ */
+
+const PORT = Number(process.env.PORT ?? 8080);
+const BRIDGE_SECRET = process.env.BRIDGE_SECRET ?? "";
+const SUPABASE_URL = process.env.SUPABASE_URL ?? "";
+const SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY ?? "";
+const SIGNAL_CLI = process.env.SIGNAL_CLI_PATH ?? "signal-cli";
+
+const db = createClient(SUPABASE_URL, SERVICE_KEY, {
+  auth: { autoRefreshToken: false, persistSession: false },
+});
+
+/** Run signal-cli to completion and resolve its stdout. */
+function runSignalCli(args: string[]): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn(SIGNAL_CLI, args);
+    let out = "";
+    let err = "";
+    proc.stdout.on("data", (d: Buffer) => {
+      out += d.toString();
+    });
+    proc.stderr.on("data", (d: Buffer) => {
+      err += d.toString();
+    });
+    proc.on("error", reject);
+    proc.on("close", (code) =>
+      code === 0 ? resolve(out) : reject(new Error(`signal-cli ${code}: ${err}`)),
+    );
+  });
+}
+
+/**
+ * Start `signal-cli link`: resolve with the `sgnl://linkdevice` URI as soon as
+ * it's printed (for the app to render as a QR), and keep the process alive
+ * until the phone completes the link — then flip the account to active.
+ */
+function startLink(userId: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn(SIGNAL_CLI, ["link", "-n", "Rokki"]);
+    let gotUri = false;
+    proc.stdout.on("data", (d: Buffer) => {
+      const m = d.toString().match(/sgnl:\/\/linkdevice\S+/);
+      if (m && !gotUri) {
+        gotUri = true;
+        resolve(m[0]);
+      }
+    });
+    proc.on("error", (e) => {
+      if (!gotUri) reject(e);
+    });
+    proc.on("close", (code) => {
+      if (code === 0) {
+        void db
+          .from("signal_accounts")
+          .update({ status: "active", linked_at: new Date().toISOString() })
+          .eq("user_id", userId);
+      } else if (!gotUri) {
+        reject(new Error(`link ended (${code}) before emitting a URI`));
+      }
+    });
+  });
+}
+
+interface InboundMessage {
+  userId: string;
+  signalId: string;
+  kind: "direct" | "group";
+  sender: string;
+  body: string;
+  externalId: string;
+  sentAt: string;
+}
+
+/** Upsert the thread and insert the inbound message. */
+async function writeInbound(m: InboundMessage): Promise<void> {
+  const { data: thread } = await db
+    .from("signal_threads")
+    .upsert(
+      {
+        user_id: m.userId,
+        signal_id: m.signalId,
+        kind: m.kind,
+        last_message_at: m.sentAt,
+      },
+      { onConflict: "user_id,signal_id" },
+    )
+    .select("id")
+    .single();
+  const threadId = (thread as { id: string } | null)?.id;
+  if (!threadId) return;
+  await db.from("signal_messages").insert({
+    thread_id: threadId,
+    user_id: m.userId,
+    external_id: m.externalId,
+    direction: "in",
+    sender: m.sender,
+    body: m.body,
+    sent_at: m.sentAt,
+  });
+}
+
+/** Map a signal-cli JSON receive event → InboundMessage (best-effort). */
+function toInbound(userId: string, evt: unknown): InboundMessage | null {
+  if (typeof evt !== "object" || evt === null) return null;
+  const env = (evt as { envelope?: unknown }).envelope;
+  if (typeof env !== "object" || env === null) return null;
+  const e = env as {
+    source?: string;
+    timestamp?: number;
+    dataMessage?: { message?: string; groupInfo?: { groupId?: string } };
+  };
+  const data = e.dataMessage;
+  if (!data || typeof data.message !== "string") return null;
+  const groupId = data.groupInfo?.groupId;
+  const ts = typeof e.timestamp === "number" ? e.timestamp : Date.now();
+  return {
+    userId,
+    signalId: groupId ?? e.source ?? "unknown",
+    kind: groupId ? "group" : "direct",
+    sender: e.source ?? "unknown",
+    body: data.message,
+    externalId: String(ts),
+    sentAt: new Date(ts).toISOString(),
+  };
+}
+
+/** Long-running receiver for one linked account. */
+function startReceiver(userId: string, number: string): void {
+  const proc = spawn(SIGNAL_CLI, ["-a", number, "-o", "json", "receive", "--timeout", "-1"]);
+  proc.stdout.on("data", (d: Buffer) => {
+    for (const line of d.toString().split("\n")) {
+      if (!line.trim()) continue;
+      try {
+        const inbound = toInbound(userId, JSON.parse(line) as unknown);
+        if (inbound) void writeInbound(inbound);
+      } catch {
+        // ignore non-JSON / unparseable lines
+      }
+    }
+  });
+  proc.on("error", () => {
+    // a real impl backs off + restarts; left to Phase-0 hardening
+  });
+}
+
+/** Start receivers for every already-active account on boot. */
+async function startReceiveLoops(): Promise<void> {
+  const { data } = await db
+    .from("signal_accounts")
+    .select("user_id, signal_number")
+    .eq("status", "active");
+  for (const a of (data ?? []) as { user_id: string; signal_number: string | null }[]) {
+    if (a.signal_number) startReceiver(a.user_id, a.signal_number);
+  }
+}
+
+const app = new Hono();
+
+app.use("*", async (c, next) => {
+  if (c.req.path === "/health") return next();
+  if (!BRIDGE_SECRET || c.req.header("x-bridge-secret") !== BRIDGE_SECRET) {
+    return c.json({ error: "unauthorized" }, 401);
+  }
+  return next();
+});
+
+app.get("/health", (c) => c.json({ ok: true, service: "signal-bridge" }));
+
+app.post("/accounts/:userId/link", async (c) => {
+  const userId = c.req.param("userId");
+  try {
+    await db.from("signal_accounts").upsert({ user_id: userId, status: "linking" });
+    const uri = await startLink(userId);
+    return c.json({ uri });
+  } catch (e) {
+    return c.json({ error: String(e) }, 500);
+  }
+});
+
+app.post("/accounts/:userId/send", async (c) => {
+  const body = (await c.req.json().catch(() => ({}))) as Partial<{
+    signalNumber: string;
+    signalId: string;
+    kind: "direct" | "group";
+    text: string;
+  }>;
+  if (!body.signalNumber || !body.signalId || !body.text) {
+    return c.json({ error: "signalNumber, signalId and text are required" }, 400);
+  }
+  const target = body.kind === "group" ? ["-g", body.signalId] : [body.signalId];
+  try {
+    await runSignalCli(["-a", body.signalNumber, "send", "-m", body.text, ...target]);
+    return c.json({ ok: true });
+  } catch (e) {
+    return c.json({ error: String(e) }, 500);
+  }
+});
+
+void startReceiveLoops();
+serve({ fetch: app.fetch, port: PORT });
+console.log(`signal-bridge listening on :${PORT}`);

--- a/apps/signal-bridge/tsconfig.json
+++ b/apps/signal-bridge/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "declaration": false,
+    "isolatedModules": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/docs/SIGNAL_INTEGRATION.md
+++ b/docs/SIGNAL_INTEGRATION.md
@@ -1,0 +1,195 @@
+# Signal integration — implementation instructions
+
+**Status:** Draft / scoping. Not yet built.
+**Goal (Zack):** a user links their own Signal account to Rokki and can send/receive
+personal messages and team messages from **either** the Signal app **or** Rokki.
+Meetings + audio/video are wanted "if possible."
+
+> [!IMPORTANT]
+> **Capability reality.** Signal can be bridged for **messaging only**. The bridge
+> tool (`signal-cli`) does text, attachments, voice *notes*, reactions, quotes,
+> mentions, and groups — bidirectionally. It **cannot** do voice/video **calls**:
+> Signal's calling is end-to-end WebRTC with no public API and no library support.
+> So **meetings / video / audio *through Signal* are out of scope** — there is no
+> technical path. A/V is covered as a **separate Rokki-native track** in §8.
+
+---
+
+## 1. What "sync Signal to Rokki" means
+
+`signal-cli` links to your existing account exactly like **Signal Desktop** — as a
+**secondary (linked) device**. Your phone stays the primary device. From the moment
+of linking, the bridge sees and can send on your account. Because it's a linked
+device, anything you send **from your phone app also appears in Rokki**, and anything
+you send **from Rokki appears on your phone** — bidirectional is inherent, no extra
+work.
+
+- "Personal messages" = your normal 1:1 Signal chats. ✅
+- "Messages to their team" = a Signal **group** (or 1:1s) with teammates **who are
+  also on Signal**. ✅  *(Signal can only message Signal users. Messaging your Rokki
+  team who are NOT on Signal stays in Rokki's own Messages module.)*
+
+---
+
+## 2. The one new piece of infrastructure
+
+Rokki is fully serverless today (Vercel + Supabase + Cloudflare + GitHub Actions).
+`signal-cli` must run **continuously** to receive messages, so this needs Rokki's
+first **always-on host**.
+
+- **Recommendation:** Fly.io (or Railway, or a small VM). ~$5/mo. Not Azure.
+- Run `signal-cli` in **JSON-RPC daemon mode** (`signal-cli -a <acct> jsonRpc` /
+  `daemon --http`) inside a small Node "Signal bridge" service.
+- This same host can later run the MCP server, so it's not Signal-only value.
+
+---
+
+## 3. Architecture
+
+```
+Phone Signal app ──(linked device)──┐
+                                     ▼
+   Rokki web ──HTTPS──► Signal bridge service (Fly.io, always-on)
+        ▲                    │  wraps signal-cli (JSON-RPC daemon)
+        │                    │  - receive loop  → writes to Supabase
+        │                    │  - send/commands ← called by Rokki API
+        └──Supabase realtime─┘  (Messages module shows it live)
+```
+
+- **Bridge ↔ Rokki auth:** the bridge exposes an internal API protected by a shared
+  service secret; per-message it acts on behalf of the owning user (account id).
+- **Inbound:** bridge receive loop → normalize → insert into Supabase → Supabase
+  realtime pushes to the Messages module (reuses existing realtime — no new stack).
+- **Outbound:** Rokki API → bridge → `signal-cli send`.
+- **Attachments:** bridge stores media via Rokki's existing file pipeline
+  (Supabase Storage), runs the existing virus scan, references the blob in the
+  message row.
+- **MCP parity (non-negotiable):** expose Signal tools on `apps/mcp-server`
+  (list threads, read, send) so the same actions work from Claude.
+
+---
+
+## 4. Data model (Supabase, new tables, RLS-scoped to the owner)
+
+```sql
+-- A user's linked Signal account (one per user for v1).
+CREATE TABLE signal_accounts (
+  user_id        UUID PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  signal_number  TEXT NOT NULL,             -- the account's E.164 number
+  device_id      INT,                       -- linked-device id from signal-cli
+  status         TEXT NOT NULL DEFAULT 'linking', -- linking|active|error|unlinked
+  -- signal-cli session/keys live on the bridge host, encrypted; we store only a
+  -- reference + status here, never raw keys in the app DB.
+  linked_at      TIMESTAMPTZ,
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- A Signal conversation (1:1 or group) mapped to a Rokki message thread.
+CREATE TABLE signal_threads (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id       UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  signal_id     TEXT NOT NULL,              -- recipient number OR group id
+  kind          TEXT NOT NULL,              -- 'direct' | 'group'
+  title         TEXT,                       -- contact name / group name
+  rokki_thread_id UUID,                     -- the Messages-module thread it feeds
+  terminal_id   UUID REFERENCES terminals(id), -- optional: pinned to a project (#7)
+  muted         BOOLEAN NOT NULL DEFAULT false,
+  sync_enabled  BOOLEAN NOT NULL DEFAULT true,
+  UNIQUE (user_id, signal_id)
+);
+
+-- Signal messages reuse the existing messages table with source='signal' so they
+-- flow through the Messages module unchanged. Add: source TEXT, external_id TEXT,
+-- signal_thread_id UUID. (Or a dedicated signal_messages table if cleaner.)
+```
+
+RLS: every row scoped to `user_id = auth.uid()` (a Signal account + its threads +
+messages are private to the owner, like a personal space).
+
+---
+
+## 5. Linking flow (the "sync" UX)
+
+1. User opens Messages → **Connect Signal**.
+2. Rokki calls the bridge → bridge runs `signal-cli link -n "Rokki"` → emits a
+   `sgnl://linkdevice?uuid=…&pub=…` URI.
+3. Rokki renders it as a **QR code** (+ copyable link).
+4. User opens **Signal app → Settings → Linked Devices → Link New Device** → scans.
+5. Bridge completes the link, records `device_id`, sets `status='active'`.
+6. Bridge does an initial **history backfill** (linked devices receive recent
+   history), then starts the receive loop.
+7. Threads appear in Messages.
+
+---
+
+## 6. Bidirectional messaging (the core build)
+
+Receive (bridge → Rokki): text, attachments, voice notes, reactions, quote-replies,
+mentions, read/typing receipts, edits, remote-deletes, disappearing-message timers
+(honor + auto-purge), group metadata.
+
+Send (Rokki → bridge → Signal): text, attachments, reactions, quote-replies,
+mentions, typing/read receipts, group actions (leave; add/remove where permitted).
+
+"Team" routing (your "messages to their team"):
+- Default: a Signal group with teammates behaves like any thread.
+- Optional value-add: **"share to a Rokki space/terminal"** — surface a Signal
+  message into a team thread so non-Signal teammates can see it. ⚠️ This exposes a
+  personal Signal message to a team space — make it explicit + opt-in per message.
+
+---
+
+## 7. Phased plan
+
+- **Phase 0 — host:** provision Fly.io, deploy the Signal bridge skeleton, prove
+  `signal-cli` links and receives for one account. *(the risky, novel part)*
+- **Phase 1 — receive + send text + attachments** for your own account, into the
+  Messages module. End-to-end for you.
+- **Phase 2 — fidelity:** reactions, quote-replies, edits, deletes, voice notes,
+  groups, typing/read, disappearing timers.
+- **Phase 3 — Rokki edge:** pin a thread to a Terminal, Signal-message→Task,
+  unified search, MCP tools (so it works from Claude), per-thread mute/sync, notifs.
+
+---
+
+## 8. Meetings + audio/video — separate, Rokki-native track
+
+Signal can't provide these (see the capability note). To get meetings + A/V chat in
+Rokki, build it natively with a **WebRTC** provider — independent of Signal:
+
+- **Recommended: LiveKit** (open-source SFU; self-host on the same always-on infra,
+  or LiveKit Cloud). Handles audio rooms, video, screen-share, recording.
+- Alternatives: Daily.co (fastest to embed), 100ms, Vonage. *(Avoid Twilio Video —
+  it was sunset end-2024.)*
+- Shape: a "Room" per terminal/meeting, join from the web app, presence + recording.
+- This is its own multi-week feature with TURN servers + a media host (more cost
+  than the Signal bridge). Decide separately.
+
+A realistic "meetings" middle-ground that **does** work with Signal: post a
+**meeting link** (Rokki room, Jitsi, Meet) into a Signal group from Rokki — i.e.,
+schedule/announce via Signal, hold the call in Rokki's own A/V.
+
+---
+
+## 9. Security & privacy (decide before building)
+
+- **E2E tradeoff:** to display Signal messages, the bridge decrypts them, so the
+  bridge host holds plaintext for synced threads. This is inherent to any bridge —
+  be explicit with users. Encrypt the `signal-cli` session/keys at rest on the host.
+- **Unofficial:** `signal-cli` is community-maintained on Signal's libraries; a
+  Signal protocol change can break it until patched. No SLA.
+- **Per-user isolation:** RLS + per-user bridge sessions; never cross accounts.
+- **Disappearing messages:** honor timers; don't let Rokki outlive the message.
+
+---
+
+## 10. Open decisions (need Zack)
+
+1. **A/V meetings:** build the separate LiveKit track, or just post Rokki/Jitsi/Meet
+   links into Signal for now?
+2. **"Team messaging":** Signal-group-with-teammates only, or also the opt-in
+   "share a Signal message into a Rokki space" bridge?
+3. **Host:** Fly.io (recommended) vs Railway vs VM.
+4. **Privacy stance on the E2E plaintext tradeoff** — acceptable for your use?
+5. **Scope:** just-you first, or multi-user from the start (multi-user = one live
+   `signal-cli` session per person → heavier ops)?

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,6 +101,28 @@ importers:
         specifier: ^5.6.3
         version: 5.9.3
 
+  apps/signal-bridge:
+    dependencies:
+      '@hono/node-server':
+        specifier: ^1.13.1
+        version: 1.19.14(hono@4.12.14)
+      '@supabase/supabase-js':
+        specifier: ^2.45.4
+        version: 2.103.3
+      hono:
+        specifier: ^4.6.3
+        version: 4.12.14
+    devDependencies:
+      '@types/node':
+        specifier: ^20.14.0
+        version: 20.19.41
+      tsx:
+        specifier: ^4.19.1
+        version: 4.21.0
+      typescript:
+        specifier: ^5.6.3
+        version: 5.9.3
+
   apps/tool-executor:
     dependencies:
       '@hono/node-server':
@@ -7707,7 +7729,7 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 20.19.39
+      '@types/node': 20.19.41
 
   '@typescript-eslint/eslint-plugin@8.58.2(@typescript-eslint/parser@8.58.2(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)':
     dependencies:

--- a/supabase/migrations/20260615130000_signal_integration.sql
+++ b/supabase/migrations/20260615130000_signal_integration.sql
@@ -1,0 +1,81 @@
+-- Signal integration — Phase 0 data model. See docs/SIGNAL_INTEGRATION.md.
+--
+-- A user links their own Signal account (as a secondary device, via the
+-- signal-bridge service) and their conversations/messages sync here. Every
+-- row is private to the owner (RLS), like a personal space. The bridge writes
+-- via the service role (bypasses RLS) on behalf of the linked user; the app
+-- reads under the user's own session. No FK into the existing messages tables
+-- yet — Signal data is self-contained for Phase 0.
+
+BEGIN;
+
+CREATE TABLE signal_accounts (
+  user_id       UUID PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  signal_number TEXT,
+  device_id     INT,
+  status        TEXT NOT NULL DEFAULT 'linking'
+                  CHECK (status IN ('linking', 'active', 'error', 'unlinked')),
+  linked_at     TIMESTAMPTZ,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE signal_threads (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id         UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  signal_id       TEXT NOT NULL,                 -- recipient number/uuid OR group id
+  kind            TEXT NOT NULL CHECK (kind IN ('direct', 'group')),
+  title           TEXT,
+  terminal_id     UUID REFERENCES terminals(id) ON DELETE SET NULL, -- optional pin
+  muted           BOOLEAN NOT NULL DEFAULT false,
+  sync_enabled    BOOLEAN NOT NULL DEFAULT true,
+  last_message_at TIMESTAMPTZ,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (user_id, signal_id)
+);
+
+CREATE INDEX signal_threads_recent_idx
+  ON signal_threads (user_id, last_message_at DESC);
+
+CREATE TABLE signal_messages (
+  id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  thread_id         UUID NOT NULL REFERENCES signal_threads(id) ON DELETE CASCADE,
+  user_id           UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  external_id       TEXT,                          -- signal-cli message timestamp/id
+  direction         TEXT NOT NULL CHECK (direction IN ('in', 'out')),
+  sender            TEXT,                          -- number/uuid of the sender
+  body              TEXT,
+  attachments       JSONB NOT NULL DEFAULT '[]'::jsonb,
+  reactions         JSONB NOT NULL DEFAULT '[]'::jsonb,
+  quote_external_id TEXT,
+  sent_at           TIMESTAMPTZ NOT NULL DEFAULT now(),
+  edited_at         TIMESTAMPTZ,
+  deleted_at        TIMESTAMPTZ,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX signal_messages_thread_idx
+  ON signal_messages (thread_id, sent_at);
+CREATE UNIQUE INDEX signal_messages_dedupe_idx
+  ON signal_messages (thread_id, external_id)
+  WHERE external_id IS NOT NULL;
+
+ALTER TABLE signal_accounts ENABLE ROW LEVEL SECURITY;
+ALTER TABLE signal_threads  ENABLE ROW LEVEL SECURITY;
+ALTER TABLE signal_messages ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "signal_accounts_owner" ON signal_accounts FOR ALL TO authenticated
+  USING (user_id = auth.uid()) WITH CHECK (user_id = auth.uid());
+CREATE POLICY "signal_threads_owner" ON signal_threads FOR ALL TO authenticated
+  USING (user_id = auth.uid()) WITH CHECK (user_id = auth.uid());
+CREATE POLICY "signal_messages_owner" ON signal_messages FOR ALL TO authenticated
+  USING (user_id = auth.uid()) WITH CHECK (user_id = auth.uid());
+
+COMMIT;
+
+-- ROLLBACK:
+-- BEGIN;
+-- DROP TABLE IF EXISTS signal_messages;
+-- DROP TABLE IF EXISTS signal_threads;
+-- DROP TABLE IF EXISTS signal_accounts;
+-- COMMIT;


### PR DESCRIPTION
Foundation for bridging a user's **own Signal account** into the Messages module (per Zack's requirements). Nothing user-facing yet — this is the spec, schema, and the standalone bridge service, ready to deploy.

### Up-front reality
Signal is **messaging-only** — `signal-cli` has no calling, and Signal's voice/video has no API. So **audio/video/meetings *through Signal* are impossible**. A/V is carved out as a **separate Rokki-native (LiveKit) track** (deferred). Full detail in `docs/SIGNAL_INTEGRATION.md`.

### What's here
- **`docs/SIGNAL_INTEGRATION.md`** — the implementation instructions (architecture, data model, linking flow, phased plan, security, open decisions).
- **Migration `20260615130000`** — `signal_accounts` / `signal_threads` / `signal_messages`, all **owner-RLS** (private to each user, like a personal space). Self-contained; no FK into existing message tables yet.
- **`apps/signal-bridge`** — a standalone **Hono** service wrapping `signal-cli`: link (secondary device), receive → Supabase, send. Plus `Dockerfile`, `fly.toml`, and a deploy `README`. Mirrors `mcp-server` conventions; `typecheck` + `build` clean (`lint`/`test` stubbed like mcp-server).

### The one thing that needs Zack
Rokki has **no always-on service today** (it's all serverless). The bridge needs a persistent host → **Fly.io (~$5/mo, not Azure)**. The README has the exact `fly launch` / volume / secrets / `fly deploy` steps. That's Phase 0's only blocker; the bridge's live behavior is validated against `signal-cli` once it's deployed.

Phase-0 skeleton: structure, auth, and DB writes are real; the exact `signal-cli` JSON envelope mapping is the live-validation step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)