### PR TITLE
feat(signal): Connect Signal in Messages module settings (Phase 1)

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -64,6 +64,14 @@ TOKEN_ENCRYPTION_KEY=
 # scheduled GH Actions workflow can call the endpoint.
 CRON_SECRET=
 
+# Signal bridge (apps/signal-bridge on Fly.io). Lets a user link their own
+# Signal account to the Messages module. Both must be set for the Connect
+# Signal flow to work; if blank, /settings/modules/messages shows a graceful
+# "not configured" state. SIGNAL_BRIDGE_SECRET must match the bridge's
+# BRIDGE_SECRET. Server-only — never expose with a NEXT_PUBLIC_ prefix.
+SIGNAL_BRIDGE_URL=
+SIGNAL_BRIDGE_SECRET=
+
 # Misc
 NODE_ENV=development
 LOG_LEVEL=debug

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -37,6 +37,7 @@
     "lucide-react": "^0.446.0",
     "next": "15.5.18",
     "pdfjs-dist": "^5.6.205",
+    "qrcode.react": "^4.2.0",
     "react": "19.2.5",
     "react-dom": "19.2.5",
     "react-markdown": "^10.1.0",

--- a/apps/web/src/app/api/v1/signal/account/route.ts
+++ b/apps/web/src/app/api/v1/signal/account/route.ts
@@ -1,0 +1,71 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { withObservability } from "@/lib/observability";
+import { isSignalBridgeConfigured } from "@/lib/signal/bridge";
+import { unauth, internal } from "@/lib/signal/responses";
+
+/**
+ * GET    /api/v1/signal/account — my Signal link status + synced-thread count.
+ * DELETE /api/v1/signal/account — disconnect (mark unlinked).
+ *
+ * Scoped to the signed-in user. The bridge writes the row via the service
+ * role; RLS lets the owner read/update their own row here.
+ */
+
+async function handleGet() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return unauth();
+
+  const { data: account } = await supabase
+    .from("signal_accounts")
+    .select("status, signal_number, device_id, linked_at, updated_at")
+    .eq("user_id", user.id)
+    .maybeSingle();
+
+  const { count } = await supabase
+    .from("signal_threads")
+    .select("id", { count: "exact", head: true })
+    .eq("user_id", user.id);
+
+  const acct = account as {
+    status?: string;
+    signal_number?: string | null;
+    linked_at?: string | null;
+  } | null;
+
+  return NextResponse.json({
+    data: {
+      status: acct?.status ?? "unlinked",
+      signal_number: acct?.signal_number ?? null,
+      linked_at: acct?.linked_at ?? null,
+      thread_count: count ?? 0,
+      configured: isSignalBridgeConfigured(),
+    },
+  });
+}
+
+async function handleDelete() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return unauth();
+
+  const { error } = await supabase
+    .from("signal_accounts")
+    // @ts-expect-error generic update collapses to never
+    .update({ status: "unlinked" })
+    .eq("user_id", user.id);
+  if (error) return internal(error.message);
+
+  return new NextResponse(null, { status: 204 });
+}
+
+export const GET = withObservability(handleGet, "GET /api/v1/signal/account");
+export const DELETE = withObservability(
+  handleDelete,
+  "DELETE /api/v1/signal/account",
+);

--- a/apps/web/src/app/api/v1/signal/link/route.ts
+++ b/apps/web/src/app/api/v1/signal/link/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { withObservability } from "@/lib/observability";
+import { bridgeStartLink } from "@/lib/signal/bridge";
+import { unauth, bridgeErrorResponse } from "@/lib/signal/responses";
+
+/**
+ * POST /api/v1/signal/link — start linking the signed-in user's Signal
+ * account as a secondary device. Returns the `sgnl://linkdevice` URI for the
+ * client to render as a QR code. The user id is taken from the session, never
+ * the request body, so you can only link your own account.
+ */
+
+// signal-cli boots a JVM and emits the device-link URI; give it headroom past
+// the default serverless timeout.
+export const maxDuration = 30;
+
+async function handlePost() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return unauth();
+
+  try {
+    const { uri } = await bridgeStartLink(user.id);
+    return NextResponse.json({ data: { uri } });
+  } catch (e) {
+    return bridgeErrorResponse(e);
+  }
+}
+
+export const POST = withObservability(handlePost, "POST /api/v1/signal/link");

--- a/apps/web/src/app/api/v1/signal/send/route.ts
+++ b/apps/web/src/app/api/v1/signal/send/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { withObservability } from "@/lib/observability";
+import { bridgeSend } from "@/lib/signal/bridge";
+import { unauth, bad, bridgeErrorResponse } from "@/lib/signal/responses";
+
+/**
+ * POST /api/v1/signal/send  { signalId, kind?, text }
+ *
+ * Send a message through the signed-in user's linked Signal account. We look
+ * up their own Signal number server-side; the caller only names the target
+ * conversation (`signalId` = recipient number/uuid for a direct chat, or a
+ * group id when `kind: "group"`).
+ */
+
+async function handlePost(request: NextRequest) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return unauth();
+
+  const body = (await request.json().catch(() => ({}))) as {
+    signalId?: string;
+    kind?: "direct" | "group";
+    text?: string;
+  };
+  const text = typeof body.text === "string" ? body.text.trim() : "";
+  if (!body.signalId || !text) return bad("signalId and text are required");
+  const kind = body.kind === "group" ? "group" : "direct";
+
+  const { data: account } = await supabase
+    .from("signal_accounts")
+    .select("signal_number, status")
+    .eq("user_id", user.id)
+    .maybeSingle();
+  const acct = account as {
+    signal_number?: string | null;
+    status?: string;
+  } | null;
+  if (!acct || acct.status !== "active" || !acct.signal_number) {
+    return bad("Signal isn't connected");
+  }
+
+  try {
+    await bridgeSend(user.id, {
+      signalNumber: acct.signal_number,
+      signalId: body.signalId,
+      kind,
+      text,
+    });
+    return NextResponse.json({ data: { ok: true } });
+  } catch (e) {
+    return bridgeErrorResponse(e);
+  }
+}
+
+export const POST = withObservability(handlePost, "POST /api/v1/signal/send");

