### PR TITLE
feat(markets): Markets module — quotes, watchlists, portfolios, alerts

### DIFF
--- a/apps/mcp-server/src/markets-tools.ts
+++ b/apps/mcp-server/src/markets-tools.ts
@@ -1,0 +1,489 @@
+/**
+ * Markets MCP tools — API + MCP parity for the markets module.
+ *
+ * Lets an LLM client drive the markets terminal: look up quotes, manage
+ * personal watchlists, record portfolio lots, check performance, and set
+ * alerts. Market-data reads hit Finnhub directly (same free feed as the web
+ * app). DB writes are scoped to USER-owned rows (user_id = session.userId) so
+ * the service-role client never mutates another tenant's data
+ * (rokki/CLAUDE.md: per-user scoping, no service-key shortcuts).
+ *
+ * The generated DB types don't yet include the `mkt_*` tables (regenerated via
+ * `supabase gen types` post-migration); following the repo convention for the
+ * Supabase client boundary, DB access here is loosely typed and query RESULTS
+ * are cast to the Row interfaces below.
+ *
+ * Registered by spreading `marketsTools` into the TOOLS array in tools.ts.
+ */
+import { admin, type AuthedSession } from "./auth.js";
+import type { ToolDefinition } from "./tools.js";
+
+// ── result helper (textResult is private to tools.ts) ──────────────────────
+
+function textResult(text: string, isError = false) {
+  return { content: [{ type: "text" as const, text }], isError };
+}
+
+// ── row shapes for the mkt_* tables this module touches ────────────────────
+
+interface WatchlistRow {
+  id: string;
+  user_id: string | null;
+  name: string;
+}
+interface WatchlistSymbolRow {
+  watchlist_id: string;
+  symbol: string;
+}
+interface PortfolioRow {
+  id: string;
+  user_id: string | null;
+  name: string;
+  base_currency: string;
+}
+interface LotRow {
+  symbol: string;
+  side: "buy" | "sell";
+  quantity: number;
+  price: number;
+  fees: number;
+  trade_date: string;
+}
+interface AlertRow {
+  symbol: string;
+  condition: string;
+  threshold: number;
+  active: boolean;
+}
+
+// Loosely-typed client boundary (generated types lack mkt_*; see file header).
+type MktClient = any;
+
+/** Loosely-typed client for the mkt_* tables (see file header). */
+const mdb = (): MktClient => admin;
+
+// ── Finnhub (free) market-data reads ───────────────────────────────────────
+
+interface FinnhubQuoteRaw {
+  c: number;
+  d: number | null;
+  dp: number | null;
+  h: number;
+  l: number;
+  o: number;
+  pc: number;
+}
+
+async function finnhubQuote(symbol: string): Promise<FinnhubQuoteRaw | null> {
+  const token = process.env.FINNHUB_API_KEY;
+  if (!token) return null;
+  const res = await fetch(
+    `https://finnhub.io/api/v1/quote?symbol=${encodeURIComponent(symbol)}&token=${token}`,
+  );
+  if (!res.ok) return null;
+  const q = (await res.json()) as FinnhubQuoteRaw;
+  return q && typeof q.c === "number" && q.c !== 0 ? q : null;
+}
+
+async function finnhubSearch(
+  query: string,
+): Promise<{ symbol: string; description: string }[]> {
+  const token = process.env.FINNHUB_API_KEY;
+  if (!token) return [];
+  const res = await fetch(
+    `https://finnhub.io/api/v1/search?q=${encodeURIComponent(query)}&token=${token}`,
+  );
+  if (!res.ok) return [];
+  const data = (await res.json()) as {
+    result?: { symbol: string; description: string }[];
+  };
+  return (data.result ?? []).slice(0, 15);
+}
+
+const sym = (v: unknown) => String(v ?? "").trim().toUpperCase();
+
+// ── tools ──────────────────────────────────────────────────────────────────
+
+export const marketsTools: ToolDefinition[] = [
+  {
+    name: "rokki_markets_quote",
+    description:
+      "Get a real-time stock/ETF quote (price, change, day range) for a symbol, e.g. AAPL or VNQ.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        symbol: { type: "string", description: "Stock symbol, e.g. AAPL." },
+      },
+      required: ["symbol"],
+      additionalProperties: false,
+    },
+    handler: async (args) => {
+      const symbol = sym(args.symbol);
+      if (!symbol) return textResult("symbol is required.", true);
+      const q = await finnhubQuote(symbol);
+      if (!q)
+        return textResult(
+          `No quote for ${symbol} (or FINNHUB_API_KEY not configured).`,
+          true,
+        );
+      const sign = (q.d ?? 0) >= 0 ? "+" : "";
+      return textResult(
+        `${symbol}: $${q.c.toFixed(2)} (${sign}${(q.d ?? 0).toFixed(2)}, ${sign}${(q.dp ?? 0).toFixed(2)}%). ` +
+          `Open ${q.o.toFixed(2)} · High ${q.h.toFixed(2)} · Low ${q.l.toFixed(2)} · Prev ${q.pc.toFixed(2)}.`,
+      );
+    },
+  },
+
+  {
+    name: "rokki_markets_search",
+    description: "Search for stock symbols by company name or ticker.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: { type: "string", description: "Company name or partial symbol." },
+      },
+      required: ["query"],
+      additionalProperties: false,
+    },
+    handler: async (args) => {
+      const query = String(args.query ?? "").trim();
+      if (!query) return textResult("query is required.", true);
+      const matches = await finnhubSearch(query);
+      if (matches.length === 0) return textResult(`No matches for "${query}".`);
+      return textResult(
+        matches.map((m) => `• ${m.symbol} — ${m.description}`).join("\n"),
+      );
+    },
+  },
+
+  {
+    name: "rokki_markets_watchlists",
+    description: "List your personal markets watchlists and their symbols.",
+    inputSchema: { type: "object", properties: {}, additionalProperties: false },
+    handler: async (_args, session: AuthedSession) => {
+      const db = mdb();
+      const { data: listData } = await db
+        .from("mkt_watchlists")
+        .select("id, name, user_id")
+        .eq("user_id", session.userId);
+      const lists = (listData ?? []) as WatchlistRow[];
+      if (lists.length === 0) return textResult("You have no watchlists yet.");
+      const { data: symData } = await db
+        .from("mkt_watchlist_symbols")
+        .select("watchlist_id, symbol")
+        .in(
+          "watchlist_id",
+          lists.map((l) => l.id),
+        );
+      const syms = (symData ?? []) as WatchlistSymbolRow[];
+      const lines = lists.map((l) => {
+        const s = syms.filter((x) => x.watchlist_id === l.id).map((x) => x.symbol);
+        return `• ${l.name}: ${s.length ? s.join(", ") : "(empty)"}`;
+      });
+      return textResult(lines.join("\n"));
+    },
+  },
+
+  {
+    name: "rokki_markets_watchlist_add",
+    description:
+      "Add a symbol to one of your personal watchlists (creates the watchlist if it doesn't exist). Requires write scope.",
+    requiresWrite: true,
+    inputSchema: {
+      type: "object",
+      properties: {
+        watchlist: { type: "string", description: "Watchlist name." },
+        symbol: { type: "string", description: "Stock symbol to add." },
+      },
+      required: ["watchlist", "symbol"],
+      additionalProperties: false,
+    },
+    handler: async (args, session: AuthedSession) => {
+      const name = String(args.watchlist ?? "").trim();
+      const symbol = sym(args.symbol);
+      if (!name || !symbol)
+        return textResult("watchlist and symbol are required.", true);
+      const db = mdb();
+      const existing = await db
+        .from("mkt_watchlists")
+        .select("id, name, user_id")
+        .eq("user_id", session.userId)
+        .eq("name", name)
+        .maybeSingle();
+      let wl = existing.data as WatchlistRow | null;
+      if (!wl) {
+        const created = await db
+          .from("mkt_watchlists")
+          .insert({ user_id: session.userId, name, created_by: session.userId })
+          .select("id, name, user_id")
+          .single();
+        if (created.error || !created.data)
+          return textResult(
+            `Could not create watchlist: ${created.error?.message ?? "unknown"}`,
+            true,
+          );
+        wl = created.data as WatchlistRow;
+      }
+      const { error } = await db
+        .from("mkt_watchlist_symbols")
+        .insert({ watchlist_id: wl.id, symbol, note: null });
+      if (error && error.code !== "23505")
+        return textResult(`Could not add symbol: ${error.message}`, true);
+      return textResult(`Added ${symbol} to "${name}".`);
+    },
+  },
+
+  {
+    name: "rokki_markets_watchlist_remove",
+    description: "Remove a symbol from one of your personal watchlists. Requires write scope.",
+    requiresWrite: true,
+    inputSchema: {
+      type: "object",
+      properties: {
+        watchlist: { type: "string", description: "Watchlist name." },
+        symbol: { type: "string", description: "Stock symbol to remove." },
+      },
+      required: ["watchlist", "symbol"],
+      additionalProperties: false,
+    },
+    handler: async (args, session: AuthedSession) => {
+      const name = String(args.watchlist ?? "").trim();
+      const symbol = sym(args.symbol);
+      if (!name || !symbol)
+        return textResult("watchlist and symbol are required.", true);
+      const db = mdb();
+      const found = await db
+        .from("mkt_watchlists")
+        .select("id")
+        .eq("user_id", session.userId)
+        .eq("name", name)
+        .maybeSingle();
+      const wl = found.data as { id: string } | null;
+      if (!wl) return textResult(`Watchlist "${name}" not found.`, true);
+      await db
+        .from("mkt_watchlist_symbols")
+        .delete()
+        .eq("watchlist_id", wl.id)
+        .eq("symbol", symbol);
+      return textResult(`Removed ${symbol} from "${name}".`);
+    },
+  },
+
+  {
+    name: "rokki_markets_portfolio_add_lot",
+    description:
+      "Record a buy/sell lot in one of your personal portfolios (creates it if needed). Requires write scope.",
+    requiresWrite: true,
+    inputSchema: {
+      type: "object",
+      properties: {
+        portfolio: { type: "string", description: "Portfolio name." },
+        symbol: { type: "string" },
+        side: { type: "string", enum: ["buy", "sell"] },
+        quantity: { type: "number", minimum: 0 },
+        price: { type: "number", minimum: 0 },
+        fees: { type: "number", minimum: 0 },
+        trade_date: { type: "string", format: "date", description: "YYYY-MM-DD (default today)." },
+      },
+      required: ["portfolio", "symbol", "side", "quantity", "price"],
+      additionalProperties: false,
+    },
+    handler: async (args, session: AuthedSession) => {
+      const name = String(args.portfolio ?? "").trim();
+      const symbol = sym(args.symbol);
+      const side = args.side === "sell" ? "sell" : "buy";
+      const quantity = Number(args.quantity);
+      const price = Number(args.price);
+      const fees = Number(args.fees ?? 0);
+      if (!name || !symbol) return textResult("portfolio and symbol are required.", true);
+      if (!(quantity > 0)) return textResult("quantity must be > 0.", true);
+      if (!(price >= 0)) return textResult("price must be ≥ 0.", true);
+      const tradeDate =
+        typeof args.trade_date === "string"
+          ? args.trade_date
+          : new Date().toISOString().slice(0, 10);
+
+      const db = mdb();
+      const existing = await db
+        .from("mkt_portfolios")
+        .select("id, name, user_id, base_currency")
+        .eq("user_id", session.userId)
+        .eq("name", name)
+        .maybeSingle();
+      let pf = existing.data as PortfolioRow | null;
+      if (!pf) {
+        const created = await db
+          .from("mkt_portfolios")
+          .insert({
+            user_id: session.userId,
+            name,
+            base_currency: "USD",
+            created_by: session.userId,
+          })
+          .select("id, name, user_id, base_currency")
+          .single();
+        if (created.error || !created.data)
+          return textResult(
+            `Could not create portfolio: ${created.error?.message ?? "unknown"}`,
+            true,
+          );
+        pf = created.data as PortfolioRow;
+      }
+      const { error } = await db.from("mkt_lots").insert({
+        portfolio_id: pf.id,
+        symbol,
+        side,
+        quantity,
+        price,
+        fees,
+        trade_date: tradeDate,
+      });
+      if (error) return textResult(`Could not add lot: ${error.message}`, true);
+      return textResult(
+        `Recorded ${side} ${quantity} ${symbol} @ ${price} in "${name}".`,
+      );
+    },
+  },
+
+  {
+    name: "rokki_markets_portfolio_performance",
+    description:
+      "Summarize a personal portfolio's holdings, market value, and unrealized P/L using live quotes.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        portfolio: { type: "string", description: "Portfolio name." },
+      },
+      required: ["portfolio"],
+      additionalProperties: false,
+    },
+    handler: async (args, session: AuthedSession) => {
+      const name = String(args.portfolio ?? "").trim();
+      if (!name) return textResult("portfolio is required.", true);
+      const db = mdb();
+      const found = await db
+        .from("mkt_portfolios")
+        .select("id, name, user_id, base_currency")
+        .eq("user_id", session.userId)
+        .eq("name", name)
+        .maybeSingle();
+      const pf = found.data as PortfolioRow | null;
+      if (!pf) return textResult(`Portfolio "${name}" not found.`, true);
+      const { data: lotData } = await db
+        .from("mkt_lots")
+        .select("symbol, side, quantity, price, fees, trade_date")
+        .eq("portfolio_id", pf.id);
+      const lots = (lotData ?? []) as LotRow[];
+
+      // Net positions via average-cost accounting.
+      const acc = new Map<string, { qty: number; cost: number }>();
+      for (const lot of lots
+        .slice()
+        .sort((a, b) => (a.trade_date < b.trade_date ? -1 : 1))) {
+        const cur = acc.get(lot.symbol) ?? { qty: 0, cost: 0 };
+        const q = Number(lot.quantity);
+        const px = Number(lot.price);
+        const fees = Number(lot.fees);
+        if (lot.side === "buy") {
+          cur.qty += q;
+          cur.cost += q * px + fees;
+        } else {
+          const avg = cur.qty > 0 ? cur.cost / cur.qty : 0;
+          const s = Math.min(q, cur.qty);
+          cur.cost -= avg * s;
+          cur.qty -= s;
+        }
+        acc.set(lot.symbol, cur);
+      }
+      const open = Array.from(acc.entries()).filter(([, v]) => v.qty > 1e-9);
+      if (open.length === 0) return textResult(`"${name}" has no open positions.`);
+
+      let mv = 0;
+      let cb = 0;
+      const lines: string[] = [];
+      for (const [symbol, v] of open) {
+        const q = await finnhubQuote(symbol);
+        const price = q?.c ?? null;
+        const value = price !== null ? price * v.qty : null;
+        const pl = value !== null ? value - v.cost : null;
+        if (value !== null) mv += value;
+        cb += v.cost;
+        lines.push(
+          `• ${symbol}: ${v.qty} sh, cost $${v.cost.toFixed(0)}` +
+            (value !== null
+              ? `, value $${value.toFixed(0)}, P/L ${pl! >= 0 ? "+" : ""}$${pl!.toFixed(0)}`
+              : ", quote unavailable"),
+        );
+      }
+      const totalPl = mv - cb;
+      return textResult(
+        `${pf.name} (${pf.base_currency}):\n${lines.join("\n")}\n` +
+          `Total value $${mv.toFixed(0)} · cost $${cb.toFixed(0)} · unrealized ${totalPl >= 0 ? "+" : ""}$${totalPl.toFixed(0)} (${cb > 0 ? ((totalPl / cb) * 100).toFixed(2) : "0.00"}%).`,
+      );
+    },
+  },
+
+  {
+    name: "rokki_markets_alerts",
+    description: "List your active price alerts.",
+    inputSchema: { type: "object", properties: {}, additionalProperties: false },
+    handler: async (_args, session: AuthedSession) => {
+      const db = mdb();
+      const { data: alertData } = await db
+        .from("mkt_alerts")
+        .select("symbol, condition, threshold, active")
+        .eq("user_id", session.userId);
+      const alerts = (alertData ?? []) as AlertRow[];
+      if (alerts.length === 0) return textResult("No alerts set.");
+      return textResult(
+        alerts
+          .map(
+            (a) =>
+              `• ${a.symbol} ${a.condition} ${a.threshold}${a.active ? "" : " (paused)"}`,
+          )
+          .join("\n"),
+      );
+    },
+  },
+
+  {
+    name: "rokki_markets_alert_create",
+    description:
+      "Create a personal price alert. condition ∈ price_above|price_below|pct_up|pct_down. Requires write scope.",
+    requiresWrite: true,
+    inputSchema: {
+      type: "object",
+      properties: {
+        symbol: { type: "string" },
+        condition: {
+          type: "string",
+          enum: ["price_above", "price_below", "pct_up", "pct_down"],
+        },
+        threshold: { type: "number" },
+      },
+      required: ["symbol", "condition", "threshold"],
+      additionalProperties: false,
+    },
+    handler: async (args, session: AuthedSession) => {
+      const symbol = sym(args.symbol);
+      const condition = String(args.condition ?? "");
+      const threshold = Number(args.threshold);
+      const valid = ["price_above", "price_below", "pct_up", "pct_down"];
+      if (!symbol) return textResult("symbol is required.", true);
+      if (!valid.includes(condition))
+        return textResult(`condition must be one of ${valid.join(", ")}.`, true);
+      if (Number.isNaN(threshold))
+        return textResult("threshold must be a number.", true);
+      const db = mdb();
+      const { error } = await db.from("mkt_alerts").insert({
+        user_id: session.userId,
+        symbol,
+        condition,
+        threshold,
+        active: true,
+      });
+      if (error) return textResult(`Could not create alert: ${error.message}`, true);
+      return textResult(`Alert set: ${symbol} ${condition} ${threshold}.`);
+    },
+  },
+];

--- a/apps/mcp-server/src/tools.ts
+++ b/apps/mcp-server/src/tools.ts
@@ -6,6 +6,7 @@ import {
   normalizePath,
 } from "./folder-path.js";
 import { isValidTicker, suggestTicker, uniqueTicker } from "./ticker.js";
+import { marketsTools } from "./markets-tools.js";
 
 /**
  * Tool registry. Covers the full read + write surface of Rokki so an LLM
@@ -3633,6 +3634,8 @@ const TOOLS: ToolDefinition[] = [
       return textResult(`Archived ${slug} from ${terminal.name}.`);
     },
   },
+  // Markets module — quotes, watchlists, portfolios, alerts (API + MCP parity).
+  ...marketsTools,
 ];
 
 /* -------------------------------------------------------------------------- */

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -72,6 +72,19 @@ CRON_SECRET=
 SIGNAL_BRIDGE_URL=
 SIGNAL_BRIDGE_SECRET=
 
+# Markets module — free, display-licensed market-data feeds. Server-only
+# (never NEXT_PUBLIC_). All calls go through the cache + facade in
+# apps/web/src/lib/markets/. If a key is blank, that data class degrades
+# gracefully (the facade returns an `unsupported`/empty result).
+#   - Finnhub:     quotes, search, profile, news, earnings  (free 60 req/min)
+#   - Twelve Data: candles (charts), FX rates               (free 8 req/min, 800/day)
+#   - FMP:         financial statements, market movers       (free ~250 req/day)
+# The MCP server (apps/mcp-server) also reads FINNHUB_API_KEY for its
+# markets quote/search tools.
+FINNHUB_API_KEY=
+TWELVEDATA_API_KEY=
+FMP_API_KEY=
+
 # Misc
 NODE_ENV=development
 LOG_LEVEL=debug

--- a/apps/web/src/app/api/v1/cron/evaluate-price-alerts/route.ts
+++ b/apps/web/src/app/api/v1/cron/evaluate-price-alerts/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { withObservability } from "@/lib/observability";
+import { evaluatePriceAlerts } from "@/lib/markets/evaluate-alerts";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 300;
+
+/**
+ * POST/GET /api/v1/cron/evaluate-price-alerts — evaluate active price alerts
+ * and fire notifications. Authenticated by CRON_SECRET (x-cron-secret header
+ * or Bearer token), matching the other cron routes. Scheduled via GitHub
+ * Actions (see docs/09_ENVIRONMENTS.md / cron workflows).
+ */
+function authorize(request: NextRequest): boolean {
+  const expected = process.env.CRON_SECRET;
+  if (!expected) return false; // no secret configured ⇒ endpoint disabled
+  if (request.headers.get("x-cron-secret") === expected) return true;
+  if (request.headers.get("authorization") === `Bearer ${expected}`) return true;
+  return false;
+}
+
+function unauthorized(): NextResponse {
+  return NextResponse.json(
+    {
+      errors: [
+        {
+          code: "unauthorized",
+          message: "Cron endpoint requires `x-cron-secret` or Bearer token",
+        },
+      ],
+    },
+    { status: 401 },
+  );
+}
+
+async function handle(request: NextRequest) {
+  if (!authorize(request)) return unauthorized();
+  const result = await evaluatePriceAlerts();
+  return NextResponse.json({ data: result });
+}
+
+export const POST = withObservability(
+  handle,
+  "POST /api/v1/cron/evaluate-price-alerts",
+);
+export const GET = withObservability(
+  handle,
+  "GET /api/v1/cron/evaluate-price-alerts",
+);

--- a/apps/web/src/app/api/v1/markets/alerts/[id]/route.ts
+++ b/apps/web/src/app/api/v1/markets/alerts/[id]/route.ts
@@ -1,0 +1,83 @@
+import { type NextRequest } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { withObservability } from "@/lib/observability";
+import { marketsDb, type MktAlertRow } from "@/lib/markets/db";
+import {
+  badRequest,
+  internal,
+  noContent,
+  notFound,
+  ok,
+  unauthorized,
+} from "@/lib/markets/api";
+
+interface Props {
+  params: Promise<{ id: string }>;
+}
+
+/**
+ * PATCH  /api/v1/markets/alerts/:id — toggle active / change threshold.
+ * DELETE /api/v1/markets/alerts/:id — remove.
+ */
+async function handlePatch(request: NextRequest, { params }: Props) {
+  const { id } = await params;
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return unauthorized();
+  const db = marketsDb(supabase);
+
+  const body = (await request.json().catch(() => ({}))) as {
+    active?: boolean;
+    threshold?: number;
+    note?: string | null;
+  };
+  const patch: Partial<MktAlertRow> = {};
+  if (body.active !== undefined) {
+    if (typeof body.active !== "boolean") return badRequest("active must be boolean");
+    patch.active = body.active;
+  }
+  if (body.threshold !== undefined) {
+    if (typeof body.threshold !== "number" || Number.isNaN(body.threshold))
+      return badRequest("threshold must be a number");
+    patch.threshold = body.threshold;
+  }
+  if (body.note !== undefined) {
+    patch.note = body.note ? body.note.trim().slice(0, 280) : null;
+  }
+  if (Object.keys(patch).length === 0) return badRequest("no fields to update");
+
+  const { data, error } = await db
+    .from("mkt_alerts")
+    .update(patch)
+    .eq("id", id)
+    .select("*")
+    .maybeSingle();
+  if (error) return internal(error.message);
+  if (!data) return notFound("Alert not found");
+  return ok({ alert: data });
+}
+
+async function handleDelete(_request: NextRequest, { params }: Props) {
+  const { id } = await params;
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return unauthorized();
+  const db = marketsDb(supabase);
+
+  const { error } = await db.from("mkt_alerts").delete().eq("id", id);
+  if (error) return internal(error.message);
+  return noContent();
+}
+
+export const PATCH = withObservability<Props>(
+  handlePatch,
+  "PATCH /api/v1/markets/alerts/:id",
+);
+export const DELETE = withObservability<Props>(
+  handleDelete,
+  "DELETE /api/v1/markets/alerts/:id",
+);

--- a/apps/web/src/app/api/v1/markets/alerts/route.ts
+++ b/apps/web/src/app/api/v1/markets/alerts/route.ts
@@ -1,0 +1,73 @@
+import { type NextRequest } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { withObservability } from "@/lib/observability";
+import { marketsDb, type MktAlertRow } from "@/lib/markets/db";
+import { isValidSymbol, normalizeSymbol } from "@/lib/markets/symbols";
+import { badRequest, internal, ok, unauthorized } from "@/lib/markets/api";
+
+const CONDITIONS: MktAlertRow["condition"][] = [
+  "price_above",
+  "price_below",
+  "pct_up",
+  "pct_down",
+];
+
+/**
+ * GET  /api/v1/markets/alerts — the user's price alerts.
+ * POST /api/v1/markets/alerts — create one. Alerts are strictly personal (RLS).
+ */
+async function handleGet(_request: NextRequest) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return unauthorized();
+  const db = marketsDb(supabase);
+
+  const { data, error } = await db
+    .from("mkt_alerts")
+    .select("*")
+    .order("created_at", { ascending: false });
+  if (error) return internal(error.message);
+  return ok({ alerts: data ?? [] });
+}
+
+async function handlePost(request: NextRequest) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return unauthorized();
+  const db = marketsDb(supabase);
+
+  const body = (await request.json().catch(() => ({}))) as {
+    symbol?: string;
+    condition?: MktAlertRow["condition"];
+    threshold?: number;
+    note?: string;
+  };
+  const symbol = normalizeSymbol(body.symbol ?? "");
+  if (!isValidSymbol(symbol)) return badRequest("Invalid symbol");
+  if (!body.condition || !CONDITIONS.includes(body.condition))
+    return badRequest(`condition must be one of ${CONDITIONS.join(", ")}`);
+  if (typeof body.threshold !== "number" || Number.isNaN(body.threshold))
+    return badRequest("threshold must be a number");
+
+  const row: Partial<MktAlertRow> = {
+    user_id: user.id,
+    symbol,
+    condition: body.condition,
+    threshold: body.threshold,
+    note: body.note?.trim().slice(0, 280) || null,
+  };
+  const { data, error } = await db
+    .from("mkt_alerts")
+    .insert(row)
+    .select("*")
+    .single();
+  if (error || !data) return internal(error?.message ?? "create failed");
+  return ok({ alert: data }, 201);
+}
+
+export const GET = withObservability(handleGet, "GET /api/v1/markets/alerts");
+export const POST = withObservability(handlePost, "POST /api/v1/markets/alerts");

--- a/apps/web/src/app/api/v1/markets/calendar/route.ts
+++ b/apps/web/src/app/api/v1/markets/calendar/route.ts
@@ -1,0 +1,36 @@
+import { type NextRequest } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { withObservability } from "@/lib/observability";
+import { getEarningsCalendar } from "@/lib/markets/providers";
+import { badRequest, mapMarketError, ok, unauthorized } from "@/lib/markets/api";
+
+/**
+ * GET /api/v1/markets/calendar?from=YYYY-MM-DD&to=YYYY-MM-DD — earnings
+ * calendar. Defaults to the next 7 days when no range is given.
+ */
+async function handleGet(request: NextRequest) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return unauthorized();
+
+  const sp = request.nextUrl.searchParams;
+  const today = new Date();
+  const weekOut = new Date(today.getTime() + 7 * 86400_000);
+  const fromIso = sp.get("from") ?? today.toISOString().slice(0, 10);
+  const toIso = sp.get("to") ?? weekOut.toISOString().slice(0, 10);
+
+  const dateRe = /^\d{4}-\d{2}-\d{2}$/;
+  if (!dateRe.test(fromIso) || !dateRe.test(toIso))
+    return badRequest("from/to must be YYYY-MM-DD");
+
+  try {
+    const events = await getEarningsCalendar(fromIso, toIso);
+    return ok({ from: fromIso, to: toIso, events });
+  } catch (e) {
+    return mapMarketError(e);
+  }
+}
+
+export const GET = withObservability(handleGet, "GET /api/v1/markets/calendar");

--- a/apps/web/src/app/api/v1/markets/candles/[symbol]/route.ts
+++ b/apps/web/src/app/api/v1/markets/candles/[symbol]/route.ts
@@ -1,0 +1,44 @@
+import { type NextRequest } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { withObservability } from "@/lib/observability";
+import { getCandles } from "@/lib/markets/providers";
+import type { Range } from "@/lib/markets/providers/types";
+import { isValidSymbol, normalizeSymbol } from "@/lib/markets/symbols";
+import { badRequest, mapMarketError, ok, unauthorized } from "@/lib/markets/api";
+
+interface Props {
+  params: Promise<{ symbol: string }>;
+}
+
+const RANGES: Range[] = ["1D", "5D", "1M", "6M", "YTD", "1Y", "5Y", "MAX"];
+
+/**
+ * GET /api/v1/markets/candles/:symbol?range=1Y — OHLC series for the chart.
+ */
+async function handleGet(request: NextRequest, { params }: Props) {
+  const { symbol: raw } = await params;
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return unauthorized();
+
+  const symbol = normalizeSymbol(decodeURIComponent(raw));
+  if (!isValidSymbol(symbol)) return badRequest("Invalid symbol");
+
+  const rangeParam = (request.nextUrl.searchParams.get("range") ?? "1Y") as Range;
+  if (!RANGES.includes(rangeParam))
+    return badRequest(`range must be one of ${RANGES.join(", ")}`);
+
+  try {
+    const candles = await getCandles(symbol, rangeParam);
+    return ok({ symbol, range: rangeParam, candles });
+  } catch (e) {
+    return mapMarketError(e);
+  }
+}
+
+export const GET = withObservability<Props>(
+  handleGet,
+  "GET /api/v1/markets/candles/:symbol",
+);

