### PR TITLE
ci: GitHub Actions deploy for the signal-bridge (Fly.io)

### DIFF
--- a/.github/workflows/deploy-signal-bridge.yml
+++ b/.github/workflows/deploy-signal-bridge.yml
@@ -1,0 +1,30 @@
+name: Deploy signal-bridge
+
+# Auto-deploys the Signal bridge to Fly.io whenever its code changes on main.
+# Builds on Fly's remote builders (no Docker in CI). One-time bootstrap (app +
+# volume + secrets + token) is done from your machine once — see
+# apps/signal-bridge/README.md. After that, this owns every deploy.
+on:
+  push:
+    branches: [main]
+    paths:
+      - "apps/signal-bridge/**"
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-signal-bridge
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy → Fly.io
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - name: Deploy
+        working-directory: apps/signal-bridge
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        run: flyctl deploy --remote-only

--- a/apps/signal-bridge/README.md
+++ b/apps/signal-bridge/README.md
@@ -29,36 +29,35 @@ All non-health routes require header `x-bridge-secret: $BRIDGE_SECRET`.
 | `PORT` | default 8080 |
 | `SIGNAL_CLI_PATH` | default `signal-cli` |
 
-## Deploy to Fly.io (Zack — the one new account)
+## Deploy
+
+Deploys run through **GitHub Actions** (`.github/workflows/deploy-signal-bridge.yml`)
+on every change to `apps/signal-bridge/**`, or manually via
+`gh workflow run deploy-signal-bridge.yml`. The build happens on **Fly's remote
+builders** — no Docker needed.
+
+### One-time bootstrap (from your machine, run once)
+Install + log in to flyctl → https://fly.io/docs/flyctl/install/ , then:
 ```bash
-# 1. one-time: install flyctl + log in
-#    https://fly.io/docs/flyctl/install/
-fly auth login
-
-# 2. from apps/signal-bridge/
-fly launch --no-deploy            # creates the app from fly.toml (keep the name)
-fly volumes create signal_data --size 1 -r iad   # persistent signal-cli session
-
-# 3. secrets
-fly secrets set \
+fly apps create rokki-signal-bridge
+fly volumes create signal_data --size 1 -r iad -a rokki-signal-bridge   # persists the signal-cli session
+fly secrets set -a rokki-signal-bridge \
   BRIDGE_SECRET="$(openssl rand -hex 32)" \
-  SUPABASE_URL="https://<prod-ref>.supabase.co" \
+  SUPABASE_URL="https://<ref>.supabase.co" \
   SUPABASE_SERVICE_ROLE_KEY="<service-role-key>"
-
-# 4. ship it
-fly deploy
-
-# 5. verify
-curl https://rokki-signal-bridge.fly.dev/health
+fly tokens create deploy -a rokki-signal-bridge   # → copy this, add to GitHub as FLY_API_TOKEN
+```
+Add the deploy token as the repo secret **`FLY_API_TOKEN`** (GitHub → Settings →
+Secrets and variables → Actions). Then trigger the first deploy:
+`gh workflow run deploy-signal-bridge.yml`. Verify:
+```bash
+curl https://rokki-signal-bridge.fly.dev/health   # {"ok":true,...}
 ```
 
-Then Rokki (Messages → Connect Signal) calls `/accounts/:userId/link`, shows the
-QR, you scan it from **Signal app → Settings → Linked Devices**, and your
-threads start syncing.
-
-> Keep `BRIDGE_SECRET` and the service-role key in Fly secrets only — never in
-> the repo. The `signal-cli` session lives on the mounted volume; treat that host
-> as holding decrypted message plaintext (the inherent E2E-bridge tradeoff).
+> Keep `BRIDGE_SECRET`, the service-role key, and the Fly token in their secret
+> stores only — never in the repo. The `signal-cli` session lives on the mounted
+> volume; treat that host as holding decrypted message plaintext (the inherent
+> E2E-bridge tradeoff).
 
 ## Local dev
 ```bash


### PR DESCRIPTION
Auto-deploys `apps/signal-bridge` to Fly.io on change (or `workflow_dispatch`), built on Fly's remote builders via a `FLY_API_TOKEN` repo secret. One-time bootstrap (app + volume + secrets + token) stays a few local `fly` commands — see the updated README. After that, GitHub owns deploys.

No app-code change; workflow + doc only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)