### PR TITLE
docs(markets): complete OpenAPI + MCP parity for Markets

### DIFF
--- a/apps/web/src/lib/mcp-parity.test.ts
+++ b/apps/web/src/lib/mcp-parity.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Guards the MCP ↔ REST parity matrix against silent drift.
+ *
+ * The matrix (`mcp-parity.ts`) is the source of truth for the "every UI
+ * feature is available via API and MCP" non-negotiable. These tests keep it
+ * honest by cross-checking it against the OpenAPI spec and the set of shipped
+ * markets MCP tools — both self-contained in the web package, so no
+ * cross-package import of the MCP server is needed.
+ *
+ * Matrix conventions (matched here): an endpoint is "<METHODS> <path>" where
+ * METHODS may be slash-combined (e.g. "GET/POST") and the path uses
+ * Express-style params (":id"). OpenAPI uses "{id}", so we normalize.
+ */
+import { describe, it, expect } from "vitest";
+import { PARITY_ROWS } from "./mcp-parity";
+import { openApiDocument } from "./openapi";
+
+/** The rokki_markets_* tools actually registered in apps/mcp-server. */
+const SHIPPED_MARKETS_TOOLS = [
+  "rokki_markets_quote",
+  "rokki_markets_search",
+  "rokki_markets_watchlists",
+  "rokki_markets_watchlist_add",
+  "rokki_markets_watchlist_remove",
+  "rokki_markets_portfolio_add_lot",
+  "rokki_markets_portfolio_performance",
+  "rokki_markets_alerts",
+  "rokki_markets_alert_create",
+] as const;
+
+const HTTP_METHODS = new Set(["GET", "POST", "PATCH", "PUT", "DELETE"]);
+
+/** Express ":param" → OpenAPI "{param}". */
+const toOpenApiPath = (p: string) => p.replace(/:([A-Za-z0-9_]+)/g, "{$1}");
+
+/** Split "GET/POST /v1/x/:id" into [{method,path}, …], one per method. */
+function expandEndpoint(entry: string): { method: string; path: string }[] {
+  const [methods = "", path = ""] = entry.split(" ");
+  return methods.split("/").map((method) => ({ method, path }));
+}
+
+const paths = openApiDocument.paths as Record<string, Record<string, unknown>>;
+const marketsRows = PARITY_ROWS.filter((r) => r.resource === "markets");
+
+describe("MCP ↔ REST parity matrix", () => {
+  it("every apiEndpoints entry is a well-formed '<METHOD[/METHOD…]> /path'", () => {
+    for (const row of PARITY_ROWS) {
+      for (const entry of row.apiEndpoints) {
+        for (const { method, path } of expandEndpoint(entry)) {
+          expect(HTTP_METHODS.has(method), `bad method in "${entry}"`).toBe(true);
+          expect(path.startsWith("/"), `bad path in "${entry}"`).toBe(true);
+        }
+      }
+    }
+  });
+
+  it("a 'missing' row never names an MCP tool", () => {
+    for (const row of PARITY_ROWS) {
+      if (row.status === "missing") {
+        expect(row.mcpTool, `${row.resource}/${row.action} is 'missing' yet names a tool`).toBeNull();
+      }
+    }
+  });
+
+  it("no duplicate (resource, action) pairs", () => {
+    const seen = new Set<string>();
+    for (const row of PARITY_ROWS) {
+      const key = `${row.resource}::${row.action}`;
+      expect(seen.has(key), `duplicate parity row: ${key}`).toBe(false);
+      seen.add(key);
+    }
+  });
+
+  it("has rows for the markets resource", () => {
+    expect(marketsRows.length).toBeGreaterThan(0);
+  });
+
+  it("every markets REST endpoint in the matrix is documented in OpenAPI", () => {
+    for (const row of marketsRows) {
+      for (const entry of row.apiEndpoints) {
+        for (const { method, path } of expandEndpoint(entry)) {
+          // Internal cron jobs are intentionally absent from the public spec.
+          if (path.startsWith("/v1/cron/")) continue;
+          const apiPath = toOpenApiPath(path);
+          const ops = paths[apiPath];
+          expect(ops, `OpenAPI is missing path ${apiPath} (referenced by parity matrix)`).toBeTruthy();
+          expect(
+            ops?.[method.toLowerCase()],
+            `OpenAPI path ${apiPath} is missing the ${method} operation`,
+          ).toBeTruthy();
+        }
+      }
+    }
+  });
+
+  it("every documented markets OpenAPI operation appears in the parity matrix", () => {
+    const matrixOps = new Set(
+      marketsRows.flatMap((r) =>
+        r.apiEndpoints.flatMap((e) =>
+          expandEndpoint(e).map(({ method, path }) => `${method} ${toOpenApiPath(path)}`),
+        ),
+      ),
+    );
+    for (const [path, ops] of Object.entries(paths)) {
+      if (!path.startsWith("/v1/markets/")) continue;
+      for (const method of Object.keys(ops)) {
+        if (!HTTP_METHODS.has(method.toUpperCase())) continue;
+        const key = `${method.toUpperCase()} ${path}`;
+        expect(matrixOps.has(key), `parity matrix is missing ${key}`).toBe(true);
+      }
+    }
+  });
+
+  it("all 9 shipped markets MCP tools are marked present in the matrix", () => {
+    const presentTools = new Set(
+      marketsRows.filter((r) => r.status === "present").map((r) => r.mcpTool),
+    );
+    for (const tool of SHIPPED_MARKETS_TOOLS) {
+      expect(presentTools.has(tool), `shipped tool ${tool} is not 'present' in the matrix`).toBe(true);
+    }
+  });
+
+  it("every 'present' markets row names a shipped tool", () => {
+    const shipped = new Set<string>(SHIPPED_MARKETS_TOOLS);
+    for (const row of marketsRows) {
+      if (row.status === "present") {
+        expect(
+          row.mcpTool !== null && shipped.has(row.mcpTool),
+          `markets row "${row.action}" is present but names unknown tool ${row.mcpTool}`,
+        ).toBe(true);
+      }
+    }
+  });
+});

--- a/apps/web/src/lib/mcp-parity.ts
+++ b/apps/web/src/lib/mcp-parity.ts
@@ -37,6 +37,7 @@ export type Resource =
   | "terminals"
   | "tasks"
   | "files"