--- a/apps/web/src/app/api/v1/markets/financials/[symbol]/route.ts
+++ b/apps/web/src/app/api/v1/markets/financials/[symbol]/route.ts
@@ -1,0 +1,43 @@
+import { type NextRequest } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { withObservability } from "@/lib/observability";
+import { getFinancials } from "@/lib/markets/providers";
+import type { StatementKind } from "@/lib/markets/providers/types";
+import { isValidSymbol, normalizeSymbol } from "@/lib/markets/symbols";
+import { badRequest, mapMarketError, ok, unauthorized } from "@/lib/markets/api";
+
+interface Props {
+  params: Promise<{ symbol: string }>;
+}
+
+const STATEMENTS: StatementKind[] = ["income", "balance", "cash"];
+
+/** GET /api/v1/markets/financials/:symbol?statement=income — statements (cached 24h upstream). */
+async function handleGet(request: NextRequest, { params }: Props) {
+  const { symbol: raw } = await params;
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return unauthorized();
+
+  const symbol = normalizeSymbol(decodeURIComponent(raw));
+  if (!isValidSymbol(symbol)) return badRequest("Invalid symbol");
+
+  const statement = (request.nextUrl.searchParams.get("statement") ??
+    "income") as StatementKind;
+  if (!STATEMENTS.includes(statement))
+    return badRequest(`statement must be one of ${STATEMENTS.join(", ")}`);
+
+  try {
+    const report = await getFinancials(symbol, statement);
+    return ok({ report });
+  } catch (e) {
+    return mapMarketError(e);
+  }
+}
+
+export const GET = withObservability<Props>(
+  handleGet,
+  "GET /api/v1/markets/financials/:symbol",
+);

--- a/apps/web/src/app/api/v1/markets/fx/route.ts
+++ b/apps/web/src/app/api/v1/markets/fx/route.ts
@@ -1,0 +1,33 @@
+import { type NextRequest } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { withObservability } from "@/lib/observability";
+import { getFxRate } from "@/lib/markets/providers";
+import { badRequest, mapMarketError, ok, unauthorized } from "@/lib/markets/api";
+
+const CCY = /^[A-Za-z]{3}$/;
+
+/** GET /api/v1/markets/fx?from=USD&to=EUR&amount=100 — currency converter. */
+async function handleGet(request: NextRequest) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return unauthorized();
+
+  const sp = request.nextUrl.searchParams;
+  const from = (sp.get("from") ?? "USD").toUpperCase();
+  const to = (sp.get("to") ?? "EUR").toUpperCase();
+  const amount = Number(sp.get("amount") ?? "1");
+  if (!CCY.test(from) || !CCY.test(to))
+    return badRequest("from/to must be 3-letter currency codes");
+  if (!Number.isFinite(amount)) return badRequest("amount must be a number");
+
+  try {
+    const rate = await getFxRate(from, to);
+    return ok({ from, to, rate, amount, converted: rate * amount });
+  } catch (e) {
+    return mapMarketError(e);
+  }
+}
+
+export const GET = withObservability(handleGet, "GET /api/v1/markets/fx");

--- a/apps/web/src/app/api/v1/markets/movers/route.ts
+++ b/apps/web/src/app/api/v1/markets/movers/route.ts
@@ -1,0 +1,30 @@
+import { type NextRequest } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { withObservability } from "@/lib/observability";
+import { getMovers } from "@/lib/markets/providers";
+import type { MoverKind } from "@/lib/markets/providers/types";
+import { badRequest, mapMarketError, ok, unauthorized } from "@/lib/markets/api";
+
+const KINDS: MoverKind[] = ["gainers", "losers", "active"];
+
+/** GET /api/v1/markets/movers?type=gainers — top gainers/losers/most-active. */
+async function handleGet(request: NextRequest) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return unauthorized();
+
+  const type = (request.nextUrl.searchParams.get("type") ?? "gainers") as MoverKind;
+  if (!KINDS.includes(type))
+    return badRequest(`type must be one of ${KINDS.join(", ")}`);
+
+  try {
+    const movers = await getMovers(type);
+    return ok({ type, movers });
+  } catch (e) {
+    return mapMarketError(e);
+  }
+}
+
+export const GET = withObservability(handleGet, "GET /api/v1/markets/movers");

--- a/apps/web/src/app/api/v1/markets/news/[symbol]/route.ts
+++ b/apps/web/src/app/api/v1/markets/news/[symbol]/route.ts
@@ -1,0 +1,38 @@
+import { type NextRequest } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { withObservability } from "@/lib/observability";
+import { getNews } from "@/lib/markets/providers";
+import { isValidSymbol, normalizeSymbol } from "@/lib/markets/symbols";
+import { badRequest, mapMarketError, ok, unauthorized } from "@/lib/markets/api";
+
+interface Props {
+  params: Promise<{ symbol: string }>;
+}
+
+/** GET /api/v1/markets/news/:symbol?days=7 — recent company news. */
+async function handleGet(request: NextRequest, { params }: Props) {
+  const { symbol: raw } = await params;
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return unauthorized();
+
+  const symbol = normalizeSymbol(decodeURIComponent(raw));
+  if (!isValidSymbol(symbol)) return badRequest("Invalid symbol");
+
+  const days = Number(request.nextUrl.searchParams.get("days") ?? "7");
+  const sinceDays = Number.isFinite(days) ? Math.min(Math.max(days, 1), 60) : 7;
+
+  try {
+    const items = await getNews(symbol, sinceDays);
+    return ok({ items });
+  } catch (e) {
+    return mapMarketError(e);
+  }
+}
+
+export const GET = withObservability<Props>(
+  handleGet,
+  "GET /api/v1/markets/news/:symbol",
+);

--- a/apps/web/src/app/api/v1/markets/options/[symbol]/route.ts
+++ b/apps/web/src/app/api/v1/markets/options/[symbol]/route.ts
@@ -1,0 +1,42 @@
+import { type NextRequest } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { withObservability } from "@/lib/observability";
+import { isValidSymbol, normalizeSymbol } from "@/lib/markets/symbols";
+import { badRequest, ok, unauthorized } from "@/lib/markets/api";
+
+interface Props {
+  params: Promise<{ symbol: string }>;
+}
+
+/**
+ * GET /api/v1/markets/options/:symbol — options chain.
+ *
+ * No provider in the configured FREE stack exposes an options chain, so this
+ * degrades gracefully: it returns `{ supported: false }` with a clear message
+ * rather than erroring, letting the UI show an upgrade hint. Wiring a paid
+ * options feed is a one-adapter change (see providers/README in the plan).
+ */
+async function handleGet(_request: NextRequest, { params }: Props) {
+  const { symbol: raw } = await params;
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return unauthorized();
+
+  const symbol = normalizeSymbol(decodeURIComponent(raw));
+  if (!isValidSymbol(symbol)) return badRequest("Invalid symbol");
+
+  return ok({
+    symbol,
+    supported: false,
+    expirations: [],
+    contracts: [],
+    note: "Options chains require a paid data feed; not available on the free tier.",
+  });
+}
+
+export const GET = withObservability<Props>(
+  handleGet,
+  "GET /api/v1/markets/options/:symbol",
+);

--- a/apps/web/src/app/api/v1/markets/overview/route.ts
+++ b/apps/web/src/app/api/v1/markets/overview/route.ts
@@ -1,0 +1,70 @@
+import { type NextRequest } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { withObservability } from "@/lib/observability";
+import { getQuotesCached } from "@/lib/markets/cache";
+import {
+  OVERVIEW_COMMODITIES,
+  OVERVIEW_FX,
+  OVERVIEW_INDICES,
+  OVERVIEW_SECTORS,
+  type OverviewItem,
+} from "@/lib/markets/overview";
+import { mapMarketError, ok, unauthorized } from "@/lib/markets/api";
+import type { Quote } from "@/lib/markets/providers/types";
+
+interface BoardRow {
+  symbol: string;
+  label: string;
+  price: number | null;
+  change: number | null;
+  changePct: number | null;
+}
+
+function toRows(items: OverviewItem[], quotes: Record<string, Quote>): BoardRow[] {
+  return items.map((it) => {
+    const q = quotes[it.symbol];
+    return {
+      symbol: it.symbol,
+      label: it.label,
+      price: q?.price ?? null,
+      change: q?.change ?? null,
+      changePct: q?.changePct ?? null,
+    };
+  });
+}
+
+/**
+ * GET /api/v1/markets/overview — indices, sectors, commodities, FX board.
+ * One cached batch quote call (60s TTL — the board doesn't need 15s freshness).
+ */
+async function handleGet(_request: NextRequest) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return unauthorized();
+
+  const all = [
+    ...OVERVIEW_INDICES,
+    ...OVERVIEW_SECTORS,
+    ...OVERVIEW_COMMODITIES,
+    ...OVERVIEW_FX,
+  ];
+
+  try {
+    const quotes = await getQuotesCached(
+      all.map((i) => i.symbol),
+      60_000,
+    );
+    return ok({
+      indices: toRows(OVERVIEW_INDICES, quotes),
+      sectors: toRows(OVERVIEW_SECTORS, quotes),
+      commodities: toRows(OVERVIEW_COMMODITIES, quotes),
+      fx: toRows(OVERVIEW_FX, quotes),
+    });
+  } catch (e) {
+    return mapMarketError(e);
+  }
+}
+
+export const GET = withObservability(handleGet, "GET /api/v1/markets/overview");

--- a/apps/web/src/app/api/v1/markets/portfolios/[id]/lots/[lotId]/route.ts
+++ b/apps/web/src/app/api/v1/markets/portfolios/[id]/lots/[lotId]/route.ts
@@ -1,0 +1,33 @@
+import { type NextRequest } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { withObservability } from "@/lib/observability";
+import { marketsDb } from "@/lib/markets/db";
+import { internal, noContent, unauthorized } from "@/lib/markets/api";
+
+interface Props {
+  params: Promise<{ id: string; lotId: string }>;
+}
+
+/** DELETE /api/v1/markets/portfolios/:id/lots/:lotId — remove a lot. */
+async function handleDelete(_request: NextRequest, { params }: Props) {
+  const { id, lotId } = await params;
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return unauthorized();
+  const db = marketsDb(supabase);
+
+  const { error } = await db
+    .from("mkt_lots")
+    .delete()
+    .eq("id", lotId)
+    .eq("portfolio_id", id);
+  if (error) return internal(error.message);
+  return noContent();
+}
+
+export const DELETE = withObservability<Props>(
+  handleDelete,
+  "DELETE /api/v1/markets/portfolios/:id/lots/:lotId",
+);

--- a/apps/web/src/app/api/v1/markets/portfolios/[id]/lots/route.ts
+++ b/apps/web/src/app/api/v1/markets/portfolios/[id]/lots/route.ts
@@ -1,0 +1,94 @@
+import { type NextRequest } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { withObservability } from "@/lib/observability";
+import { marketsDb, type MktLotRow } from "@/lib/markets/db";
+import { isValidSymbol, normalizeSymbol } from "@/lib/markets/symbols";
+import { badRequest, internal, ok, unauthorized } from "@/lib/markets/api";
+
+interface Props {
+  params: Promise<{ id: string }>;
+}
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * GET  /api/v1/markets/portfolios/:id/lots — list lots.
+ * POST /api/v1/markets/portfolios/:id/lots — add a lot.
+ */
+async function handleGet(_request: NextRequest, { params }: Props) {
+  const { id } = await params;
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return unauthorized();
+  const db = marketsDb(supabase);
+
+  const { data, error } = await db
+    .from("mkt_lots")
+    .select("*")
+    .eq("portfolio_id", id)
+    .order("trade_date", { ascending: false });
+  if (error) return internal(error.message);
+  return ok({ lots: data ?? [] });
+}
+
+async function handlePost(request: NextRequest, { params }: Props) {
+  const { id } = await params;
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return unauthorized();
+  const db = marketsDb(supabase);
+
+  const body = (await request.json().catch(() => ({}))) as {
+    symbol?: string;
+    side?: string;
+    quantity?: number;
+    price?: number;
+    fees?: number;
+    tradeDate?: string;
+    note?: string;
+  };
+
+  const symbol = normalizeSymbol(body.symbol ?? "");
+  if (!isValidSymbol(symbol)) return badRequest("Invalid symbol");
+  if (body.side !== "buy" && body.side !== "sell")
+    return badRequest("side must be 'buy' or 'sell'");
+  if (typeof body.quantity !== "number" || body.quantity <= 0)
+    return badRequest("quantity must be a positive number");
+  if (typeof body.price !== "number" || body.price < 0)
+    return badRequest("price must be a non-negative number");
+  if (body.fees !== undefined && (typeof body.fees !== "number" || body.fees < 0))
+    return badRequest("fees must be a non-negative number");
+  const tradeDate = body.tradeDate ?? new Date().toISOString().slice(0, 10);
+  if (!DATE_RE.test(tradeDate)) return badRequest("tradeDate must be YYYY-MM-DD");
+
+  const row: Partial<MktLotRow> = {
+    portfolio_id: id,
+    symbol,
+    side: body.side,
+    quantity: body.quantity,
+    price: body.price,
+    fees: body.fees ?? 0,
+    trade_date: tradeDate,
+    note: body.note?.trim().slice(0, 280) || null,
+  };
+  const { data, error } = await db
+    .from("mkt_lots")
+    .insert(row)
+    .select("*")
+    .single();
+  if (error || !data) return internal(error?.message ?? "create failed");
+  return ok({ lot: data }, 201);
+}
+
+export const GET = withObservability<Props>(
+  handleGet,
+  "GET /api/v1/markets/portfolios/:id/lots",
+);
+export const POST = withObservability<Props>(
+  handlePost,
+  "POST /api/v1/markets/portfolios/:id/lots",
+);

--- a/apps/web/src/app/api/v1/markets/portfolios/[id]/route.ts
+++ b/apps/web/src/app/api/v1/markets/portfolios/[id]/route.ts
@@ -1,0 +1,118 @@
+import { type NextRequest } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { withObservability } from "@/lib/observability";
+import { marketsDb, type MktLotRow, type MktPortfolioRow } from "@/lib/markets/db";
+import { getQuotesCached } from "@/lib/markets/cache";
+import { computePerformance, computePositions } from "@/lib/markets/portfolio";
+import {
+  badRequest,
+  internal,
+  noContent,
+  notFound,
+  ok,
+  unauthorized,
+} from "@/lib/markets/api";
+
+interface Props {
+  params: Promise<{ id: string }>;
+}
+
+/**
+ * GET    /api/v1/markets/portfolios/:id — portfolio + lots + live performance.
+ * PATCH  /api/v1/markets/portfolios/:id — rename / change base currency.
+ * DELETE /api/v1/markets/portfolios/:id — delete (cascades lots).
+ */
+async function handleGet(_request: NextRequest, { params }: Props) {
+  const { id } = await params;
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return unauthorized();
+  const db = marketsDb(supabase);
+
+  const { data: portfolio, error } = await db
+    .from("mkt_portfolios")
+    .select("*")
+    .eq("id", id)
+    .maybeSingle();
+  if (error) return internal(error.message);
+  if (!portfolio) return notFound("Portfolio not found");
+
+  const { data: lots } = await db
+    .from("mkt_lots")
+    .select("*")
+    .eq("portfolio_id", id)
+    .order("trade_date");
+
+  const ledger = (lots ?? []) as MktLotRow[];
+  const positions = computePositions(ledger);
+  const symbols = positions.filter((p) => p.quantity > 0).map((p) => p.symbol);
+  const quotes = await getQuotesCached(symbols);
+  const performance = computePerformance(positions, quotes);
+
+  return ok({ portfolio, lots: ledger, performance });
+}
+
+async function handlePatch(request: NextRequest, { params }: Props) {
+  const { id } = await params;
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return unauthorized();
+  const db = marketsDb(supabase);
+
+  const body = (await request.json().catch(() => ({}))) as {
+    name?: string;
+    baseCurrency?: string;
+  };
+  const patch: Partial<MktPortfolioRow> = {};
+  if (body.name !== undefined) {
+    const n = body.name.trim();
+    if (!n) return badRequest("name cannot be empty");
+    if (n.length > 80) return badRequest("name must be ≤ 80 characters");
+    patch.name = n;
+  }
+  if (body.baseCurrency !== undefined) {
+    patch.base_currency = body.baseCurrency.toUpperCase().slice(0, 3);
+  }
+  if (Object.keys(patch).length === 0) return badRequest("no fields to update");
+
+  const { data, error } = await db
+    .from("mkt_portfolios")
+    .update(patch)
+    .eq("id", id)
+    .select("*")
+    .maybeSingle();
+  if (error) return internal(error.message);
+  if (!data) return notFound("Portfolio not found");
+  return ok({ portfolio: data });
+}
+
+async function handleDelete(_request: NextRequest, { params }: Props) {
+  const { id } = await params;
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return unauthorized();
+  const db = marketsDb(supabase);
+
+  const { error } = await db.from("mkt_portfolios").delete().eq("id", id);
+  if (error) return internal(error.message);
+  return noContent();
+}
+
+export const GET = withObservability<Props>(
+  handleGet,
+  "GET /api/v1/markets/portfolios/:id",
+);
+export const PATCH = withObservability<Props>(
+  handlePatch,
+  "PATCH /api/v1/markets/portfolios/:id",
+);
+export const DELETE = withObservability<Props>(
+  handleDelete,
+  "DELETE /api/v1/markets/portfolios/:id",
+);

--- a/apps/web/src/app/api/v1/markets/portfolios/route.ts
+++ b/apps/web/src/app/api/v1/markets/portfolios/route.ts
@@ -1,0 +1,88 @@
+import { type NextRequest } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { withObservability } from "@/lib/observability";
+import { marketsDb, type MktPortfolioRow, type ScopeKind } from "@/lib/markets/db";
+import { badRequest, internal, ok, unauthorized } from "@/lib/markets/api";
+
+const SCOPES: ScopeKind[] = ["user", "space", "terminal"];
+
+/**
+ * GET  /api/v1/markets/portfolios?scope=&scopeId= — list portfolios at a scope.
+ * POST /api/v1/markets/portfolios — create a portfolio.
+ */
+async function handleGet(request: NextRequest) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return unauthorized();
+  const db = marketsDb(supabase);
+
+  const scope = (request.nextUrl.searchParams.get("scope") ?? "user") as ScopeKind;
+  if (!SCOPES.includes(scope)) return badRequest("invalid scope");
+  const scopeId = request.nextUrl.searchParams.get("scopeId");
+
+  let query = db
+    .from("mkt_portfolios")
+    .select("*")
+    .is("archived_at", null)
+    .order("created_at");
+  if (scope === "user") query = query.eq("user_id", user.id);
+  else if (scope === "space") {
+    if (!scopeId) return badRequest("scopeId required for space scope");
+    query = query.eq("space_id", scopeId);
+  } else {
+    if (!scopeId) return badRequest("scopeId required for terminal scope");
+    query = query.eq("terminal_id", scopeId);
+  }
+
+  const { data, error } = await query;
+  if (error) return internal(error.message);
+  return ok({ portfolios: data ?? [] });
+}
+
+async function handlePost(request: NextRequest) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return unauthorized();
+  const db = marketsDb(supabase);
+
+  const body = (await request.json().catch(() => ({}))) as {
+    name?: string;
+    baseCurrency?: string;
+    scope?: ScopeKind;
+    scopeId?: string;
+  };
+  const name = body.name?.trim();
+  if (!name) return badRequest("name is required");
+  if (name.length > 80) return badRequest("name must be ≤ 80 characters");
+  const scope = body.scope ?? "user";
+  if (!SCOPES.includes(scope)) return badRequest("invalid scope");
+
+  const row: Partial<MktPortfolioRow> = {
+    name,
+    base_currency: (body.baseCurrency ?? "USD").toUpperCase().slice(0, 3),
+    created_by: user.id,
+  };
+  if (scope === "user") row.user_id = user.id;
+  else if (scope === "space") {
+    if (!body.scopeId) return badRequest("scopeId required for space scope");
+    row.space_id = body.scopeId;
+  } else {
+    if (!body.scopeId) return badRequest("scopeId required for terminal scope");
+    row.terminal_id = body.scopeId;
+  }
+
+  const { data, error } = await db
+    .from("mkt_portfolios")
+    .insert(row)
+    .select("*")
+    .single();
+  if (error || !data) return internal(error?.message ?? "create failed");
+  return ok({ portfolio: data }, 201);
+}
+
+export const GET = withObservability(handleGet, "GET /api/v1/markets/portfolios");
+export const POST = withObservability(handlePost, "POST /api/v1/markets/portfolios");

--- a/apps/web/src/app/api/v1/markets/profile/[symbol]/route.ts
+++ b/apps/web/src/app/api/v1/markets/profile/[symbol]/route.ts
@@ -1,0 +1,35 @@
+import { type NextRequest } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { withObservability } from "@/lib/observability";
+import { getProfile } from "@/lib/markets/providers";
+import { isValidSymbol, normalizeSymbol } from "@/lib/markets/symbols";
+import { badRequest, mapMarketError, ok, unauthorized } from "@/lib/markets/api";
+
+interface Props {
+  params: Promise<{ symbol: string }>;
+}
+
+/** GET /api/v1/markets/profile/:symbol — company profile / fundamentals header. */
+async function handleGet(_request: NextRequest, { params }: Props) {
+  const { symbol: raw } = await params;
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return unauthorized();
+
+  const symbol = normalizeSymbol(decodeURIComponent(raw));
+  if (!isValidSymbol(symbol)) return badRequest("Invalid symbol");
+
+  try {
+    const profile = await getProfile(symbol);
+    return ok({ profile });
+  } catch (e) {
+    return mapMarketError(e);
+  }
+}
+
+export const GET = withObservability<Props>(
+  handleGet,
+  "GET /api/v1/markets/profile/:symbol",
+);

--- a/apps/web/src/app/api/v1/markets/quote/[symbol]/route.ts
+++ b/apps/web/src/app/api/v1/markets/quote/[symbol]/route.ts
@@ -1,0 +1,40 @@
+import { type NextRequest } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { withObservability } from "@/lib/observability";
+import { getQuoteCached } from "@/lib/markets/cache";
+import { isValidSymbol, normalizeSymbol } from "@/lib/markets/symbols";
+import { badRequest, mapMarketError, ok, unauthorized } from "@/lib/markets/api";
+
+interface Props {
+  params: Promise<{ symbol: string }>;
+}
+
+/**
+ * GET /api/v1/markets/quote/:symbol — normalized quote, served from the
+ * TTL'd cache (15s) so free-tier provider limits are respected.
+ *
+ * Spec: MARKETS_MODULE_PLAN.md §7
+ */
+async function handleGet(_request: NextRequest, { params }: Props) {
+  const { symbol: raw } = await params;
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return unauthorized();
+
+  const symbol = normalizeSymbol(decodeURIComponent(raw));
+  if (!isValidSymbol(symbol)) return badRequest("Invalid symbol");
+
+  try {
+    const { quote, cached } = await getQuoteCached(symbol);
+    return ok({ quote, cached });
+  } catch (e) {
+    return mapMarketError(e);
+  }
+}
+
+export const GET = withObservability<Props>(
+  handleGet,
+  "GET /api/v1/markets/quote/:symbol",
+);

--- a/apps/web/src/app/api/v1/markets/quotes/route.ts
+++ b/apps/web/src/app/api/v1/markets/quotes/route.ts
@@ -1,0 +1,35 @@
+import { type NextRequest } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { withObservability } from "@/lib/observability";
+import { getQuotesCached } from "@/lib/markets/cache";
+import { isValidSymbol, normalizeSymbol } from "@/lib/markets/symbols";
+import { badRequest, mapMarketError, ok, unauthorized } from "@/lib/markets/api";
+
+/**
+ * GET /api/v1/markets/quotes?symbols=AAPL,MSFT,NVDA — batch quotes for a
+ * watchlist. One call, cache-served, so a 30-row watchlist isn't 30 requests.
+ */
+async function handleGet(request: NextRequest) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return unauthorized();
+
+  const raw = request.nextUrl.searchParams.get("symbols") ?? "";
+  const symbols = raw
+    .split(",")
+    .map((s) => normalizeSymbol(s))
+    .filter((s) => s && isValidSymbol(s));
+  if (symbols.length === 0) return badRequest("symbols is required");
+  if (symbols.length > 100) return badRequest("max 100 symbols per request");
+
+  try {
+    const quotes = await getQuotesCached(symbols);
+    return ok({ quotes });
+  } catch (e) {
+    return mapMarketError(e);
+  }
+}
+
+export const GET = withObservability(handleGet, "GET /api/v1/markets/quotes");

--- a/apps/web/src/app/api/v1/markets/screener/route.ts
+++ b/apps/web/src/app/api/v1/markets/screener/route.ts
@@ -1,0 +1,76 @@
+import { type NextRequest } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { withObservability } from "@/lib/observability";
+import { getQuotesCached } from "@/lib/markets/cache";
+import { SCREENER_UNIVERSE } from "@/lib/markets/screener-universe";
+import { isValidSymbol, normalizeSymbol } from "@/lib/markets/symbols";
+import { badRequest, mapMarketError, ok, unauthorized } from "@/lib/markets/api";
+
+interface ScreenerFilters {
+  minPrice?: number;
+  maxPrice?: number;
+  minChangePct?: number;
+  maxChangePct?: number;
+  minMarketCap?: number;
+  maxMarketCap?: number;
+}
+
+/**
+ * POST /api/v1/markets/screener — filter a candidate universe on fields we
+ * have from free quotes (price, % change, market cap). Body:
+ *   { universe?: string[], filters: ScreenerFilters, sort?, limit? }
+ */
+async function handlePost(request: NextRequest) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return unauthorized();
+
+  const body = (await request.json().catch(() => ({}))) as {
+    universe?: string[];
+    filters?: ScreenerFilters;
+    sort?: "changePct" | "price" | "marketCap";
+    limit?: number;
+  };
+
+  let universe = SCREENER_UNIVERSE;
+  if (Array.isArray(body.universe) && body.universe.length > 0) {
+    universe = body.universe.map(normalizeSymbol).filter(isValidSymbol);
+    if (universe.length === 0) return badRequest("universe has no valid symbols");
+    if (universe.length > 100) return badRequest("universe capped at 100 symbols");
+  }
+
+  const f = body.filters ?? {};
+  const sort = body.sort ?? "changePct";
+  const limit = Math.min(Math.max(body.limit ?? 50, 1), 100);
+
+  try {
+    const quotes = await getQuotesCached(universe, 60_000);
+    let rows = Object.values(quotes).filter((q) => {
+      if (f.minPrice !== undefined && q.price < f.minPrice) return false;
+      if (f.maxPrice !== undefined && q.price > f.maxPrice) return false;
+      if (f.minChangePct !== undefined && q.changePct < f.minChangePct) return false;
+      if (f.maxChangePct !== undefined && q.changePct > f.maxChangePct) return false;
+      if (f.minMarketCap !== undefined && (q.marketCap ?? 0) < f.minMarketCap) return false;
+      if (f.maxMarketCap !== undefined && (q.marketCap ?? Infinity) > f.maxMarketCap) return false;
+      return true;
+    });
+
+    rows = rows.sort((a, b) => {
+      if (sort === "price") return b.price - a.price;
+      if (sort === "marketCap") return (b.marketCap ?? 0) - (a.marketCap ?? 0);
+      return b.changePct - a.changePct;
+    });
+
+    return ok({
+      count: rows.length,
+      results: rows.slice(0, limit),
+      note: "Screens price / % change / market cap from free quotes. Fundamental filters (P/E, yield) require a paid feed.",
+    });
+  } catch (e) {
+    return mapMarketError(e);
+  }
+}
+
+export const POST = withObservability(handlePost, "POST /api/v1/markets/screener");

