### PR TITLE
fix(signal-bridge): Node 22 base image for native WebSocket

### DIFF
--- a/apps/signal-bridge/Dockerfile
+++ b/apps/signal-bridge/Dockerfile
@@ -2,7 +2,7 @@
 # (Fly.io). Build context is this directory; run `pnpm build` first locally OR
 # let the image build it. signal-cli is a Java app from AsamK/signal-cli.
 
-FROM node:20-bookworm-slim
+FROM node:22-bookworm-slim
 
 # Java runtime for signal-cli + tools to fetch it.
 RUN apt-get update \


### PR DESCRIPTION
## Problem
The signal-bridge Fly app crash-looped on boot (exit 1) and Fly parked the machine after 10 restarts, so `/health` was unreachable.

**Root cause:** `@supabase/supabase-js` floated up to 2.108.x, whose `createClient` eagerly constructs a Realtime client that requires a global `WebSocket`. Node 20 has none (that's Node 22+), so construction threw at `dist/index.js:22` before the HTTP server ever started. The bridge doesn't even use realtime — only `.from()` DB writes — but the constructor throws regardless.

## Fix
Bump the base image `node:20-bookworm-slim` → `node:22-bookworm-slim`. Node 22 ships native `WebSocket`. One line, no new dependency, no code change.

## Status
Already deployed directly to Fly via `flyctl deploy` to unblock — `/health` now returns `{"ok":true,"service":"signal-bridge"}` and the machine is in `started` state. This PR lands the same fix in-repo so the CI deploy workflow (which builds from `main`) stays consistent and doesn't revert to Node 20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)