### PR TITLE
feat(signal): unified inbox — Signal threads in the Messages view

### DIFF
--- a/apps/web/src/app/api/v1/messages/threads/route.ts
+++ b/apps/web/src/app/api/v1/messages/threads/route.ts
@@ -1,6 +1,12 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { withObservability } from "@/lib/observability";
+import {
+  signalThreadToInbox,
+  mergeInboxThreads,
+  type InboxThread,
+  type SignalThreadRow,
+} from "@/lib/signal/inbox";
 
 /**
  * GET  /api/v1/messages/threads    — threads I can see, newest first
@@ -196,7 +202,25 @@ async function handleGet() {
     };
   });
 
-  return NextResponse.json({ data: decorated });
+  // Native Rokki threads, plus the user's linked Signal conversations merged
+  // in (one unified inbox). Signal rows are RLS-scoped to the owner.
+  const nativeThreads: InboxThread[] = decorated.map((d) => ({
+    ...d,
+    source: "rokki" as const,
+  }));
+
+  const { data: signalRows } = await supabase
+    .from("signal_threads")
+    .select("id, signal_id, kind, title, last_message_at, created_at")
+    .eq("user_id", user.id)
+    .eq("sync_enabled", true);
+  const signalThreads = ((signalRows ?? []) as SignalThreadRow[]).map(
+    signalThreadToInbox,
+  );
+
+  return NextResponse.json({
+    data: mergeInboxThreads(nativeThreads, signalThreads),
+  });
 }
 
 async function handlePost(request: NextRequest) {

--- a/apps/web/src/app/api/v1/signal/threads/[id]/route.ts
+++ b/apps/web/src/app/api/v1/signal/threads/[id]/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { withObservability } from "@/lib/observability";
+import { unauth } from "@/lib/signal/responses";
+
+interface Props {
+  params: Promise<{ id: string }>;
+}
+
+/**
+ * GET /api/v1/signal/threads/:id — the thread + its messages, oldest first.
+ * RLS scopes signal_threads / signal_messages to the owner, so a thread that
+ * isn't yours simply returns null/[].
+ */
+async function handleGet(_req: NextRequest, { params }: Props) {
+  const { id } = await params;
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return unauth();
+
+  const { data: thread } = await supabase
+    .from("signal_threads")
+    .select("id, signal_id, kind, title, muted, sync_enabled, last_message_at")
+    .eq("id", id)
+    .maybeSingle();
+
+  const { data: messages } = await supabase
+    .from("signal_messages")
+    .select(
+      "id, direction, sender, body, attachments, sent_at, edited_at, deleted_at",
+    )
+    .eq("thread_id", id)
+    .is("deleted_at", null)
+    .order("sent_at", { ascending: true });
+
+  return NextResponse.json({
+    data: { thread: thread ?? null, messages: messages ?? [] },
+  });
+}
+
+export const GET = withObservability(
+  handleGet,
+  "GET /api/v1/signal/threads/:id",
+);

--- a/apps/web/src/components/dashboard/MessagesCard.tsx
+++ b/apps/web/src/components/dashboard/MessagesCard.tsx
@@ -2,13 +2,20 @@
 
 import Link from "next/link";
 import { useCallback, useEffect, useState } from "react";
-import { Hash, User as UserIcon, MessageSquarePlus, Settings2 } from "lucide-react";
+import {
+  Hash,
+  User as UserIcon,
+  MessageSquare,
+  MessageSquarePlus,
+  Settings2,
+} from "lucide-react";
 import { DashboardCard } from "./DashboardCard";
 import { useRealtimeTable } from "@/lib/supabase/realtime";
 
 interface ThreadSummary {
   id: string;
-  kind: "dm" | "terminal" | "space";
+  kind: "dm" | "terminal" | "space" | "group" | "reminders" | "signal";
+  source?: "rokki" | "signal";
   label: string;
   last_message_at: string;
 }