--- a/apps/web/src/app/settings/modules/messages/page.tsx
+++ b/apps/web/src/app/settings/modules/messages/page.tsx
@@ -1,0 +1,42 @@
+import { redirect } from "next/navigation";
+import Link from "next/link";
+import { createClient } from "@/lib/supabase/server";
+import { TopBar } from "@/components/TopBar";
+import { SettingsHeader } from "@/components/settings/settings-ui";
+import { SignalConnection } from "@/components/settings/SignalConnection";
+
+/**
+ * Messages module settings — per-module settings reached from the MODULES
+ * gear (→ Module settings → Messages) or the Messages card header. Right now
+ * this is where you connect external messaging: Signal.
+ */
+export default async function MessagesModuleSettingsPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) redirect("/login");
+
+  return (
+    <div className="flex min-h-screen flex-col bg-bg-0">
+      <TopBar>
+        <Link href="/" className="text-text-3 hover:text-text-1">
+          Dashboard
+        </Link>
+        <span className="text-text-3">/</span>
+        <Link href="/settings/modules" className="text-text-3 hover:text-text-1">
+          Module settings
+        </Link>
+        <span className="text-text-3">/</span>
+        <span className="text-text-0">Messages</span>
+      </TopBar>
+      <main className="mx-auto w-full max-w-3xl flex-1 p-6">
+        <SettingsHeader
+          title="Messages"
+          description="Connect external messaging to your Messages module. Link your own Signal account to send and receive from Rokki or your phone."
+        />
+        <SignalConnection />
+      </main>
+    </div>
+  );
+}

--- a/apps/web/src/components/dashboard/MessagesCard.tsx
+++ b/apps/web/src/components/dashboard/MessagesCard.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useCallback, useEffect, useState } from "react";
-import { Hash, User as UserIcon, MessageSquarePlus } from "lucide-react";
+import { Hash, User as UserIcon, MessageSquarePlus, Settings2 } from "lucide-react";
 import { DashboardCard } from "./DashboardCard";
 import { useRealtimeTable } from "@/lib/supabase/realtime";
 