--- a/apps/web/src/app/api/v1/markets/search/route.ts
+++ b/apps/web/src/app/api/v1/markets/search/route.ts
@@ -1,0 +1,30 @@
+import { type NextRequest } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { withObservability } from "@/lib/observability";
+import { searchSymbols } from "@/lib/markets/providers";
+import { badRequest, mapMarketError, ok, unauthorized } from "@/lib/markets/api";
+
+/**
+ * GET /api/v1/markets/search?q=apple — symbol search for the `⌘K` palette
+ * and the watchlist add box.
+ */
+async function handleGet(request: NextRequest) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return unauthorized();
+
+  const q = request.nextUrl.searchParams.get("q")?.trim() ?? "";
+  if (q.length < 1) return badRequest("Query `q` is required");
+  if (q.length > 64) return badRequest("Query too long");
+
+  try {
+    const matches = await searchSymbols(q);
+    return ok({ matches });
+  } catch (e) {
+    return mapMarketError(e);
+  }
+}
+
+export const GET = withObservability(handleGet, "GET /api/v1/markets/search");

--- a/apps/web/src/app/api/v1/markets/watchlists/[id]/route.ts
+++ b/apps/web/src/app/api/v1/markets/watchlists/[id]/route.ts
@@ -1,0 +1,81 @@
+import { type NextRequest } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { withObservability } from "@/lib/observability";
+import { marketsDb, type MktWatchlistRow } from "@/lib/markets/db";
+import {
+  badRequest,
+  internal,
+  noContent,
+  notFound,
+  ok,
+  unauthorized,
+} from "@/lib/markets/api";
+
+interface Props {
+  params: Promise<{ id: string }>;
+}
+
+/**
+ * PATCH  /api/v1/markets/watchlists/:id — rename / reorder.
+ * DELETE /api/v1/markets/watchlists/:id — delete (cascades symbols). RLS gates.
+ */
+async function handlePatch(request: NextRequest, { params }: Props) {
+  const { id } = await params;
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return unauthorized();
+  const db = marketsDb(supabase);
+
+  const body = (await request.json().catch(() => ({}))) as {
+    name?: string;
+    display_order?: number;
+  };
+  const patch: Partial<MktWatchlistRow> = {};
+  if (body.name !== undefined) {
+    const n = body.name.trim();
+    if (!n) return badRequest("name cannot be empty");
+    if (n.length > 80) return badRequest("name must be ≤ 80 characters");
+    patch.name = n;
+  }
+  if (body.display_order !== undefined) {
+    if (!Number.isInteger(body.display_order))
+      return badRequest("display_order must be an integer");
+    patch.display_order = body.display_order;
+  }
+  if (Object.keys(patch).length === 0) return badRequest("no fields to update");
+
+  const { data, error } = await db
+    .from("mkt_watchlists")
+    .update(patch)
+    .eq("id", id)
+    .select("*")
+    .maybeSingle();
+  if (error) return internal(error.message);
+  if (!data) return notFound("Watchlist not found");
+  return ok({ watchlist: data });
+}
+
+async function handleDelete(_request: NextRequest, { params }: Props) {
+  const { id } = await params;
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return unauthorized();
+  const db = marketsDb(supabase);
+
+  const { error } = await db.from("mkt_watchlists").delete().eq("id", id);
+  if (error) return internal(error.message);
+  return noContent();
+}
+
+export const PATCH = withObservability<Props>(
+  handlePatch,
+  "PATCH /api/v1/markets/watchlists/:id",
+);
+export const DELETE = withObservability<Props>(
+  handleDelete,
+  "DELETE /api/v1/markets/watchlists/:id",
+);

--- a/apps/web/src/app/api/v1/markets/watchlists/[id]/symbols/route.ts
+++ b/apps/web/src/app/api/v1/markets/watchlists/[id]/symbols/route.ts
@@ -1,0 +1,88 @@
+import { type NextRequest } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { withObservability } from "@/lib/observability";
+import { marketsDb, type MktWatchlistSymbolRow } from "@/lib/markets/db";
+import { isValidSymbol, normalizeSymbol } from "@/lib/markets/symbols";
+import {
+  badRequest,
+  internal,
+  noContent,
+  ok,
+  unauthorized,
+} from "@/lib/markets/api";
+
+interface Props {
+  params: Promise<{ id: string }>;
+}
+
+/**
+ * POST   /api/v1/markets/watchlists/:id/symbols   { symbol, note? } — add.
+ * DELETE /api/v1/markets/watchlists/:id/symbols?symbol=AAPL          — remove.
+ *
+ * RLS on mkt_watchlist_symbols inherits the parent watchlist's visibility.
+ */
+async function handlePost(request: NextRequest, { params }: Props) {
+  const { id } = await params;
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return unauthorized();
+  const db = marketsDb(supabase);
+
+  const body = (await request.json().catch(() => ({}))) as {
+    symbol?: string;
+    note?: string;
+  };
+  const symbol = normalizeSymbol(body.symbol ?? "");
+  if (!isValidSymbol(symbol)) return badRequest("Invalid symbol");
+  const note = body.note?.trim().slice(0, 280) || null;
+
+  const row: Partial<MktWatchlistSymbolRow> = {
+    watchlist_id: id,
+    symbol,
+    note,
+  };
+  const { data, error } = await db
+    .from("mkt_watchlist_symbols")
+    .insert(row)
+    .select("*")
+    .single();
+  if (error) {
+    if (error.code === "23505") return badRequest("Symbol already on this watchlist");
+    return internal(error.message);
+  }
+  return ok({ symbol: data }, 201);
+}
+
+async function handleDelete(request: NextRequest, { params }: Props) {
+  const { id } = await params;
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return unauthorized();
+  const db = marketsDb(supabase);
+
+  const symbol = normalizeSymbol(
+    request.nextUrl.searchParams.get("symbol") ?? "",
+  );
+  if (!isValidSymbol(symbol)) return badRequest("Invalid symbol");
+
+  const { error } = await db
+    .from("mkt_watchlist_symbols")
+    .delete()
+    .eq("watchlist_id", id)
+    .eq("symbol", symbol);
+  if (error) return internal(error.message);
+  return noContent();
+}
+
+export const POST = withObservability<Props>(
+  handlePost,
+  "POST /api/v1/markets/watchlists/:id/symbols",
+);
+export const DELETE = withObservability<Props>(
+  handleDelete,
+  "DELETE /api/v1/markets/watchlists/:id/symbols",
+);

--- a/apps/web/src/app/api/v1/markets/watchlists/route.ts
+++ b/apps/web/src/app/api/v1/markets/watchlists/route.ts
@@ -1,0 +1,113 @@
+import { type NextRequest } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { withObservability } from "@/lib/observability";
+import {
+  marketsDb,
+  type MktWatchlistRow,
+  type MktWatchlistSymbolRow,
+  type ScopeKind,
+} from "@/lib/markets/db";
+import { badRequest, internal, ok, unauthorized } from "@/lib/markets/api";
+
+const SCOPES: ScopeKind[] = ["user", "space", "terminal"];
+
+/**
+ * GET  /api/v1/markets/watchlists?scope=user|space|terminal&scopeId=… — list
+ *      watchlists at a scope (RLS gates visibility), each with its symbols.
+ * POST /api/v1/markets/watchlists — create a watchlist.
+ */
+async function handleGet(request: NextRequest) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return unauthorized();
+  const db = marketsDb(supabase);
+
+  const scope = (request.nextUrl.searchParams.get("scope") ?? "user") as ScopeKind;
+  if (!SCOPES.includes(scope)) return badRequest("invalid scope");
+  const scopeId = request.nextUrl.searchParams.get("scopeId");
+
+  let query = db
+    .from("mkt_watchlists")
+    .select("*")
+    .is("archived_at", null)
+    .order("display_order");
+
+  if (scope === "user") query = query.eq("user_id", user.id);
+  else if (scope === "space") {
+    if (!scopeId) return badRequest("scopeId required for space scope");
+    query = query.eq("space_id", scopeId);
+  } else {
+    if (!scopeId) return badRequest("scopeId required for terminal scope");
+    query = query.eq("terminal_id", scopeId);
+  }
+
+  const { data: lists, error } = await query;
+  if (error) return internal(error.message);
+
+  const rows = (lists ?? []) as MktWatchlistRow[];
+  const ids = rows.map((l) => l.id);
+  const symbolsByList = new Map<string, MktWatchlistSymbolRow[]>();
+  if (ids.length > 0) {
+    const { data: syms } = await db
+      .from("mkt_watchlist_symbols")
+      .select("*")
+      .in("watchlist_id", ids)
+      .order("display_order");
+    for (const s of (syms ?? []) as MktWatchlistSymbolRow[]) {
+      const arr = symbolsByList.get(s.watchlist_id) ?? [];
+      arr.push(s);
+      symbolsByList.set(s.watchlist_id, arr);
+    }
+  }
+
+  const watchlists = rows.map((l) => ({
+    ...l,
+    symbols: symbolsByList.get(l.id) ?? [],
+  }));
+  return ok({ watchlists });
+}
+
+async function handlePost(request: NextRequest) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return unauthorized();
+  const db = marketsDb(supabase);
+
+  const body = (await request.json().catch(() => ({}))) as {
+    name?: string;
+    scope?: ScopeKind;
+    scopeId?: string;
+  };
+
+  const name = body.name?.trim();
+  if (!name) return badRequest("name is required");
+  if (name.length > 80) return badRequest("name must be ≤ 80 characters");
+
+  const scope = body.scope ?? "user";
+  if (!SCOPES.includes(scope)) return badRequest("invalid scope");
+
+  const row: Partial<MktWatchlistRow> = { name, created_by: user.id };
+  if (scope === "user") row.user_id = user.id;
+  else if (scope === "space") {
+    if (!body.scopeId) return badRequest("scopeId required for space scope");
+    row.space_id = body.scopeId;
+  } else {
+    if (!body.scopeId) return badRequest("scopeId required for terminal scope");
+    row.terminal_id = body.scopeId;
+  }
+
+  const { data, error } = await db
+    .from("mkt_watchlists")
+    .insert(row)
+    .select("*")
+    .single();
+  if (error || !data) return internal(error?.message ?? "create failed");
+  return ok({ watchlist: data }, 201);
+}
+
+export const GET = withObservability(handleGet, "GET /api/v1/markets/watchlists");
+export const POST = withObservability(handlePost, "POST /api/v1/markets/watchlists");

--- a/apps/web/src/app/app/markets/alerts/page.tsx
+++ b/apps/web/src/app/app/markets/alerts/page.tsx
@@ -1,0 +1,26 @@
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { ScopedModuleShell } from "@/components/pane/ScopedModuleShell";
+import { AlertsView } from "@/modules/markets/components/AlertsView";
+import { marketsDb } from "@/lib/markets/db";
+
+export const metadata = { title: "Price Alerts — Rokki" };
+
+export default async function AlertsPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) redirect("/login");
+
+  const { data: alerts } = await marketsDb(supabase)
+    .from("mkt_alerts")
+    .select("*")
+    .order("created_at", { ascending: false });
+
+  return (
+    <ScopedModuleShell scopeKind="user" activeSlug="markets" flagOffBehavior="render">
+      <AlertsView initial={alerts ?? []} />
+    </ScopedModuleShell>
+  );
+}

--- a/apps/web/src/app/app/markets/overview/page.tsx
+++ b/apps/web/src/app/app/markets/overview/page.tsx
@@ -1,0 +1,20 @@
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { ScopedModuleShell } from "@/components/pane/ScopedModuleShell";
+import { MarketsBoard } from "@/modules/markets/components/MarketsBoard";
+
+export const metadata = { title: "Markets Overview — Rokki" };
+
+export default async function MarketsOverviewPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) redirect("/login");
+
+  return (
+    <ScopedModuleShell scopeKind="user" activeSlug="markets" flagOffBehavior="render">
+      <MarketsBoard />
+    </ScopedModuleShell>
+  );
+}

--- a/apps/web/src/app/app/markets/page.tsx
+++ b/apps/web/src/app/app/markets/page.tsx
@@ -1,0 +1,30 @@
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { ScopedModuleShell } from "@/components/pane/ScopedModuleShell";
+import { MarketsDashboard } from "@/modules/markets/components/MarketsDashboard";
+import { loadPortfolios, loadWatchlists } from "@/modules/markets/lib/server-data";
+
+export const metadata = { title: "Markets — Rokki" };
+
+export default async function AppMarketsPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) redirect("/login");
+
+  const [watchlists, portfolios] = await Promise.all([
+    loadWatchlists(supabase, "user", user.id),
+    loadPortfolios(supabase, "user", user.id),
+  ]);
+
+  return (
+    <ScopedModuleShell scopeKind="user" activeSlug="markets" flagOffBehavior="render">
+      <MarketsDashboard
+        scope="user"
+        initialWatchlists={watchlists}
+        initialPortfolios={portfolios}
+      />
+    </ScopedModuleShell>
+  );
+}

--- a/apps/web/src/app/app/markets/portfolio/[id]/page.tsx
+++ b/apps/web/src/app/app/markets/portfolio/[id]/page.tsx
@@ -1,0 +1,46 @@
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { ScopedModuleShell } from "@/components/pane/ScopedModuleShell";
+import { PortfolioView } from "@/modules/markets/components/PortfolioView";
+import { marketsDb } from "@/lib/markets/db";
+import { getQuotesCached } from "@/lib/markets/cache";
+import { computePerformance, computePositions } from "@/lib/markets/portfolio";
+
+interface Props {
+  params: Promise<{ id: string }>;
+}
+
+export default async function PortfolioPage({ params }: Props) {
+  const { id } = await params;
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) redirect("/login");
+  const db = marketsDb(supabase);
+
+  const { data: portfolio } = await db
+    .from("mkt_portfolios")
+    .select("*")
+    .eq("id", id)
+    .maybeSingle();
+  if (!portfolio) redirect("/app/markets");
+
+  const { data: lots } = await db
+    .from("mkt_lots")
+    .select("*")
+    .eq("portfolio_id", id)
+    .order("trade_date", { ascending: false });
+
+  const ledger = lots ?? [];
+  const positions = computePositions(ledger);
+  const symbols = positions.filter((p) => p.quantity > 0).map((p) => p.symbol);
+  const quotes = await getQuotesCached(symbols);
+  const performance = computePerformance(positions, quotes);
+
+  return (
+    <ScopedModuleShell scopeKind="user" activeSlug="markets" flagOffBehavior="render">
+      <PortfolioView initial={{ portfolio, lots: ledger, performance }} />
+    </ScopedModuleShell>
+  );
+}

--- a/apps/web/src/app/app/markets/quote/[symbol]/page.tsx
+++ b/apps/web/src/app/app/markets/quote/[symbol]/page.tsx
@@ -1,0 +1,45 @@
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { ScopedModuleShell } from "@/components/pane/ScopedModuleShell";
+import { QuoteView } from "@/modules/markets/components/QuoteView";
+import { getQuoteCached } from "@/lib/markets/cache";
+import { getProfile } from "@/lib/markets/providers";
+import { isValidSymbol, normalizeSymbol } from "@/lib/markets/symbols";
+import type { CompanyProfile, Quote } from "@/lib/markets/providers/types";
+
+interface Props {
+  params: Promise<{ symbol: string }>;
+}
+
+export default async function QuotePage({ params }: Props) {
+  const { symbol: raw } = await params;
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) redirect("/login");
+
+  const symbol = normalizeSymbol(decodeURIComponent(raw));
+  if (!isValidSymbol(symbol)) redirect("/app/markets");
+
+  let quote: Quote | null = null;
+  let profile: CompanyProfile | null = null;
+  await Promise.all([
+    getQuoteCached(symbol)
+      .then((r) => {
+        quote = r.quote;
+      })
+      .catch(() => {}),
+    getProfile(symbol)
+      .then((p) => {
+        profile = p;
+      })
+      .catch(() => {}),
+  ]);
+
+  return (
+    <ScopedModuleShell scopeKind="user" activeSlug="markets" flagOffBehavior="render">
+      <QuoteView symbol={symbol} initialQuote={quote} profile={profile} />
+    </ScopedModuleShell>
+  );
+}

--- a/apps/web/src/app/app/markets/screener/page.tsx
+++ b/apps/web/src/app/app/markets/screener/page.tsx
@@ -1,0 +1,20 @@
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { ScopedModuleShell } from "@/components/pane/ScopedModuleShell";
+import { ScreenerView } from "@/modules/markets/components/ScreenerView";
+
+export const metadata = { title: "Screener — Rokki" };
+
+export default async function ScreenerPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) redirect("/login");
+
+  return (
+    <ScopedModuleShell scopeKind="user" activeSlug="markets" flagOffBehavior="render">
+      <ScreenerView />
+    </ScopedModuleShell>
+  );
+}

--- a/apps/web/src/app/p/[ticker]/markets/page.tsx
+++ b/apps/web/src/app/p/[ticker]/markets/page.tsx
@@ -1,0 +1,43 @@
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { ScopedModuleShell } from "@/components/pane/ScopedModuleShell";
+import { MarketsDashboard } from "@/modules/markets/components/MarketsDashboard";
+import { loadPortfolios, loadWatchlists } from "@/modules/markets/lib/server-data";
+import { resolveTerminalBySegment } from "@/lib/resolve-terminal";
+
+interface Props {
+  params: Promise<{ ticker: string }>;
+}
+
+export default async function TerminalMarketsPage({ params }: Props) {
+  const { ticker } = await params;
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) redirect("/login");
+
+  const terminal = await resolveTerminalBySegment(supabase, ticker);
+  if (!terminal) redirect("/");
+
+  const [watchlists, portfolios] = await Promise.all([
+    loadWatchlists(supabase, "terminal", terminal.id),
+    loadPortfolios(supabase, "terminal", terminal.id),
+  ]);
+
+  return (
+    <ScopedModuleShell
+      scopeKind="terminal"
+      scopeKey={ticker}
+      activeSlug="markets"
+      flagOffBehavior="render"
+    >
+      <MarketsDashboard
+        scope="terminal"
+        scopeId={terminal.id}
+        initialWatchlists={watchlists}
+        initialPortfolios={portfolios}
+      />
+    </ScopedModuleShell>
+  );
+}

--- a/apps/web/src/app/s/[slug]/markets/page.tsx
+++ b/apps/web/src/app/s/[slug]/markets/page.tsx
@@ -1,0 +1,47 @@
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { ScopedModuleShell } from "@/components/pane/ScopedModuleShell";
+import { MarketsDashboard } from "@/modules/markets/components/MarketsDashboard";
+import { loadPortfolios, loadWatchlists } from "@/modules/markets/lib/server-data";
+
+interface Props {
+  params: Promise<{ slug: string }>;
+}
+
+export default async function SpaceMarketsPage({ params }: Props) {
+  const { slug } = await params;
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) redirect("/login");
+
+  const { data: spaceRow } = await supabase
+    .from("spaces")
+    .select("id, name")
+    .eq("slug", slug)
+    .maybeSingle();
+  const space = spaceRow as { id: string; name: string } | null;
+  if (!space) redirect("/");
+
+  const [watchlists, portfolios] = await Promise.all([
+    loadWatchlists(supabase, "space", space.id),
+    loadPortfolios(supabase, "space", space.id),
+  ]);
+
+  return (
+    <ScopedModuleShell
+      scopeKind="space"
+      scopeKey={slug}
+      activeSlug="markets"
+      flagOffBehavior="render"
+    >
+      <MarketsDashboard
+        scope="space"
+        scopeId={space.id}
+        initialWatchlists={watchlists}
+        initialPortfolios={portfolios}
+      />
+    </ScopedModuleShell>
+  );
+}

--- a/apps/web/src/lib/markets/admin.ts
+++ b/apps/web/src/lib/markets/admin.ts
@@ -1,0 +1,32 @@
+/**
+ * Lazy service-role Supabase client for system-level markets operations.
+ *
+ * Used ONLY for non-user-initiated writes that legitimately need to bypass
+ * RLS: filling the public `mkt_quote_cache` from the server-side fetch layer,
+ * and the cron alert evaluator firing `notifications`. All user-initiated
+ * watchlist/portfolio/alert CRUD goes through the per-user RLS client
+ * (`@/lib/supabase/server`) — never this one. (rokki/CLAUDE.md non-negotiable.)
+ */
+import "server-only";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@rokki/db";
+import { marketsDb, type MarketsClient } from "./db";
+
+let cached: SupabaseClient<Database> | null = null;
+
+/** Raw service-role client (knows the generated Rokki schema, e.g. notifications). */
+export function marketsAdminBase(): SupabaseClient<Database> {
+  if (!cached) {
+    cached = createClient<Database>(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.SUPABASE_SERVICE_ROLE_KEY!,
+      { auth: { autoRefreshToken: false, persistSession: false } },
+    );
+  }
+  return cached;
+}
+
+/** Service-role client re-typed to know the mkt_* tables. */
+export function marketsAdmin(): MarketsClient {
+  return marketsDb(marketsAdminBase());
+}

--- a/apps/web/src/lib/markets/api.ts
+++ b/apps/web/src/lib/markets/api.ts
@@ -1,0 +1,51 @@
+/**
+ * Shared response + error helpers for the markets API routes.
+ *
+ * Matches Rokki's envelope conventions: success → `{ data }`, error →
+ * `{ errors: [{ code, message }] }` with the right status. Centralized here
+ * because the markets module adds ~20 routes that all share this shape.
+ */
+import { NextResponse } from "next/server";
+import { MarketDataError } from "./http";
+
+export function ok<T>(data: T, status = 200): NextResponse {
+  return NextResponse.json({ data }, { status });
+}
+
+export function noContent(): NextResponse {
+  return new NextResponse(null, { status: 204 });
+}
+
+export function errResponse(
+  code: string,
+  message: string,
+  status: number,
+): NextResponse {
+  return NextResponse.json({ errors: [{ code, message }] }, { status });
+}
+
+export const unauthorized = () =>
+  errResponse("unauthenticated", "Sign in required", 401);
+
+export const badRequest = (message: string) =>
+  errResponse("invalid_request", message, 400);
+
+export const notFound = (message = "Not found") =>
+  errResponse("not_found", message, 404);
+
+export const forbidden = (message = "Not allowed") =>
+  errResponse("forbidden", message, 403);
+
+export const internal = (message: string) =>
+  errResponse("internal_error", message, 500);
+
+/** Map a provider/MarketDataError to the right HTTP error envelope. */
+export function mapMarketError(e: unknown): NextResponse {
+  if (e instanceof MarketDataError) {
+    if (e.status === 404) return notFound(e.message);
+    if (e.status === 503)
+      return errResponse("tool_disabled", e.message, 503);
+    return errResponse("upstream_error", e.message, 502);
+  }
+  return internal(e instanceof Error ? e.message : "Unexpected error");
+}

--- a/apps/web/src/lib/markets/cache.ts
+++ b/apps/web/src/lib/markets/cache.ts
@@ -1,0 +1,134 @@
+/**
+ * Quote cache — the thing that makes free tiers viable.
+ *
+ * Reads/writes the durable `mkt_quote_cache` table via the service-role
+ * client (public market data, not tenant data). On a cache miss or stale row
+ * it fetches from the provider facade, upserts the normalized quote, and
+ * mirrors a row into `mkt_instruments` so search/autocomplete has data. The
+ * UI subscribes to `mkt_quote_cache` via Realtime, so an upsert here updates
+ * every open pane live.
+ */
+import "server-only";
+import { marketsAdmin } from "./admin";
+import { getQuote } from "./providers";
+import type { Quote } from "./providers/types";
+
+/** Default freshness window for an interactive quote. */
+const DEFAULT_TTL_MS = 15_000;
+
+interface CacheRow {
+  symbol: string;
+  payload: Quote;
+  provider: string;
+  fetched_at: string;
+}
+
+function isFresh(fetchedAt: string, ttlMs: number): boolean {
+  return Date.now() - new Date(fetchedAt).getTime() < ttlMs;
+}
+
+async function persist(quote: Quote): Promise<void> {
+  const admin = marketsAdmin();
+  const nowIso = new Date().toISOString();
+  await admin
+    .from("mkt_quote_cache")
+    .upsert(
+      {
+        symbol: quote.symbol,
+        payload: quote,
+        provider: quote.provider,
+        fetched_at: nowIso,
+      },
+      { onConflict: "symbol" },
+    );
+  await admin
+    .from("mkt_instruments")
+    .upsert(
+      {
+        symbol: quote.symbol,
+        name: quote.name ?? "",
+        exchange: quote.exchange,
+        currency: quote.currency,
+        updated_at: nowIso,
+      },
+      { onConflict: "symbol" },
+    );
+}
+
+/**
+ * Get a single quote, served from cache when fresh. On miss/stale, fetches
+ * live, persists, and returns. Throws MarketDataError on provider failure
+ * only when there is no cached row to fall back to.
+ */
+export async function getQuoteCached(
+  symbol: string,
+  ttlMs = DEFAULT_TTL_MS,
+): Promise<{ quote: Quote; cached: boolean }> {
+  const admin = marketsAdmin();
+  const { data } = await admin
+    .from("mkt_quote_cache")
+    .select("symbol, payload, provider, fetched_at")
+    .eq("symbol", symbol)
+    .maybeSingle();
+  const cachedRow = data as CacheRow | null;
+
+  if (cachedRow && isFresh(cachedRow.fetched_at, ttlMs)) {
+    return { quote: cachedRow.payload, cached: true };
+  }
+
+  try {
+    const quote = await getQuote(symbol);
+    await persist(quote);
+    return { quote, cached: false };
+  } catch (e) {
+    // Serve a stale row rather than erroring if we have one.
+    if (cachedRow) return { quote: cachedRow.payload, cached: true };
+    throw e;
+  }
+}
+
+/**
+ * Batch variant for watchlists. Returns a map symbol→quote. Fetches only the
+ * stale/missing symbols, in parallel, to stay within provider rate limits.
+ */
+export async function getQuotesCached(
+  symbols: string[],
+  ttlMs = DEFAULT_TTL_MS,
+): Promise<Record<string, Quote>> {
+  const unique = Array.from(new Set(symbols));
+  if (unique.length === 0) return {};
+  const admin = marketsAdmin();
+  const { data } = await admin
+    .from("mkt_quote_cache")
+    .select("symbol, payload, provider, fetched_at")
+    .in("symbol", unique);
+
+  const rows = (data ?? []) as CacheRow[];
+  const bySymbol = new Map(rows.map((r) => [r.symbol, r] as const));
+  const out: Record<string, Quote> = {};
+  const stale: string[] = [];
+
+  for (const sym of unique) {
+    const row = bySymbol.get(sym);
+    if (row && isFresh(row.fetched_at, ttlMs)) {
+      out[sym] = row.payload;
+    } else {
+      if (row) out[sym] = row.payload; // optimistic stale value
+      stale.push(sym);
+    }
+  }
+
+  await Promise.all(
+    stale.map(async (sym) => {
+      try {
+        const quote = await getQuote(sym);
+        await persist(quote);
+        out[sym] = quote;
+      } catch {
+        // keep stale/absent — caller renders "—"
+      }
+    }),
+  );
+
+  return out;
+}

--- a/apps/web/src/lib/markets/db.ts
+++ b/apps/web/src/lib/markets/db.ts
@@ -1,0 +1,86 @@
+/**
+ * Typed Row interfaces for the markets tables + a loosely-typed client accessor.
+ *
+ * The generated `@rokki/db` types don't yet include the `mkt_*` tables — they're
+ * picked up when `supabase gen types` is re-run after the
+ * `20260616010000_markets_init.sql` migration. Until then we follow the repo's
+ * established convention for the Supabase client boundary (see
+ * `lib/resolve-terminal.ts`, `lib/dashboard-queries.ts`, which alias the client
+ * to `any`): `marketsDb()` returns a loosely-typed client so `.from("mkt_*")`
+ * resolves, and query RESULTS are cast back to the Row interfaces below at each
+ * call site. Delete `marketsDb` and switch to the generated types once they
+ * include `mkt_*`.
+ */
+
+export type ScopeKind = "user" | "space" | "terminal";
+
+export interface MktWatchlistRow {
+  id: string;
+  user_id: string | null;
+  space_id: string | null;
+  terminal_id: string | null;
+  name: string;
+  display_order: number;
+  created_by: string;
+  created_at: string;
+  archived_at: string | null;
+}
+
+export interface MktWatchlistSymbolRow {
+  id: string;
+  watchlist_id: string;
+  symbol: string;
+  display_order: number;
+  note: string | null;
+  added_at: string;
+}
+
+export interface MktPortfolioRow {
+  id: string;
+  user_id: string | null;
+  space_id: string | null;
+  terminal_id: string | null;
+  name: string;
+  base_currency: string;
+  created_by: string;
+  created_at: string;
+  archived_at: string | null;
+}
+
+export interface MktLotRow {
+  id: string;
+  portfolio_id: string;
+  symbol: string;
+  side: "buy" | "sell";
+  quantity: number;
+  price: number;
+  fees: number;
+  trade_date: string;
+  note: string | null;
+  created_at: string;
+}
+
+export interface MktAlertRow {
+  id: string;
+  user_id: string;
+  symbol: string;
+  condition: "price_above" | "price_below" | "pct_up" | "pct_down";
+  threshold: number;
+  active: boolean;
+  note: string | null;
+  last_triggered_at: string | null;
+  created_at: string;
+}
+
+/**
+ * Loosely-typed Supabase client for the markets tables. Mirrors the repo's
+ * `AnySupabaseClient` convention (see lib/resolve-terminal.ts) until the
+ * generated types include `mkt_*`.
+ */
+// Client boundary type — intentionally `any` (rule not enabled in repo config).
+export type MarketsClient = any;
+
+/** Re-type any Rokki Supabase client to one that accepts the mkt_* tables. */
+export function marketsDb(client: unknown): MarketsClient {
+  return client as MarketsClient;
+}