@@ -76,6 +83,8 @@ export function MessagesCard() {
               >
                 {t.kind === "terminal" ? (
                   <Hash className="h-3 w-3 flex-shrink-0 text-text-3" />
+                ) : t.source === "signal" ? (
+                  <MessageSquare className="h-3 w-3 flex-shrink-0 text-success" />
                 ) : (
                   <UserIcon className="h-3 w-3 flex-shrink-0 text-text-3" />
                 )}

--- a/apps/web/src/components/messages/MessagesInbox.tsx
+++ b/apps/web/src/components/messages/MessagesInbox.tsx
@@ -2,18 +2,30 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import Link from "next/link";
-import { Send, Hash, User as UserIcon, Pin, Bell, RefreshCw } from "lucide-react";
+import {
+  Send,
+  Hash,
+  User as UserIcon,
+  Pin,
+  Bell,
+  RefreshCw,
+  MessageSquare,
+} from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useRealtimeTable } from "@/lib/supabase/realtime";
 import { createClient } from "@/lib/supabase/client";
+import { SignalThreadView } from "./SignalThreadView";
 
 interface ThreadSummary {
   id: string;
-  kind: "dm" | "terminal" | "space" | "group" | "reminders";
+  kind: "dm" | "terminal" | "space" | "group" | "reminders" | "signal";
+  source?: "rokki" | "signal";
   label: string;
   last_message_at: string;
   href_ticker?: string | null;
   other_user_id?: string | null;
+  signal_id?: string;
+  signal_kind?: "direct" | "group";
 }
 
 interface PingingTask {
@@ -63,6 +75,11 @@ export function MessagesInbox() {
   const [refreshingReminders, setRefreshingReminders] = useState(false);
   const scrollerRef = useRef<HTMLDivElement>(null);
 
+  const active = threads.find((t) => t.id === activeId) ?? null;
+  // Signal threads load + send through a different pipeline (the bridge), so
+  // the native message-load and realtime below skip them.
+  const activeIsSignal = active?.source === "signal";
+
   // Who am I?
   useEffect(() => {
     const supa = createClient();
@@ -99,20 +116,21 @@ export function MessagesInbox() {
     });
   }, []);
   useEffect(() => {
-    if (activeId) void loadMessages(activeId);
-  }, [activeId, loadMessages]);
+    if (activeId && !activeIsSignal) void loadMessages(activeId);
+  }, [activeId, activeIsSignal, loadMessages]);
 
-  // Realtime: any message insert under the active thread appends in place.
+  // Realtime: any message insert under the active (native) thread appends in
+  // place. Signal threads have their own realtime inside SignalThreadView.
   useRealtimeTable<{ id: string; thread_id: string }>(
     {
       table: "messages",
       filter: activeId ? `thread_id=eq.${activeId}` : undefined,
-      enabled: !!activeId,
+      enabled: !!activeId && !activeIsSignal,
       channelKey: activeId ? `msg:${activeId}` : undefined,
     },
     {
       onInsert: () => {
-        if (activeId) void loadMessages(activeId);
+        if (activeId && !activeIsSignal) void loadMessages(activeId);
         void loadThreads();
       },
     },
@@ -207,8 +225,6 @@ export function MessagesInbox() {
     }
   }
 
-  const active = threads.find((t) => t.id === activeId) ?? null;
-
   return (
     <div className="flex h-full min-h-0 rounded border border-border bg-bg-1">
       <aside className="w-[260px] flex-shrink-0 border-r border-border">
@@ -256,6 +272,8 @@ export function MessagesInbox() {
                     <Hash className="h-3 w-3 flex-shrink-0 text-text-3" />
                   ) : t.kind === "reminders" ? (
                     <Bell className="h-3 w-3 flex-shrink-0 text-accent" />
+                  ) : t.source === "signal" ? (
+                    <MessageSquare className="h-3 w-3 flex-shrink-0 text-success" />
                   ) : (
                     <UserIcon className="h-3 w-3 flex-shrink-0 text-text-3" />
                   )}