+  | "markets"
   | "folders"
   | "comments"
   | "members"
@@ -83,9 +84,9 @@ export interface ParityRow {
  * The audit. Add a row per API endpoint or MCP tool, sorted by
  * resource then by action.
  *
- * Last reconciled: 2026-04-27 against:
+ * Last reconciled: 2026-06-17 against:
  *   - apps/web/src/app/api/v1/**\/route.ts (REST surface)
- *   - apps/mcp-server/src/tools.ts (MCP tool registry)
+ *   - apps/mcp-server/src/tools.ts + markets-tools.ts (MCP tool registry)
  */
 export const PARITY_ROWS: ParityRow[] = [
   // ----- auth -----
@@ -932,6 +933,252 @@ export const PARITY_ROWS: ParityRow[] = [
     mcpTool: "rokki_draft_update",
     status: "present",
     note: "MCP-only — uses sampling. Intentional.",
+  },
+
+  // ----- markets -----
+  // The 9 shipped rokki_markets_* tools cover the core read/manage loop
+  // (quote, search, watchlist add/remove, portfolio add-lot + performance,
+  // alert list/create). The remaining data + management endpoints exist in
+  // REST but have no MCP equivalent yet — tracked here as the gap backlog.
+  {
+    resource: "markets",
+    action: "Get a quote",
+    apiEndpoints: ["GET /v1/markets/quote/:symbol"],
+    mcpTool: "rokki_markets_quote",
+    status: "present",
+    note: "",
+  },
+  {
+    resource: "markets",
+    action: "Batch quotes for a watchlist",
+    apiEndpoints: ["GET /v1/markets/quotes"],
+    mcpTool: null,
+    status: "missing",
+    note: "rokki_markets_quote fetches one symbol; no batch tool. Low priority — agents can loop.",
+    priority: "low",
+  },
+  {
+    resource: "markets",
+    action: "Search symbols",
+    apiEndpoints: ["GET /v1/markets/search"],
+    mcpTool: "rokki_markets_search",
+    status: "present",
+    note: "",
+  },
+  {
+    resource: "markets",
+    action: "List watchlists",
+    apiEndpoints: ["GET /v1/markets/watchlists"],
+    mcpTool: "rokki_markets_watchlists",
+    status: "present",
+    note: "",
+  },
+  {
+    resource: "markets",
+    action: "Add symbol to watchlist",
+    apiEndpoints: ["POST /v1/markets/watchlists", "POST /v1/markets/watchlists/:id/symbols"],
+    mcpTool: "rokki_markets_watchlist_add",
+    status: "present",
+    note: "Tool creates the watchlist if it doesn't exist, then adds the symbol.",
+  },
+  {
+    resource: "markets",
+    action: "Remove symbol from watchlist",
+    apiEndpoints: ["DELETE /v1/markets/watchlists/:id/symbols"],
+    mcpTool: "rokki_markets_watchlist_remove",
+    status: "present",
+    note: "",
+  },
+  {
+    resource: "markets",
+    action: "Rename / reorder watchlist",
+    apiEndpoints: ["PATCH /v1/markets/watchlists/:id"],
+    mcpTool: null,
+    status: "missing",
+    note: "Management action; no MCP tool. Low priority.",
+    priority: "low",
+  },
+  {
+    resource: "markets",
+    action: "Delete watchlist",
+    apiEndpoints: ["DELETE /v1/markets/watchlists/:id"],
+    mcpTool: null,
+    status: "missing",
+    note: "Management action; no MCP tool. Low priority.",
+    priority: "low",
+  },
+  {
+    resource: "markets",
+    action: "List portfolios",
+    apiEndpoints: ["GET /v1/markets/portfolios"],
+    mcpTool: null,
+    status: "missing",
+    note: "performance tool takes a portfolio by name and auto-creates; no explicit list tool.",
+    priority: "medium",
+  },
+  {
+    resource: "markets",
+    action: "Create / rename / delete portfolio",
+    apiEndpoints: [
+      "POST /v1/markets/portfolios",
+      "PATCH /v1/markets/portfolios/:id",
+      "DELETE /v1/markets/portfolios/:id",
+    ],
+    mcpTool: null,
+    status: "missing",
+    note: "add-lot auto-creates a portfolio; explicit lifecycle management is REST-only.",
+    priority: "low",
+  },
+  {
+    resource: "markets",
+    action: "Add a trade lot",
+    apiEndpoints: ["POST /v1/markets/portfolios", "POST /v1/markets/portfolios/:id/lots"],
+    mcpTool: "rokki_markets_portfolio_add_lot",
+    status: "present",
+    note: "Tool creates the portfolio if needed, then records the lot.",
+  },
+  {
+    resource: "markets",
+    action: "List / delete trade lots",
+    apiEndpoints: [
+      "GET /v1/markets/portfolios/:id/lots",
+      "DELETE /v1/markets/portfolios/:id/lots/:lotId",
+    ],
+    mcpTool: null,
+    status: "missing",
+    note: "Lot ledger editing is REST-only. Low priority.",
+    priority: "low",
+  },
+  {
+    resource: "markets",
+    action: "Portfolio performance",
+    apiEndpoints: ["GET /v1/markets/portfolios/:id"],
+    mcpTool: "rokki_markets_portfolio_performance",
+    status: "present",
+    note: "Computes positions + unrealized P/L from live quotes.",
+  },
+  {
+    resource: "markets",
+    action: "List price alerts",
+    apiEndpoints: ["GET /v1/markets/alerts"],
+    mcpTool: "rokki_markets_alerts",
+    status: "present",
+    note: "",
+  },
+  {
+    resource: "markets",
+    action: "Create price alert",
+    apiEndpoints: ["POST /v1/markets/alerts"],
+    mcpTool: "rokki_markets_alert_create",
+    status: "present",
+    note: "",
+  },
+  {
+    resource: "markets",
+    action: "Toggle / modify / delete alert",
+    apiEndpoints: ["PATCH /v1/markets/alerts/:id", "DELETE /v1/markets/alerts/:id"],
+    mcpTool: null,
+    status: "missing",
+    note: "Alert editing/removal is REST-only. Medium priority — agents create but can't tidy.",
+    priority: "medium",
+  },
+  {
+    resource: "markets",
+    action: "Candle / chart series",
+    apiEndpoints: ["GET /v1/markets/candles/:symbol"],
+    mcpTool: null,
+    status: "missing",
+    note: "No MCP tool to fetch OHLC for an agent to analyze trends. High priority.",
+    priority: "high",
+  },
+  {
+    resource: "markets",
+    action: "Company news",
+    apiEndpoints: ["GET /v1/markets/news/:symbol"],
+    mcpTool: null,
+    status: "missing",
+    note: "No MCP tool; agents can't pull recent headlines for a symbol. High priority.",
+    priority: "high",
+  },
+  {
+    resource: "markets",
+    action: "Company profile / fundamentals",
+    apiEndpoints: ["GET /v1/markets/profile/:symbol"],
+    mcpTool: null,
+    status: "missing",
+    note: "No MCP tool. Medium priority.",
+    priority: "medium",
+  },
+  {
+    resource: "markets",
+    action: "Market movers",
+    apiEndpoints: ["GET /v1/markets/movers"],
+    mcpTool: null,
+    status: "missing",
+    note: "No MCP tool for gainers/losers/active. Medium priority.",
+    priority: "medium",
+  },
+  {
+    resource: "markets",
+    action: "Financial statements",
+    apiEndpoints: ["GET /v1/markets/financials/:symbol"],
+    mcpTool: null,
+    status: "missing",
+    note: "No MCP tool. Medium priority.",
+    priority: "medium",
+  },
+  {
+    resource: "markets",
+    action: "Market overview board",
+    apiEndpoints: ["GET /v1/markets/overview"],
+    mcpTool: null,
+    status: "missing",
+    note: "Indices/sectors/commodities/FX snapshot has no MCP tool. High priority.",
+    priority: "high",
+  },
+  {
+    resource: "markets",
+    action: "Earnings calendar",
+    apiEndpoints: ["GET /v1/markets/calendar"],
+    mcpTool: null,
+    status: "missing",
+    note: "No MCP tool. Medium priority.",
+    priority: "medium",
+  },
+  {
+    resource: "markets",
+    action: "Stock screener",
+    apiEndpoints: ["POST /v1/markets/screener"],
+    mcpTool: null,
+    status: "missing",
+    note: "No MCP tool to screen by price/%/market-cap. Medium priority.",
+    priority: "medium",
+  },
+  {
+    resource: "markets",
+    action: "FX convert",
+    apiEndpoints: ["GET /v1/markets/fx"],
+    mcpTool: null,
+    status: "missing",
+    note: "No MCP tool. Low priority.",
+    priority: "low",
+  },
+  {
+    resource: "markets",
+    action: "Options chain",
+    apiEndpoints: ["GET /v1/markets/options/:symbol"],
+    mcpTool: null,
+    status: "missing",
+    note: "REST endpoint is a stub (paid feed required); no MCP tool. Low priority.",
+    priority: "low",
+  },
+  {
+    resource: "markets",
+    action: "Evaluate price alerts (scheduled)",
+    apiEndpoints: ["GET /v1/cron/evaluate-price-alerts", "POST /v1/cron/evaluate-price-alerts"],
+    mcpTool: null,
+    status: "admin-only",
+    note: "Internal cron job (CRON_SECRET auth) that fans triggered alerts into notifications. Not user-facing.",
   },
 ];
 

--- a/apps/web/src/lib/openapi.ts
+++ b/apps/web/src/lib/openapi.ts
@@ -428,6 +428,390 @@ const schemas = {
   },
 
   EmptyObject: { type: "object", additionalProperties: false },
+
+  // -- Markets ------------------------------------------------------------
+  // Normalized, provider-agnostic shapes (see lib/markets/providers/types.ts)
+  // plus the persisted mkt_* rows (see lib/markets/db.ts). Markets responses
+  // use the standard `{ data: { … } }` envelope but with named inner keys
+  // (e.g. `{ data: { quote, cached } }`), so the path entries below wrap
+  // these schemas in inline objects rather than `dataResp(ref(...))`.
+
+  MktQuote: {
+    type: "object",
+    required: ["symbol", "price", "change", "changePct", "currency", "marketState", "asOf", "provider"],
+    properties: {
+      symbol: { type: "string" },
+      name: { type: "string" },
+      price: { type: "number" },
+      change: { type: "number" },
+      changePct: { type: "number" },
+      open: { type: "number", nullable: true },
+      high: { type: "number", nullable: true },
+      low: { type: "number", nullable: true },
+      prevClose: { type: "number", nullable: true },
+      volume: { type: "number", nullable: true },
+      marketCap: { type: "number", nullable: true },
+      peRatio: { type: "number", nullable: true },
+      week52High: { type: "number", nullable: true },
+      week52Low: { type: "number", nullable: true },
+      currency: { type: "string" },
+      exchange: { type: "string", nullable: true },
+      marketState: { type: "string", enum: ["pre", "open", "post", "closed", "unknown"] },
+      asOf: { type: "string", format: "date-time", description: "ISO timestamp the quote was sourced." },
+      provider: { type: "string" },
+    },
+  },
+
+  MktSymbolMatch: {
+    type: "object",
+    required: ["symbol", "name", "type"],
+    properties: {
+      symbol: { type: "string" },
+      name: { type: "string" },
+      exchange: { type: "string", nullable: true },
+      type: { type: "string", description: "Instrument type (stock, etf, crypto, fx, index, …)." },
+    },
+  },
+
+  MktCompanyProfile: {
+    type: "object",
+    required: ["symbol", "name", "currency", "provider"],
+    properties: {
+      symbol: { type: "string" },
+      name: { type: "string" },
+      exchange: { type: "string", nullable: true },
+      industry: { type: "string", nullable: true },
+      sector: { type: "string", nullable: true },
+      country: { type: "string", nullable: true },
+      currency: { type: "string" },
+      marketCap: { type: "number", nullable: true },
+      sharesOutstanding: { type: "number", nullable: true },
+      logo: { type: "string", nullable: true },
+      weburl: { type: "string", nullable: true },
+      ipo: { type: "string", nullable: true },
+      description: { type: "string", nullable: true },
+      beta: { type: "number", nullable: true },
+      dividendYield: { type: "number", nullable: true },
+      provider: { type: "string" },
+    },
+  },
+
+  MktCandle: {
+    type: "object",
+    required: ["time", "open", "high", "low", "close", "volume"],
+    properties: {
+      time: { type: "integer", description: "Unix seconds." },
+      open: { type: "number" },
+      high: { type: "number" },
+      low: { type: "number" },
+      close: { type: "number" },
+      volume: { type: "number" },
+    },
+  },
+
+  MktNewsItem: {
+    type: "object",
+    required: ["id", "headline", "source", "url", "datetime", "symbols"],
+    properties: {
+      id: { type: "string" },
+      headline: { type: "string" },
+      summary: { type: "string", nullable: true },
+      source: { type: "string" },
+      url: { type: "string" },
+      imageUrl: { type: "string", nullable: true },
+      datetime: { type: "string", format: "date-time" },
+      symbols: { type: "array", items: { type: "string" } },
+    },
+  },
+
+  MktFinancialReport: {
+    type: "object",
+    required: ["symbol", "statement", "currency", "periods", "provider"],
+    properties: {
+      symbol: { type: "string" },
+      statement: { type: "string", enum: ["income", "balance", "cash"] },
+      currency: { type: "string" },
+      periods: {
+        type: "array",
+        items: {
+          type: "object",
+          required: ["fiscalDate", "period", "lineItems"],
+          properties: {
+            fiscalDate: { type: "string", format: "date", description: "Fiscal period end." },
+            period: { type: "string", enum: ["Q", "FY"] },
+            lineItems: { type: "object", additionalProperties: { type: "number", nullable: true } },
+          },
+        },
+      },
+      provider: { type: "string" },
+    },
+  },
+
+  MktEarningsEvent: {
+    type: "object",
+    required: ["symbol", "date"],
+    properties: {
+      symbol: { type: "string" },
+      date: { type: "string", format: "date" },
+      hour: { type: "string", enum: ["bmo", "amc", "dmh"], nullable: true },
+      epsEstimate: { type: "number", nullable: true },
+      epsActual: { type: "number", nullable: true },
+      revenueEstimate: { type: "number", nullable: true },
+      revenueActual: { type: "number", nullable: true },
+    },
+  },
+
+  MktMover: {
+    type: "object",
+    required: ["symbol", "price", "change", "changePct"],
+    properties: {
+      symbol: { type: "string" },
+      name: { type: "string", nullable: true },
+      price: { type: "number" },
+      change: { type: "number" },
+      changePct: { type: "number" },
+      volume: { type: "number", nullable: true },
+    },
+  },
+
+  MktOverviewRow: {
+    type: "object",
+    required: ["symbol", "label", "price", "change", "changePct"],
+    properties: {
+      symbol: { type: "string" },
+      label: { type: "string" },
+      price: { type: "number" },
+      change: { type: "number" },
+      changePct: { type: "number" },
+    },
+  },
+
+  MktWatchlistSymbol: {
+    type: "object",
+    required: ["id", "watchlist_id", "symbol", "display_order", "added_at"],
+    properties: {
+      id: { type: "string", format: "uuid" },
+      watchlist_id: { type: "string", format: "uuid" },
+      symbol: { type: "string" },
+      display_order: { type: "integer" },
+      note: { type: "string", nullable: true },
+      added_at: { type: "string", format: "date-time" },
+    },
+  },
+
+  MktWatchlist: {
+    type: "object",
+    required: ["id", "name", "display_order", "created_by", "created_at"],
+    properties: {
+      id: { type: "string", format: "uuid" },
+      user_id: { type: "string", format: "uuid", nullable: true },
+      space_id: { type: "string", format: "uuid", nullable: true },
+      terminal_id: { type: "string", format: "uuid", nullable: true },
+      name: { type: "string", maxLength: 120 },
+      display_order: { type: "integer" },
+      created_by: { type: "string", format: "uuid" },
+      created_at: { type: "string", format: "date-time" },
+      archived_at: { type: "string", format: "date-time", nullable: true },
+      symbols: {
+        type: "array",
+        items: { $ref: "#/components/schemas/MktWatchlistSymbol" },
+        description: "Present on list/read; ordered by display_order.",
+      },
+    },
+  },
+
+  MktWatchlistCreate: {
+    type: "object",
+    required: ["name"],
+    properties: {
+      name: { type: "string", minLength: 1, maxLength: 120 },
+      scope: { type: "string", enum: ["user", "space", "terminal"], default: "user" },
+      scopeId: { type: "string", description: "Required when scope is space or terminal (the space/terminal id)." },
+    },
+  },
+
+  MktWatchlistPatch: {
+    type: "object",
+    properties: {
+      name: { type: "string", minLength: 1, maxLength: 120 },
+      display_order: { type: "integer" },
+    },
+  },
+
+  MktWatchlistSymbolCreate: {
+    type: "object",
+    required: ["symbol"],
+    properties: {
+      symbol: { type: "string" },
+      note: { type: "string", nullable: true, maxLength: 280 },
+    },
+  },
+
+  MktPortfolio: {
+    type: "object",
+    required: ["id", "name", "base_currency", "created_by", "created_at"],
+    properties: {
+      id: { type: "string", format: "uuid" },
+      user_id: { type: "string", format: "uuid", nullable: true },
+      space_id: { type: "string", format: "uuid", nullable: true },
+      terminal_id: { type: "string", format: "uuid", nullable: true },
+      name: { type: "string", maxLength: 120 },
+      base_currency: { type: "string", description: "ISO 4217, 3 letters." },
+      created_by: { type: "string", format: "uuid" },
+      created_at: { type: "string", format: "date-time" },
+      archived_at: { type: "string", format: "date-time", nullable: true },
+    },
+  },
+
+  MktPortfolioCreate: {
+    type: "object",
+    required: ["name"],
+    properties: {
+      name: { type: "string", minLength: 1, maxLength: 120 },
+      baseCurrency: { type: "string", default: "USD" },
+      scope: { type: "string", enum: ["user", "space", "terminal"], default: "user" },
+      scopeId: { type: "string", description: "Required when scope is space or terminal." },
+    },
+  },
+
+  MktPortfolioPatch: {
+    type: "object",
+    properties: {
+      name: { type: "string", minLength: 1, maxLength: 120 },
+      baseCurrency: { type: "string" },
+    },
+  },
+
+  MktLot: {
+    type: "object",
+    required: ["id", "portfolio_id", "symbol", "side", "quantity", "price", "fees", "trade_date", "created_at"],
+    properties: {
+      id: { type: "string", format: "uuid" },
+      portfolio_id: { type: "string", format: "uuid" },
+      symbol: { type: "string" },
+      side: { type: "string", enum: ["buy", "sell"] },
+      quantity: { type: "number" },
+      price: { type: "number" },
+      fees: { type: "number" },
+      trade_date: { type: "string", format: "date" },
+      note: { type: "string", nullable: true },
+      created_at: { type: "string", format: "date-time" },
+    },
+  },
+
+  MktLotCreate: {
+    type: "object",
+    required: ["symbol", "side", "quantity", "price"],
+    properties: {
+      symbol: { type: "string" },
+      side: { type: "string", enum: ["buy", "sell"] },
+      quantity: { type: "number", exclusiveMinimum: 0 },
+      price: { type: "number", minimum: 0 },
+      fees: { type: "number", minimum: 0, default: 0 },
+      tradeDate: { type: "string", format: "date", description: "Defaults to today (UTC) if omitted." },
+      note: { type: "string", nullable: true, maxLength: 280 },
+    },
+  },
+
+  MktPositionPerformance: {
+    type: "object",
+    required: ["symbol", "quantity", "avgCost", "costBasis", "realizedPL"],
+    properties: {
+      symbol: { type: "string" },
+      quantity: { type: "number" },
+      avgCost: { type: "number" },
+      costBasis: { type: "number" },
+      realizedPL: { type: "number" },
+      price: { type: "number", nullable: true },
+      marketValue: { type: "number", nullable: true },
+      unrealizedPL: { type: "number", nullable: true },
+      unrealizedPct: { type: "number", nullable: true },
+      dayChange: { type: "number", nullable: true },
+      weight: { type: "number", nullable: true },
+    },
+  },
+
+  MktPortfolioPerformance: {
+    type: "object",
+    required: [
+      "positions",
+      "totalMarketValue",
+      "totalCostBasis",
+      "totalUnrealizedPL",
+      "totalRealizedPL",
+      "totalDayChange",
+      "unrealizedPct",
+    ],
+    properties: {
+      positions: { type: "array", items: { $ref: "#/components/schemas/MktPositionPerformance" } },
+      totalMarketValue: { type: "number" },
+      totalCostBasis: { type: "number" },
+      totalUnrealizedPL: { type: "number" },
+      totalRealizedPL: { type: "number" },
+      totalDayChange: { type: "number" },
+      unrealizedPct: { type: "number" },
+    },
+  },
+
+  MktAlert: {
+    type: "object",
+    required: ["id", "user_id", "symbol", "condition", "threshold", "active", "created_at"],
+    properties: {
+      id: { type: "string", format: "uuid" },
+      user_id: { type: "string", format: "uuid" },
+      symbol: { type: "string" },
+      condition: { type: "string", enum: ["price_above", "price_below", "pct_up", "pct_down"] },
+      threshold: { type: "number" },
+      active: { type: "boolean" },
+      note: { type: "string", nullable: true },
+      last_triggered_at: { type: "string", format: "date-time", nullable: true },
+      created_at: { type: "string", format: "date-time" },
+    },
+  },
+
+  MktAlertCreate: {
+    type: "object",
+    required: ["symbol", "condition", "threshold"],
+    properties: {
+      symbol: { type: "string" },
+      condition: { type: "string", enum: ["price_above", "price_below", "pct_up", "pct_down"] },
+      threshold: { type: "number" },
+      note: { type: "string", nullable: true, maxLength: 280 },
+    },
+  },
+
+  MktAlertPatch: {
+    type: "object",
+    properties: {
+      active: { type: "boolean" },
+      threshold: { type: "number" },
+      note: { type: "string", nullable: true, maxLength: 280 },
+    },
+  },
+
+  MktScreenerRequest: {
+    type: "object",
+    properties: {
+      universe: {
+        type: "array",
+        items: { type: "string" },
+        description: "Optional symbol universe (max 100). Defaults to the built-in screener universe.",
+      },
+      filters: {
+        type: "object",
+        properties: {
+          minPrice: { type: "number" },
+          maxPrice: { type: "number" },
+          minChangePct: { type: "number" },
+          maxChangePct: { type: "number" },
+          minMarketCap: { type: "number" },
+          maxMarketCap: { type: "number" },
+        },
+      },
+      sort: { type: "string", enum: ["changePct", "price", "marketCap"], default: "changePct" },
+      limit: { type: "integer", minimum: 1, maximum: 100, default: 50 },
+    },
+  },
 } as const;
 
 // ---------------------------------------------------------------------------