--- a/apps/web/src/lib/markets/evaluate-alerts.ts
+++ b/apps/web/src/lib/markets/evaluate-alerts.ts
@@ -1,0 +1,99 @@
+/**
+ * Price-alert evaluator (system job — runs from the cron route).
+ *
+ * Pulls active alerts, fetches each distinct symbol's quote (cached, 60s),
+ * and fires a `notifications` row for any tripped alert that's outside its
+ * cooldown. Uses the service-role client because this is a system job, not a
+ * user-initiated mutation (rokki/CLAUDE.md exception).
+ */
+import "server-only";
+import { marketsAdmin, marketsAdminBase } from "./admin";
+import { getQuotesCached } from "./cache";
+import type { MktAlertRow } from "./db";
+import type { Quote } from "./providers/types";
+
+/** Don't re-fire the same alert more than once per 6h. */
+const COOLDOWN_MS = 6 * 60 * 60 * 1000;
+
+function tripped(alert: MktAlertRow, quote: Quote): boolean {
+  switch (alert.condition) {
+    case "price_above":
+      return quote.price >= alert.threshold;
+    case "price_below":
+      return quote.price <= alert.threshold;
+    case "pct_up":
+      return quote.changePct >= alert.threshold;
+    case "pct_down":
+      return quote.changePct <= alert.threshold;
+    default:
+      return false;
+  }
+}
+
+function phrase(alert: MktAlertRow, quote: Quote): string {
+  switch (alert.condition) {
+    case "price_above":
+      return `${alert.symbol} rose above ${alert.threshold} (now ${quote.price.toFixed(2)})`;
+    case "price_below":
+      return `${alert.symbol} fell below ${alert.threshold} (now ${quote.price.toFixed(2)})`;
+    case "pct_up":
+      return `${alert.symbol} is up ${quote.changePct.toFixed(2)}% (≥ ${alert.threshold}%)`;
+    case "pct_down":
+      return `${alert.symbol} is down ${quote.changePct.toFixed(2)}% (≤ ${alert.threshold}%)`;
+    default:
+      return `${alert.symbol} alert triggered`;
+  }
+}
+
+export interface AlertRunResult {
+  evaluated: number;
+  triggered: number;
+}
+
+export async function evaluatePriceAlerts(): Promise<AlertRunResult> {
+  const admin = marketsAdmin();
+  const base = marketsAdminBase();
+
+  const { data: alerts } = await admin
+    .from("mkt_alerts")
+    .select("*")
+    .eq("active", true);
+  const list = (alerts ?? []) as MktAlertRow[];
+  if (list.length === 0) return { evaluated: 0, triggered: 0 };
+
+  const symbols = Array.from(new Set(list.map((a) => a.symbol)));
+  const quotes = await getQuotesCached(symbols, 60_000);
+
+  const now = Date.now();
+  let triggered = 0;
+
+  for (const a of list) {
+    const q = quotes[a.symbol];
+    if (!q || !tripped(a, q)) continue;
+    if (
+      a.last_triggered_at &&
+      now - new Date(a.last_triggered_at).getTime() < COOLDOWN_MS
+    ) {
+      continue;
+    }
+
+    await base.from("notifications").insert({
+      user_id: a.user_id,
+      kind: "system",
+      title: `Price alert: ${a.symbol}`,
+      body: phrase(a, q),
+      entity_type: "mkt_alert",
+      entity_id: a.id,
+      url: `/app/markets/quote/${encodeURIComponent(a.symbol)}`,
+    } as never);
+
+    await admin
+      .from("mkt_alerts")
+      .update({ last_triggered_at: new Date().toISOString() })
+      .eq("id", a.id);
+
+    triggered += 1;
+  }
+
+  return { evaluated: list.length, triggered };
+}