@@ -271,6 +289,15 @@ export function MessagesInbox() {
       </aside>
 
       <section className="flex min-h-0 flex-1 flex-col">
+        {activeIsSignal && active ? (
+          <SignalThreadView
+            threadId={active.id}
+            signalId={active.signal_id ?? ""}
+            signalKind={active.signal_kind ?? "direct"}
+            label={active.label}
+          />
+        ) : (
+          <>
         <header className="flex h-9 flex-shrink-0 items-center gap-2 border-b border-border bg-bg-0 px-3">
           {active ? (
             <>
@@ -459,6 +486,8 @@ export function MessagesInbox() {
             </button>
           </form>
         ) : null}
+          </>
+        )}
       </section>
     </div>
   );

--- a/apps/web/src/components/messages/SignalThreadView.tsx
+++ b/apps/web/src/components/messages/SignalThreadView.tsx
@@ -1,0 +1,184 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Send, MessageSquare, Loader2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { useRealtimeTable } from "@/lib/supabase/realtime";
+
+interface SignalMessage {
+  id: string;
+  direction: "in" | "out";
+  sender: string | null;
+  body: string | null;
+  sent_at: string;
+}
+
+/**
+ * The conversation pane for a Signal thread, swapped into the Messages inbox
+ * when the active thread's source is "signal". Kept separate from the native
+ * conversation so neither path complicates the other: messages come from
+ * signal_messages (direction in/out), and the composer sends via the bridge
+ * through /api/v1/signal/send.
+ */
+export function SignalThreadView({
+  threadId,
+  signalId,
+  signalKind,
+  label,
+}: {
+  threadId: string;
+  signalId: string;
+  signalKind: "direct" | "group";
+  label: string;
+}) {
+  const [messages, setMessages] = useState<SignalMessage[]>([]);
+  const [draft, setDraft] = useState("");
+  const [sending, setSending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const scrollerRef = useRef<HTMLDivElement>(null);
+
+  const load = useCallback(async () => {
+    const r = await fetch(`/api/v1/signal/threads/${threadId}`, {
+      credentials: "include",
+    });
+    if (!r.ok) {
+      setMessages([]);
+      return;
+    }
+    const body = (await r.json()) as { data?: { messages?: SignalMessage[] } };
+    setMessages(body.data?.messages ?? []);
+    requestAnimationFrame(() => {
+      scrollerRef.current?.scrollTo(0, scrollerRef.current.scrollHeight);
+    });
+  }, [threadId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  useRealtimeTable<{ id: string; thread_id: string }>(
+    {
+      table: "signal_messages",
+      filter: `thread_id=eq.${threadId}`,
+      channelKey: `sig:${threadId}`,
+    },
+    { onInsert: () => void load(), onUpdate: () => void load() },
+  );
+
+  async function submit(e?: React.FormEvent) {
+    e?.preventDefault();
+    const text = draft.trim();
+    if (!text || sending) return;
+    setSending(true);
+    setError(null);
+    try {
+      const r = await fetch("/api/v1/signal/send", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({ signalId, kind: signalKind, text }),
+      });
+      if (r.ok) {
+        setDraft("");
+        await load();
+      } else {
+        const b = (await r.json().catch(() => ({}))) as {
+          errors?: { message: string }[];
+        };
+        setError(b.errors?.[0]?.message ?? "Couldn’t send.");
+      }
+    } finally {
+      setSending(false);
+    }
+  }
+
+  return (
+    <>
+      <header className="flex h-9 flex-shrink-0 items-center gap-2 border-b border-border bg-bg-0 px-3">
+        <MessageSquare className="h-3 w-3 text-success" />
+        <span className="text-xs text-text-1">{label}</span>
+        <span className="rounded-sm border border-border px-1.5 py-px text-[10px] uppercase tracking-wide text-text-3">
+          Signal
+        </span>
+      </header>
+      <div ref={scrollerRef} className="flex-1 overflow-y-auto px-3 py-2 text-xs">
+        {messages.length === 0 ? (
+          <p className="py-10 text-center text-text-3">
+            No messages yet in this Signal chat.
+          </p>
+        ) : (
+          <ul className="flex flex-col gap-2">
+            {messages.map((m) => {
+              const mine = m.direction === "out";
+              return (
+                <li
+                  key={m.id}
+                  className={cn(
+                    "flex flex-col rounded-sm px-2 py-1",
+                    mine ? "items-end" : "items-start",
+                  )}
+                >
+                  <div
+                    className={cn(
+                      "max-w-[75%] rounded px-2 py-1 text-xs",
+                      mine ? "bg-accent text-bg-0" : "bg-bg-2 text-text-0",
+                    )}
+                  >
+                    {m.body}
+                  </div>
+                  <div className="mt-0.5 flex items-center gap-1 text-[10px] text-text-3">
+                    <span>{mine ? "you" : (m.sender ?? "them")}</span>
+                    <span>·</span>
+                    <span>{formatRelative(m.sent_at)}</span>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+      <form
+        onSubmit={submit}
+        className="flex flex-col gap-1 border-t border-border bg-bg-1 p-2"
+      >
+        {error ? (
+          <span className="px-1 text-[10px] text-danger">{error}</span>
+        ) : null}
+        <div className="flex gap-2">
+          <input
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            placeholder={`Message ${label} on Signal`}
+            className="flex-1 rounded-sm border border-border bg-bg-0 px-2 py-1.5 text-xs text-text-0 outline-none focus:border-border-focus"
+            disabled={sending}
+          />
+          <button
+            type="submit"
+            disabled={!draft.trim() || sending}
+            className="flex items-center gap-1 rounded-sm bg-accent px-2 py-1 text-xs text-bg-0 disabled:opacity-40"
+          >
+            {sending ? (
+              <Loader2 className="h-3 w-3 animate-spin" />
+            ) : (
+              <Send className="h-3 w-3" />
+            )}
+            Send
+          </button>
+        </div>
+      </form>
+    </>
+  );
+}
+
+function formatRelative(iso: string): string {
+  const ms = Date.now() - new Date(iso).getTime();
+  const s = Math.floor(ms / 1000);
+  if (s < 60) return "now";
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h`;
+  const d = Math.floor(h / 24);
+  if (d < 7) return `${d}d`;
+  return new Date(iso).toLocaleDateString();
+}

--- a/apps/web/src/lib/signal/inbox.test.ts
+++ b/apps/web/src/lib/signal/inbox.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import {
+  signalThreadToInbox,
+  mergeInboxThreads,
+  type InboxThread,
+  type SignalThreadRow,
+} from "./inbox";
+
+const row = (over: Partial<SignalThreadRow> = {}): SignalThreadRow => ({
+  id: "t1",
+  signal_id: "+15551234567",
+  kind: "direct",
+  title: null,
+  last_message_at: "2026-06-15T10:00:00Z",
+  created_at: "2026-06-01T00:00:00Z",
+  ...over,
+});
+
+describe("signalThreadToInbox", () => {
+  it("tags source/kind as signal and carries the send target", () => {
+    const t = signalThreadToInbox(row());
+    expect(t.source).toBe("signal");
+    expect(t.kind).toBe("signal");
+    expect(t.signal_id).toBe("+15551234567");
+    expect(t.signal_kind).toBe("direct");
+  });
+
+  it("prefers the title, falls back to signal_id", () => {
+    expect(signalThreadToInbox(row({ title: "Mom" })).label).toBe("Mom");
+    expect(signalThreadToInbox(row({ title: "  " })).label).toBe("+15551234567");
+    expect(signalThreadToInbox(row({ title: null })).label).toBe("+15551234567");
+  });
+
+  it("maps group kind, defaults anything else to direct", () => {
+    expect(signalThreadToInbox(row({ kind: "group" })).signal_kind).toBe("group");
+    expect(signalThreadToInbox(row({ kind: "weird" })).signal_kind).toBe("direct");
+  });
+
+  it("falls back to created_at when there are no messages yet", () => {
+    const t = signalThreadToInbox(row({ last_message_at: null }));
+    expect(t.last_message_at).toBe("2026-06-01T00:00:00Z");
+  });
+});
+
+describe("mergeInboxThreads", () => {
+  it("interleaves native + signal, newest activity first", () => {
+    const native: InboxThread[] = [
+      { id: "n1", kind: "dm", source: "rokki", label: "Carlos", last_message_at: "2026-06-15T09:00:00Z" },
+      { id: "n2", kind: "terminal", source: "rokki", label: "#HELIOS", last_message_at: "2026-06-15T12:00:00Z" },
+    ];
+    const signal: InboxThread[] = [
+      signalThreadToInbox(row({ id: "s1", last_message_at: "2026-06-15T11:00:00Z" })),
+    ];
+    const merged = mergeInboxThreads(native, signal);
+    expect(merged.map((t) => t.id)).toEqual(["n2", "s1", "n1"]);
+  });
+
+  it("returns a new array and does not mutate inputs", () => {
+    const native: InboxThread[] = [
+      { id: "n1", kind: "dm", source: "rokki", label: "a", last_message_at: "2026-06-15T09:00:00Z" },
+    ];
+    const signal: InboxThread[] = [];
+    const merged = mergeInboxThreads(native, signal);
+    expect(merged).not.toBe(native);
+    expect(native).toHaveLength(1);
+  });
+});

--- a/apps/web/src/lib/signal/inbox.ts
+++ b/apps/web/src/lib/signal/inbox.ts
@@ -1,0 +1,61 @@
+/**
+ * Pure helpers for merging Signal threads into the unified Messages inbox.
+ * DOM-free and side-effect-free so they're unit-testable and shared between
+ * the threads API (server) and the inbox UI (client types).
+ */
+
+export type ThreadSource = "rokki" | "signal";
+
+/** A thread row as the inbox consumes it — native or Signal, one shape. */
+export interface InboxThread {
+  id: string;
+  /** Native kind ("dm" | "terminal" | …) or "signal". */
+  kind: string;
+  source: ThreadSource;
+  label: string;
+  last_message_at: string;
+  /** Signal-only: recipient number/uuid or group id — the send target. */
+  signal_id?: string;
+  /** Signal-only: direct vs group conversation. */
+  signal_kind?: "direct" | "group";
+  href_ticker?: string | null;
+  other_user_id?: string | null;
+}
+
+/** Shape selected from the `signal_threads` table. */
+export interface SignalThreadRow {
+  id: string;
+  signal_id: string;
+  kind: string;
+  title: string | null;
+  last_message_at: string | null;
+  created_at: string;
+}
+
+/** Map a `signal_threads` row to a unified inbox thread. */
+export function signalThreadToInbox(t: SignalThreadRow): InboxThread {
+  const signalKind: "direct" | "group" =
+    t.kind === "group" ? "group" : "direct";
+  const title = t.title?.trim();
+  return {
+    id: t.id,
+    kind: "signal",
+    source: "signal",
+    label: title || t.signal_id,
+    last_message_at: t.last_message_at ?? t.created_at,
+    signal_id: t.signal_id,
+    signal_kind: signalKind,
+  };
+}
+
+/** Merge native + Signal threads into one list, newest activity first. */
+export function mergeInboxThreads(
+  native: InboxThread[],
+  signal: InboxThread[],
+): InboxThread[] {
+  return [...native, ...signal].sort(
+    (a, b) =>
+      new Date(b.last_message_at).getTime() -
+      new Date(a.last_message_at).getTime(),
+  );
+}


### PR DESCRIPTION
Builds on the Connect-Signal feature (#240): your linked **Signal conversations now show up in the Messages module** alongside native Rokki threads — one unified inbox, send/receive from either Rokki or your phone.

## What's here
- **Merged thread list**: `GET /api/v1/messages/threads` now folds in the user's `signal_threads` (RLS-scoped, `sync_enabled`), tagged `source: "signal"`, sorted with native threads by last activity. Pure merge/label logic lives in `lib/signal/inbox.ts`.
- **Signal conversation route**: `GET /api/v1/signal/threads/[id]` → the thread + its messages (oldest first).
- **`SignalThreadView`**: renders a Signal chat (direction in/out bubbles), live via `signal_messages` realtime, composer → `/api/v1/signal/send`. Deliberately **isolated** from the native conversation pane — the inbox just swaps it into the right pane when the active thread is Signal, so neither path complicates the other.
- **Signal badge** (green message icon) on inbox rows and the dashboard Messages card.
- Native message-load + realtime **skip** Signal threads (they have their own pipeline).

## Verified
`@rokki/web` typecheck ✅ · 18 signal/inbox unit tests ✅ · `next lint` ✅. The merge/label logic is covered by unit tests; the live conversation UI gets its final visual check once a real Signal account is linked (depends on the Vercel env vars from #240 + scanning the QR — task #47).

## Sequencing note
This is additive and safe with **zero** Signal data — the inbox is unchanged until threads exist. The end-to-end Signal experience (threads actually appearing, send/receive) lights up the moment the bridge env vars are set and an account is linked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)