@@ -1820,6 +2204,357 @@ const paths: Record<string, AnyRecord> = {
     patch: todoStub("PATCH", "Update an outgoing webhook"),
     delete: todoStub("DELETE", "Delete an outgoing webhook"),
   },
+
+  // -- Markets ------------------------------------------------------------
+  "/v1/markets/quote/{symbol}": {
+    get: op({
+      tags: ["markets"],
+      summary: "Get a normalized quote",
+      description: "Served from a 15s TTL cache so free-tier provider limits are respected.",
+      parameters: paramsFor("/v1/markets/quote/{symbol}"),
+      responses: dataResp({
+        type: "object",
+        required: ["quote", "cached"],
+        properties: { quote: ref("MktQuote"), cached: { type: "boolean" } },
+      }),
+    }),
+  },
+  "/v1/markets/quotes": {
+    get: op({
+      tags: ["markets"],
+      summary: "Batch quotes for a watchlist",
+      parameters: [
+        {
+          name: "symbols",
+          in: "query",
+          required: true,
+          schema: { type: "string" },
+          description: "Comma-separated symbols (max 100).",
+        },
+      ],
+      responses: dataResp({
+        type: "object",
+        required: ["quotes"],
+        properties: {
+          quotes: {
+            type: "object",
+            additionalProperties: ref("MktQuote"),
+            description: "Keyed by symbol.",
+          },
+        },
+      }),
+    }),
+  },
+  "/v1/markets/search": {
+    get: op({
+      tags: ["markets"],
+      summary: "Search symbols by name or ticker",
+      parameters: [{ name: "q", in: "query", required: true, schema: { type: "string" } }],
+      responses: dataResp({
+        type: "object",
+        required: ["matches"],
+        properties: { matches: { type: "array", items: ref("MktSymbolMatch") } },
+      }),
+    }),
+  },
+  "/v1/markets/watchlists": {
+    get: op({
+      tags: ["markets"],
+      summary: "List watchlists in a scope",
+      parameters: [
+        { name: "scope", in: "query", required: false, schema: { type: "string", enum: ["user", "space", "terminal"], default: "user" } },
+        { name: "scopeId", in: "query", required: false, schema: { type: "string" }, description: "Required when scope is space or terminal." },
+      ],
+      responses: dataResp({
+        type: "object",
+        required: ["watchlists"],
+        properties: { watchlists: { type: "array", items: ref("MktWatchlist") } },
+      }),
+    }),
+    post: op({
+      tags: ["markets"],
+      summary: "Create a watchlist",
+      requestBody: { required: true, content: { "application/json": { schema: ref("MktWatchlistCreate") } } },
+      responses: dataResp({ type: "object", required: ["watchlist"], properties: { watchlist: ref("MktWatchlist") } }, 201),
+    }),
+  },
+  "/v1/markets/watchlists/{id}": {
+    patch: op({
+      tags: ["markets"],
+      summary: "Rename or reorder a watchlist",
+      parameters: paramsFor("/v1/markets/watchlists/{id}"),
+      requestBody: { required: true, content: { "application/json": { schema: ref("MktWatchlistPatch") } } },
+      responses: dataResp({ type: "object", required: ["watchlist"], properties: { watchlist: ref("MktWatchlist") } }),
+    }),
+    delete: op({
+      tags: ["markets"],
+      summary: "Delete a watchlist",
+      parameters: paramsFor("/v1/markets/watchlists/{id}"),
+      responses: noContent,
+    }),
+  },
+  "/v1/markets/watchlists/{id}/symbols": {
+    post: op({
+      tags: ["markets"],
+      summary: "Add a symbol to a watchlist",
+      parameters: paramsFor("/v1/markets/watchlists/{id}"),
+      requestBody: { required: true, content: { "application/json": { schema: ref("MktWatchlistSymbolCreate") } } },
+      responses: dataResp({ type: "object", required: ["symbol"], properties: { symbol: ref("MktWatchlistSymbol") } }, 201),
+    }),
+    delete: op({
+      tags: ["markets"],
+      summary: "Remove a symbol from a watchlist",
+      parameters: [
+        ...paramsFor("/v1/markets/watchlists/{id}"),
+        { name: "symbol", in: "query", required: true, schema: { type: "string" } },
+      ],
+      responses: noContent,
+    }),
+  },
+  "/v1/markets/alerts": {
+    get: op({
+      tags: ["markets"],
+      summary: "List your price alerts",
+      responses: dataResp({ type: "object", required: ["alerts"], properties: { alerts: { type: "array", items: ref("MktAlert") } } }),
+    }),
+    post: op({
+      tags: ["markets"],
+      summary: "Create a price alert",
+      requestBody: { required: true, content: { "application/json": { schema: ref("MktAlertCreate") } } },
+      responses: dataResp({ type: "object", required: ["alert"], properties: { alert: ref("MktAlert") } }, 201),
+    }),
+  },
+  "/v1/markets/alerts/{id}": {
+    patch: op({
+      tags: ["markets"],
+      summary: "Toggle or modify a price alert",
+      parameters: paramsFor("/v1/markets/alerts/{id}"),
+      requestBody: { required: true, content: { "application/json": { schema: ref("MktAlertPatch") } } },
+      responses: dataResp({ type: "object", required: ["alert"], properties: { alert: ref("MktAlert") } }),
+    }),
+    delete: op({
+      tags: ["markets"],
+      summary: "Delete a price alert",
+      parameters: paramsFor("/v1/markets/alerts/{id}"),
+      responses: noContent,
+    }),
+  },
+  "/v1/markets/portfolios": {
+    get: op({
+      tags: ["markets"],
+      summary: "List portfolios in a scope",
+      parameters: [
+        { name: "scope", in: "query", required: false, schema: { type: "string", enum: ["user", "space", "terminal"], default: "user" } },
+        { name: "scopeId", in: "query", required: false, schema: { type: "string" }, description: "Required when scope is space or terminal." },
+      ],
+      responses: dataResp({ type: "object", required: ["portfolios"], properties: { portfolios: { type: "array", items: ref("MktPortfolio") } } }),
+    }),
+    post: op({
+      tags: ["markets"],
+      summary: "Create a portfolio",
+      requestBody: { required: true, content: { "application/json": { schema: ref("MktPortfolioCreate") } } },
+      responses: dataResp({ type: "object", required: ["portfolio"], properties: { portfolio: ref("MktPortfolio") } }, 201),
+    }),
+  },
+  "/v1/markets/portfolios/{id}": {
+    get: op({
+      tags: ["markets"],
+      summary: "Portfolio detail with live performance",
+      description: "Returns the portfolio, its lot ledger, and computed positions/P&L from live quotes.",
+      parameters: paramsFor("/v1/markets/portfolios/{id}"),
+      responses: dataResp({
+        type: "object",
+        required: ["portfolio", "lots", "performance"],
+        properties: {
+          portfolio: ref("MktPortfolio"),
+          lots: { type: "array", items: ref("MktLot") },
+          performance: ref("MktPortfolioPerformance"),
+        },
+      }),
+    }),
+    patch: op({
+      tags: ["markets"],
+      summary: "Rename a portfolio / change base currency",
+      parameters: paramsFor("/v1/markets/portfolios/{id}"),
+      requestBody: { required: true, content: { "application/json": { schema: ref("MktPortfolioPatch") } } },
+      responses: dataResp({ type: "object", required: ["portfolio"], properties: { portfolio: ref("MktPortfolio") } }),
+    }),
+    delete: op({
+      tags: ["markets"],
+      summary: "Delete a portfolio",
+      parameters: paramsFor("/v1/markets/portfolios/{id}"),
+      responses: noContent,
+    }),
+  },
+  "/v1/markets/portfolios/{id}/lots": {
+    get: op({
+      tags: ["markets"],
+      summary: "List trade lots in a portfolio",
+      parameters: paramsFor("/v1/markets/portfolios/{id}"),
+      responses: dataResp({ type: "object", required: ["lots"], properties: { lots: { type: "array", items: ref("MktLot") } } }),
+    }),
+    post: op({
+      tags: ["markets"],
+      summary: "Record a trade lot",
+      parameters: paramsFor("/v1/markets/portfolios/{id}"),
+      requestBody: { required: true, content: { "application/json": { schema: ref("MktLotCreate") } } },
+      responses: dataResp({ type: "object", required: ["lot"], properties: { lot: ref("MktLot") } }, 201),
+    }),
+  },
+  "/v1/markets/portfolios/{id}/lots/{lotId}": {
+    delete: op({
+      tags: ["markets"],
+      summary: "Delete a trade lot",
+      parameters: paramsFor("/v1/markets/portfolios/{id}/lots/{lotId}"),
+      responses: noContent,
+    }),
+  },
+  "/v1/markets/candles/{symbol}": {
+    get: op({
+      tags: ["markets"],
+      summary: "OHLC candle series for charts",
+      parameters: [
+        ...paramsFor("/v1/markets/candles/{symbol}"),
+        { name: "range", in: "query", required: false, schema: { type: "string", enum: ["1D", "5D", "1M", "6M", "YTD", "1Y", "5Y", "MAX"], default: "1Y" } },
+      ],
+      responses: dataResp({
+        type: "object",
+        required: ["symbol", "range", "candles"],
+        properties: { symbol: { type: "string" }, range: { type: "string" }, candles: { type: "array", items: ref("MktCandle") } },
+      }),
+    }),
+  },
+  "/v1/markets/news/{symbol}": {
+    get: op({
+      tags: ["markets"],
+      summary: "Recent company news",
+      parameters: [
+        ...paramsFor("/v1/markets/news/{symbol}"),
+        { name: "days", in: "query", required: false, schema: { type: "integer", minimum: 1, maximum: 60, default: 7 } },
+      ],
+      responses: dataResp({ type: "object", required: ["items"], properties: { items: { type: "array", items: ref("MktNewsItem") } } }),
+    }),
+  },
+  "/v1/markets/profile/{symbol}": {
+    get: op({
+      tags: ["markets"],
+      summary: "Company profile / fundamentals header",
+      parameters: paramsFor("/v1/markets/profile/{symbol}"),
+      responses: dataResp({ type: "object", required: ["profile"], properties: { profile: ref("MktCompanyProfile") } }),
+    }),
+  },
+  "/v1/markets/movers": {
+    get: op({
+      tags: ["markets"],
+      summary: "Top gainers / losers / most-active",
+      parameters: [
+        { name: "type", in: "query", required: false, schema: { type: "string", enum: ["gainers", "losers", "active"], default: "gainers" } },
+      ],
+      responses: dataResp({
+        type: "object",
+        required: ["type", "movers"],
+        properties: { type: { type: "string" }, movers: { type: "array", items: ref("MktMover") } },
+      }),
+    }),
+  },
+  "/v1/markets/options/{symbol}": {
+    get: op({
+      tags: ["markets"],
+      summary: "Options chain (stub — paid feed required)",
+      description: "Returns supported:false on the free tier; structure is stable for when a paid feed is wired in.",
+      parameters: paramsFor("/v1/markets/options/{symbol}"),
+      responses: dataResp({
+        type: "object",
+        required: ["symbol", "supported", "expirations", "contracts"],
+        properties: {
+          symbol: { type: "string" },
+          supported: { type: "boolean" },
+          expirations: { type: "array", items: { type: "string" } },
+          contracts: { type: "array", items: { type: "object", additionalProperties: true } },
+          note: { type: "string" },
+        },
+      }),
+    }),
+  },
+  "/v1/markets/financials/{symbol}": {
+    get: op({
+      tags: ["markets"],
+      summary: "Financial statements",
+      description: "Cached 24h.",
+      parameters: [
+        ...paramsFor("/v1/markets/financials/{symbol}"),
+        { name: "statement", in: "query", required: false, schema: { type: "string", enum: ["income", "balance", "cash"], default: "income" } },
+      ],
+      responses: dataResp({ type: "object", required: ["report"], properties: { report: ref("MktFinancialReport") } }),
+    }),
+  },
+  "/v1/markets/overview": {
+    get: op({
+      tags: ["markets"],
+      summary: "Market overview board",
+      description: "Indices, sectors, commodities, and FX in one call.",
+      responses: dataResp({
+        type: "object",
+        required: ["indices", "sectors", "commodities", "fx"],
+        properties: {
+          indices: { type: "array", items: ref("MktOverviewRow") },
+          sectors: { type: "array", items: ref("MktOverviewRow") },
+          commodities: { type: "array", items: ref("MktOverviewRow") },
+          fx: { type: "array", items: ref("MktOverviewRow") },
+        },
+      }),
+    }),
+  },
+  "/v1/markets/calendar": {
+    get: op({
+      tags: ["markets"],
+      summary: "Earnings calendar",
+      parameters: [
+        { name: "from", in: "query", required: false, schema: { type: "string", format: "date" } },
+        { name: "to", in: "query", required: false, schema: { type: "string", format: "date" } },
+      ],
+      responses: dataResp({
+        type: "object",
+        required: ["from", "to", "events"],
+        properties: { from: { type: "string", format: "date" }, to: { type: "string", format: "date" }, events: { type: "array", items: ref("MktEarningsEvent") } },
+      }),
+    }),
+  },
+  "/v1/markets/screener": {
+    post: op({
+      tags: ["markets"],
+      summary: "Screen stocks by price / % change / market cap",
+      description: "Fundamental filters (P/E, yield) require a paid feed; this screens from free quotes.",
+      requestBody: { required: false, content: { "application/json": { schema: ref("MktScreenerRequest") } } },
+      responses: dataResp({
+        type: "object",
+        required: ["count", "results"],
+        properties: { count: { type: "integer" }, results: { type: "array", items: ref("MktQuote") }, note: { type: "string" } },
+      }),
+    }),
+  },
+  "/v1/markets/fx": {
+    get: op({
+      tags: ["markets"],
+      summary: "Convert a currency amount",
+      parameters: [
+        { name: "from", in: "query", required: true, schema: { type: "string" } },
+        { name: "to", in: "query", required: true, schema: { type: "string" } },
+        { name: "amount", in: "query", required: false, schema: { type: "number", default: 1 } },
+      ],
+      responses: dataResp({
+        type: "object",
+        required: ["from", "to", "rate", "amount", "converted"],
+        properties: {
+          from: { type: "string" },
+          to: { type: "string" },
+          rate: { type: "number" },
+          amount: { type: "number" },
+          converted: { type: "number" },
+        },
+      }),
+    }),
+  },
 };
 
 // ---------------------------------------------------------------------------