--- a/apps/web/src/lib/markets/format.ts
+++ b/apps/web/src/lib/markets/format.ts
@@ -1,0 +1,96 @@
+/**
+ * Number / currency formatting for the markets module.
+ *
+ * Client-safe (no server imports). Centralizes the finance formatting so
+ * price/percent/compact rendering is consistent across every table and card.
+ * Color classes return LITERAL Tailwind class names (never build them with
+ * template strings — Tailwind's JIT can't see `text-${x}`).
+ */
+
+export function fmtPrice(n: number | null | undefined, currency = "USD"): string {
+  if (n === null || n === undefined || Number.isNaN(n)) return "—";
+  const symbol = currency === "USD" ? "$" : "";
+  const suffix = currency === "USD" ? "" : ` ${currency}`;
+  return `${symbol}${n.toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}${suffix}`;
+}
+
+export function fmtChange(n: number | null | undefined): string {
+  if (n === null || n === undefined || Number.isNaN(n)) return "—";
+  const sign = n > 0 ? "+" : "";
+  return `${sign}${n.toFixed(2)}`;
+}
+
+export function fmtPct(n: number | null | undefined): string {
+  if (n === null || n === undefined || Number.isNaN(n)) return "—";
+  const sign = n > 0 ? "+" : "";
+  return `${sign}${n.toFixed(2)}%`;
+}
+
+/** Compact magnitude: 1.2K / 3.4M / 5.6B / 7.8T. */
+export function fmtCompact(n: number | null | undefined): string {
+  if (n === null || n === undefined || Number.isNaN(n)) return "—";
+  const abs = Math.abs(n);
+  if (abs >= 1e12) return `${(n / 1e12).toFixed(2)}T`;
+  if (abs >= 1e9) return `${(n / 1e9).toFixed(2)}B`;
+  if (abs >= 1e6) return `${(n / 1e6).toFixed(2)}M`;
+  if (abs >= 1e3) return `${(n / 1e3).toFixed(1)}K`;
+  return n.toLocaleString();
+}
+
+export function fmtVolume(n: number | null | undefined): string {
+  if (n === null || n === undefined || Number.isNaN(n)) return "—";
+  return fmtCompact(n);
+}
+
+export function fmtMarketCap(n: number | null | undefined): string {
+  if (n === null || n === undefined || Number.isNaN(n)) return "—";
+  return `$${fmtCompact(n)}`;
+}
+
+/** Tailwind text color class for a signed value (literal class names). */
+export function changeClass(n: number | null | undefined): string {
+  if (n === null || n === undefined || Number.isNaN(n) || n === 0)
+    return "text-text-2";
+  return n > 0 ? "text-success" : "text-danger";
+}
+
+export function fmtDate(iso: string | null | undefined): string {
+  if (!iso) return "—";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "—";
+  return d.toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+export function fmtDateTime(iso: string | null | undefined): string {
+  if (!iso) return "—";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "—";
+  return d.toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+/** Relative time: "3m ago", "2h ago", "5d ago". */
+export function fmtRelative(iso: string | null | undefined): string {
+  if (!iso) return "—";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "—";
+  const secs = Math.round((Date.now() - d.getTime()) / 1000);
+  if (secs < 60) return "just now";
+  const mins = Math.round(secs / 60);
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.round(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  const days = Math.round(hrs / 24);
+  return `${days}d ago`;
+}

--- a/apps/web/src/lib/markets/http.ts
+++ b/apps/web/src/lib/markets/http.ts
@@ -1,0 +1,88 @@
+/**
+ * Shared outbound HTTP helper for market-data providers.
+ *
+ * Mirrors the timeout/error conventions of `lib/signal/bridge.ts`:
+ * AbortController timeout, `cache: "no-store"`, a typed error class so
+ * callers can distinguish upstream failures from bugs. Server-only — these
+ * calls carry provider API keys and must never run in the browser.
+ */
+import "server-only";
+
+export class MarketDataError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string,
+    public readonly provider?: string,
+  ) {
+    super(message);
+    this.name = "MarketDataError";
+  }
+}
+
+/**
+ * GET a URL and parse JSON, with a hard timeout. Throws MarketDataError on
+ * non-2xx or network failure so the route layer can map it to `upstream_error`.
+ */
+export async function fetchJson<T>(
+  url: string,
+  opts: { timeoutMs?: number; provider?: string } = {},
+): Promise<T> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), opts.timeoutMs ?? 10_000);
+  try {
+    const res = await fetch(url, {
+      method: "GET",
+      signal: controller.signal,
+      cache: "no-store",
+      headers: { accept: "application/json" },
+    });
+    const text = await res.text();
+    let data: unknown = {};
+    try {
+      data = text ? JSON.parse(text) : {};
+    } catch {
+      throw new MarketDataError(
+        502,
+        `Non-JSON response from ${opts.provider ?? "provider"}`,
+        opts.provider,
+      );
+    }
+    if (!res.ok) {
+      const msg =
+        (data as { error?: string; message?: string } | null)?.error ??
+        (data as { message?: string } | null)?.message ??
+        `HTTP ${res.status}`;
+      throw new MarketDataError(res.status, msg, opts.provider);
+    }
+    return data as T;
+  } catch (e) {
+    if (e instanceof MarketDataError) throw e;
+    if (e instanceof Error && e.name === "AbortError") {
+      throw new MarketDataError(504, "Provider request timed out", opts.provider);
+    }
+    throw new MarketDataError(
+      502,
+      e instanceof Error ? e.message : "Provider unreachable",
+      opts.provider,
+    );
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** True when the provider's API key env var is present. */
+export function hasKey(envVar: string): boolean {
+  return Boolean(process.env[envVar]);
+}
+
+export function requireKey(envVar: string, provider: string): string {
+  const v = process.env[envVar];
+  if (!v) {
+    throw new MarketDataError(
+      503,
+      `${provider} not configured — ${envVar} is missing`,
+      provider,
+    );
+  }
+  return v;
+}

--- a/apps/web/src/lib/markets/overview.ts
+++ b/apps/web/src/lib/markets/overview.ts
@@ -1,0 +1,47 @@
+/**
+ * Market overview board configuration.
+ *
+ * Uses liquid ETFs as index/sector proxies so quotes resolve cleanly on free
+ * tiers (Finnhub/Twelve Data quote ETFs reliably; raw index symbols are spotty
+ * on free plans). Labels are what the UI shows.
+ */
+import "server-only";
+
+export interface OverviewItem {
+  symbol: string;
+  label: string;
+}
+
+export const OVERVIEW_INDICES: OverviewItem[] = [
+  { symbol: "SPY", label: "S&P 500" },
+  { symbol: "QQQ", label: "Nasdaq 100" },
+  { symbol: "DIA", label: "Dow 30" },
+  { symbol: "IWM", label: "Russell 2000" },
+  { symbol: "VXX", label: "Volatility" },
+];
+
+export const OVERVIEW_SECTORS: OverviewItem[] = [
+  { symbol: "XLK", label: "Technology" },
+  { symbol: "XLF", label: "Financials" },
+  { symbol: "XLE", label: "Energy" },
+  { symbol: "XLV", label: "Health Care" },
+  { symbol: "XLY", label: "Cons. Disc." },
+  { symbol: "XLP", label: "Cons. Staples" },
+  { symbol: "XLI", label: "Industrials" },
+  { symbol: "XLU", label: "Utilities" },
+  { symbol: "XLB", label: "Materials" },
+  { symbol: "XLRE", label: "Real Estate" },
+  { symbol: "XLC", label: "Comm. Services" },
+];
+
+export const OVERVIEW_COMMODITIES: OverviewItem[] = [
+  { symbol: "GLD", label: "Gold" },
+  { symbol: "SLV", label: "Silver" },
+  { symbol: "USO", label: "Crude Oil" },
+];
+
+export const OVERVIEW_FX: OverviewItem[] = [
+  { symbol: "EUR/USD", label: "EUR / USD" },
+  { symbol: "USD/JPY", label: "USD / JPY" },
+  { symbol: "GBP/USD", label: "GBP / USD" },
+];

--- a/apps/web/src/lib/markets/portfolio.test.ts
+++ b/apps/web/src/lib/markets/portfolio.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import { computePerformance, computePositions } from "./portfolio";
+import type { MktLotRow } from "./db";
+import type { Quote } from "./providers/types";
+
+function lot(p: Partial<MktLotRow>): MktLotRow {
+  return {
+    id: crypto.randomUUID(),
+    portfolio_id: "pf",
+    symbol: "AAPL",
+    side: "buy",
+    quantity: 1,
+    price: 100,
+    fees: 0,
+    trade_date: "2026-01-01",
+    note: null,
+    created_at: "2026-01-01T00:00:00Z",
+    ...p,
+  };
+}
+
+function quote(symbol: string, price: number, change = 0): Quote {
+  return {
+    symbol,
+    price,
+    change,
+    changePct: 0,
+    open: null,
+    high: null,
+    low: null,
+    prevClose: null,
+    volume: null,
+    marketCap: null,
+    peRatio: null,
+    week52High: null,
+    week52Low: null,
+    currency: "USD",
+    exchange: null,
+    marketState: "closed",
+    asOf: "2026-01-01T00:00:00Z",
+    provider: "test",
+  };
+}
+
+describe("computePositions", () => {
+  it("averages cost across buys and includes fees", () => {
+    const [pos] = computePositions([
+      lot({ side: "buy", quantity: 10, price: 100, fees: 5 }),
+      lot({ side: "buy", quantity: 10, price: 120, fees: 5 }),
+    ]);
+    expect(pos.quantity).toBe(20);
+    // (10*100+5 + 10*120+5) / 20 = 2210/20 = 110.5
+    expect(pos.avgCost).toBeCloseTo(110.5);
+    expect(pos.costBasis).toBeCloseTo(2210);
+  });
+
+  it("realizes P/L on a sell at average cost", () => {
+    const [pos] = computePositions([
+      lot({ side: "buy", quantity: 10, price: 100 }),
+      lot({ side: "sell", quantity: 4, price: 150, trade_date: "2026-02-01" }),
+    ]);
+    expect(pos.quantity).toBe(6);
+    // realized = (150 - 100) * 4 = 200
+    expect(pos.realizedPL).toBeCloseTo(200);
+    expect(pos.costBasis).toBeCloseTo(600);
+  });
+
+  it("processes lots in trade-date order regardless of input order", () => {
+    const [pos] = computePositions([
+      lot({ side: "sell", quantity: 5, price: 150, trade_date: "2026-03-01" }),
+      lot({ side: "buy", quantity: 10, price: 100, trade_date: "2026-01-01" }),
+    ]);
+    expect(pos.quantity).toBe(5);
+    expect(pos.realizedPL).toBeCloseTo(250);
+  });
+});
+
+describe("computePerformance", () => {
+  it("computes market value, unrealized P/L, and weights", () => {
+    const positions = computePositions([
+      lot({ symbol: "AAPL", quantity: 10, price: 100 }),
+      lot({ symbol: "MSFT", quantity: 5, price: 200 }),
+    ]);
+    const perf = computePerformance(positions, {
+      AAPL: quote("AAPL", 150, 2),
+      MSFT: quote("MSFT", 220, -1),
+    });
+    expect(perf.totalMarketValue).toBeCloseTo(10 * 150 + 5 * 220); // 2600
+    expect(perf.totalCostBasis).toBeCloseTo(1000 + 1000); // 2000
+    expect(perf.totalUnrealizedPL).toBeCloseTo(600);
+    expect(perf.totalDayChange).toBeCloseTo(10 * 2 + 5 * -1); // 15
+    const aapl = perf.positions.find((p) => p.symbol === "AAPL");
+    expect(aapl?.weight).toBeCloseTo((1500 / 2600) * 100);
+  });
+
+  it("handles a missing quote without throwing", () => {
+    const positions = computePositions([lot({ symbol: "ZZZZ", quantity: 3, price: 10 })]);
+    const perf = computePerformance(positions, {});
+    expect(perf.positions[0].marketValue).toBeNull();
+    expect(perf.totalMarketValue).toBe(0);
+  });
+});

--- a/apps/web/src/lib/markets/portfolio.ts
+++ b/apps/web/src/lib/markets/portfolio.ts
@@ -1,0 +1,141 @@
+/**
+ * Portfolio math — pure functions, no I/O.
+ *
+ * Average-cost-basis position accounting from a lot ledger, plus live
+ * performance (market value, unrealized P/L, day change, allocation) given a
+ * quote map. Kept pure so it's trivially unit-testable and reusable by the
+ * API route and the MCP `portfolio_performance` tool.
+ */
+import type { MktLotRow } from "./db";
+import type { Quote } from "./providers/types";
+
+export interface PortfolioPosition {
+  symbol: string;
+  quantity: number;
+  avgCost: number;
+  costBasis: number;
+  realizedPL: number;
+}
+
+export interface PositionPerformance extends PortfolioPosition {
+  price: number | null;
+  marketValue: number | null;
+  unrealizedPL: number | null;
+  unrealizedPct: number | null;
+  dayChange: number | null;
+  weight: number | null;
+}
+
+export interface PortfolioPerformance {
+  positions: PositionPerformance[];
+  totalMarketValue: number;
+  totalCostBasis: number;
+  totalUnrealizedPL: number;
+  totalRealizedPL: number;
+  totalDayChange: number;
+  unrealizedPct: number;
+}
+
+/** Reduce a lot ledger to net positions using average-cost accounting. */
+export function computePositions(lots: MktLotRow[]): PortfolioPosition[] {
+  const order = [...lots].sort((a, b) =>
+    a.trade_date < b.trade_date ? -1 : a.trade_date > b.trade_date ? 1 : 0,
+  );
+
+  const acc = new Map<
+    string,
+    { qty: number; cost: number; realized: number }
+  >();
+
+  for (const lot of order) {
+    const cur = acc.get(lot.symbol) ?? { qty: 0, cost: 0, realized: 0 };
+    const q = Number(lot.quantity);
+    const px = Number(lot.price);
+    const fees = Number(lot.fees);
+    if (lot.side === "buy") {
+      cur.qty += q;
+      cur.cost += q * px + fees;
+    } else {
+      const avg = cur.qty > 0 ? cur.cost / cur.qty : 0;
+      const sellQty = Math.min(q, cur.qty);
+      cur.realized += (px - avg) * sellQty - fees;
+      cur.cost -= avg * sellQty;
+      cur.qty -= sellQty;
+      if (cur.qty <= 1e-9) {
+        cur.qty = 0;
+        cur.cost = 0;
+      }
+    }
+    acc.set(lot.symbol, cur);
+  }
+
+  return Array.from(acc.entries()).map(([symbol, v]) => ({
+    symbol,
+    quantity: v.qty,
+    avgCost: v.qty > 0 ? v.cost / v.qty : 0,
+    costBasis: v.cost,
+    realizedPL: v.realized,
+  }));
+}
+
+/** Combine positions with live quotes into a full performance snapshot. */
+export function computePerformance(
+  positions: PortfolioPosition[],
+  quotes: Record<string, Quote>,
+): PortfolioPerformance {
+  const open = positions.filter((p) => p.quantity > 0);
+
+  const enriched = open.map((p): PositionPerformance => {
+    const q = quotes[p.symbol];
+    const price = q?.price ?? null;
+    const marketValue = price !== null ? price * p.quantity : null;
+    const unrealizedPL =
+      marketValue !== null ? marketValue - p.costBasis : null;
+    const unrealizedPct =
+      unrealizedPL !== null && p.costBasis > 0
+        ? (unrealizedPL / p.costBasis) * 100
+        : null;
+    const dayChange = q ? q.change * p.quantity : null;
+    return {
+      ...p,
+      price,
+      marketValue,
+      unrealizedPL,
+      unrealizedPct,
+      dayChange,
+      weight: null,
+    };
+  });
+
+  const totalMarketValue = enriched.reduce(
+    (s, p) => s + (p.marketValue ?? 0),
+    0,
+  );
+  const totalCostBasis = enriched.reduce((s, p) => s + p.costBasis, 0);
+  const totalUnrealizedPL = enriched.reduce(
+    (s, p) => s + (p.unrealizedPL ?? 0),
+    0,
+  );
+  const totalRealizedPL = positions.reduce((s, p) => s + p.realizedPL, 0);
+  const totalDayChange = enriched.reduce((s, p) => s + (p.dayChange ?? 0), 0);
+
+  for (const p of enriched) {
+    p.weight =
+      totalMarketValue > 0 && p.marketValue !== null
+        ? (p.marketValue / totalMarketValue) * 100
+        : null;
+  }
+
+  return {
+    positions: enriched.sort(
+      (a, b) => (b.marketValue ?? 0) - (a.marketValue ?? 0),
+    ),
+    totalMarketValue,
+    totalCostBasis,
+    totalUnrealizedPL,
+    totalRealizedPL,
+    totalDayChange,
+    unrealizedPct:
+      totalCostBasis > 0 ? (totalUnrealizedPL / totalCostBasis) * 100 : 0,
+  };
+}

--- a/apps/web/src/lib/markets/providers/finnhub.ts
+++ b/apps/web/src/lib/markets/providers/finnhub.ts
@@ -1,0 +1,224 @@
+/**
+ * Finnhub adapter — quotes, symbol search, company profile, news, earnings.
+ *
+ * Free tier: 60 req/min, real-time-ish US quotes, no key in the URL path
+ * (passed as `token`). Display permitted with attribution. Candles are NOT
+ * on Finnhub's free tier — those route to Twelve Data.
+ *
+ * Docs: https://finnhub.io/docs/api
+ */
+import "server-only";
+import { fetchJson, hasKey, requireKey, MarketDataError } from "../http";
+import type {
+  CompanyProfile,
+  EarningsEvent,
+  MarketDataProvider,
+  NewsItem,
+  Quote,
+  SymbolMatch,
+} from "./types";
+
+const BASE = "https://finnhub.io/api/v1";
+const KEY_ENV = "FINNHUB_API_KEY";
+
+function url(path: string, params: Record<string, string>): string {
+  const token = requireKey(KEY_ENV, "Finnhub");
+  const qs = new URLSearchParams({ ...params, token }).toString();
+  return `${BASE}${path}?${qs}`;
+}
+
+interface FinnhubQuote {
+  c: number; // current
+  d: number | null; // change
+  dp: number | null; // change %
+  h: number; // high
+  l: number; // low
+  o: number; // open
+  pc: number; // prev close
+  t: number; // unix seconds
+}
+
+interface FinnhubProfile {
+  name?: string;
+  exchange?: string;
+  finnhubIndustry?: string;
+  country?: string;
+  currency?: string;
+  marketCapitalization?: number; // in millions
+  shareOutstanding?: number;
+  logo?: string;
+  weburl?: string;
+  ipo?: string;
+}
+
+interface FinnhubSearch {
+  count: number;
+  result: { symbol: string; description: string; type: string }[];
+}
+
+interface FinnhubNews {
+  id: number;
+  headline: string;
+  summary: string;
+  source: string;
+  url: string;
+  image: string;
+  datetime: number; // unix seconds
+  related: string;
+}
+
+interface FinnhubEarnings {
+  earningsCalendar: {
+    symbol: string;
+    date: string;
+    hour: string;
+    epsEstimate: number | null;
+    epsActual: number | null;
+    revenueEstimate: number | null;
+    revenueActual: number | null;
+  }[];
+}
+
+function mapInstrumentType(t: string): SymbolMatch["type"] {
+  const v = t.toLowerCase();
+  if (v.includes("etf")) return "etf";
+  if (v.includes("crypto")) return "crypto";
+  if (v.includes("index")) return "index";
+  if (v.includes("common") || v.includes("stock") || v.includes("equity"))
+    return "stock";
+  return "unknown";
+}
+
+export const finnhub: MarketDataProvider = {
+  id: "finnhub",
+  attribution: "Data by Finnhub",
+
+  async quote(symbol) {
+    const q = await fetchJson<FinnhubQuote>(
+      url("/quote", { symbol }),
+      { provider: "finnhub" },
+    );
+    if (!q || typeof q.c !== "number" || q.c === 0) {
+      throw new MarketDataError(404, `No quote for ${symbol}`, "finnhub");
+    }
+    let profile: FinnhubProfile | null = null;
+    try {
+      profile = await fetchJson<FinnhubProfile>(
+        url("/stock/profile2", { symbol }),
+        { provider: "finnhub" },
+      );
+    } catch {
+      // profile is best-effort enrichment
+    }
+    const result: Quote = {
+      symbol,
+      name: profile?.name,
+      price: q.c,
+      change: q.d ?? 0,
+      changePct: q.dp ?? 0,
+      open: q.o ?? null,
+      high: q.h ?? null,
+      low: q.l ?? null,
+      prevClose: q.pc ?? null,
+      volume: null,
+      marketCap: profile?.marketCapitalization
+        ? profile.marketCapitalization * 1e6
+        : null,
+      peRatio: null,
+      week52High: null,
+      week52Low: null,
+      currency: profile?.currency ?? "USD",
+      exchange: profile?.exchange ?? null,
+      marketState: "unknown",
+      asOf: q.t ? new Date(q.t * 1000).toISOString() : new Date().toISOString(),
+      provider: "finnhub",
+    };
+    return result;
+  },
+
+  async search(query) {
+    const res = await fetchJson<FinnhubSearch>(
+      url("/search", { q: query }),
+      { provider: "finnhub" },
+    );
+    return (res.result ?? []).slice(0, 20).map((r) => ({
+      symbol: r.symbol,
+      name: r.description,
+      exchange: null,
+      type: mapInstrumentType(r.type ?? ""),
+    }));
+  },
+
+  async profile(symbol) {
+    const p = await fetchJson<FinnhubProfile>(
+      url("/stock/profile2", { symbol }),
+      { provider: "finnhub" },
+    );
+    if (!p || !p.name) {
+      throw new MarketDataError(404, `No profile for ${symbol}`, "finnhub");
+    }
+    const result: CompanyProfile = {
+      symbol,
+      name: p.name,
+      exchange: p.exchange ?? null,
+      industry: p.finnhubIndustry ?? null,
+      sector: p.finnhubIndustry ?? null,
+      country: p.country ?? null,
+      currency: p.currency ?? "USD",
+      marketCap: p.marketCapitalization ? p.marketCapitalization * 1e6 : null,
+      sharesOutstanding: p.shareOutstanding ? p.shareOutstanding * 1e6 : null,
+      logo: p.logo ?? null,
+      weburl: p.weburl ?? null,
+      ipo: p.ipo ?? null,
+      description: null,
+      beta: null,
+      dividendYield: null,
+      provider: "finnhub",
+    };
+    return result;
+  },
+
+  async news(symbol, sinceDays) {
+    const to = new Date();
+    const from = new Date(to.getTime() - sinceDays * 86400_000);
+    const fmt = (d: Date) => d.toISOString().slice(0, 10);
+    const items = await fetchJson<FinnhubNews[]>(
+      url("/company-news", { symbol, from: fmt(from), to: fmt(to) }),
+      { provider: "finnhub" },
+    );
+    return (items ?? []).slice(0, 30).map<NewsItem>((n) => ({
+      id: String(n.id),
+      headline: n.headline,
+      summary: n.summary || null,
+      source: n.source,
+      url: n.url,
+      imageUrl: n.image || null,
+      datetime: new Date(n.datetime * 1000).toISOString(),
+      symbols: n.related ? n.related.split(",").filter(Boolean) : [symbol],
+    }));
+  },
+
+  async earningsCalendar(fromIso, toIso) {
+    const res = await fetchJson<FinnhubEarnings>(
+      url("/calendar/earnings", {
+        from: fromIso.slice(0, 10),
+        to: toIso.slice(0, 10),
+      }),
+      { provider: "finnhub" },
+    );
+    return (res.earningsCalendar ?? []).map<EarningsEvent>((e) => ({
+      symbol: e.symbol,
+      date: e.date,
+      hour:
+        e.hour === "bmo" || e.hour === "amc" || e.hour === "dmh"
+          ? e.hour
+          : null,
+      epsEstimate: e.epsEstimate,
+      epsActual: e.epsActual,
+      revenueEstimate: e.revenueEstimate,
+      revenueActual: e.revenueActual,
+    }));
+  },
+};
+
+export const finnhubAvailable = () => hasKey(KEY_ENV);

--- a/apps/web/src/lib/markets/providers/fmp.ts
+++ b/apps/web/src/lib/markets/providers/fmp.ts
@@ -1,0 +1,140 @@
+/**
+ * Financial Modeling Prep adapter — financial statements and market movers.
+ *
+ * Free tier: ~250 req/day, US large-caps. Used for income/balance/cash-flow
+ * statements (cached 24h) and gainers/losers/most-active movers. Degrades
+ * gracefully — if the key is absent or the tier doesn't cover a symbol, the
+ * facade returns an empty/unsupported result.
+ *
+ * Docs: https://site.financialmodelingprep.com/developer/docs
+ */
+import "server-only";
+import { fetchJson, hasKey, requireKey, MarketDataError } from "../http";
+import type {
+  FinancialPeriod,
+  FinancialReport,
+  MarketDataProvider,
+  Mover,
+  MoverKind,
+  StatementKind,
+} from "./types";
+
+const BASE = "https://financialmodelingprep.com/api/v3";
+const KEY_ENV = "FMP_API_KEY";
+
+function url(path: string, params: Record<string, string> = {}): string {
+  const apikey = requireKey(KEY_ENV, "FMP");
+  const qs = new URLSearchParams({ ...params, apikey }).toString();
+  return `${BASE}${path}?${qs}`;
+}
+
+const STATEMENT_PATH: Record<StatementKind, string> = {
+  income: "/income-statement",
+  balance: "/balance-sheet-statement",
+  cash: "/cash-flow-statement",
+};
+
+type FmpStatementRow = Record<string, string | number | null> & {
+  date?: string;
+  period?: string;
+  reportedCurrency?: string;
+};
+
+interface FmpMover {
+  symbol: string;
+  name: string;
+  price: number;
+  change: number;
+  changesPercentage: number;
+}
+
+const MOVER_PATH: Record<MoverKind, string> = {
+  gainers: "/stock_market/gainers",
+  losers: "/stock_market/losers",
+  active: "/stock_market/actives",
+};
+
+/** Columns we surface per statement, in display order. */
+const LINE_ITEMS: Record<StatementKind, string[]> = {
+  income: [
+    "revenue",
+    "costOfRevenue",
+    "grossProfit",
+    "operatingExpenses",
+    "operatingIncome",
+    "netIncome",
+    "eps",
+    "ebitda",
+  ],
+  balance: [
+    "totalAssets",
+    "totalCurrentAssets",
+    "cashAndCashEquivalents",
+    "totalLiabilities",
+    "totalCurrentLiabilities",
+    "totalDebt",
+    "totalStockholdersEquity",
+  ],
+  cash: [
+    "netCashProvidedByOperatingActivities",
+    "netCashUsedForInvestingActivites",
+    "netCashUsedProvidedByFinancingActivities",
+    "freeCashFlow",
+    "capitalExpenditure",
+    "dividendsPaid",
+  ],
+};
+
+export const fmp: MarketDataProvider = {
+  id: "fmp",
+  attribution: "Fundamentals by Financial Modeling Prep",
+
+  async financials(symbol, statement: StatementKind) {
+    const rows = await fetchJson<FmpStatementRow[]>(
+      url(`${STATEMENT_PATH[statement]}/${encodeURIComponent(symbol)}`, {
+        period: "quarter",
+        limit: "8",
+      }),
+      { provider: "fmp" },
+    );
+    if (!Array.isArray(rows) || rows.length === 0) {
+      throw new MarketDataError(404, `No ${statement} data for ${symbol}`, "fmp");
+    }
+    const keys = LINE_ITEMS[statement];
+    const periods: FinancialPeriod[] = rows.map((r) => {
+      const lineItems: Record<string, number | null> = {};
+      for (const k of keys) {
+        const v = r[k];
+        lineItems[k] = typeof v === "number" ? v : v ? Number(v) : null;
+      }
+      return {
+        fiscalDate: String(r.date ?? ""),
+        period: String(r.period ?? "").toUpperCase().startsWith("Q") ? "Q" : "FY",
+        lineItems,
+      };
+    });
+    return {
+      symbol,
+      statement,
+      currency: String(rows[0]?.reportedCurrency ?? "USD"),
+      periods,
+      provider: "fmp",
+    } satisfies FinancialReport;
+  },
+
+  async movers(kind) {
+    const rows = await fetchJson<FmpMover[]>(url(MOVER_PATH[kind]), {
+      provider: "fmp",
+    });
+    return (rows ?? []).slice(0, 25).map<Mover>((r) => ({
+      symbol: r.symbol,
+      name: r.name ?? null,
+      price: r.price,
+      change: r.change,
+      changePct: r.changesPercentage,
+      volume: null,
+    }));
+  },
+};
+
+export const fmpAvailable = () => hasKey(KEY_ENV);

--- a/apps/web/src/lib/markets/providers/index.ts
+++ b/apps/web/src/lib/markets/providers/index.ts
@@ -1,0 +1,125 @@
+/**
+ * Market-data facade.
+ *
+ * The single public entry point for market data. Picks the right provider per
+ * data class, falls back to a secondary when the primary is unconfigured or
+ * fails, and throws `MarketDataError(503, "unsupported")` when nothing can
+ * serve a class. Routes call these functions and never touch a provider
+ * directly — so swapping a free tier for a paid feed is a change here only.
+ */
+import "server-only";
+import { MarketDataError } from "../http";
+import { finnhub, finnhubAvailable } from "./finnhub";
+import { twelvedata, twelvedataAvailable } from "./twelvedata";
+import { fmp, fmpAvailable } from "./fmp";
+import type {
+  Candle,
+  CompanyProfile,
+  EarningsEvent,
+  FinancialReport,
+  Mover,
+  MoverKind,
+  NewsItem,
+  Quote,
+  Range,
+  StatementKind,
+  SymbolMatch,
+} from "./types";
+
+interface Attempt<T> {
+  available: boolean;
+  run: () => Promise<T>;
+}
+
+async function firstOf<T>(cls: string, attempts: Attempt<T>[]): Promise<T> {
+  const live = attempts.filter((a) => a.available);
+  if (live.length === 0) {
+    throw new MarketDataError(503, `No provider configured for ${cls}`);
+  }
+  let lastErr: unknown;
+  for (const a of live) {
+    try {
+      return await a.run();
+    } catch (e) {
+      lastErr = e;
+    }
+  }
+  if (lastErr instanceof MarketDataError) throw lastErr;
+  throw new MarketDataError(
+    502,
+    `All providers failed for ${cls}: ${
+      lastErr instanceof Error ? lastErr.message : "unknown"
+    }`,
+  );
+}
+
+export function getQuote(symbol: string): Promise<Quote> {
+  return firstOf("quote", [
+    { available: finnhubAvailable() && !!finnhub.quote, run: () => finnhub.quote!(symbol) },
+    { available: twelvedataAvailable() && !!twelvedata.quote, run: () => twelvedata.quote!(symbol) },
+  ]);
+}
+
+export function searchSymbols(query: string): Promise<SymbolMatch[]> {
+  return firstOf("search", [
+    { available: finnhubAvailable() && !!finnhub.search, run: () => finnhub.search!(query) },
+    { available: twelvedataAvailable() && !!twelvedata.search, run: () => twelvedata.search!(query) },
+  ]);
+}
+
+export function getCandles(symbol: string, range: Range): Promise<Candle[]> {
+  return firstOf("candles", [
+    { available: twelvedataAvailable() && !!twelvedata.candles, run: () => twelvedata.candles!(symbol, range) },
+  ]);
+}
+
+export function getProfile(symbol: string): Promise<CompanyProfile> {
+  return firstOf("profile", [
+    { available: finnhubAvailable() && !!finnhub.profile, run: () => finnhub.profile!(symbol) },
+  ]);
+}
+
+export function getNews(symbol: string, sinceDays = 7): Promise<NewsItem[]> {
+  return firstOf("news", [
+    { available: finnhubAvailable() && !!finnhub.news, run: () => finnhub.news!(symbol, sinceDays) },
+  ]);
+}
+
+export function getFinancials(
+  symbol: string,
+  statement: StatementKind,
+): Promise<FinancialReport> {
+  return firstOf("financials", [
+    { available: fmpAvailable() && !!fmp.financials, run: () => fmp.financials!(symbol, statement) },
+  ]);
+}
+
+export function getEarningsCalendar(
+  fromIso: string,
+  toIso: string,
+): Promise<EarningsEvent[]> {
+  return firstOf("calendar", [
+    { available: finnhubAvailable() && !!finnhub.earningsCalendar, run: () => finnhub.earningsCalendar!(fromIso, toIso) },
+  ]);
+}
+
+export function getMovers(kind: MoverKind): Promise<Mover[]> {
+  return firstOf("movers", [
+    { available: fmpAvailable() && !!fmp.movers, run: () => fmp.movers!(kind) },
+  ]);
+}
+
+export function getFxRate(from: string, to: string): Promise<number> {
+  return firstOf("fx", [
+    { available: twelvedataAvailable() && !!twelvedata.fxRate, run: () => twelvedata.fxRate!(from, to) },
+  ]);
+}
+
+/** Which providers are configured — for diagnostics / the attribution footer. */
+export function configuredProviders(): { id: string; attribution: string }[] {
+  const out: { id: string; attribution: string }[] = [];
+  if (finnhubAvailable()) out.push({ id: finnhub.id, attribution: finnhub.attribution });
+  if (twelvedataAvailable()) out.push({ id: twelvedata.id, attribution: twelvedata.attribution });
+  if (fmpAvailable()) out.push({ id: fmp.id, attribution: fmp.attribution });
+  return out;
+}

--- a/apps/web/src/lib/markets/providers/twelvedata.ts
+++ b/apps/web/src/lib/markets/providers/twelvedata.ts
@@ -1,0 +1,206 @@
+/**
+ * Twelve Data adapter — candles (charts), FX rates, and quote/search fallback.
+ *
+ * Free tier: 8 req/min, 800 req/day. Covers OHLC time series for stocks, ETFs,
+ * FX, and crypto, plus a symbol search and a quote endpoint. We use it as the
+ * primary candle source (Finnhub free has no candles) and as a fallback for
+ * quotes/search.
+ *
+ * Docs: https://twelvedata.com/docs
+ */
+import "server-only";
+import { fetchJson, hasKey, requireKey, MarketDataError } from "../http";
+import type {
+  Candle,
+  MarketDataProvider,
+  Quote,
+  Range,
+  SymbolMatch,
+} from "./types";
+
+const BASE = "https://api.twelvedata.com";
+const KEY_ENV = "TWELVEDATA_API_KEY";
+
+function url(path: string, params: Record<string, string>): string {
+  const apikey = requireKey(KEY_ENV, "Twelve Data");
+  const qs = new URLSearchParams({ ...params, apikey }).toString();
+  return `${BASE}${path}?${qs}`;
+}
+
+/** Map a UI range to (interval, outputsize) for the time_series endpoint. */
+function rangeToParams(range: Range): { interval: string; outputsize: string } {
+  switch (range) {
+    case "1D":
+      return { interval: "5min", outputsize: "78" };
+    case "5D":
+      return { interval: "30min", outputsize: "65" };
+    case "1M":
+      return { interval: "1day", outputsize: "22" };
+    case "6M":
+      return { interval: "1day", outputsize: "130" };
+    case "YTD":
+      return { interval: "1day", outputsize: "260" };
+    case "1Y":
+      return { interval: "1day", outputsize: "260" };
+    case "5Y":
+      return { interval: "1week", outputsize: "260" };
+    case "MAX":
+      return { interval: "1month", outputsize: "360" };
+    default:
+      return { interval: "1day", outputsize: "130" };
+  }
+}
+
+interface TDTimeSeries {
+  status?: string;
+  message?: string;
+  values?: {
+    datetime: string;
+    open: string;
+    high: string;
+    low: string;
+    close: string;
+    volume?: string;
+  }[];
+}
+
+interface TDQuote {
+  status?: string;
+  message?: string;
+  symbol?: string;
+  name?: string;
+  exchange?: string;
+  currency?: string;
+  open?: string;
+  high?: string;
+  low?: string;
+  close?: string;
+  previous_close?: string;
+  change?: string;
+  percent_change?: string;
+  volume?: string;
+  fifty_two_week?: { high?: string; low?: string };
+  is_market_open?: boolean;
+}
+
+interface TDSearch {
+  data?: {
+    symbol: string;
+    instrument_name: string;
+    exchange: string;
+    instrument_type: string;
+  }[];
+}
+
+interface TDPrice {
+  price?: string;
+  status?: string;
+}
+
+const num = (s: string | undefined | null): number | null => {
+  if (s === undefined || s === null || s === "") return null;
+  const n = Number(s);
+  return Number.isNaN(n) ? null : n;
+};
+
+export const twelvedata: MarketDataProvider = {
+  id: "twelvedata",
+  attribution: "Data by Twelve Data",
+
+  async candles(symbol, range) {
+    const { interval, outputsize } = rangeToParams(range);
+    const res = await fetchJson<TDTimeSeries>(
+      url("/time_series", { symbol, interval, outputsize }),
+      { provider: "twelvedata" },
+    );
+    if (res.status === "error") {
+      throw new MarketDataError(
+        502,
+        res.message ?? `No candles for ${symbol}`,
+        "twelvedata",
+      );
+    }
+    const values = res.values ?? [];
+    // Twelve Data returns newest-first; charts want oldest-first.
+    return values
+      .slice()
+      .reverse()
+      .map<Candle>((v) => ({
+        time: Math.floor(new Date(v.datetime).getTime() / 1000),
+        open: Number(v.open),
+        high: Number(v.high),
+        low: Number(v.low),
+        close: Number(v.close),
+        volume: v.volume ? Number(v.volume) : 0,
+      }))
+      .filter((c) => !Number.isNaN(c.close));
+  },
+
+  async quote(symbol) {
+    const q = await fetchJson<TDQuote>(
+      url("/quote", { symbol }),
+      { provider: "twelvedata" },
+    );
+    if (q.status === "error" || !q.close) {
+      throw new MarketDataError(
+        404,
+        q.message ?? `No quote for ${symbol}`,
+        "twelvedata",
+      );
+    }
+    const result: Quote = {
+      symbol,
+      name: q.name,
+      price: num(q.close) ?? 0,
+      change: num(q.change) ?? 0,
+      changePct: num(q.percent_change) ?? 0,
+      open: num(q.open),
+      high: num(q.high),
+      low: num(q.low),
+      prevClose: num(q.previous_close),
+      volume: num(q.volume),
+      marketCap: null,
+      peRatio: null,
+      week52High: num(q.fifty_two_week?.high),
+      week52Low: num(q.fifty_two_week?.low),
+      currency: q.currency ?? "USD",
+      exchange: q.exchange ?? null,
+      marketState: q.is_market_open ? "open" : "closed",
+      asOf: new Date().toISOString(),
+      provider: "twelvedata",
+    };
+    return result;
+  },
+
+  async search(query) {
+    const res = await fetchJson<TDSearch>(
+      url("/symbol_search", { symbol: query }),
+      { provider: "twelvedata" },
+    );
+    return (res.data ?? []).slice(0, 20).map<SymbolMatch>((r) => ({
+      symbol: r.symbol,
+      name: r.instrument_name,
+      exchange: r.exchange ?? null,
+      type:
+        r.instrument_type?.toLowerCase().includes("etf")
+          ? "etf"
+          : r.instrument_type?.toLowerCase().includes("digital")
+            ? "crypto"
+            : "stock",
+    }));
+  },
+
+  async fxRate(from, to) {
+    const res = await fetchJson<TDPrice>(
+      url("/price", { symbol: `${from}/${to}` }),
+      { provider: "twelvedata" },
+    );
+    const p = num(res.price ?? null);
+    if (p === null) {
+      throw new MarketDataError(404, `No FX rate ${from}/${to}`, "twelvedata");
+    }
+    return p;
+  },
+};
+
+export const twelvedataAvailable = () => hasKey(KEY_ENV);

--- a/apps/web/src/lib/markets/providers/types.ts
+++ b/apps/web/src/lib/markets/providers/types.ts
@@ -1,0 +1,187 @@
+/**
+ * Market-data provider contract.
+ *
+ * One interface, swappable implementations (Finnhub, Twelve Data, FMP, …).
+ * The registry in `./index.ts` maps each data class to a concrete provider,
+ * so "quotes from Finnhub, candles from Twelve Data" is configuration, not
+ * hardcoded call sites. Swapping a free tier for a paid feed at scale is a
+ * one-file change.
+ *
+ * All shapes are NORMALIZED — provider-specific payloads are flattened into
+ * these types inside each adapter so the rest of the app never sees a raw
+ * vendor response.
+ */
+
+/** A stock/instrument identifier, e.g. "AAPL", "BTC-USD". NOT a terminal ticker. */
+export type Symbol = string;
+
+export type InstrumentType =
+  | "stock"
+  | "etf"
+  | "crypto"
+  | "fx"
+  | "index"
+  | "future"
+  | "bond"
+  | "unknown";
+
+export type MarketState = "pre" | "open" | "post" | "closed" | "unknown";
+
+export interface Quote {
+  symbol: Symbol;
+  name?: string;
+  price: number;
+  change: number;
+  changePct: number;
+  open: number | null;
+  high: number | null;
+  low: number | null;
+  prevClose: number | null;
+  volume: number | null;
+  marketCap: number | null;
+  peRatio: number | null;
+  week52High: number | null;
+  week52Low: number | null;
+  currency: string;
+  exchange: string | null;
+  marketState: MarketState;
+  /** ISO timestamp the quote was sourced. */
+  asOf: string;
+  provider: string;
+}
+
+export interface SymbolMatch {
+  symbol: Symbol;
+  name: string;
+  exchange: string | null;
+  type: InstrumentType;
+}
+
+export interface CompanyProfile {
+  symbol: Symbol;
+  name: string;
+  exchange: string | null;
+  industry: string | null;
+  sector: string | null;
+  country: string | null;
+  currency: string;
+  marketCap: number | null;
+  sharesOutstanding: number | null;
+  logo: string | null;
+  weburl: string | null;
+  ipo: string | null;
+  description: string | null;
+  beta: number | null;
+  dividendYield: number | null;
+  provider: string;
+}
+
+/** Chart range presets, mapped to (interval, lookback) inside adapters. */
+export type Range = "1D" | "5D" | "1M" | "6M" | "YTD" | "1Y" | "5Y" | "MAX";
+
+export type Interval = "1m" | "5m" | "15m" | "30m" | "60m" | "1d" | "1wk" | "1mo";
+
+export interface Candle {
+  /** Unix seconds. */
+  time: number;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  volume: number;
+}
+
+export interface NewsItem {
+  id: string;
+  headline: string;
+  summary: string | null;
+  source: string;
+  url: string;
+  imageUrl: string | null;
+  /** ISO timestamp. */
+  datetime: string;
+  symbols: Symbol[];
+}
+
+export type StatementKind = "income" | "balance" | "cash";
+
+export interface FinancialPeriod {
+  /** ISO date of the fiscal period end. */
+  fiscalDate: string;
+  /** "Q" (quarterly) or "FY" (annual). */
+  period: "Q" | "FY";
+  lineItems: Record<string, number | null>;
+}
+
+export interface FinancialReport {
+  symbol: Symbol;
+  statement: StatementKind;
+  currency: string;
+  periods: FinancialPeriod[];
+  provider: string;
+}
+
+export interface EarningsEvent {
+  symbol: Symbol;
+  /** ISO date. */
+  date: string;
+  hour: "bmo" | "amc" | "dmh" | null;
+  epsEstimate: number | null;
+  epsActual: number | null;
+  revenueEstimate: number | null;
+  revenueActual: number | null;
+}
+
+export interface Mover {
+  symbol: Symbol;
+  name: string | null;
+  price: number;
+  change: number;
+  changePct: number;
+  volume: number | null;
+}
+
+export type MoverKind = "gainers" | "losers" | "active";
+
+export interface OverviewQuote {
+  symbol: Symbol;
+  label: string;
+  price: number;
+  change: number;
+  changePct: number;
+}
+
+export interface DataClassMap {
+  quote: 1;
+  search: 1;
+  profile: 1;
+  candles: 1;
+  news: 1;
+  financials: 1;
+  calendar: 1;
+  movers: 1;
+  fx: 1;
+}
+
+export type DataClass = keyof DataClassMap;
+
+/**
+ * A market-data provider. Every method is optional: each free-tier adapter
+ * implements only what its tier actually covers, and the facade in
+ * `./index.ts` orchestrates provider selection + fallback, degrading
+ * gracefully (empty result or `unsupported`) when nothing can serve a class.
+ */
+export interface MarketDataProvider {
+  readonly id: string;
+  /** Rendered in the UI footer — free tiers require attribution. */
+  readonly attribution: string;
+  quote?(symbol: Symbol): Promise<Quote>;
+  search?(query: string): Promise<SymbolMatch[]>;
+  candles?(symbol: Symbol, range: Range): Promise<Candle[]>;
+  profile?(symbol: Symbol): Promise<CompanyProfile>;
+  news?(symbol: Symbol, sinceDays: number): Promise<NewsItem[]>;
+  financials?(symbol: Symbol, statement: StatementKind): Promise<FinancialReport>;
+  earningsCalendar?(fromIso: string, toIso: string): Promise<EarningsEvent[]>;
+  movers?(kind: MoverKind): Promise<Mover[]>;
+  fxRate?(from: string, to: string): Promise<number>;
+}

--- a/apps/web/src/lib/markets/screener-universe.ts
+++ b/apps/web/src/lib/markets/screener-universe.ts
@@ -1,0 +1,19 @@
+/**
+ * Default screener universe.
+ *
+ * Free tiers don't expose a fundamentals-wide screener, so the screener runs
+ * over a candidate universe (this default large-cap set, the user's watchlist
+ * symbols, or an explicit `universe` in the request) and filters on the
+ * fields we DO have from quotes (price, % change, market cap). Deeper
+ * fundamental filters (P/E, yield) require a paid feed — surfaced honestly
+ * in the UI.
+ */
+import "server-only";
+
+export const SCREENER_UNIVERSE: string[] = [
+  "AAPL", "MSFT", "GOOGL", "AMZN", "NVDA", "META", "TSLA", "BRK.B", "AVGO",
+  "JPM", "V", "MA", "UNH", "HD", "PG", "JNJ", "COST", "ABBV", "WMT", "KO",
+  "PEP", "BAC", "CRM", "NFLX", "AMD", "ADBE", "DIS", "INTC", "CSCO", "ORCL",
+  // Real-estate / REIT lens (Zack's domain)
+  "PLD", "AMT", "EQIX", "SPG", "O", "VICI", "AVB", "EQR", "VNQ", "MAA",
+];

--- a/apps/web/src/lib/markets/symbols.ts
+++ b/apps/web/src/lib/markets/symbols.ts
@@ -1,0 +1,21 @@
+/**
+ * Stock-symbol normalization + validation.
+ *
+ * A market "symbol" (AAPL, BRK.B, BTC-USD, ^GSPC) is deliberately separate
+ * from a Rokki terminal "ticker" (terminals.ticker, validated by
+ * apps/mcp-server/src/ticker.ts). Do not reuse the terminal-ticker helpers
+ * for instruments — symbols allow ".", "-", ":", "^" and are case-folded.
+ */
+
+const SYMBOL_RE = /^[A-Z0-9][A-Z0-9.\-:^]{0,19}$/;
+
+/** Upper-case and trim a user-entered symbol. */
+export function normalizeSymbol(raw: string): string {
+  return raw.trim().toUpperCase();
+}
+
+/** Validate a normalized symbol (1–20 chars, allowed instrument chars). */
+export function isValidSymbol(raw: string): boolean {
+  const s = normalizeSymbol(raw);
+  return SYMBOL_RE.test(s);
+}

--- a/apps/web/src/modules/index.ts
+++ b/apps/web/src/modules/index.ts
@@ -17,6 +17,7 @@ import { filesManifest } from "./files/manifest";
 import { messengerManifest } from "./messenger/manifest";
 import { scheduleManifest } from "./schedule/manifest";
 import { goalsManifest } from "./goals/manifest";
+import { marketsManifest } from "./markets/manifest";
 
 let registered = false;
 
@@ -32,6 +33,7 @@ export function registerAllModules(): void {
   registerModule(messengerManifest);
   registerModule(scheduleManifest);
   registerModule(goalsManifest);
+  registerModule(marketsManifest);
   registered = true;
 }
 

--- a/apps/web/src/modules/markets/components/AlertsView.tsx
+++ b/apps/web/src/modules/markets/components/AlertsView.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { Button } from "@/components/ui/Button";
+import type { MktAlertRow } from "@/lib/markets/db";
+import {
+  createAlert,
+  deleteAlert,
+  updateAlert,
+} from "../lib/client-api";
+import { AttributionFooter } from "./AttributionFooter";
+
+const CONDITIONS: { key: MktAlertRow["condition"]; label: string }[] = [
+  { key: "price_above", label: "Price above" },
+  { key: "price_below", label: "Price below" },
+  { key: "pct_up", label: "Day % above" },
+  { key: "pct_down", label: "Day % below" },
+];
+
+export function AlertsView({ initial }: { initial: MktAlertRow[] }) {
+  const [alerts, setAlerts] = useState(initial);
+  const [symbol, setSymbol] = useState("");
+  const [condition, setCondition] = useState<MktAlertRow["condition"]>("price_above");
+  const [threshold, setThreshold] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  async function add() {
+    setError(null);
+    const t = Number(threshold);
+    if (!symbol.trim()) return setError("Symbol is required");
+    if (Number.isNaN(t)) return setError("Threshold must be a number");
+    setBusy(true);
+    try {
+      const a = await createAlert(symbol.trim().toUpperCase(), condition, t);
+      setAlerts((prev) => [a, ...prev]);
+      setSymbol("");
+      setThreshold("");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not create alert");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function toggle(a: MktAlertRow) {
+    const updated = await updateAlert(a.id, { active: !a.active }).catch(() => null);
+    if (updated) setAlerts((prev) => prev.map((x) => (x.id === a.id ? updated : x)));
+  }
+
+  async function remove(id: string) {
+    await deleteAlert(id).catch(() => {});
+    setAlerts((prev) => prev.filter((a) => a.id !== id));
+  }
+
+  function label(c: MktAlertRow["condition"]) {
+    return CONDITIONS.find((x) => x.key === c)?.label ?? c;
+  }
+
+  return (
+    <div className="space-y-4 p-2 sm:p-3">
+      <div className="flex items-center gap-3">
+        <h1 className="text-lg font-semibold text-text-0">Price Alerts</h1>
+        <Link href="/app/markets" className="text-xs text-text-2 hover:text-text-0">
+          ← Dashboard
+        </Link>
+      </div>
+
+      <div className="flex flex-wrap items-end gap-2 rounded border border-border bg-bg-1 p-3">
+        <input
+          value={symbol}
+          onChange={(e) => setSymbol(e.target.value)}
+          placeholder="Symbol"
+          className="w-24 rounded border border-border bg-bg-2 px-2 py-1 text-xs uppercase text-text-1 placeholder:text-text-3"
+        />
+        <select
+          value={condition}
+          onChange={(e) => setCondition(e.target.value as MktAlertRow["condition"])}
+          className="rounded border border-border bg-bg-2 px-2 py-1 text-xs text-text-1"
+        >
+          {CONDITIONS.map((c) => (
+            <option key={c.key} value={c.key}>
+              {c.label}
+            </option>
+          ))}
+        </select>
+        <input
+          value={threshold}
+          onChange={(e) => setThreshold(e.target.value)}
+          placeholder="Threshold"
+          type="number"
+          className="w-28 rounded border border-border bg-bg-2 px-2 py-1 text-xs text-text-1 placeholder:text-text-3"
+        />
+        <Button size="sm" variant="accent" onClick={add} loading={busy}>
+          Add alert
+        </Button>
+      </div>
+
+      {error && <p className="text-xs text-danger">{error}</p>}
+
+      <div className="overflow-hidden rounded border border-border bg-bg-1">
+        <table className="w-full text-xs">
+          <thead>
+            <tr className="border-b border-border bg-bg-2 text-[10px] uppercase tracking-wide text-text-3">
+              <th className="px-3 py-1 text-left font-semibold">Symbol</th>
+              <th className="px-3 py-1 text-left font-semibold">Condition</th>
+              <th className="px-3 py-1 text-right font-semibold">Threshold</th>
+              <th className="px-3 py-1 text-center font-semibold">Status</th>
+              <th className="w-16 px-2 py-1" />
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border">
+            {alerts.length === 0 ? (
+              <tr>
+                <td colSpan={5} className="px-3 py-3 text-text-3">
+                  No alerts. Create one above — they’re evaluated by a scheduled job
+                  and notify you in Rokki when tripped.
+                </td>
+              </tr>
+            ) : (
+              alerts.map((a) => (
+                <tr key={a.id} className="group hover:bg-bg-2">
+                  <td className="px-3 py-1 font-mono font-semibold text-accent">{a.symbol}</td>
+                  <td className="px-3 py-1 text-text-1">{label(a.condition)}</td>
+                  <td className="px-3 py-1 text-right font-mono">{a.threshold}</td>
+                  <td className="px-3 py-1 text-center">
+                    <button
+                      onClick={() => toggle(a)}
+                      className={`rounded-sm px-1.5 py-0.5 text-[10px] font-semibold uppercase ${
+                        a.active ? "text-success" : "text-text-3"
+                      }`}
+                    >
+                      {a.active ? "Active" : "Paused"}
+                    </button>
+                  </td>
+                  <td className="px-2 py-1 text-right">
+                    <button
+                      onClick={() => remove(a.id)}
+                      className="text-[10px] uppercase text-text-3 opacity-0 transition-opacity hover:text-danger group-hover:opacity-100"
+                    >
+                      Del
+                    </button>
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      <AttributionFooter />
+    </div>
+  );
+}

--- a/apps/web/src/modules/markets/components/AttributionFooter.tsx
+++ b/apps/web/src/modules/markets/components/AttributionFooter.tsx
@@ -1,0 +1,13 @@
+/**
+ * Data attribution footer. Free-tier feeds require credit; this is part of the
+ * module layout so it can't be forgotten. Static — no provider import needed.
+ */
+export function AttributionFooter() {
+  return (
+    <footer className="mt-4 border-t border-border px-1 pt-2 text-[10px] text-text-3">
+      Market data by Finnhub &amp; Twelve Data · fundamentals by Financial
+      Modeling Prep. Quotes may be delayed. For information only — not investment
+      advice.
+    </footer>
+  );
+}

--- a/apps/web/src/modules/markets/components/FinancialsTable.tsx
+++ b/apps/web/src/modules/markets/components/FinancialsTable.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { fmtCompact } from "@/lib/markets/format";
+import { getFinancials } from "../lib/client-api";
+import type { FinancialReport, StatementKind } from "@/lib/markets/providers/types";
+
+const TABS: { key: StatementKind; label: string }[] = [
+  { key: "income", label: "Income" },
+  { key: "balance", label: "Balance" },
+  { key: "cash", label: "Cash Flow" },
+];
+
+const LABELS: Record<string, string> = {
+  revenue: "Revenue",
+  costOfRevenue: "Cost of Revenue",
+  grossProfit: "Gross Profit",
+  operatingExpenses: "Operating Expenses",
+  operatingIncome: "Operating Income",
+  netIncome: "Net Income",
+  eps: "EPS",
+  ebitda: "EBITDA",
+  totalAssets: "Total Assets",
+  totalCurrentAssets: "Current Assets",
+  cashAndCashEquivalents: "Cash & Equivalents",
+  totalLiabilities: "Total Liabilities",
+  totalCurrentLiabilities: "Current Liabilities",
+  totalDebt: "Total Debt",
+  totalStockholdersEquity: "Shareholders' Equity",
+  netCashProvidedByOperatingActivities: "Operating Cash Flow",
+  netCashUsedForInvestingActivites: "Investing Cash Flow",
+  netCashUsedProvidedByFinancingActivities: "Financing Cash Flow",
+  freeCashFlow: "Free Cash Flow",
+  capitalExpenditure: "CapEx",
+  dividendsPaid: "Dividends Paid",
+};
+
+export function FinancialsTable({ symbol }: { symbol: string }) {
+  const [statement, setStatement] = useState<StatementKind>("income");
+  const [report, setReport] = useState<FinancialReport | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    getFinancials(symbol, statement)
+      .then((r) => !cancelled && setReport(r))
+      .catch((e) => {
+        if (!cancelled) {
+          setReport(null);
+          setError(e instanceof Error ? e.message : "Financials unavailable");
+        }
+      })
+      .finally(() => !cancelled && setLoading(false));
+    return () => {
+      cancelled = true;
+    };
+  }, [symbol, statement]);
+
+  const rowKeys = report?.periods[0]
+    ? Object.keys(report.periods[0].lineItems)
+    : [];
+
+  return (
+    <div>
+      <div className="mb-2 flex gap-1">
+        {TABS.map((t) => (
+          <button
+            key={t.key}
+            onClick={() => setStatement(t.key)}
+            className={`rounded-sm px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${
+              statement === t.key
+                ? "bg-bg-3 text-text-0"
+                : "text-text-2 hover:bg-bg-2 hover:text-text-0"
+            }`}
+          >
+            {t.label}
+          </button>
+        ))}
+      </div>
+
+      {loading && <p className="p-3 text-xs text-text-3">Loading…</p>}
+      {!loading && error && <p className="p-3 text-xs text-danger">{error}</p>}
+      {!loading && !error && report && report.periods.length > 0 && (
+        <div className="overflow-x-auto rounded border border-border bg-bg-1">
+          <table className="w-full text-xs">
+            <thead>
+              <tr className="border-b border-border bg-bg-2 text-[10px] uppercase tracking-wide text-text-3">
+                <th className="px-3 py-1 text-left font-semibold">Line item</th>
+                {report.periods.map((p) => (
+                  <th key={p.fiscalDate} className="px-3 py-1 text-right font-semibold">
+                    {p.fiscalDate.slice(0, 7)}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border">
+              {rowKeys.map((k) => (
+                <tr key={k} className="hover:bg-bg-2">
+                  <td className="px-3 py-1 text-text-1">{LABELS[k] ?? k}</td>
+                  {report.periods.map((p) => (
+                    <td key={p.fiscalDate} className="px-3 py-1 text-right font-mono text-text-2">
+                      {p.lineItems[k] === null || p.lineItems[k] === undefined
+                        ? "—"
+                        : fmtCompact(p.lineItems[k] as number)}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <p className="px-3 py-1 text-[10px] text-text-3">
+            {report.currency} · {report.provider}
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/modules/markets/components/MarketsBoard.tsx
+++ b/apps/web/src/modules/markets/components/MarketsBoard.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { changeClass, fmtChange, fmtPct, fmtPrice } from "@/lib/markets/format";
+import type { Mover, MoverKind } from "@/lib/markets/providers/types";
+import { getMovers, getOverview, type BoardRow } from "../lib/client-api";
+import { AttributionFooter } from "./AttributionFooter";
+
+function BoardGroup({ title, rows }: { title: string; rows: BoardRow[] }) {
+  return (
+    <div className="overflow-hidden rounded border border-border bg-bg-1">
+      <header className="border-b border-border bg-bg-2 px-3 py-1 text-[10px] font-semibold uppercase tracking-wide text-text-3">
+        {title}
+      </header>
+      <table className="w-full text-xs">
+        <tbody className="divide-y divide-border">
+          {rows.map((r) => (
+            <tr key={r.symbol} className="hover:bg-bg-2">
+              <td className="px-3 py-1 text-text-1">{r.label}</td>
+              <td className="px-3 py-1 text-right font-mono">{fmtPrice(r.price)}</td>
+              <td className={`px-3 py-1 text-right font-mono ${changeClass(r.changePct)}`}>
+                {fmtPct(r.changePct)}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+const MOVER_TABS: { key: MoverKind; label: string }[] = [
+  { key: "gainers", label: "Gainers" },
+  { key: "losers", label: "Losers" },
+  { key: "active", label: "Most Active" },
+];
+
+export function MarketsBoard() {
+  const [board, setBoard] = useState<Awaited<ReturnType<typeof getOverview>> | null>(
+    null,
+  );
+  const [boardErr, setBoardErr] = useState<string | null>(null);
+  const [moverKind, setMoverKind] = useState<MoverKind>("gainers");
+  const [movers, setMovers] = useState<Mover[]>([]);
+  const [moverErr, setMoverErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    getOverview()
+      .then(setBoard)
+      .catch((e) => setBoardErr(e instanceof Error ? e.message : "Unavailable"));
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    setMoverErr(null);
+    getMovers(moverKind)
+      .then((m) => !cancelled && setMovers(m))
+      .catch((e) => {
+        if (!cancelled) {
+          setMovers([]);
+          setMoverErr(e instanceof Error ? e.message : "Movers unavailable");
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [moverKind]);
+
+  return (
+    <div className="space-y-4 p-2 sm:p-3">
+      <div className="flex items-center gap-3">
+        <h1 className="text-lg font-semibold text-text-0">Markets</h1>
+        <Link href="/app/markets" className="text-xs text-text-2 hover:text-text-0">
+          ← Dashboard
+        </Link>
+      </div>
+
+      {boardErr && <p className="text-xs text-danger">{boardErr}</p>}
+      {board && (
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+          <BoardGroup title="Indices" rows={board.indices} />
+          <BoardGroup title="Sectors" rows={board.sectors} />
+          <BoardGroup title="Commodities" rows={board.commodities} />
+          <BoardGroup title="FX" rows={board.fx} />
+        </div>
+      )}
+
+      <div>
+        <div className="mb-2 flex gap-1">
+          {MOVER_TABS.map((t) => (
+            <button
+              key={t.key}
+              onClick={() => setMoverKind(t.key)}
+              className={`rounded-sm px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${
+                moverKind === t.key
+                  ? "bg-bg-3 text-text-0"
+                  : "text-text-2 hover:bg-bg-2 hover:text-text-0"
+              }`}
+            >
+              {t.label}
+            </button>
+          ))}
+        </div>
+        {moverErr ? (
+          <p className="text-xs text-text-3">{moverErr}</p>
+        ) : (
+          <div className="overflow-hidden rounded border border-border bg-bg-1">
+            <table className="w-full text-xs">
+              <thead>
+                <tr className="border-b border-border bg-bg-2 text-[10px] uppercase tracking-wide text-text-3">
+                  <th className="px-3 py-1 text-left font-semibold">Symbol</th>
+                  <th className="px-3 py-1 text-left font-semibold">Name</th>
+                  <th className="px-3 py-1 text-right font-semibold">Price</th>
+                  <th className="px-3 py-1 text-right font-semibold">Chg</th>
+                  <th className="px-3 py-1 text-right font-semibold">Chg %</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border">
+                {movers.map((m) => (
+                  <tr key={m.symbol} className="hover:bg-bg-2">
+                    <td className="px-3 py-1">
+                      <Link
+                        href={`/app/markets/quote/${encodeURIComponent(m.symbol)}`}
+                        className="font-mono font-semibold text-accent hover:underline"
+                      >
+                        {m.symbol}
+                      </Link>
+                    </td>
+                    <td className="max-w-[200px] truncate px-3 py-1 text-text-2">
+                      {m.name ?? "—"}
+                    </td>
+                    <td className="px-3 py-1 text-right font-mono">{fmtPrice(m.price)}</td>
+                    <td className={`px-3 py-1 text-right font-mono ${changeClass(m.change)}`}>
+                      {fmtChange(m.change)}
+                    </td>
+                    <td className={`px-3 py-1 text-right font-mono ${changeClass(m.changePct)}`}>
+                      {fmtPct(m.changePct)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+
+      <AttributionFooter />
+    </div>
+  );
+}

--- a/apps/web/src/modules/markets/components/MarketsDashboard.tsx
+++ b/apps/web/src/modules/markets/components/MarketsDashboard.tsx
@@ -1,0 +1,285 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { Plus } from "lucide-react";
+import { Button } from "@/components/ui/Button";
+import { useRealtimeTable } from "@/lib/supabase/realtime";
+import type { Quote } from "@/lib/markets/providers/types";
+import type { MktPortfolioRow, ScopeKind } from "@/lib/markets/db";
+import {
+  addSymbol,
+  createPortfolio,
+  createWatchlist,
+  deletePortfolio,
+  deleteWatchlist,
+  getQuotes,
+  listPortfolios,
+  listWatchlists,
+  removeSymbol,
+  type WatchlistWithSymbols,
+} from "../lib/client-api";
+import { SymbolSearch } from "./SymbolSearch";
+import { WatchlistPanel } from "./WatchlistPanel";
+import { AttributionFooter } from "./AttributionFooter";
+
+interface QuoteCacheRow {
+  symbol: string;
+  payload: Quote;
+}
+
+export function MarketsDashboard({
+  scope,
+  scopeId,
+  initialWatchlists,
+  initialPortfolios,
+}: {
+  scope: ScopeKind;
+  scopeId?: string;
+  initialWatchlists: WatchlistWithSymbols[];
+  initialPortfolios: MktPortfolioRow[];
+}) {
+  const [watchlists, setWatchlists] = useState(initialWatchlists);
+  const [portfolios, setPortfolios] = useState(initialPortfolios);
+  const [quotes, setQuotes] = useState<Record<string, Quote>>({});
+  const [targetId, setTargetId] = useState(initialWatchlists[0]?.id ?? "");
+  const [newList, setNewList] = useState("");
+  const [newPortfolio, setNewPortfolio] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const allSymbols = useMemo(
+    () =>
+      Array.from(
+        new Set(watchlists.flatMap((w) => w.symbols.map((s) => s.symbol))),
+      ),
+    [watchlists],
+  );
+
+  const refreshWatchlists = useCallback(async () => {
+    const w = await listWatchlists(scope, scopeId);
+    setWatchlists(w);
+    if (!w.find((x) => x.id === targetId)) setTargetId(w[0]?.id ?? "");
+  }, [scope, scopeId, targetId]);
+
+  useEffect(() => {
+    if (allSymbols.length === 0) {
+      setQuotes({});
+      return;
+    }
+    let cancelled = false;
+    getQuotes(allSymbols)
+      .then((q) => {
+        if (!cancelled) setQuotes((prev) => ({ ...prev, ...q }));
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [allSymbols]);
+
+  // Live price updates: the cache table is published to Realtime.
+  useRealtimeTable<QuoteCacheRow>(
+    { table: "mkt_quote_cache", channelKey: "markets-quotes" },
+    {
+      onUpdate: (row) => {
+        if (row?.payload?.symbol)
+          setQuotes((prev) => ({ ...prev, [row.payload.symbol]: row.payload }));
+      },
+      onInsert: (row) => {
+        if (row?.payload?.symbol)
+          setQuotes((prev) => ({ ...prev, [row.payload.symbol]: row.payload }));
+      },
+    },
+  );
+
+  async function handleAdd(symbol: string) {
+    setError(null);
+    if (!targetId) {
+      setError("Create a watchlist first.");
+      return;
+    }
+    try {
+      await addSymbol(targetId, symbol);
+      await refreshWatchlists();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not add symbol");
+    }
+  }
+
+  async function handleRemove(watchlistId: string, symbol: string) {
+    await removeSymbol(watchlistId, symbol).catch(() => {});
+    await refreshWatchlists();
+  }
+
+  async function handleDeleteWatchlist(id: string) {
+    await deleteWatchlist(id).catch(() => {});
+    await refreshWatchlists();
+  }
+
+  async function handleNewList() {
+    const name = newList.trim();
+    if (!name) return;
+    try {
+      await createWatchlist(name, scope, scopeId);
+      setNewList("");
+      await refreshWatchlists();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not create watchlist");
+    }
+  }
+
+  async function handleNewPortfolio() {
+    const name = newPortfolio.trim();
+    if (!name) return;
+    try {
+      await createPortfolio(name, scope, scopeId);
+      setNewPortfolio("");
+      setPortfolios(await listPortfolios(scope, scopeId));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not create portfolio");
+    }
+  }
+
+  async function handleDeletePortfolio(id: string) {
+    await deletePortfolio(id).catch(() => {});
+    setPortfolios(await listPortfolios(scope, scopeId));
+  }
+
+  return (
+    <div className="space-y-4 p-2 sm:p-3">
+      {/* Toolbar */}
+      <div className="flex flex-wrap items-center gap-2">
+        <SymbolSearch
+          onPick={targetId ? handleAdd : undefined}
+          placeholder={
+            targetId ? "Add symbol to watchlist…" : "Search symbol…"
+          }
+        />
+        {watchlists.length > 0 && (
+          <select
+            value={targetId}
+            onChange={(e) => setTargetId(e.target.value)}
+            className="rounded border border-border bg-bg-2 px-2 py-1 text-xs text-text-1"
+            aria-label="Target watchlist"
+          >
+            {watchlists.map((w) => (
+              <option key={w.id} value={w.id}>
+                {w.name}
+              </option>
+            ))}
+          </select>
+        )}
+        <div className="flex items-center gap-1">
+          <input
+            value={newList}
+            onChange={(e) => setNewList(e.target.value)}
+            onKeyDown={(e) => e.key === "Enter" && handleNewList()}
+            placeholder="New watchlist"
+            className="w-32 rounded border border-border bg-bg-2 px-2 py-1 text-xs text-text-1 placeholder:text-text-3"
+          />
+          <Button size="sm" variant="ghost" onClick={handleNewList}>
+            <Plus className="h-3 w-3" /> List
+          </Button>
+        </div>
+        <Link
+          href="/app/markets/overview"
+          className="text-xs text-text-2 hover:text-text-0"
+        >
+          Markets ↗
+        </Link>
+        <Link
+          href="/app/markets/screener"
+          className="text-xs text-text-2 hover:text-text-0"
+        >
+          Screener ↗
+        </Link>
+        <Link
+          href="/app/markets/alerts"
+          className="text-xs text-text-2 hover:text-text-0"
+        >
+          Alerts ↗
+        </Link>
+      </div>
+
+      {error && <p className="text-xs text-danger">{error}</p>}
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        {/* Watchlists */}
+        <div className="space-y-3">
+          <h2 className="text-[10px] font-semibold uppercase tracking-wide text-text-3">
+            Watchlists
+          </h2>
+          {watchlists.length === 0 ? (
+            <p className="text-xs text-text-3">
+              No watchlists yet. Create one above.
+            </p>
+          ) : (
+            watchlists.map((w) => (
+              <WatchlistPanel
+                key={w.id}
+                watchlist={w}
+                quotes={quotes}
+                onRemoveSymbol={handleRemove}
+                onDelete={handleDeleteWatchlist}
+              />
+            ))
+          )}
+        </div>
+
+        {/* Portfolios */}
+        <div className="space-y-3">
+          <h2 className="text-[10px] font-semibold uppercase tracking-wide text-text-3">
+            Portfolios
+          </h2>
+          <div className="flex items-center gap-1">
+            <input
+              value={newPortfolio}
+              onChange={(e) => setNewPortfolio(e.target.value)}
+              onKeyDown={(e) => e.key === "Enter" && handleNewPortfolio()}
+              placeholder="New portfolio"
+              className="w-40 rounded border border-border bg-bg-2 px-2 py-1 text-xs text-text-1 placeholder:text-text-3"
+            />
+            <Button size="sm" variant="ghost" onClick={handleNewPortfolio}>
+              <Plus className="h-3 w-3" /> Portfolio
+            </Button>
+          </div>
+          {portfolios.length === 0 ? (
+            <p className="text-xs text-text-3">No portfolios yet.</p>
+          ) : (
+            <div className="overflow-hidden rounded border border-border bg-bg-1">
+              <table className="w-full text-xs">
+                <tbody className="divide-y divide-border">
+                  {portfolios.map((p) => (
+                    <tr key={p.id} className="group hover:bg-bg-2">
+                      <td className="px-3 py-1.5">
+                        <Link
+                          href={`/app/markets/portfolio/${p.id}`}
+                          className="font-semibold text-text-0 hover:underline"
+                        >
+                          {p.name}
+                        </Link>
+                        <span className="ml-2 text-[10px] uppercase text-text-3">
+                          {p.base_currency}
+                        </span>
+                      </td>
+                      <td className="px-3 py-1.5 text-right">
+                        <button
+                          onClick={() => handleDeletePortfolio(p.id)}
+                          className="text-[10px] uppercase text-text-3 opacity-0 transition-opacity hover:text-danger group-hover:opacity-100"
+                        >
+                          Delete
+                        </button>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      </div>
+
+      <AttributionFooter />
+    </div>
+  );
+}

--- a/apps/web/src/modules/markets/components/NewsList.tsx
+++ b/apps/web/src/modules/markets/components/NewsList.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { fmtRelative } from "@/lib/markets/format";
+import { getNews } from "../lib/client-api";
+import type { NewsItem } from "@/lib/markets/providers/types";
+
+export function NewsList({ symbol }: { symbol: string }) {
+  const [items, setItems] = useState<NewsItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    getNews(symbol, 14)
+      .then((i) => !cancelled && setItems(i))
+      .catch((e) => !cancelled && setError(e instanceof Error ? e.message : "No news"))
+      .finally(() => !cancelled && setLoading(false));
+    return () => {
+      cancelled = true;
+    };
+  }, [symbol]);
+
+  if (loading) return <p className="p-3 text-xs text-text-3">Loading news…</p>;
+  if (error) return <p className="p-3 text-xs text-danger">{error}</p>;
+  if (items.length === 0)
+    return <p className="p-3 text-xs text-text-3">No recent news.</p>;
+
+  return (
+    <ul className="divide-y divide-border">
+      {items.map((n) => (
+        <li key={n.id} className="px-3 py-2 hover:bg-bg-2">
+          <a
+            href={n.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="block"
+          >
+            <p className="text-xs font-medium text-text-0">{n.headline}</p>
+            <p className="mt-0.5 text-[10px] text-text-3">
+              {n.source} · {fmtRelative(n.datetime)}
+            </p>
+          </a>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/apps/web/src/modules/markets/components/PortfolioView.tsx
+++ b/apps/web/src/modules/markets/components/PortfolioView.tsx
@@ -1,0 +1,249 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/Button";
+import {
+  changeClass,
+  fmtChange,
+  fmtCompact,
+  fmtPct,
+  fmtPrice,
+} from "@/lib/markets/format";
+import type { MktLotRow, MktPortfolioRow } from "@/lib/markets/db";
+import type { PortfolioPerformance } from "@/lib/markets/portfolio";
+import { addLot, deleteLot, getPortfolio } from "../lib/client-api";
+import { AttributionFooter } from "./AttributionFooter";
+
+interface Data {
+  portfolio: MktPortfolioRow;
+  lots: MktLotRow[];
+  performance: PortfolioPerformance;
+}
+
+const emptyForm = {
+  symbol: "",
+  side: "buy" as "buy" | "sell",
+  quantity: "",
+  price: "",
+  fees: "",
+  tradeDate: "",
+};
+
+export function PortfolioView({ initial }: { initial: Data }) {
+  const [data, setData] = useState<Data>(initial);
+  const [form, setForm] = useState(emptyForm);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const { portfolio, performance, lots } = data;
+  const cur = portfolio.base_currency;
+
+  async function refresh() {
+    setData(await getPortfolio(portfolio.id));
+  }
+
+  async function submit() {
+    setError(null);
+    const quantity = Number(form.quantity);
+    const price = Number(form.price);
+    if (!form.symbol.trim()) return setError("Symbol is required");
+    if (!(quantity > 0)) return setError("Quantity must be > 0");
+    if (!(price >= 0)) return setError("Price must be ≥ 0");
+    setBusy(true);
+    try {
+      await addLot(portfolio.id, {
+        symbol: form.symbol.trim().toUpperCase(),
+        side: form.side,
+        quantity,
+        price,
+        fees: form.fees ? Number(form.fees) : 0,
+        tradeDate: form.tradeDate || undefined,
+      });
+      setForm(emptyForm);
+      await refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not add lot");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function removeLot(id: string) {
+    await deleteLot(portfolio.id, id).catch(() => {});
+    await refresh();
+  }
+
+  return (
+    <div className="space-y-4 p-2 sm:p-3">
+      {/* Header KPIs */}
+      <div className="flex flex-wrap items-end justify-between gap-3">
+        <h1 className="text-lg font-semibold text-text-0">{portfolio.name}</h1>
+        <div className="flex gap-6">
+          <div className="text-right">
+            <div className="text-[10px] uppercase tracking-wide text-text-3">Value</div>
+            <div className="font-mono text-sm text-text-0">
+              {fmtPrice(performance.totalMarketValue, cur)}
+            </div>
+          </div>
+          <div className="text-right">
+            <div className="text-[10px] uppercase tracking-wide text-text-3">Unrealized</div>
+            <div className={`font-mono text-sm ${changeClass(performance.totalUnrealizedPL)}`}>
+              {fmtChange(performance.totalUnrealizedPL)} ({fmtPct(performance.unrealizedPct)})
+            </div>
+          </div>
+          <div className="text-right">
+            <div className="text-[10px] uppercase tracking-wide text-text-3">Day</div>
+            <div className={`font-mono text-sm ${changeClass(performance.totalDayChange)}`}>
+              {fmtChange(performance.totalDayChange)}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Holdings */}
+      <div className="overflow-x-auto rounded border border-border bg-bg-1">
+        <table className="w-full text-xs">
+          <thead>
+            <tr className="border-b border-border bg-bg-2 text-[10px] uppercase tracking-wide text-text-3">
+              <th className="px-3 py-1 text-left font-semibold">Symbol</th>
+              <th className="px-3 py-1 text-right font-semibold">Qty</th>
+              <th className="px-3 py-1 text-right font-semibold">Avg Cost</th>
+              <th className="px-3 py-1 text-right font-semibold">Price</th>
+              <th className="px-3 py-1 text-right font-semibold">Mkt Value</th>
+              <th className="px-3 py-1 text-right font-semibold">Unreal. P/L</th>
+              <th className="px-3 py-1 text-right font-semibold">Weight</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border">
+            {performance.positions.length === 0 ? (
+              <tr>
+                <td colSpan={7} className="px-3 py-3 text-text-3">
+                  No open positions. Add a lot below.
+                </td>
+              </tr>
+            ) : (
+              performance.positions.map((p) => (
+                <tr key={p.symbol} className="hover:bg-bg-2">
+                  <td className="px-3 py-1 font-mono font-semibold text-accent">{p.symbol}</td>
+                  <td className="px-3 py-1 text-right font-mono">{p.quantity}</td>
+                  <td className="px-3 py-1 text-right font-mono text-text-2">
+                    {fmtPrice(p.avgCost, cur)}
+                  </td>
+                  <td className="px-3 py-1 text-right font-mono">{fmtPrice(p.price, cur)}</td>
+                  <td className="px-3 py-1 text-right font-mono">{fmtPrice(p.marketValue, cur)}</td>
+                  <td className={`px-3 py-1 text-right font-mono ${changeClass(p.unrealizedPL)}`}>
+                    {fmtChange(p.unrealizedPL)} ({fmtPct(p.unrealizedPct)})
+                  </td>
+                  <td className="px-3 py-1 text-right font-mono text-text-2">
+                    {p.weight !== null ? `${p.weight.toFixed(1)}%` : "—"}
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Add lot */}
+      <div className="rounded border border-border bg-bg-1 p-3">
+        <h2 className="mb-2 text-[10px] font-semibold uppercase tracking-wide text-text-3">
+          Add lot
+        </h2>
+        <div className="flex flex-wrap items-end gap-2">
+          <input
+            value={form.symbol}
+            onChange={(e) => setForm({ ...form, symbol: e.target.value })}
+            placeholder="Symbol"
+            className="w-24 rounded border border-border bg-bg-2 px-2 py-1 text-xs uppercase text-text-1 placeholder:text-text-3"
+          />
+          <select
+            value={form.side}
+            onChange={(e) => setForm({ ...form, side: e.target.value as "buy" | "sell" })}
+            className="rounded border border-border bg-bg-2 px-2 py-1 text-xs text-text-1"
+          >
+            <option value="buy">Buy</option>
+            <option value="sell">Sell</option>
+          </select>
+          <input
+            value={form.quantity}
+            onChange={(e) => setForm({ ...form, quantity: e.target.value })}
+            placeholder="Qty"
+            type="number"
+            className="w-20 rounded border border-border bg-bg-2 px-2 py-1 text-xs text-text-1 placeholder:text-text-3"
+          />
+          <input
+            value={form.price}
+            onChange={(e) => setForm({ ...form, price: e.target.value })}
+            placeholder="Price"
+            type="number"
+            className="w-24 rounded border border-border bg-bg-2 px-2 py-1 text-xs text-text-1 placeholder:text-text-3"
+          />
+          <input
+            value={form.fees}
+            onChange={(e) => setForm({ ...form, fees: e.target.value })}
+            placeholder="Fees"
+            type="number"
+            className="w-20 rounded border border-border bg-bg-2 px-2 py-1 text-xs text-text-1 placeholder:text-text-3"
+          />
+          <input
+            value={form.tradeDate}
+            onChange={(e) => setForm({ ...form, tradeDate: e.target.value })}
+            type="date"
+            className="rounded border border-border bg-bg-2 px-2 py-1 text-xs text-text-1"
+          />
+          <Button size="sm" variant="accent" onClick={submit} loading={busy}>
+            Add
+          </Button>
+        </div>
+        {error && <p className="mt-2 text-xs text-danger">{error}</p>}
+      </div>
+
+      {/* Lot ledger */}
+      {lots.length > 0 && (
+        <details className="rounded border border-border bg-bg-1">
+          <summary className="cursor-pointer px-3 py-1.5 text-[10px] font-semibold uppercase tracking-wide text-text-3">
+            Lot ledger ({lots.length})
+          </summary>
+          <table className="w-full text-xs">
+            <thead>
+              <tr className="border-y border-border bg-bg-2 text-[10px] uppercase tracking-wide text-text-3">
+                <th className="px-3 py-1 text-left font-semibold">Date</th>
+                <th className="px-3 py-1 text-left font-semibold">Symbol</th>
+                <th className="px-3 py-1 text-left font-semibold">Side</th>
+                <th className="px-3 py-1 text-right font-semibold">Qty</th>
+                <th className="px-3 py-1 text-right font-semibold">Price</th>
+                <th className="w-8 px-2 py-1" />
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border">
+              {lots.map((l) => (
+                <tr key={l.id} className="group hover:bg-bg-2">
+                  <td className="px-3 py-1 font-mono text-text-2">{l.trade_date}</td>
+                  <td className="px-3 py-1 font-mono text-accent">{l.symbol}</td>
+                  <td className="px-3 py-1 uppercase text-text-2">{l.side}</td>
+                  <td className="px-3 py-1 text-right font-mono">{l.quantity}</td>
+                  <td className="px-3 py-1 text-right font-mono">{fmtPrice(l.price, cur)}</td>
+                  <td className="px-2 py-1 text-right">
+                    <button
+                      onClick={() => removeLot(l.id)}
+                      className="text-[10px] uppercase text-text-3 opacity-0 transition-opacity hover:text-danger group-hover:opacity-100"
+                    >
+                      Del
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </details>
+      )}
+
+      <p className="text-[10px] text-text-3">
+        Realized P/L to date: {fmtChange(performance.totalRealizedPL)} {cur} ·{" "}
+        cost basis {fmtCompact(performance.totalCostBasis)}
+      </p>
+
+      <AttributionFooter />
+    </div>
+  );
+}

--- a/apps/web/src/modules/markets/components/PriceChart.tsx
+++ b/apps/web/src/modules/markets/components/PriceChart.tsx
@@ -1,0 +1,291 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { getCandles } from "../lib/client-api";
+import type { Candle, Range } from "@/lib/markets/providers/types";
+
+const RANGES: Range[] = ["1D", "5D", "1M", "6M", "YTD", "1Y", "5Y", "MAX"];
+
+const COLORS = {
+  up: "#3fb950",
+  down: "#f85149",
+  line: "#58a6ff",
+  ma: "#ff9d00",
+  grid: "#3b3b45",
+  text: "#9099a4",
+  vol: "#2d2d32",
+};
+
+function sma(values: number[], period: number): (number | null)[] {
+  const out: (number | null)[] = [];
+  let sum = 0;
+  for (let i = 0; i < values.length; i++) {
+    sum += values[i]!;
+    if (i >= period) sum -= values[i - period]!;
+    out.push(i >= period - 1 ? sum / period : null);
+  }
+  return out;
+}
+
+/**
+ * Dependency-free canvas price chart. Line/candle modes, range presets, an
+ * optional 50-period MA overlay, a volume strip, and a crosshair tooltip.
+ * Kept in-house so the build carries no charting dependency.
+ */
+export function PriceChart({
+  symbol,
+  initialRange = "1Y",
+}: {
+  symbol: string;
+  initialRange?: Range;
+}) {
+  const [range, setRange] = useState<Range>(initialRange);
+  const [type, setType] = useState<"line" | "candle">("line");
+  const [showMA, setShowMA] = useState(true);
+  const [candles, setCandles] = useState<Candle[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [hover, setHover] = useState<number | null>(null);
+  const [width, setWidth] = useState(640);
+
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const height = 340;
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    getCandles(symbol, range)
+      .then((c) => {
+        if (!cancelled) setCandles(c);
+      })
+      .catch((e) => {
+        if (!cancelled) setError(e instanceof Error ? e.message : "Chart unavailable");
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [symbol, range]);
+
+  useEffect(() => {
+    const el = wrapRef.current;
+    if (!el) return;
+    const ro = new ResizeObserver((entries) => {
+      const w = entries[0]?.contentRect.width;
+      if (w) setWidth(Math.max(320, Math.floor(w)));
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  const draw = useCallback(() => {
+    const canvas = canvasRef.current;
+    if (!canvas || candles.length < 2) return;
+    const dpr = window.devicePixelRatio || 1;
+    canvas.width = width * dpr;
+    canvas.height = height * dpr;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    ctx.scale(dpr, dpr);
+    ctx.clearRect(0, 0, width, height);
+
+    const padL = 8;
+    const padR = 54;
+    const priceTop = 8;
+    const priceBottom = height - 64;
+    const volTop = height - 56;
+    const volBottom = height - 18;
+    const plotW = width - padL - padR;
+
+    const highs = candles.map((c) => c.high);
+    const lows = candles.map((c) => c.low);
+    const closes = candles.map((c) => c.close);
+    const max = Math.max(...highs);
+    const min = Math.min(...lows);
+    const range1 = max - min || 1;
+    const maxVol = Math.max(...candles.map((c) => c.volume), 1);
+
+    const x = (i: number) => padL + (i / (candles.length - 1)) * plotW;
+    const y = (p: number) => priceTop + (1 - (p - min) / range1) * (priceBottom - priceTop);
+
+    // Horizontal grid + price labels
+    ctx.font = "10px ui-monospace, monospace";
+    ctx.fillStyle = COLORS.text;
+    ctx.strokeStyle = COLORS.grid;
+    ctx.lineWidth = 0.5;
+    for (let g = 0; g <= 4; g++) {
+      const p = min + (range1 * g) / 4;
+      const yy = y(p);
+      ctx.beginPath();
+      ctx.moveTo(padL, yy);
+      ctx.lineTo(padL + plotW, yy);
+      ctx.stroke();
+      ctx.fillText(p.toFixed(2), padL + plotW + 4, yy + 3);
+    }
+
+    // Volume bars
+    for (let i = 0; i < candles.length; i++) {
+      const c = candles[i]!;
+      const bx = x(i);
+      const bh = (c.volume / maxVol) * (volBottom - volTop);
+      ctx.fillStyle = COLORS.vol;
+      const bw = Math.max(1, plotW / candles.length - 1);
+      ctx.fillRect(bx - bw / 2, volBottom - bh, bw, bh);
+    }
+
+    if (type === "line") {
+      ctx.beginPath();
+      closes.forEach((c, i) => {
+        const xx = x(i);
+        const yy = y(c);
+        if (i === 0) ctx.moveTo(xx, yy);
+        else ctx.lineTo(xx, yy);
+      });
+      ctx.strokeStyle = COLORS.line;
+      ctx.lineWidth = 1.25;
+      ctx.stroke();
+    } else {
+      const cw = Math.max(1, plotW / candles.length - 1.5);
+      for (let i = 0; i < candles.length; i++) {
+        const c = candles[i]!;
+        const xx = x(i);
+        const up = c.close >= c.open;
+        ctx.strokeStyle = up ? COLORS.up : COLORS.down;
+        ctx.fillStyle = up ? COLORS.up : COLORS.down;
+        ctx.beginPath();
+        ctx.moveTo(xx, y(c.high));
+        ctx.lineTo(xx, y(c.low));
+        ctx.stroke();
+        const yo = y(c.open);
+        const yc = y(c.close);
+        const top = Math.min(yo, yc);
+        const bh = Math.max(1, Math.abs(yc - yo));
+        ctx.fillRect(xx - cw / 2, top, cw, bh);
+      }
+    }
+
+    // MA overlay
+    if (showMA && candles.length > 50) {
+      const ma = sma(closes, 50);
+      ctx.beginPath();
+      let started = false;
+      ma.forEach((m, i) => {
+        if (m === null) return;
+        const xx = x(i);
+        const yy = y(m);
+        if (!started) {
+          ctx.moveTo(xx, yy);
+          started = true;
+        } else ctx.lineTo(xx, yy);
+      });
+      ctx.strokeStyle = COLORS.ma;
+      ctx.lineWidth = 1;
+      ctx.stroke();
+    }
+
+    // Crosshair
+    if (hover !== null && hover >= 0 && hover < candles.length) {
+      const xx = x(hover);
+      ctx.strokeStyle = COLORS.grid;
+      ctx.lineWidth = 0.5;
+      ctx.beginPath();
+      ctx.moveTo(xx, priceTop);
+      ctx.lineTo(xx, priceBottom);
+      ctx.stroke();
+    }
+  }, [candles, type, showMA, hover, width]);
+
+  useEffect(() => {
+    draw();
+  }, [draw]);
+
+  function onMove(e: React.MouseEvent<HTMLCanvasElement>) {
+    if (candles.length < 2) return;
+    const rect = e.currentTarget.getBoundingClientRect();
+    const px = e.clientX - rect.left;
+    const padL = 8;
+    const padR = 54;
+    const plotW = width - padL - padR;
+    const i = Math.round(((px - padL) / plotW) * (candles.length - 1));
+    setHover(Math.min(Math.max(i, 0), candles.length - 1));
+  }
+
+  const hc = hover !== null ? candles[hover] : null;
+
+  return (
+    <div ref={wrapRef} className="w-full">
+      <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
+        <div className="flex gap-0.5">
+          {RANGES.map((r) => (
+            <button
+              key={r}
+              onClick={() => setRange(r)}
+              className={`rounded-sm px-1.5 py-0.5 text-[10px] font-semibold ${
+                range === r
+                  ? "bg-bg-3 text-text-0"
+                  : "text-text-2 hover:bg-bg-2 hover:text-text-0"
+              }`}
+            >
+              {r}
+            </button>
+          ))}
+        </div>
+        <div className="flex items-center gap-1">
+          <button
+            onClick={() => setType(type === "line" ? "candle" : "line")}
+            className="rounded-sm px-1.5 py-0.5 text-[10px] font-semibold text-text-2 hover:bg-bg-2 hover:text-text-0"
+          >
+            {type === "line" ? "Line" : "Candles"}
+          </button>
+          <button
+            onClick={() => setShowMA((v) => !v)}
+            className={`rounded-sm px-1.5 py-0.5 text-[10px] font-semibold ${
+              showMA ? "text-accent" : "text-text-2 hover:text-text-0"
+            }`}
+          >
+            MA50
+          </button>
+        </div>
+      </div>
+
+      <div className="relative">
+        {loading && (
+          <div className="flex h-[340px] items-center justify-center text-xs text-text-3">
+            Loading chart…
+          </div>
+        )}
+        {!loading && error && (
+          <div className="flex h-[340px] items-center justify-center text-xs text-danger">
+            {error}
+          </div>
+        )}
+        {!loading && !error && candles.length < 2 && (
+          <div className="flex h-[340px] items-center justify-center text-xs text-text-3">
+            No chart data for this symbol/range.
+          </div>
+        )}
+        {!loading && !error && candles.length >= 2 && (
+          <>
+            <canvas
+              ref={canvasRef}
+              style={{ width, height }}
+              onMouseMove={onMove}
+              onMouseLeave={() => setHover(null)}
+            />
+            {hc && (
+              <div className="pointer-events-none absolute left-2 top-2 rounded border border-border bg-bg-1/95 px-2 py-1 font-mono text-[10px] text-text-2">
+                {new Date(hc.time * 1000).toLocaleDateString()} · O {hc.open.toFixed(2)} · H{" "}
+                {hc.high.toFixed(2)} · L {hc.low.toFixed(2)} · C{" "}
+                <span className="text-text-0">{hc.close.toFixed(2)}</span>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/modules/markets/components/QuoteView.tsx
+++ b/apps/web/src/modules/markets/components/QuoteView.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  changeClass,
+  fmtChange,
+  fmtCompact,
+  fmtMarketCap,
+  fmtPct,
+  fmtPrice,
+} from "@/lib/markets/format";
+import type { CompanyProfile, Quote } from "@/lib/markets/providers/types";
+import { getQuote } from "../lib/client-api";
+import { PriceChart } from "./PriceChart";
+import { NewsList } from "./NewsList";
+import { FinancialsTable } from "./FinancialsTable";
+import { AttributionFooter } from "./AttributionFooter";
+
+type Tab = "summary" | "chart" | "news" | "financials";
+const TABS: { key: Tab; label: string }[] = [
+  { key: "summary", label: "Summary" },
+  { key: "chart", label: "Chart" },
+  { key: "news", label: "News" },
+  { key: "financials", label: "Financials" },
+];
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex flex-col border-b border-border py-1">
+      <span className="text-[10px] uppercase tracking-wide text-text-3">{label}</span>
+      <span className="font-mono text-xs text-text-1">{value}</span>
+    </div>
+  );
+}
+
+export function QuoteView({
+  symbol,
+  initialQuote,
+  profile,
+}: {
+  symbol: string;
+  initialQuote: Quote | null;
+  profile: CompanyProfile | null;
+}) {
+  const [tab, setTab] = useState<Tab>("summary");
+  const [quote, setQuote] = useState<Quote | null>(initialQuote);
+
+  useEffect(() => {
+    let cancelled = false;
+    getQuote(symbol)
+      .then((r) => !cancelled && setQuote(r.quote))
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [symbol]);
+
+  return (
+    <div className="space-y-3 p-2 sm:p-3">
+      {/* Header */}
+      <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+        <h1 className="font-mono text-xl font-bold text-text-0">{symbol}</h1>
+        {(quote?.name || profile?.name) && (
+          <span className="text-sm text-text-2">{quote?.name ?? profile?.name}</span>
+        )}
+        {profile?.exchange && (
+          <span className="text-[10px] uppercase text-text-3">{profile.exchange}</span>
+        )}
+        <div className="ml-auto flex items-baseline gap-2">
+          <span className="font-mono text-xl text-text-0">
+            {fmtPrice(quote?.price, quote?.currency)}
+          </span>
+          <span className={`font-mono text-sm ${changeClass(quote?.change)}`}>
+            {fmtChange(quote?.change)} ({fmtPct(quote?.changePct)})
+          </span>
+        </div>
+      </div>
+
+      {/* Tabs */}
+      <div className="flex gap-1 border-b border-border">
+        {TABS.map((t) => (
+          <button
+            key={t.key}
+            onClick={() => setTab(t.key)}
+            className={`-mb-px border-b-2 px-2 py-1 text-[11px] font-semibold uppercase tracking-wide ${
+              tab === t.key
+                ? "border-accent text-text-0"
+                : "border-transparent text-text-2 hover:text-text-0"
+            }`}
+          >
+            {t.label}
+          </button>
+        ))}
+      </div>
+
+      {tab === "summary" && (
+        <div className="grid gap-4 md:grid-cols-2">
+          <div className="grid grid-cols-2 gap-x-6">
+            <Stat label="Open" value={fmtPrice(quote?.open, quote?.currency)} />
+            <Stat label="Prev Close" value={fmtPrice(quote?.prevClose, quote?.currency)} />
+            <Stat label="Day High" value={fmtPrice(quote?.high, quote?.currency)} />
+            <Stat label="Day Low" value={fmtPrice(quote?.low, quote?.currency)} />
+            <Stat label="52W High" value={fmtPrice(quote?.week52High, quote?.currency)} />
+            <Stat label="52W Low" value={fmtPrice(quote?.week52Low, quote?.currency)} />
+            <Stat label="Volume" value={fmtCompact(quote?.volume)} />
+            <Stat label="Market Cap" value={fmtMarketCap(quote?.marketCap ?? profile?.marketCap)} />
+            <Stat label="Sector" value={profile?.sector ?? "—"} />
+            <Stat label="Country" value={profile?.country ?? "—"} />
+          </div>
+          <div className="space-y-2 text-xs text-text-2">
+            {profile?.description ? (
+              <p>{profile.description}</p>
+            ) : (
+              <p className="text-text-3">No company profile available.</p>
+            )}
+            {profile?.weburl && (
+              <a
+                href={profile.weburl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-info hover:underline"
+              >
+                {profile.weburl}
+              </a>
+            )}
+          </div>
+        </div>
+      )}
+
+      {tab === "chart" && <PriceChart symbol={symbol} />}
+      {tab === "news" && (
+        <div className="overflow-hidden rounded border border-border bg-bg-1">
+          <NewsList symbol={symbol} />
+        </div>
+      )}
+      {tab === "financials" && <FinancialsTable symbol={symbol} />}
+
+      <AttributionFooter />
+    </div>
+  );
+}

--- a/apps/web/src/modules/markets/components/ScreenerView.tsx
+++ b/apps/web/src/modules/markets/components/ScreenerView.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { Button } from "@/components/ui/Button";
+import { changeClass, fmtMarketCap, fmtPct, fmtPrice } from "@/lib/markets/format";
+import type { Quote } from "@/lib/markets/providers/types";
+import { runScreener, type ScreenerFilters } from "../lib/client-api";
+import { AttributionFooter } from "./AttributionFooter";
+
+const numOrUndef = (s: string) => (s.trim() === "" ? undefined : Number(s));
+
+export function ScreenerView() {
+  const [f, setF] = useState({
+    minPrice: "",
+    maxPrice: "",
+    minChangePct: "",
+    minMarketCap: "",
+  });
+  const [results, setResults] = useState<Quote[]>([]);
+  const [note, setNote] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [ran, setRan] = useState(false);
+
+  async function run() {
+    setBusy(true);
+    setError(null);
+    const filters: ScreenerFilters = {
+      minPrice: numOrUndef(f.minPrice),
+      maxPrice: numOrUndef(f.maxPrice),
+      minChangePct: numOrUndef(f.minChangePct),
+      minMarketCap: f.minMarketCap.trim()
+        ? Number(f.minMarketCap) * 1e9
+        : undefined,
+    };
+    try {
+      const r = await runScreener(filters);
+      setResults(r.results);
+      setNote(r.note);
+      setRan(true);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Screener failed");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="space-y-4 p-2 sm:p-3">
+      <div className="flex items-center gap-3">
+        <h1 className="text-lg font-semibold text-text-0">Screener</h1>
+        <Link href="/app/markets" className="text-xs text-text-2 hover:text-text-0">
+          ← Dashboard
+        </Link>
+      </div>
+
+      <div className="flex flex-wrap items-end gap-2 rounded border border-border bg-bg-1 p-3">
+        <label className="flex flex-col text-[10px] uppercase tracking-wide text-text-3">
+          Min price
+          <input
+            value={f.minPrice}
+            onChange={(e) => setF({ ...f, minPrice: e.target.value })}
+            type="number"
+            className="mt-0.5 w-24 rounded border border-border bg-bg-2 px-2 py-1 text-xs text-text-1"
+          />
+        </label>
+        <label className="flex flex-col text-[10px] uppercase tracking-wide text-text-3">
+          Max price
+          <input
+            value={f.maxPrice}
+            onChange={(e) => setF({ ...f, maxPrice: e.target.value })}
+            type="number"
+            className="mt-0.5 w-24 rounded border border-border bg-bg-2 px-2 py-1 text-xs text-text-1"
+          />
+        </label>
+        <label className="flex flex-col text-[10px] uppercase tracking-wide text-text-3">
+          Min day %
+          <input
+            value={f.minChangePct}
+            onChange={(e) => setF({ ...f, minChangePct: e.target.value })}
+            type="number"
+            className="mt-0.5 w-24 rounded border border-border bg-bg-2 px-2 py-1 text-xs text-text-1"
+          />
+        </label>
+        <label className="flex flex-col text-[10px] uppercase tracking-wide text-text-3">
+          Min mkt cap ($B)
+          <input
+            value={f.minMarketCap}
+            onChange={(e) => setF({ ...f, minMarketCap: e.target.value })}
+            type="number"
+            className="mt-0.5 w-28 rounded border border-border bg-bg-2 px-2 py-1 text-xs text-text-1"
+          />
+        </label>
+        <Button size="sm" variant="accent" onClick={run} loading={busy}>
+          Run
+        </Button>
+      </div>
+
+      {error && <p className="text-xs text-danger">{error}</p>}
+
+      {ran && (
+        <div className="overflow-hidden rounded border border-border bg-bg-1">
+          <table className="w-full text-xs">
+            <thead>
+              <tr className="border-b border-border bg-bg-2 text-[10px] uppercase tracking-wide text-text-3">
+                <th className="px-3 py-1 text-left font-semibold">Symbol</th>
+                <th className="px-3 py-1 text-right font-semibold">Price</th>
+                <th className="px-3 py-1 text-right font-semibold">Day %</th>
+                <th className="px-3 py-1 text-right font-semibold">Mkt Cap</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border">
+              {results.length === 0 ? (
+                <tr>
+                  <td colSpan={4} className="px-3 py-3 text-text-3">
+                    No matches.
+                  </td>
+                </tr>
+              ) : (
+                results.map((q) => (
+                  <tr key={q.symbol} className="hover:bg-bg-2">
+                    <td className="px-3 py-1">
+                      <Link
+                        href={`/app/markets/quote/${encodeURIComponent(q.symbol)}`}
+                        className="font-mono font-semibold text-accent hover:underline"
+                      >
+                        {q.symbol}
+                      </Link>
+                    </td>
+                    <td className="px-3 py-1 text-right font-mono">{fmtPrice(q.price)}</td>
+                    <td className={`px-3 py-1 text-right font-mono ${changeClass(q.changePct)}`}>
+                      {fmtPct(q.changePct)}
+                    </td>
+                    <td className="px-3 py-1 text-right font-mono text-text-2">
+                      {fmtMarketCap(q.marketCap)}
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {note && <p className="text-[10px] text-text-3">{note}</p>}
+
+      <AttributionFooter />
+    </div>
+  );
+}

--- a/apps/web/src/modules/markets/components/SymbolSearch.tsx
+++ b/apps/web/src/modules/markets/components/SymbolSearch.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Search } from "lucide-react";
+import { searchSymbols } from "../lib/client-api";
+import type { SymbolMatch } from "@/lib/markets/providers/types";
+
+/**
+ * Debounced symbol search box. Selecting a result navigates to the (universal)
+ * quote page. Used in the dashboard header and as a quick lookup.
+ */
+export function SymbolSearch({
+  onPick,
+  placeholder = "Search symbol or company…",
+  autoFocus = false,
+}: {
+  onPick?: (symbol: string) => void;
+  placeholder?: string;
+  autoFocus?: boolean;
+}) {
+  const router = useRouter();
+  const [q, setQ] = useState("");
+  const [results, setResults] = useState<SymbolMatch[]>([]);
+  const [open, setOpen] = useState(false);
+  const [active, setActive] = useState(0);
+  const boxRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (q.trim().length < 1) {
+      setResults([]);
+      return;
+    }
+    const t = setTimeout(() => {
+      searchSymbols(q.trim())
+        .then((r) => {
+          setResults(r);
+          setOpen(true);
+          setActive(0);
+        })
+        .catch(() => setResults([]));
+    }, 250);
+    return () => clearTimeout(t);
+  }, [q]);
+
+  useEffect(() => {
+    function onDoc(e: MouseEvent) {
+      if (boxRef.current && !boxRef.current.contains(e.target as Node))
+        setOpen(false);
+    }
+    document.addEventListener("mousedown", onDoc);
+    return () => document.removeEventListener("mousedown", onDoc);
+  }, []);
+
+  function pick(symbol: string) {
+    setOpen(false);
+    setQ("");
+    setResults([]);
+    if (onPick) onPick(symbol);
+    else router.push(`/app/markets/quote/${encodeURIComponent(symbol)}`);
+  }
+
+  function onKey(e: React.KeyboardEvent) {
+    if (!open || results.length === 0) return;
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setActive((a) => Math.min(a + 1, results.length - 1));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setActive((a) => Math.max(a - 1, 0));
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      const r = results[active];
+      if (r) pick(r.symbol);
+    } else if (e.key === "Escape") {
+      setOpen(false);
+    }
+  }
+
+  return (
+    <div ref={boxRef} className="relative w-full max-w-sm">
+      <div className="flex items-center gap-2 rounded border border-border bg-bg-2 px-2 py-1">
+        <Search className="h-3.5 w-3.5 text-text-3" />
+        <input
+          value={q}
+          autoFocus={autoFocus}
+          onChange={(e) => setQ(e.target.value)}
+          onKeyDown={onKey}
+          onFocus={() => results.length > 0 && setOpen(true)}
+          placeholder={placeholder}
+          className="w-full bg-transparent text-xs text-text-0 placeholder:text-text-3 focus:outline-none"
+          aria-label="Search symbols"
+        />
+      </div>
+      {open && results.length > 0 && (
+        <ul className="absolute z-20 mt-1 max-h-72 w-full overflow-y-auto rounded border border-border bg-bg-1 shadow-lg">
+          {results.map((r, i) => (
+            <li key={`${r.symbol}-${i}`}>
+              <button
+                type="button"
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  pick(r.symbol);
+                }}
+                onMouseEnter={() => setActive(i)}
+                className={`flex w-full items-center justify-between gap-3 px-2 py-1.5 text-left text-xs ${
+                  i === active ? "bg-bg-2" : "hover:bg-bg-2"
+                }`}
+              >
+                <span className="font-mono font-semibold text-accent">
+                  {r.symbol}
+                </span>
+                <span className="truncate text-text-2">{r.name}</span>
+                <span className="shrink-0 text-[10px] uppercase text-text-3">
+                  {r.type}
+                </span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/modules/markets/components/WatchlistPanel.tsx
+++ b/apps/web/src/modules/markets/components/WatchlistPanel.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import Link from "next/link";
+import { X } from "lucide-react";
+import { fmtChange, fmtPct, fmtPrice, changeClass } from "@/lib/markets/format";
+import type { Quote } from "@/lib/markets/providers/types";
+import type { WatchlistWithSymbols } from "../lib/client-api";
+
+/**
+ * A single watchlist rendered as a dense quote table. Quotes come from the
+ * parent (batched + live-updated); this component is presentational plus
+ * add/remove affordances.
+ */
+export function WatchlistPanel({
+  watchlist,
+  quotes,
+  onRemoveSymbol,
+  onDelete,
+}: {
+  watchlist: WatchlistWithSymbols;
+  quotes: Record<string, Quote>;
+  onRemoveSymbol: (watchlistId: string, symbol: string) => void;
+  onDelete: (watchlistId: string) => void;
+}) {
+  const symbols = [...watchlist.symbols].sort(
+    (a, b) => a.display_order - b.display_order,
+  );
+
+  return (
+    <div className="overflow-hidden rounded border border-border bg-bg-1">
+      <header className="flex items-center justify-between border-b border-border bg-bg-2 px-3 py-1.5">
+        <h3 className="text-xs font-semibold text-text-0">{watchlist.name}</h3>
+        <button
+          onClick={() => onDelete(watchlist.id)}
+          className="text-[10px] uppercase tracking-wide text-text-3 hover:text-danger"
+          aria-label={`Delete ${watchlist.name}`}
+        >
+          Delete
+        </button>
+      </header>
+
+      {symbols.length === 0 ? (
+        <p className="px-3 py-3 text-xs text-text-3">
+          No symbols yet. Use search above to add one.
+        </p>
+      ) : (
+        <table className="w-full text-xs">
+          <thead>
+            <tr className="border-b border-border text-[10px] uppercase tracking-wide text-text-3">
+              <th className="px-3 py-1 text-left font-semibold">Symbol</th>
+              <th className="px-3 py-1 text-right font-semibold">Price</th>
+              <th className="px-3 py-1 text-right font-semibold">Chg</th>
+              <th className="px-3 py-1 text-right font-semibold">Chg %</th>
+              <th className="w-8 px-2 py-1" />
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border">
+            {symbols.map((s) => {
+              const q = quotes[s.symbol];
+              return (
+                <tr key={s.id} className="group hover:bg-bg-2">
+                  <td className="px-3 py-1">
+                    <Link
+                      href={`/app/markets/quote/${encodeURIComponent(s.symbol)}`}
+                      className="font-mono font-semibold text-accent hover:underline"
+                    >
+                      {s.symbol}
+                    </Link>
+                  </td>
+                  <td className="px-3 py-1 text-right font-mono">
+                    {q ? fmtPrice(q.price, q.currency) : "—"}
+                  </td>
+                  <td className={`px-3 py-1 text-right font-mono ${changeClass(q?.change)}`}>
+                    {q ? fmtChange(q.change) : "—"}
+                  </td>
+                  <td className={`px-3 py-1 text-right font-mono ${changeClass(q?.changePct)}`}>
+                    {q ? fmtPct(q.changePct) : "—"}
+                  </td>
+                  <td className="px-2 py-1 text-right">
+                    <button
+                      onClick={() => onRemoveSymbol(watchlist.id, s.symbol)}
+                      className="text-text-3 opacity-0 transition-opacity hover:text-danger group-hover:opacity-100"
+                      aria-label={`Remove ${s.symbol}`}
+                    >
+                      <X className="h-3 w-3" />
+                    </button>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/modules/markets/lib/client-api.ts
+++ b/apps/web/src/modules/markets/lib/client-api.ts
@@ -1,0 +1,226 @@
+/**
+ * Client-side typed wrappers around the markets REST API.
+ *
+ * Browser-safe (plain fetch — the repo uses no SWR/React Query). Each call
+ * unwraps `{ data }` or throws an Error carrying the server's first error
+ * message, so components can `try/catch` and render a message.
+ */
+"use client";
+
+import type {
+  Candle,
+  EarningsEvent,
+  FinancialReport,
+  Mover,
+  MoverKind,
+  NewsItem,
+  Quote,
+  Range,
+  StatementKind,
+  SymbolMatch,
+} from "@/lib/markets/providers/types";
+import type {
+  MktAlertRow,
+  MktLotRow,
+  MktPortfolioRow,
+  MktWatchlistRow,
+  MktWatchlistSymbolRow,
+  ScopeKind,
+} from "@/lib/markets/db";
+import type { PortfolioPerformance } from "@/lib/markets/portfolio";
+
+async function req<T>(url: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(url, {
+    ...init,
+    headers: { "content-type": "application/json", ...(init?.headers ?? {}) },
+  });
+  if (res.status === 204) return undefined as T;
+  const json = (await res.json().catch(() => ({}))) as {
+    data?: T;
+    errors?: { code: string; message: string }[];
+  };
+  if (!res.ok) {
+    throw new Error(json.errors?.[0]?.message ?? `Request failed (${res.status})`);
+  }
+  return json.data as T;
+}
+
+const B = "/api/v1/markets";
+const enc = encodeURIComponent;
+
+/* ── market data ─────────────────────────────────────────────────────────── */
+
+export const searchSymbols = (q: string) =>
+  req<{ matches: SymbolMatch[] }>(`${B}/search?q=${enc(q)}`).then((d) => d.matches);
+
+export const getQuote = (symbol: string) =>
+  req<{ quote: Quote; cached: boolean }>(`${B}/quote/${enc(symbol)}`);
+
+export const getQuotes = (symbols: string[]) =>
+  symbols.length === 0
+    ? Promise.resolve({} as Record<string, Quote>)
+    : req<{ quotes: Record<string, Quote> }>(
+        `${B}/quotes?symbols=${enc(symbols.join(","))}`,
+      ).then((d) => d.quotes);
+
+export const getCandles = (symbol: string, range: Range) =>
+  req<{ candles: Candle[] }>(`${B}/candles/${enc(symbol)}?range=${range}`).then(
+    (d) => d.candles,
+  );
+
+export const getNews = (symbol: string, days = 7) =>
+  req<{ items: NewsItem[] }>(`${B}/news/${enc(symbol)}?days=${days}`).then(
+    (d) => d.items,
+  );
+
+export const getFinancials = (symbol: string, statement: StatementKind) =>
+  req<{ report: FinancialReport }>(
+    `${B}/financials/${enc(symbol)}?statement=${statement}`,
+  ).then((d) => d.report);
+
+export interface BoardRow {
+  symbol: string;
+  label: string;
+  price: number | null;
+  change: number | null;
+  changePct: number | null;
+}
+export const getOverview = () =>
+  req<{
+    indices: BoardRow[];
+    sectors: BoardRow[];
+    commodities: BoardRow[];
+    fx: BoardRow[];
+  }>(`${B}/overview`);
+
+export const getMovers = (type: MoverKind) =>
+  req<{ movers: Mover[] }>(`${B}/movers?type=${type}`).then((d) => d.movers);
+
+export const getCalendar = (from: string, to: string) =>
+  req<{ events: EarningsEvent[] }>(`${B}/calendar?from=${from}&to=${to}`).then(
+    (d) => d.events,
+  );
+
+export interface ScreenerFilters {
+  minPrice?: number;
+  maxPrice?: number;
+  minChangePct?: number;
+  maxChangePct?: number;
+  minMarketCap?: number;
+  maxMarketCap?: number;
+}
+export const runScreener = (filters: ScreenerFilters, universe?: string[]) =>
+  req<{ count: number; results: Quote[]; note: string }>(`${B}/screener`, {
+    method: "POST",
+    body: JSON.stringify({ filters, universe }),
+  });
+
+export const convertFx = (from: string, to: string, amount: number) =>
+  req<{ from: string; to: string; rate: number; amount: number; converted: number }>(
+    `${B}/fx?from=${from}&to=${to}&amount=${amount}`,
+  );
+
+/* ── watchlists ──────────────────────────────────────────────────────────── */
+
+export type WatchlistWithSymbols = MktWatchlistRow & {
+  symbols: MktWatchlistSymbolRow[];
+};
+
+export const listWatchlists = (scope: ScopeKind, scopeId?: string) =>
+  req<{ watchlists: WatchlistWithSymbols[] }>(
+    `${B}/watchlists?scope=${scope}${scopeId ? `&scopeId=${scopeId}` : ""}`,
+  ).then((d) => d.watchlists);
+
+export const createWatchlist = (name: string, scope: ScopeKind, scopeId?: string) =>
+  req<{ watchlist: MktWatchlistRow }>(`${B}/watchlists`, {
+    method: "POST",
+    body: JSON.stringify({ name, scope, scopeId }),
+  }).then((d) => d.watchlist);
+
+export const deleteWatchlist = (id: string) =>
+  req<void>(`${B}/watchlists/${id}`, { method: "DELETE" });
+
+export const addSymbol = (watchlistId: string, symbol: string, note?: string) =>
+  req<{ symbol: MktWatchlistSymbolRow }>(`${B}/watchlists/${watchlistId}/symbols`, {
+    method: "POST",
+    body: JSON.stringify({ symbol, note }),
+  }).then((d) => d.symbol);
+
+export const removeSymbol = (watchlistId: string, symbol: string) =>
+  req<void>(`${B}/watchlists/${watchlistId}/symbols?symbol=${enc(symbol)}`, {
+    method: "DELETE",
+  });
+
+/* ── portfolios ──────────────────────────────────────────────────────────── */
+
+export const listPortfolios = (scope: ScopeKind, scopeId?: string) =>
+  req<{ portfolios: MktPortfolioRow[] }>(
+    `${B}/portfolios?scope=${scope}${scopeId ? `&scopeId=${scopeId}` : ""}`,
+  ).then((d) => d.portfolios);
+
+export const getPortfolio = (id: string) =>
+  req<{
+    portfolio: MktPortfolioRow;
+    lots: MktLotRow[];
+    performance: PortfolioPerformance;
+  }>(`${B}/portfolios/${id}`);
+
+export const createPortfolio = (
+  name: string,
+  scope: ScopeKind,
+  scopeId?: string,
+) =>
+  req<{ portfolio: MktPortfolioRow }>(`${B}/portfolios`, {
+    method: "POST",
+    body: JSON.stringify({ name, scope, scopeId }),
+  }).then((d) => d.portfolio);
+
+export const deletePortfolio = (id: string) =>
+  req<void>(`${B}/portfolios/${id}`, { method: "DELETE" });
+
+export const addLot = (
+  portfolioId: string,
+  lot: {
+    symbol: string;
+    side: "buy" | "sell";
+    quantity: number;
+    price: number;
+    fees?: number;
+    tradeDate?: string;
+  },
+) =>
+  req<{ lot: MktLotRow }>(`${B}/portfolios/${portfolioId}/lots`, {
+    method: "POST",
+    body: JSON.stringify(lot),
+  }).then((d) => d.lot);
+
+export const deleteLot = (portfolioId: string, lotId: string) =>
+  req<void>(`${B}/portfolios/${portfolioId}/lots/${lotId}`, { method: "DELETE" });
+
+/* ── alerts ──────────────────────────────────────────────────────────────── */
+
+export const listAlerts = () =>
+  req<{ alerts: MktAlertRow[] }>(`${B}/alerts`).then((d) => d.alerts);
+
+export const createAlert = (
+  symbol: string,
+  condition: MktAlertRow["condition"],
+  threshold: number,
+  note?: string,
+) =>
+  req<{ alert: MktAlertRow }>(`${B}/alerts`, {
+    method: "POST",
+    body: JSON.stringify({ symbol, condition, threshold, note }),
+  }).then((d) => d.alert);
+
+export const updateAlert = (
+  id: string,
+  patch: { active?: boolean; threshold?: number },
+) =>
+  req<{ alert: MktAlertRow }>(`${B}/alerts/${id}`, {
+    method: "PATCH",
+    body: JSON.stringify(patch),
+  }).then((d) => d.alert);
+
+export const deleteAlert = (id: string) =>
+  req<void>(`${B}/alerts/${id}`, { method: "DELETE" });

--- a/apps/web/src/modules/markets/lib/server-data.ts
+++ b/apps/web/src/modules/markets/lib/server-data.ts
@@ -1,0 +1,71 @@
+/**
+ * Server-side loaders for markets pages. RLS-scoped (per-user client), used by
+ * the server components to hydrate the dashboard / portfolio / alerts views.
+ */
+import "server-only";
+import {
+  marketsDb,
+  type MktPortfolioRow,
+  type MktWatchlistRow,
+  type MktWatchlistSymbolRow,
+  type ScopeKind,
+} from "@/lib/markets/db";
+
+export type WatchlistWithSymbols = MktWatchlistRow & {
+  symbols: MktWatchlistSymbolRow[];
+};
+
+function scopeColumn(scope: ScopeKind): "user_id" | "space_id" | "terminal_id" {
+  if (scope === "space") return "space_id";
+  if (scope === "terminal") return "terminal_id";
+  return "user_id";
+}
+
+export async function loadWatchlists(
+  supabase: unknown,
+  scope: ScopeKind,
+  scopeValue: string,
+): Promise<WatchlistWithSymbols[]> {
+  const db = marketsDb(supabase);
+  const { data: lists } = await db
+    .from("mkt_watchlists")
+    .select("*")
+    .is("archived_at", null)
+    .eq(scopeColumn(scope), scopeValue)
+    .order("display_order");
+
+  const rows = (lists ?? []) as MktWatchlistRow[];
+  if (rows.length === 0) return [];
+
+  const { data: syms } = await db
+    .from("mkt_watchlist_symbols")
+    .select("*")
+    .in(
+      "watchlist_id",
+      rows.map((l) => l.id),
+    )
+    .order("display_order");
+
+  const byList = new Map<string, MktWatchlistSymbolRow[]>();
+  for (const s of (syms ?? []) as MktWatchlistSymbolRow[]) {
+    const arr = byList.get(s.watchlist_id) ?? [];
+    arr.push(s);
+    byList.set(s.watchlist_id, arr);
+  }
+  return rows.map((l) => ({ ...l, symbols: byList.get(l.id) ?? [] }));
+}
+
+export async function loadPortfolios(
+  supabase: unknown,
+  scope: ScopeKind,
+  scopeValue: string,
+): Promise<MktPortfolioRow[]> {
+  const db = marketsDb(supabase);
+  const { data } = await db
+    .from("mkt_portfolios")
+    .select("*")
+    .is("archived_at", null)
+    .eq(scopeColumn(scope), scopeValue)
+    .order("created_at");
+  return (data ?? []) as MktPortfolioRow[];
+}

--- a/apps/web/src/modules/markets/manifest.ts
+++ b/apps/web/src/modules/markets/manifest.ts
@@ -1,0 +1,35 @@
+/**
+ * Markets module manifest.
+ *
+ * A dense, keyboard-first markets terminal — quotes, charts, watchlists,
+ * portfolios, market overview, news, calendars, financials, alerts. Backed
+ * by free, display-licensed data feeds behind a swappable provider adapter
+ * (see `apps/web/src/lib/markets/providers/`).
+ *
+ * Opt-in (not `enabled_by_default` in `modules_catalog`); installed per
+ * scope via the marketplace. Available at all three scopes:
+ *   - user     → `/app/markets`        (your watchlists + portfolios)
+ *   - space    → `/s/[slug]/markets`   (shared firm watchlists / comps)
+ *   - terminal → `/p/[ticker]/markets` (per-deal public-comp tracking)
+ *
+ * NOTE: the terminal route uses `[ticker]` — that is the TERMINAL ticker
+ * (terminals.ticker), not a stock symbol. Stock symbols live under
+ * `/app/markets/quote/[symbol]`.
+ */
+import type { ModuleManifest } from "@rokki/sdk";
+
+export const marketsManifest: ModuleManifest = {
+  slug: "markets",
+  name: "Markets",
+  description:
+    "Real-time quotes, charts, watchlists, portfolios, and market news — a keyboard-first markets terminal.",
+  icon: "trending-up",
+  scopes: ["user", "space", "terminal"],
+  vertical: null,
+  routes: {
+    user: "/app/markets",
+    space: "/s/[slug]/markets",
+    terminal: "/p/[ticker]/markets",
+  },
+  fnKey: { label: "Markets", default: 6 },
+};

--- a/supabase/migrations/20260616010000_markets_init.sql
+++ b/supabase/migrations/20260616010000_markets_init.sql
@@ -1,0 +1,262 @@
+-- Markets module — quotes, watchlists, portfolios, and price alerts.
+--
+-- Adds the data layer for the "markets" module (essentially-Yahoo-Finance):
+-- a public instrument/quote cache (filled server-side from free, display-
+-- licensed feeds), plus tenant-scoped watchlists, portfolios with lot-level
+-- holdings, and personal price alerts. Everything is RLS-gated to
+-- space/terminal membership (or the owning user) per rokki/CLAUDE.md.
+--
+-- See docs/01_DATA_MODEL.md §1.X and Claude/rokki-markets/MARKETS_MODULE_PLAN.md.
+--
+-- NOTE: "symbol" (e.g. AAPL) is a STOCK identifier and is intentionally
+-- distinct from a terminal "ticker" (terminals.ticker). Never conflate them.
+
+BEGIN;
+
+-- ───────────────────────────────────────────────────────────────────
+-- mkt_instruments — reference cache for symbol search/autocomplete.
+-- Public market data (not tenant data): readable by any authenticated
+-- user; written only by the server-side fetch layer (service role).
+-- ───────────────────────────────────────────────────────────────────
+
+CREATE TABLE mkt_instruments (
+  symbol     TEXT PRIMARY KEY,
+  name       TEXT NOT NULL DEFAULT '',
+  exchange   TEXT,
+  type       TEXT NOT NULL DEFAULT 'stock'
+               CHECK (type IN ('stock','etf','crypto','fx','index','future','bond','unknown')),
+  currency   TEXT NOT NULL DEFAULT 'USD',
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE mkt_instruments ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "mkt_instruments_read" ON mkt_instruments
+  FOR SELECT TO authenticated USING (TRUE);
+
+-- ───────────────────────────────────────────────────────────────────
+-- mkt_quote_cache — durable, server-managed quote cache. TTL is enforced
+-- in app code (lib/markets/cache.ts); this table is the source of truth
+-- the UI subscribes to via Supabase Realtime so watchlist rows update
+-- live without client-side polling.
+-- ───────────────────────────────────────────────────────────────────
+
+CREATE TABLE mkt_quote_cache (
+  symbol     TEXT PRIMARY KEY,
+  payload    JSONB NOT NULL,            -- normalized Quote (see providers/types.ts)
+  provider   TEXT NOT NULL,
+  fetched_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE mkt_quote_cache ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "mkt_quote_cache_read" ON mkt_quote_cache
+  FOR SELECT TO authenticated USING (TRUE);
+
+-- Realtime: publish quote updates so subscribed panes update live.
+ALTER TABLE mkt_quote_cache REPLICA IDENTITY FULL;
+ALTER PUBLICATION supabase_realtime ADD TABLE mkt_quote_cache;
+
+-- ───────────────────────────────────────────────────────────────────
+-- mkt_watchlists — scope-polymorphic (exactly one of user/space/terminal).
+-- ───────────────────────────────────────────────────────────────────
+
+CREATE TABLE mkt_watchlists (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id       UUID REFERENCES auth.users(id) ON DELETE CASCADE,
+  space_id      UUID REFERENCES spaces(id) ON DELETE CASCADE,
+  terminal_id   UUID REFERENCES terminals(id) ON DELETE CASCADE,
+  name          TEXT NOT NULL CHECK (char_length(name) BETWEEN 1 AND 80),
+  display_order INT NOT NULL DEFAULT 0,
+  created_by    UUID NOT NULL REFERENCES auth.users(id),
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  archived_at   TIMESTAMPTZ,
+  CONSTRAINT mkt_watchlists_one_scope CHECK (
+    (user_id IS NOT NULL)::int
+  + (space_id IS NOT NULL)::int
+  + (terminal_id IS NOT NULL)::int = 1
+  )
+);
+
+CREATE INDEX idx_mkt_watchlists_user     ON mkt_watchlists(user_id)     WHERE archived_at IS NULL;
+CREATE INDEX idx_mkt_watchlists_space    ON mkt_watchlists(space_id)    WHERE archived_at IS NULL;
+CREATE INDEX idx_mkt_watchlists_terminal ON mkt_watchlists(terminal_id) WHERE archived_at IS NULL;
+
+ALTER TABLE mkt_watchlists ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "mkt_watchlists_read" ON mkt_watchlists
+  FOR SELECT TO authenticated USING (
+    (user_id = auth.uid())
+    OR (space_id IN (SELECT space_id FROM space_members WHERE user_id = auth.uid()))
+    OR (terminal_id IN (SELECT terminal_id FROM terminal_members WHERE user_id = auth.uid()))
+  );
+
+CREATE POLICY "mkt_watchlists_write" ON mkt_watchlists
+  FOR ALL TO authenticated
+  USING (
+    (user_id = auth.uid())
+    OR (space_id IN (SELECT space_id FROM space_members WHERE user_id = auth.uid()))
+    OR (terminal_id IN (SELECT terminal_id FROM terminal_members WHERE user_id = auth.uid()))
+  )
+  WITH CHECK (
+    (user_id = auth.uid())
+    OR (space_id IN (SELECT space_id FROM space_members WHERE user_id = auth.uid()))
+    OR (terminal_id IN (SELECT terminal_id FROM terminal_members WHERE user_id = auth.uid()))
+  );
+
+-- ───────────────────────────────────────────────────────────────────
+-- mkt_watchlist_symbols — members inherit visibility from the watchlist.
+-- ───────────────────────────────────────────────────────────────────
+
+CREATE TABLE mkt_watchlist_symbols (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  watchlist_id  UUID NOT NULL REFERENCES mkt_watchlists(id) ON DELETE CASCADE,
+  symbol        TEXT NOT NULL,
+  display_order INT NOT NULL DEFAULT 0,
+  note          TEXT CHECK (note IS NULL OR char_length(note) <= 280),
+  added_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (watchlist_id, symbol)
+);
+
+CREATE INDEX idx_mkt_watchlist_symbols_wl ON mkt_watchlist_symbols(watchlist_id);
+
+ALTER TABLE mkt_watchlist_symbols ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "mkt_watchlist_symbols_read" ON mkt_watchlist_symbols
+  FOR SELECT TO authenticated USING (
+    watchlist_id IN (SELECT id FROM mkt_watchlists)
+  );
+
+CREATE POLICY "mkt_watchlist_symbols_write" ON mkt_watchlist_symbols
+  FOR ALL TO authenticated
+  USING (watchlist_id IN (SELECT id FROM mkt_watchlists))
+  WITH CHECK (watchlist_id IN (SELECT id FROM mkt_watchlists));
+
+-- ───────────────────────────────────────────────────────────────────
+-- mkt_portfolios — scope-polymorphic, like watchlists.
+-- ───────────────────────────────────────────────────────────────────
+
+CREATE TABLE mkt_portfolios (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id       UUID REFERENCES auth.users(id) ON DELETE CASCADE,
+  space_id      UUID REFERENCES spaces(id) ON DELETE CASCADE,
+  terminal_id   UUID REFERENCES terminals(id) ON DELETE CASCADE,
+  name          TEXT NOT NULL CHECK (char_length(name) BETWEEN 1 AND 80),
+  base_currency TEXT NOT NULL DEFAULT 'USD',
+  created_by    UUID NOT NULL REFERENCES auth.users(id),
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  archived_at   TIMESTAMPTZ,
+  CONSTRAINT mkt_portfolios_one_scope CHECK (
+    (user_id IS NOT NULL)::int
+  + (space_id IS NOT NULL)::int
+  + (terminal_id IS NOT NULL)::int = 1
+  )
+);
+
+CREATE INDEX idx_mkt_portfolios_user     ON mkt_portfolios(user_id)     WHERE archived_at IS NULL;
+CREATE INDEX idx_mkt_portfolios_space    ON mkt_portfolios(space_id)    WHERE archived_at IS NULL;
+CREATE INDEX idx_mkt_portfolios_terminal ON mkt_portfolios(terminal_id) WHERE archived_at IS NULL;
+
+ALTER TABLE mkt_portfolios ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "mkt_portfolios_read" ON mkt_portfolios
+  FOR SELECT TO authenticated USING (
+    (user_id = auth.uid())
+    OR (space_id IN (SELECT space_id FROM space_members WHERE user_id = auth.uid()))
+    OR (terminal_id IN (SELECT terminal_id FROM terminal_members WHERE user_id = auth.uid()))
+  );
+
+CREATE POLICY "mkt_portfolios_write" ON mkt_portfolios
+  FOR ALL TO authenticated
+  USING (
+    (user_id = auth.uid())
+    OR (space_id IN (SELECT space_id FROM space_members WHERE user_id = auth.uid()))
+    OR (terminal_id IN (SELECT terminal_id FROM terminal_members WHERE user_id = auth.uid()))
+  )
+  WITH CHECK (
+    (user_id = auth.uid())
+    OR (space_id IN (SELECT space_id FROM space_members WHERE user_id = auth.uid()))
+    OR (terminal_id IN (SELECT terminal_id FROM terminal_members WHERE user_id = auth.uid()))
+  );
+
+-- ───────────────────────────────────────────────────────────────────
+-- mkt_lots — lot-level holdings; inherit visibility from the portfolio.
+-- ───────────────────────────────────────────────────────────────────
+
+CREATE TABLE mkt_lots (
+  id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  portfolio_id UUID NOT NULL REFERENCES mkt_portfolios(id) ON DELETE CASCADE,
+  symbol       TEXT NOT NULL,
+  side         TEXT NOT NULL CHECK (side IN ('buy','sell')),
+  quantity     NUMERIC NOT NULL CHECK (quantity > 0),
+  price        NUMERIC NOT NULL CHECK (price >= 0),   -- per share, trade currency
+  fees         NUMERIC NOT NULL DEFAULT 0 CHECK (fees >= 0),
+  trade_date   DATE NOT NULL,
+  note         TEXT CHECK (note IS NULL OR char_length(note) <= 280),
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_mkt_lots_portfolio ON mkt_lots(portfolio_id);
+
+ALTER TABLE mkt_lots ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "mkt_lots_read" ON mkt_lots
+  FOR SELECT TO authenticated USING (
+    portfolio_id IN (SELECT id FROM mkt_portfolios)
+  );
+
+CREATE POLICY "mkt_lots_write" ON mkt_lots
+  FOR ALL TO authenticated
+  USING (portfolio_id IN (SELECT id FROM mkt_portfolios))
+  WITH CHECK (portfolio_id IN (SELECT id FROM mkt_portfolios));
+
+-- ───────────────────────────────────────────────────────────────────
+-- mkt_alerts — strictly personal price/percent alerts.
+-- ───────────────────────────────────────────────────────────────────
+
+CREATE TABLE mkt_alerts (
+  id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id           UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  symbol            TEXT NOT NULL,
+  condition         TEXT NOT NULL CHECK (condition IN ('price_above','price_below','pct_up','pct_down')),
+  threshold         NUMERIC NOT NULL,
+  active            BOOLEAN NOT NULL DEFAULT TRUE,
+  note              TEXT CHECK (note IS NULL OR char_length(note) <= 280),
+  last_triggered_at TIMESTAMPTZ,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_mkt_alerts_active ON mkt_alerts(symbol) WHERE active;
+CREATE INDEX idx_mkt_alerts_user   ON mkt_alerts(user_id);
+
+ALTER TABLE mkt_alerts ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "mkt_alerts_own" ON mkt_alerts
+  FOR ALL TO authenticated
+  USING (user_id = auth.uid())
+  WITH CHECK (user_id = auth.uid());
+
+-- ───────────────────────────────────────────────────────────────────
+-- Catalog seed — surface "markets" in the module marketplace. Opt-in
+-- (enabled_by_default = FALSE), available at all three scopes.
+-- ───────────────────────────────────────────────────────────────────
+
+INSERT INTO modules_catalog (slug, name, description, icon, scopes, enabled_by_default) VALUES
+  ('markets', 'Markets',
+   'Real-time quotes, charts, watchlists, portfolios, and market news.',
+   'trending-up', ARRAY['user','space','terminal'], FALSE);
+
+COMMIT;
+
+-- ROLLBACK:
+-- BEGIN;
+-- DELETE FROM modules_catalog WHERE slug = 'markets';
+-- ALTER PUBLICATION supabase_realtime DROP TABLE mkt_quote_cache;
+-- DROP TABLE IF EXISTS mkt_alerts CASCADE;
+-- DROP TABLE IF EXISTS mkt_lots CASCADE;
+-- DROP TABLE IF EXISTS mkt_portfolios CASCADE;
+-- DROP TABLE IF EXISTS mkt_watchlist_symbols CASCADE;
+-- DROP TABLE IF EXISTS mkt_watchlists CASCADE;
+-- DROP TABLE IF EXISTS mkt_quote_cache CASCADE;
+-- DROP TABLE IF EXISTS mkt_instruments CASCADE;
+-- COMMIT;

--- a/supabase/migrations/rollbacks/20260616010000_markets_init.down.sql
+++ b/supabase/migrations/rollbacks/20260616010000_markets_init.down.sql
@@ -1,0 +1,27 @@
+-- Rollback for 20260616010000_markets_init.sql
+--
+-- Drops every mkt_* table, removes mkt_quote_cache from the realtime
+-- publication, and deletes the 'markets' modules_catalog row. Mirrors the
+-- inline `-- ROLLBACK:` block in the forward migration; this standalone
+-- file exists so the rollback is callable directly (per MODULE_PLAN.md §11.2).
+--
+-- Apply with:
+--   psql $DATABASE_URL < supabase/migrations/rollbacks/20260616010000_markets_init.down.sql
+
+BEGIN;
+
+DELETE FROM modules_catalog WHERE slug = 'markets';
+
+-- Realtime publication membership must be dropped before the table.
+ALTER PUBLICATION supabase_realtime DROP TABLE mkt_quote_cache;
+
+-- Drop in reverse dependency order. Child tables first.
+DROP TABLE IF EXISTS mkt_alerts CASCADE;
+DROP TABLE IF EXISTS mkt_lots CASCADE;
+DROP TABLE IF EXISTS mkt_portfolios CASCADE;
+DROP TABLE IF EXISTS mkt_watchlist_symbols CASCADE;
+DROP TABLE IF EXISTS mkt_watchlists CASCADE;
+DROP TABLE IF EXISTS mkt_quote_cache CASCADE;
+DROP TABLE IF EXISTS mkt_instruments CASCADE;
+
+COMMIT;


### PR DESCRIPTION
Ships the **Markets** module (essentially-Yahoo-Finance) end-to-end as an opt-in Rokki module.

## What's included (69 files)
- **DB** (`20260616010000_markets_init.sql`): `mkt_instruments`, `mkt_quote_cache` (REPLICA IDENTITY FULL + realtime), `mkt_watchlists`/`mkt_watchlist_symbols`, `mkt_portfolios`/`mkt_lots`, `mkt_alerts` — all RLS-gated to user/space/terminal membership, scope-polymorphic, with a rollback block. Seeds `modules_catalog` with `markets` (opt-in, all three scopes).
- **Data facade** (`lib/markets/`): free, display-licensed feeds — **Finnhub** (quotes/search/profile/news/earnings), **Twelve Data** (candles/FX), **FMP** (financials/movers) — behind a durable cache. **Degrades gracefully with no keys** (returns empty/unsupported), so it deploys safely to sandbox without secrets.
- **REST API** under `/api/v1/markets/*` (quotes, candles, search, watchlists, portfolios+lots, alerts, movers, screener, financials, news, fx, calendar, options, overview) + a `evaluate-price-alerts` cron.
- **UI**: user/space/terminal pages + module components (board, dashboard, quote, chart, watchlist, portfolio, screener, alerts, news, search).
- **MCP parity**: markets tools in `apps/mcp-server`.
- Module manifest registered; `symbol` (AAPL) kept distinct from terminal `ticker`.

## Verified locally
web typecheck ✅ · mcp-server typecheck ✅ · markets unit tests 5/5 ✅ · migration harness `0 broken` ✅ · lint clean ✅.

## To get live data (optional, later)
Set `FINNHUB_API_KEY`, `TWELVEDATA_API_KEY`, `FMP_API_KEY` in Vercel (free tiers). Without them the module installs and renders but shows empty data.

## Note
Markets is opt-in (`enabled_by_default=FALSE`) and, like all v1 modules, surfaces through the module-system UI gated by the `pane_shell_enabled` flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)