@@ -51,6 +51,16 @@ export function MessagesCard() {
       title="Messages"
       count={threads.length}
       expandHref="/messages"
+      headerRight={
+        <Link
+          href="/settings/modules/messages"
+          aria-label="Messages settings"
+          title="Connect Signal & settings"
+          className="rounded-sm p-1 text-text-3 hover:bg-bg-2 hover:text-text-0"
+        >
+          <Settings2 className="h-3 w-3" />
+        </Link>
+      }
     >
       {loading && threads.length === 0 ? (
         <p className="px-3 py-4 text-center text-xs text-text-3">Loading…</p>

--- a/apps/web/src/components/settings/ModuleSettingsForm.tsx
+++ b/apps/web/src/components/settings/ModuleSettingsForm.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import {
   Calendar,
   CheckSquare,
@@ -9,6 +10,7 @@ import {
   EyeOff,
   Plus,
   RotateCcw,
+  Settings2,
   type LucideIcon,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -25,6 +27,11 @@ const ICONS: Record<string, LucideIcon> = {
   week: Calendar,
   tasks: CheckSquare,
   messages: MessageSquare,
+};
+
+/** Modules with their own settings page get a Configure gear on their row. */
+const MODULE_SETTINGS_HREF: Record<string, string> = {
+  messages: "/settings/modules/messages",
 };
 
 const LAYOUT_OPTIONS: readonly { value: DashLayoutPreset; label: string }[] = [
@@ -89,6 +96,16 @@ export function ModuleSettingsForm() {
                 <span className="flex-1 truncate text-xs text-text-1">
                   {m.label}
                 </span>
+                {MODULE_SETTINGS_HREF[m.id] ? (
+                  <Link
+                    href={MODULE_SETTINGS_HREF[m.id]}
+                    aria-label={`${m.label} settings`}
+                    title="Configure"
+                    className="rounded-sm p-1 text-text-3 hover:bg-bg-3 hover:text-text-0"
+                  >
+                    <Settings2 className="h-3.5 w-3.5" aria-hidden="true" />
+                  </Link>
+                ) : null}
                 <span className="flex items-center gap-2 text-2xs text-text-3">
                   Open on load
                   <Toggle

--- a/apps/web/src/components/settings/SignalConnection.tsx
+++ b/apps/web/src/components/settings/SignalConnection.tsx
@@ -1,0 +1,362 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { QRCodeSVG } from "qrcode.react";
+import {
+  Loader2,
+  Link2,
+  Unlink,
+  Smartphone,
+  ShieldCheck,
+  AlertTriangle,
+  MessageSquare,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import { useRealtimeTable } from "@/lib/supabase/realtime";
+import {
+  describeSignalStatus,
+  toneTextClass,
+  type SignalStatus,
+} from "@/lib/signal/status";
+import { SettingsCard, SettingRow } from "./settings-ui";
+
+interface SignalAccount {
+  status: SignalStatus;
+  signal_number: string | null;
+  linked_at: string | null;
+  thread_count: number;
+  configured: boolean;
+}
+
+/** Roughly 4 minutes of polling at 2.5s while a QR is on screen. */
+const MAX_POLLS = 96;
+
+/**
+ * Connect Signal — the body of the Messages module settings page. Links the
+ * user's own Signal account (as a secondary device) to Rokki so their
+ * conversations sync into the Messages module and they can send from either
+ * place. Talks only to our /api/v1/signal/* routes; the bridge secret never
+ * reaches the browser.
+ */
+export function SignalConnection() {
+  const [account, setAccount] = useState<SignalAccount | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [linkUri, setLinkUri] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [expired, setExpired] = useState(false);
+
+  const load = useCallback(async () => {
+    try {
+      const r = await fetch("/api/v1/signal/account", {
+        credentials: "include",
+      });
+      if (!r.ok) return;
+      const body = (await r.json()) as { data?: SignalAccount };
+      if (!body.data) return;
+      setAccount(body.data);
+      if (body.data.status === "active") {
+        setLinkUri(null);
+        setExpired(false);
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  // Keep status + counts fresh: the bridge writes via the service role, and
+  // RLS scopes these realtime events to the owner's own rows.
+  useRealtimeTable<{ user_id: string }>(
+    { table: "signal_accounts", channelKey: "signal:account" },
+    { onInsert: () => void load(), onUpdate: () => void load() },
+  );
+  useRealtimeTable<{ id: string }>(
+    { table: "signal_threads", channelKey: "signal:threads" },
+    { onInsert: () => void load(), onUpdate: () => void load() },
+  );
+
+  // While a QR is on screen, poll for the link to complete (realtime is the
+  // happy path; this is the safety net + it expires the QR after a while).
+  useEffect(() => {
+    if (!linkUri) return;
+    let attempts = 0;
+    const t = setInterval(() => {
+      attempts += 1;
+      if (attempts > MAX_POLLS) {
+        setLinkUri(null);
+        setExpired(true);
+        clearInterval(t);
+        return;
+      }
+      void load();
+    }, 2500);
+    return () => clearInterval(t);
+  }, [linkUri, load]);
+
+  const connect = useCallback(async () => {
+    setBusy(true);
+    setError(null);
+    setExpired(false);
+    try {
+      const r = await fetch("/api/v1/signal/link", {
+        method: "POST",
+        credentials: "include",
+      });
+      const body = (await r.json().catch(() => ({}))) as {
+        data?: { uri: string };
+        errors?: { message: string }[];
+      };
+      if (!r.ok || !body.data?.uri) {
+        setError(body.errors?.[0]?.message ?? "Couldn't start linking.");
+        return;
+      }
+      setLinkUri(body.data.uri);
+      void load();
+    } catch {
+      setError("Couldn't reach the server. Try again.");
+    } finally {
+      setBusy(false);
+    }
+  }, [load]);
+
+  const disconnect = useCallback(async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      await fetch("/api/v1/signal/account", {
+        method: "DELETE",
+        credentials: "include",
+      });
+      setLinkUri(null);
+      await load();
+    } finally {
+      setBusy(false);
+    }
+  }, [load]);
+
+  if (loading && !account) {
+    return (
+      <SettingsCard title="Signal">
+        <p className="px-4 py-6 text-center text-xs text-text-3">Loading…</p>
+      </SettingsCard>
+    );
+  }
+
+  if (account && !account.configured) {
+    return (
+      <SettingsCard title="Signal" description="Send and receive Signal messages from Rokki.">
+        <div className="flex items-start gap-3 px-4 py-4">
+          <AlertTriangle className="mt-0.5 h-4 w-4 flex-shrink-0 text-warning" aria-hidden="true" />
+          <div className="text-xs text-text-2">
+            <p className="text-text-1">Signal isn’t set up on this workspace yet.</p>
+            <p className="mt-1 text-text-3">
+              An admin needs to configure the Signal bridge
+              (<code className="font-mono text-2xs">SIGNAL_BRIDGE_URL</code> and{" "}
+              <code className="font-mono text-2xs">SIGNAL_BRIDGE_SECRET</code>) before
+              accounts can be linked.
+            </p>
+          </div>
+        </div>
+      </SettingsCard>
+    );
+  }
+
+  const view = describeSignalStatus(account?.status);
+
+  return (
+    <div className="flex flex-col gap-4">
+      <SettingsCard
+        title="Signal"
+        description="Link your own Signal account to send and receive messages from Rokki or your phone — they stay in sync."
+        meta={
+          <span className="inline-flex items-center gap-1.5">
+            <span
+              className={cn(
+                "h-1.5 w-1.5 rounded-full",
+                view.connected ? "bg-success" : "bg-text-3",
+              )}
+              aria-hidden="true"
+            />
+            <span className={toneTextClass(view.tone)}>{view.label}</span>
+          </span>
+        }
+      >
+        {/* Connected */}
+        {view.connected ? (
+          <div className="divide-y divide-border">
+            <SettingRow
+              label={
+                <span className="inline-flex items-center gap-2">
+                  <Smartphone className="h-3.5 w-3.5 text-text-3" aria-hidden="true" />
+                  {account?.signal_number ?? "Linked"}
+                </span>
+              }
+              description={
+                account?.linked_at
+                  ? `Linked ${formatWhen(account.linked_at)}`
+                  : "Linked as a secondary device."
+              }
+            >
+              <button
+                type="button"
+                onClick={disconnect}
+                disabled={busy}
+                className={cn(
+                  "inline-flex items-center gap-1.5 rounded-sm border border-border bg-bg-1 px-2.5 py-1.5",
+                  "text-2xs font-semibold uppercase tracking-wide text-text-2",
+                  "hover:bg-bg-2 hover:text-danger disabled:opacity-50",
+                )}
+              >
+                {busy ? (
+                  <Loader2 className="h-3 w-3 animate-spin" aria-hidden="true" />
+                ) : (
+                  <Unlink className="h-3 w-3" aria-hidden="true" />
+                )}
+                Disconnect
+              </button>
+            </SettingRow>
+            <SettingRow
+              label={
+                <span className="inline-flex items-center gap-2">
+                  <MessageSquare className="h-3.5 w-3.5 text-text-3" aria-hidden="true" />
+                  Synced conversations
+                </span>
+              }
+              description="Your Signal chats appear in the Messages module."
+            >
+              <span className="font-mono text-xs text-text-1">
+                {account?.thread_count ?? 0}
+              </span>
+            </SettingRow>
+          </div>
+        ) : linkUri ? (
+          /* Linking — QR on screen */
+          <div className="flex flex-col items-center gap-4 px-4 py-5">
+            <div className="rounded-md bg-white p-3 shadow-sm">
+              <QRCodeSVG value={linkUri} size={196} level="M" />
+            </div>
+            <ol className="w-full max-w-sm space-y-1.5 text-xs text-text-2">
+              <Step n={1}>Open Signal on your phone.</Step>
+              <Step n={2}>
+                Go to <span className="text-text-1">Settings → Linked Devices → Link New Device</span>.
+              </Step>
+              <Step n={3}>Scan this code.</Step>
+            </ol>
+            <div className="flex items-center gap-2 text-2xs text-text-3">
+              <Loader2 className="h-3 w-3 animate-spin" aria-hidden="true" />
+              Waiting for you to scan…
+            </div>
+            <button
+              type="button"
+              onClick={() => setLinkUri(null)}
+              className="text-2xs text-text-3 underline-offset-2 hover:text-text-1 hover:underline"
+            >
+              Cancel
+            </button>
+          </div>
+        ) : (
+          /* Not connected */
+          <div className="flex flex-col gap-3 px-4 py-4">
+            <p className="text-xs text-text-2">
+              Rokki links to Signal as a secondary device — like Signal Desktop.
+              Your phone stays the primary device, and nothing changes about how
+              Signal works.
+            </p>
+            {expired ? (
+              <p className="text-2xs text-warning">
+                That link expired before it was scanned. Generate a new one.
+              </p>
+            ) : null}
+            {error ? <p className="text-2xs text-danger">{error}</p> : null}
+            <div>
+              <button
+                type="button"
+                onClick={connect}
+                disabled={busy}
+                className={cn(
+                  "inline-flex items-center gap-1.5 rounded-sm border border-accent bg-accent px-3 py-1.5",
+                  "text-2xs font-semibold uppercase tracking-wide text-bg-0",
+                  "hover:opacity-90 disabled:opacity-50",
+                )}
+              >
+                {busy ? (
+                  <Loader2 className="h-3 w-3 animate-spin" aria-hidden="true" />
+                ) : (
+                  <Link2 className="h-3 w-3" aria-hidden="true" />
+                )}
+                Connect Signal
+              </button>
+            </div>
+          </div>
+        )}
+      </SettingsCard>
+
+      <SettingsCard title="Good to know">
+        <div className="divide-y divide-border text-xs text-text-2">
+          <Note icon={MessageSquare}>
+            <span className="text-text-1">Messaging only.</span> Signal calls
+            (audio/video) can’t be bridged — there’s no API for them. Meetings and
+            A/V are a separate, Rokki-native feature.
+          </Note>
+          <Note icon={ShieldCheck}>
+            <span className="text-text-1">Privacy.</span> To show your messages,
+            the bridge decrypts them, so synced chats are readable on Rokki’s
+            server while linked — inherent to any Signal bridge. Disappearing-message
+            timers are honored.
+          </Note>
+          <Note icon={Smartphone}>
+            <span className="text-text-1">Your phone stays in charge.</span>{" "}
+            Unlink anytime from Signal → Settings → Linked Devices, or with
+            Disconnect above.
+          </Note>
+        </div>
+      </SettingsCard>
+    </div>
+  );
+}
+
+function Step({ n, children }: { n: number; children: React.ReactNode }) {
+  return (
+    <li className="flex items-start gap-2">
+      <span className="mt-px flex h-4 w-4 flex-shrink-0 items-center justify-center rounded-full border border-border font-mono text-[9px] text-text-3">
+        {n}
+      </span>
+      <span>{children}</span>
+    </li>
+  );
+}
+
+function Note({
+  icon: Icon,
+  children,
+}: {
+  icon: typeof MessageSquare;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex items-start gap-2.5 px-4 py-2.5">
+      <Icon className="mt-0.5 h-3.5 w-3.5 flex-shrink-0 text-text-3" aria-hidden="true" />
+      <p className="leading-snug text-text-3">{children}</p>
+    </div>
+  );
+}
+
+function formatWhen(iso: string): string {
+  const ms = Date.now() - new Date(iso).getTime();
+  const m = Math.floor(ms / 60000);
+  if (m < 1) return "just now";
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  const d = Math.floor(h / 24);
+  if (d < 7) return `${d}d ago`;
+  return new Date(iso).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}

--- a/apps/web/src/lib/signal/bridge.test.ts
+++ b/apps/web/src/lib/signal/bridge.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  isSignalBridgeConfigured,
+  bridgeStartLink,
+  bridgeSend,
+  SignalBridgeError,
+  SignalBridgeNotConfiguredError,
+} from "./bridge";
+
+/** Build a minimal Response-like stub for the global fetch mock. */
+function fetchOk(status: number, body: unknown) {
+  return vi.fn(async (_url: string, _init?: RequestInit) => {
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      text: async () =>
+        typeof body === "string" ? body : JSON.stringify(body),
+    } as unknown as Response;
+  });
+}
+
+const ORIGINAL = {
+  url: process.env.SIGNAL_BRIDGE_URL,
+  secret: process.env.SIGNAL_BRIDGE_SECRET,
+};
+
+beforeEach(() => {
+  process.env.SIGNAL_BRIDGE_URL = "https://bridge.example.com/";
+  process.env.SIGNAL_BRIDGE_SECRET = "s3cr3t";
+});
+
+afterEach(() => {
+  process.env.SIGNAL_BRIDGE_URL = ORIGINAL.url;
+  process.env.SIGNAL_BRIDGE_SECRET = ORIGINAL.secret;
+  vi.unstubAllGlobals();
+});
+
+describe("isSignalBridgeConfigured", () => {
+  it("is true when both env vars are set", () => {
+    expect(isSignalBridgeConfigured()).toBe(true);
+  });
+  it("is false when either is missing", () => {
+    delete process.env.SIGNAL_BRIDGE_SECRET;
+    expect(isSignalBridgeConfigured()).toBe(false);
+    process.env.SIGNAL_BRIDGE_SECRET = "s3cr3t";
+    delete process.env.SIGNAL_BRIDGE_URL;
+    expect(isSignalBridgeConfigured()).toBe(false);
+  });
+});
+
+describe("bridgeStartLink", () => {
+  it("throws SignalBridgeNotConfiguredError when env is missing", async () => {
+    delete process.env.SIGNAL_BRIDGE_URL;
+    await expect(bridgeStartLink("user-1")).rejects.toBeInstanceOf(
+      SignalBridgeNotConfiguredError,
+    );
+  });
+
+  it("trims the trailing slash, sends the secret header, and returns the uri", async () => {
+    const fetchMock = fetchOk(200, { uri: "sgnl://linkdevice?uuid=abc" });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const out = await bridgeStartLink("user-1");
+    expect(out).toEqual({ uri: "sgnl://linkdevice?uuid=abc" });
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://bridge.example.com/accounts/user-1/link");
+    expect(init?.method).toBe("POST");
+    const headers = init?.headers as Record<string, string>;
+    expect(headers["x-bridge-secret"]).toBe("s3cr3t");
+  });
+
+  it("maps a non-2xx response to SignalBridgeError with the bridge's message", async () => {
+    vi.stubGlobal("fetch", fetchOk(502, { error: "link ended (1)" }));
+    const err = await bridgeStartLink("user-1").catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(SignalBridgeError);
+    expect((err as SignalBridgeError).status).toBe(502);
+    expect((err as SignalBridgeError).message).toBe("link ended (1)");
+  });
+});
+
+describe("bridgeSend", () => {
+  it("posts the payload as JSON with the content-type header", async () => {
+    const fetchMock = fetchOk(200, { ok: true });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await bridgeSend("user-1", {
+      signalNumber: "+15551234567",
+      signalId: "+15557654321",
+      kind: "direct",
+      text: "hi",
+    });
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://bridge.example.com/accounts/user-1/send");
+    expect(init?.method).toBe("POST");
+    const headers = init?.headers as Record<string, string>;
+    expect(headers["content-type"]).toBe("application/json");
+    expect(JSON.parse(String(init?.body))).toEqual({
+      signalNumber: "+15551234567",
+      signalId: "+15557654321",
+      kind: "direct",
+      text: "hi",
+    });
+  });
+});

--- a/apps/web/src/lib/signal/bridge.ts
+++ b/apps/web/src/lib/signal/bridge.ts
@@ -1,0 +1,109 @@
+/**
+ * Server-only client for the Signal bridge (apps/signal-bridge, deployed to
+ * Fly.io). The bridge holds the signal-cli session and the Supabase
+ * service-role key; Rokki talks to it over HTTPS, authenticated by a shared
+ * secret (`x-bridge-secret`).
+ *
+ * NEVER import this from a client component — SIGNAL_BRIDGE_SECRET must stay
+ * on the server. The Connect-Signal UI talks to our own /api/v1/signal/*
+ * routes, which in turn call this helper.
+ */
+
+export class SignalBridgeNotConfiguredError extends Error {
+  constructor() {
+    super("Signal bridge is not configured");
+    this.name = "SignalBridgeNotConfiguredError";
+  }
+}
+
+export class SignalBridgeError extends Error {
+  readonly status: number;
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = "SignalBridgeError";
+    this.status = status;
+  }
+}
+
+/** True when both bridge env vars are present (drives the UI's "configured"
+ *  state without leaking the values). */
+export function isSignalBridgeConfigured(): boolean {
+  return Boolean(
+    process.env.SIGNAL_BRIDGE_URL && process.env.SIGNAL_BRIDGE_SECRET,
+  );
+}
+
+function config(): { url: string; secret: string } {
+  const url = process.env.SIGNAL_BRIDGE_URL;
+  const secret = process.env.SIGNAL_BRIDGE_SECRET;
+  if (!url || !secret) throw new SignalBridgeNotConfiguredError();
+  return { url: url.replace(/\/+$/, ""), secret };
+}
+
+async function bridgeFetch<T>(
+  path: string,
+  init: { method: "GET" | "POST"; body?: unknown; timeoutMs?: number },
+): Promise<T> {
+  const { url, secret } = config();
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), init.timeoutMs ?? 15_000);
+  try {
+    const res = await fetch(`${url}${path}`, {
+      method: init.method,
+      headers: {
+        "x-bridge-secret": secret,
+        ...(init.body ? { "content-type": "application/json" } : {}),
+      },
+      body: init.body ? JSON.stringify(init.body) : undefined,
+      signal: controller.signal,
+      cache: "no-store",
+    });
+    const text = await res.text();
+    const data: unknown = text ? JSON.parse(text) : {};
+    if (!res.ok) {
+      const msg =
+        (data as { error?: string } | null)?.error ?? `bridge ${res.status}`;
+      throw new SignalBridgeError(res.status, msg);
+    }
+    return data as T;
+  } catch (e) {
+    if (e instanceof SignalBridgeError) throw e;
+    if (e instanceof Error && e.name === "AbortError") {
+      throw new SignalBridgeError(504, "Signal bridge timed out");
+    }
+    throw new SignalBridgeError(
+      502,
+      e instanceof Error ? e.message : "Signal bridge unreachable",
+    );
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Start linking this user's Signal account as a secondary device. Resolves
+ * with the `sgnl://linkdevice?...` URI to render as a QR for the Signal app
+ * to scan. (signal-cli spins up a JVM and emits the URI, so allow extra time.)
+ */
+export function bridgeStartLink(userId: string): Promise<{ uri: string }> {
+  return bridgeFetch<{ uri: string }>(
+    `/accounts/${encodeURIComponent(userId)}/link`,
+    { method: "POST", timeoutMs: 25_000 },
+  );
+}
+
+/** Send a message on the user's behalf through their linked Signal account. */
+export function bridgeSend(
+  userId: string,
+  payload: {
+    signalNumber: string;
+    signalId: string;
+    kind: "direct" | "group";
+    text: string;
+  },
+): Promise<{ ok: true }> {
+  return bridgeFetch<{ ok: true }>(
+    `/accounts/${encodeURIComponent(userId)}/send`,
+    { method: "POST", body: payload },
+  );
+}

--- a/apps/web/src/lib/signal/responses.ts
+++ b/apps/web/src/lib/signal/responses.ts
@@ -1,0 +1,55 @@
+import { NextResponse } from "next/server";
+import {
+  SignalBridgeError,
+  SignalBridgeNotConfiguredError,
+} from "./bridge";
+
+/**
+ * Shared JSON error responses for the /api/v1/signal/* routes, in the app's
+ * standard `{ errors: [{ code, message }] }` shape.
+ */
+
+export function unauth() {
+  return NextResponse.json(
+    { errors: [{ code: "unauthenticated", message: "Sign in required" }] },
+    { status: 401 },
+  );
+}
+
+export function bad(message: string) {
+  return NextResponse.json(
+    { errors: [{ code: "invalid_request", message }] },
+    { status: 400 },
+  );
+}
+
+export function internal(message: string) {
+  return NextResponse.json(
+    { errors: [{ code: "internal_error", message }] },
+    { status: 500 },
+  );
+}
+
+/** Map a thrown bridge error to the right HTTP response. */
+export function bridgeErrorResponse(e: unknown) {
+  if (e instanceof SignalBridgeNotConfiguredError) {
+    return NextResponse.json(
+      {
+        errors: [
+          {
+            code: "not_configured",
+            message: "Signal isn't set up on this Rokki instance yet.",
+          },
+        ],
+      },
+      { status: 503 },
+    );
+  }
+  if (e instanceof SignalBridgeError) {
+    return NextResponse.json(
+      { errors: [{ code: "bridge_error", message: e.message }] },
+      { status: 502 },
+    );
+  }
+  return internal(e instanceof Error ? e.message : "Unexpected error");
+}

--- a/apps/web/src/lib/signal/status.test.ts
+++ b/apps/web/src/lib/signal/status.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import {
+  describeSignalStatus,
+  toneTextClass,
+  type SignalTone,
+} from "./status";
+
+describe("describeSignalStatus", () => {
+  it("maps active → connected/positive", () => {
+    const v = describeSignalStatus("active");
+    expect(v).toEqual({ label: "Connected", tone: "positive", connected: true });
+  });
+
+  it("maps linking → waiting/warning, not connected", () => {
+    const v = describeSignalStatus("linking");
+    expect(v.connected).toBe(false);
+    expect(v.tone).toBe("warning");
+    expect(v.label).toMatch(/scan/i);
+  });
+
+  it("maps error → danger, not connected", () => {
+    const v = describeSignalStatus("error");
+    expect(v).toEqual({
+      label: "Connection error",
+      tone: "danger",
+      connected: false,
+    });
+  });
+
+  it("treats unlinked, null, undefined, and junk as not connected", () => {
+    for (const s of ["unlinked", null, undefined, "wat"]) {
+      const v = describeSignalStatus(s);
+      expect(v.connected).toBe(false);
+      expect(v.tone).toBe("muted");
+      expect(v.label).toBe("Not connected");
+    }
+  });
+});
+
+describe("toneTextClass", () => {
+  it("returns a real token for every tone", () => {
+    const tones: SignalTone[] = ["positive", "warning", "danger", "muted"];
+    for (const t of tones) expect(toneTextClass(t)).toMatch(/^text-/);
+  });
+
+  it("maps positive → success and danger → danger", () => {
+    expect(toneTextClass("positive")).toBe("text-success");
+    expect(toneTextClass("danger")).toBe("text-danger");
+    expect(toneTextClass("warning")).toBe("text-warning");
+    expect(toneTextClass("muted")).toBe("text-text-3");
+  });
+});

--- a/apps/web/src/lib/signal/status.ts
+++ b/apps/web/src/lib/signal/status.ts
@@ -1,0 +1,49 @@
+/**
+ * Pure presentation model for a linked Signal account's status. DOM-free and
+ * side-effect-free so it's unit-testable and safe to import from a client
+ * component. Mirrors the `status` CHECK on `signal_accounts`
+ * (linking | active | error | unlinked).
+ */
+
+export type SignalStatus = "unlinked" | "linking" | "active" | "error";
+
+export type SignalTone = "positive" | "muted" | "warning" | "danger";
+
+export interface SignalStatusView {
+  label: string;
+  tone: SignalTone;
+  /** True only when the account is linked and receiving. */
+  connected: boolean;
+}
+
+export function describeSignalStatus(
+  status: string | null | undefined,
+): SignalStatusView {
+  switch (status) {
+    case "active":
+      return { label: "Connected", tone: "positive", connected: true };
+    case "linking":
+      return { label: "Waiting for scan", tone: "warning", connected: false };
+    case "error":
+      return { label: "Connection error", tone: "danger", connected: false };
+    case "unlinked":
+    default:
+      return { label: "Not connected", tone: "muted", connected: false };
+  }
+}
+
+/** Tailwind text-color token for a tone — keeps the dot/label colors in one
+ *  place so the component stays declarative. */
+export function toneTextClass(tone: SignalTone): string {
+  switch (tone) {
+    case "positive":
+      return "text-success";
+    case "warning":
+      return "text-warning";
+    case "danger":
+      return "text-danger";
+    case "muted":
+    default:
+      return "text-text-3";
+  }
+}

--- a/docs/SIGNAL_INTEGRATION.md
+++ b/docs/SIGNAL_INTEGRATION.md
@@ -1,9 +1,23 @@
 # Signal integration — implementation instructions
 
-**Status:** Draft / scoping. Not yet built.
+**Status:** Phase 0 **shipped** — the bridge is live on Fly.io
+(`https://rokki-signal-bridge.fly.dev/health`). Phase 1 **built** — Connect
+Signal lives in the Messages module settings (`/settings/modules/messages`):
+linking QR flow, status, disconnect, synced-thread count, send route. Remaining
+to go live: set `SIGNAL_BRIDGE_URL` + `SIGNAL_BRIDGE_SECRET` in Vercel, then link
+a real account to validate the `toInbound` envelope mapping.
 **Goal (Zack):** a user links their own Signal account to Rokki and can send/receive
 personal messages and team messages from **either** the Signal app **or** Rokki.
 Meetings + audio/video are wanted "if possible."
+
+> [!NOTE]
+> **Configuring Rokki → bridge (one-time, per environment).** The web app reaches
+> the bridge through two server-only env vars: `SIGNAL_BRIDGE_URL`
+> (`https://rokki-signal-bridge.fly.dev`) and `SIGNAL_BRIDGE_SECRET` (must equal
+> the bridge's `BRIDGE_SECRET`). Set both in Vercel (sandbox first). If they're
+> blank, `/settings/modules/messages` shows a graceful "not set up yet" state
+> instead of erroring. The Connect-Signal UI only ever calls our own
+> `/api/v1/signal/*` routes — the secret never reaches the browser.
 
 > [!IMPORTANT]
 > **Capability reality.** Signal can be bridged for **messaging only**. The bridge

--- a/packages/db/src/generated.ts
+++ b/packages/db/src/generated.ts
@@ -1918,6 +1918,142 @@ export type Database = {
           },
         ]
       }
+      signal_accounts: {
+        Row: {
+          created_at: string
+          device_id: number | null
+          linked_at: string | null
+          signal_number: string | null
+          status: string
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          device_id?: number | null
+          linked_at?: string | null
+          signal_number?: string | null
+          status?: string
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          device_id?: number | null
+          linked_at?: string | null
+          signal_number?: string | null
+          status?: string
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: []
+      }
+      signal_messages: {
+        Row: {
+          attachments: Json
+          body: string | null
+          created_at: string
+          deleted_at: string | null
+          direction: string
+          edited_at: string | null
+          external_id: string | null
+          id: string
+          quote_external_id: string | null
+          reactions: Json
+          sender: string | null
+          sent_at: string
+          thread_id: string
+          user_id: string
+        }
+        Insert: {
+          attachments?: Json
+          body?: string | null
+          created_at?: string
+          deleted_at?: string | null
+          direction: string
+          edited_at?: string | null
+          external_id?: string | null
+          id?: string
+          quote_external_id?: string | null
+          reactions?: Json
+          sender?: string | null
+          sent_at?: string
+          thread_id: string
+          user_id: string
+        }
+        Update: {
+          attachments?: Json
+          body?: string | null
+          created_at?: string
+          deleted_at?: string | null
+          direction?: string
+          edited_at?: string | null
+          external_id?: string | null
+          id?: string
+          quote_external_id?: string | null
+          reactions?: Json
+          sender?: string | null
+          sent_at?: string
+          thread_id?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "signal_messages_thread_id_fkey"
+            columns: ["thread_id"]
+            isOneToOne: false
+            referencedRelation: "signal_threads"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      signal_threads: {
+        Row: {
+          created_at: string
+          id: string
+          kind: string
+          last_message_at: string | null
+          muted: boolean
+          signal_id: string
+          sync_enabled: boolean
+          terminal_id: string | null
+          title: string | null
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          kind: string
+          last_message_at?: string | null
+          muted?: boolean
+          signal_id: string
+          sync_enabled?: boolean
+          terminal_id?: string | null
+          title?: string | null
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          kind?: string
+          last_message_at?: string | null
+          muted?: boolean
+          signal_id?: string
+          sync_enabled?: boolean
+          terminal_id?: string | null
+          title?: string | null
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "signal_threads_terminal_id_fkey"
+            columns: ["terminal_id"]
+            isOneToOne: false
+            referencedRelation: "terminals"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       space_members: {
         Row: {
           joined_at: string

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -198,6 +198,9 @@ importers:
       pdfjs-dist:
         specifier: ^5.6.205
         version: 5.6.205
+      qrcode.react:
+        specifier: ^4.2.0
+        version: 4.2.0(react@19.2.5)
       react:
         specifier: 19.2.5
         version: 19.2.5
@@ -4473,6 +4476,11 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  qrcode.react@4.2.0:
+    resolution: {integrity: sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -10158,6 +10166,10 @@ snapshots:
   proxy-from-env@1.1.0: {}
 
   punycode@2.3.1: {}
+
+  qrcode.react@4.2.0(react@19.2.5):
+    dependencies:
+      react: 19.2.5
 
   queue-microtask@1.2.3: {}
 

--- a/supabase/migrations/20260615150000_signal_realtime_publication.sql
+++ b/supabase/migrations/20260615150000_signal_realtime_publication.sql
@@ -1,0 +1,19 @@
+-- Publish the Signal tables to Supabase Realtime.
+--
+-- The Phase-0 migration (20260615130000_signal_integration.sql) created these
+-- tables but didn't stream them. The bridge writes inbound messages and flips
+-- link status via the service role; publishing here lets the Messages module
+-- and the Connect-Signal settings page update live as that happens.
+--
+-- RLS still applies at subscribe time (Realtime pipes events through the same
+-- policies as SELECT), and every signal_* row is scoped to its owner, so each
+-- socket only ever sees its own account's events.
+
+ALTER PUBLICATION supabase_realtime ADD TABLE signal_accounts;
+ALTER PUBLICATION supabase_realtime ADD TABLE signal_threads;
+ALTER PUBLICATION supabase_realtime ADD TABLE signal_messages;
+
+-- ROLLBACK:
+-- ALTER PUBLICATION supabase_realtime DROP TABLE signal_messages;
+-- ALTER PUBLICATION supabase_realtime DROP TABLE signal_threads;
+-- ALTER PUBLICATION supabase_realtime DROP TABLE signal_accounts;


### PR DESCRIPTION
Builds the Rokki side of the Signal integration on top of the live Fly bridge (Phase 0). A user links their **own** Signal account from the Messages module settings and can send/receive from Rokki or their phone.

## Where it lives
**Module settings → Messages** (`/settings/modules/messages`), reachable from:
- a **Configure** gear on the Messages row in `/settings/modules`, and
- a gear on the **Messages dashboard card** header.

## What's here
- **Connect Signal UI** (`SignalConnection.tsx`): status pill, **Connect** → renders the `sgnl://linkdevice` URI as a **QR code** (via `qrcode.react`, generated **client-side** so the provisioning URI never leaves the browser), polls until the phone completes linking, then shows the linked number + synced-thread count + **Disconnect**. Includes a messaging-only / privacy note.
- **Server routes** `/api/v1/signal/{account,link,send}`: proxy to the bridge with the `x-bridge-secret` header. The user id comes from the **session**, never the request body — you can only link/act on your own account. The bridge secret stays server-only.
- **Env**: `SIGNAL_BRIDGE_URL` + `SIGNAL_BRIDGE_SECRET` (server-only, added to `.env.example`). If unset, the page shows a graceful **"not configured"** state instead of erroring.
- **DB types**: hand-added `signal_accounts/threads/messages` to `generated.ts` (the migration shipped to sandbox in #237 but types were never regenerated; this unblocks the strict typecheck — regenerate from the DB later).
- **Migration** `20260615150000_signal_realtime_publication.sql`: publishes `signal_*` to `supabase_realtime` so status/messages stream live (RLS still scopes each socket to the owner). Has a rollback block.
- **Tests**: pure status model + bridge client (mocked fetch/env) — **12 passing**.

## Verified locally
`@rokki/db` + `@rokki/web` typecheck ✅ · `next lint` ✅ (only pre-existing warnings) · signal unit tests 12/12 ✅ · migration harness `0 broken` ✅.

## To go live (manual, can't be done from CI)
Set **`SIGNAL_BRIDGE_URL`** = `https://rokki-signal-bridge.fly.dev` and **`SIGNAL_BRIDGE_SECRET`** (= the bridge's `BRIDGE_SECRET`) in **Vercel** (sandbox first). Then link a real Signal account — that's the Phase-0 acceptance step that validates the live `signal-cli` JSON → `toInbound` mapping.

## Scope notes
- Signal is **messaging-only** — calls can't be bridged (separate Rokki-native A/V track later).
- This wires the **connection + status + synced count**; merging Signal threads into the main inbox view is the next slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)