@@ -1860,6 +2595,7 @@ export const openApiDocument = {
     { name: "terminals", description: "Working contexts inside a space (a project, matter, client)." },
     { name: "tasks", description: "Tasks, subtasks, comments, assignees, watchers." },
     { name: "files", description: "Files and folders inside a terminal." },
+    { name: "markets", description: "Quotes, charts, watchlists, portfolios, alerts, and market data." },
     { name: "tools", description: "Marketplace tools and invocations." },
     { name: "approvals", description: "Approval requests for guarded actions." },
     { name: "comments", description: "Comments on any commentable target." },

--- a/docs/12_MCP_PARITY.md
+++ b/docs/12_MCP_PARITY.md
@@ -23,17 +23,24 @@ For each row:
 
 ## 12.2 Counts
 
-Last reconciled: 2026-04-27 against:
+Last reconciled: 2026-06-17 against:
 - `apps/web/src/app/api/v1/**/route.ts`
-- `apps/mcp-server/src/tools.ts`
+- `apps/mcp-server/src/tools.ts` + `markets-tools.ts`
 
 | Status | Count |
 |---|---|
-| Present | 35 |
+| Present | 44 |
 | Partial | 6 |
-| Missing | 35 |
-| UI-only | 16 |
-| **Total** | 92 |
+| Missing | 52 |
+| UI-only | 17 |
+| **Total** | 119 |
+
+> The 2026-06-17 reconcile added the **Markets** module: 27 rows (9 present,
+> 17 missing, 1 internal cron). A regression test —
+> `apps/web/src/lib/mcp-parity.test.ts` — now cross-checks the matrix against
+> the OpenAPI spec (every markets REST endpoint is documented and vice-versa)
+> and against the shipped `rokki_markets_*` tool set, so this section can't
+> silently drift from the code again.
 
 ## 12.3 Closing the gaps — recommended priority order
 
@@ -120,6 +127,27 @@ These improve agent UX but don't unblock new workflows.
 - **Specialized assignee tools** — `rokki_add_task_assignee`,
   `rokki_remove_task_assignee`. Currently set at create/update; explicit
   add/remove tools are nicer ergonomics for agents.
+
+### 12.3.4 Markets module
+
+Shipped 2026-06-16 with 22 REST endpoints and 9 MCP tools. The tools cover
+the core loop (quote, search, watchlist add/remove, portfolio add-lot +
+performance, alert list/create); the read-heavy data surface is the gap.
+
+- **High priority** — `rokki_markets_candles` (OHLC for trend analysis),
+  `rokki_markets_news` (recent headlines for a symbol), and
+  `rokki_markets_overview` (indices/sectors/commodities/FX snapshot). These
+  are the things an agent needs to actually reason about a position.
+- **Medium priority** — `rokki_markets_profile`, `rokki_markets_movers`,
+  `rokki_markets_financials`, `rokki_markets_calendar`,
+  `rokki_markets_screener`, list portfolios, and alert edit/delete
+  (`rokki_markets_alert_update` / `_delete`).
+- **Low priority** — batch quotes, watchlist rename/delete, portfolio
+  lifecycle (create/rename/delete), lot list/delete, `rokki_markets_fx`,
+  and options (REST is a paid-feed stub).
+
+The `/v1/cron/evaluate-price-alerts` endpoint is an internal scheduled job
+(CRON_SECRET auth) and is intentionally MCP-exempt — see §12.4.
 
 ## 12.4 Intentionally not exposed via MCP
 


### PR DESCRIPTION
## What

Overnight item #4. The Markets module shipped 22 REST routes + 9 MCP tools but was **completely absent** from the OpenAPI spec and the MCP↔REST parity matrix — a gap in the API+MCP-parity non-negotiable, and an undocumented public contract.

## Changes

**OpenAPI** (`apps/web/src/lib/openapi.ts`)
- 24 new markets schemas matching `lib/markets/providers/types.ts` + `lib/markets/db.ts` exactly (Quote, CompanyProfile, Candle, NewsItem, FinancialReport, EarningsEvent, Mover, OverviewRow, Watchlist/Symbol, Portfolio, Lot, Position/PortfolioPerformance, Alert, request bodies, screener request).
- All **22 markets paths** documented — correct methods, path + query params, request bodies, and the real `{ data: { … } }` response envelopes (the routes use named inner keys like `{ data: { quote, cached } }`, not bare `data`).
- New `markets` tag.

**Parity matrix** (`apps/web/src/lib/mcp-parity.ts`)
- `markets` added to the `Resource` union + **27 rows**: 9 present (shipped `rokki_markets_*` tools), 17 missing (the read-heavy data surface — candles/news/overview/etc., each prioritized), 1 admin-only (internal `evaluate-price-alerts` cron).

**Regression test** (`apps/web/src/lib/mcp-parity.test.ts` — NEW)
- Cross-checks the matrix ⇄ OpenAPI both directions for markets, verifies all 9 shipped tools are accounted for, and asserts structural invariants. **This is what stops the matrix silently drifting from the code again** — the root cause of why markets fell out of the audit in the first place.

**Docs** — `docs/12_MCP_PARITY.md` counts reconciled (44/6/52/17, total 119) + a Markets gap-priority subsection.

## Verification

- 593 web tests pass (585 + 8 new parity tests); typecheck + lint clean.
- No runtime/behavior changes — this is spec + audit + test only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)