### PR TITLE
feat(signal): sync contacts + groups, names on threads, new-message picker

### DIFF
--- a/apps/signal-bridge/src/index.ts
+++ b/apps/signal-bridge/src/index.ts
@@ -229,6 +229,82 @@ async function writeInbound(m: InboundMessage): Promise<void> {
   });
 }
 
+// ── contact / group directory sync ────────────────────────────────────────────
+
+interface RawContact {
+  number?: string;
+  uuid?: string;
+  name?: string;
+  profileName?: string;
+  profile?: { givenName?: string; familyName?: string };
+}
+interface RawGroupInfo {
+  id?: string;
+  name?: string;
+}
+
+function contactName(c: RawContact): string | null {
+  const profile = [c.profile?.givenName, c.profile?.familyName]
+    .filter(Boolean)
+    .join(" ")
+    .trim();
+  return c.name?.trim() || c.profileName?.trim() || profile || null;
+}
+
+/**
+ * Pull the account's Signal contacts + groups into signal_contacts (so Rokki
+ * can show names + offer a "new message" picker) and back-fill thread titles
+ * with the resolved names. Signal is the source of truth; this is a refresh.
+ */
+async function syncContacts(userId: string, number: string): Promise<void> {
+  try {
+    const [contacts, groups] = await Promise.all([
+      rpcCall<RawContact[]>("listContacts", { account: number }).catch(() => []),
+      rpcCall<RawGroupInfo[]>("listGroups", { account: number }).catch(() => []),
+    ]);
+    const now = new Date().toISOString();
+    const rows: {
+      user_id: string;
+      signal_id: string;
+      kind: "direct" | "group";
+      name: string | null;
+      updated_at: string;
+    }[] = [];
+    for (const c of contacts ?? []) {
+      const id = c.number ?? c.uuid;
+      if (!id) continue;
+      rows.push({ user_id: userId, signal_id: id, kind: "direct", name: contactName(c), updated_at: now });
+    }
+    for (const g of groups ?? []) {
+      if (!g.id) continue;
+      rows.push({ user_id: userId, signal_id: g.id, kind: "group", name: g.name?.trim() || null, updated_at: now });
+    }
+    if (rows.length === 0) return;
+    await db.from("signal_contacts").upsert(rows, { onConflict: "user_id,signal_id" });
+
+    // Back-fill titles on existing threads that now have a name.
+    const nameById = new Map(rows.map((r) => [r.signal_id, r.name]));
+    const { data: threads } = await db
+      .from("signal_threads")
+      .select("id, signal_id, title")
+      .eq("user_id", userId);
+    for (const t of (threads ?? []) as { id: string; signal_id: string; title: string | null }[]) {
+      const name = nameById.get(t.signal_id);
+      if (name && name !== t.title) {
+        await db.from("signal_threads").update({ title: name }).eq("id", t.id);
+      }
+    }
+    console.log(`[contacts] synced ${rows.length} for ${userId}`);
+  } catch (e) {
+    console.log(`[contacts] sync failed for ${userId}: ${String(e)}`);
+  }
+}
+
+/** Sync contacts for every active account (called once the RPC is ready). */
+async function syncAllContacts(): Promise<void> {
+  for (const [number, userId] of accountToUser) void syncContacts(userId, number);
+}
+
 // ── signal-cli daemon + JSON-RPC client ───────────────────────────────────────
 
 let daemon: ChildProcess | null = null;
@@ -280,6 +356,8 @@ function connectRpc(): void {
     rpcReady = true;
     rpcBuffer = "";
     console.log("[rpc] connected to daemon");
+    // The daemon is up — refresh each account's contact directory.
+    setTimeout(() => void syncAllContacts(), 1_000);
   });
   sock.on("data", (chunk: Buffer) => {
     rpcBuffer += chunk.toString();
@@ -479,6 +557,19 @@ app.post("/accounts/:userId/send", async (c) => {
     const status = msg.includes("starting up") ? 503 : 500;
     return c.json({ error: msg }, status);
   }
+});
+
+app.post("/accounts/:userId/sync", async (c) => {
+  const userId = c.req.param("userId");
+  const { data } = await db
+    .from("signal_accounts")
+    .select("signal_number")
+    .eq("user_id", userId)
+    .maybeSingle();
+  const number = (data as { signal_number?: string | null } | null)?.signal_number;
+  if (!number) return c.json({ error: "Signal isn't connected" }, 400);
+  await syncContacts(userId, number);
+  return c.json({ ok: true });
 });
 
 void (async () => {

--- a/apps/web/src/app/api/v1/signal/contacts/route.ts
+++ b/apps/web/src/app/api/v1/signal/contacts/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { withObservability } from "@/lib/observability";
+import { unauth } from "@/lib/signal/responses";
+
+/**
+ * GET /api/v1/signal/contacts — the signed-in user's synced Signal contacts +
+ * groups (from signal_contacts). Drives the "new message" picker. RLS scopes
+ * to the owner.
+ */
+async function handleGet() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return unauth();
+
+  const { data } = await supabase
+    .from("signal_contacts")
+    .select("signal_id, kind, name")
+    .eq("user_id", user.id)
+    .order("name", { ascending: true });
+
+  return NextResponse.json({ data: data ?? [] });
+}
+
+export const GET = withObservability(handleGet, "GET /api/v1/signal/contacts");

--- a/apps/web/src/app/api/v1/signal/sync/route.ts
+++ b/apps/web/src/app/api/v1/signal/sync/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { withObservability } from "@/lib/observability";
+import { bridgeSyncContacts } from "@/lib/signal/bridge";
+import { unauth, bridgeErrorResponse } from "@/lib/signal/responses";
+
+/**
+ * POST /api/v1/signal/sync — refresh the signed-in user's Signal contact +
+ * group directory (signal-cli listContacts/listGroups) into signal_contacts.
+ * The bridge also runs this on boot; this is the on-demand trigger.
+ */
+
+// The bridge calls signal-cli over RPC and writes rows; give it headroom.
+export const maxDuration = 40;
+
+async function handlePost() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return unauth();
+
+  try {
+    await bridgeSyncContacts(user.id);
+    return NextResponse.json({ data: { ok: true } });
+  } catch (e) {
+    return bridgeErrorResponse(e);
+  }
+}
+
+export const POST = withObservability(handlePost, "POST /api/v1/signal/sync");

--- a/apps/web/src/app/api/v1/signal/threads/route.ts
+++ b/apps/web/src/app/api/v1/signal/threads/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { withObservability } from "@/lib/observability";
+import { unauth, bad } from "@/lib/signal/responses";
+
+/**
+ * POST /api/v1/signal/threads { signalId, kind?, title? } — ensure a Signal
+ * conversation exists for a contact and return its id, so the "new message"
+ * picker can open a chat with someone who hasn't messaged yet. Idempotent
+ * (upsert on user_id+signal_id). RLS scopes to the owner.
+ */
+async function handlePost(request: NextRequest) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return unauth();
+
+  const body = (await request.json().catch(() => ({}))) as {
+    signalId?: string;
+    kind?: "direct" | "group";
+    title?: string;
+  };
+  if (!body.signalId) return bad("signalId is required");
+  const kind = body.kind === "group" ? "group" : "direct";
+
+  const row: {
+    user_id: string;
+    signal_id: string;
+    kind: "direct" | "group";
+    title?: string;
+  } = { user_id: user.id, signal_id: body.signalId, kind };
+  if (body.title) row.title = body.title;
+
+  const { data, error } = await supabase
+    .from("signal_threads")
+    // @ts-expect-error generic upsert collapses to never
+    .upsert(row, { onConflict: "user_id,signal_id" })
+    .select("id")
+    .single();
+  if (error || !data) {
+    return NextResponse.json(
+      { errors: [{ message: error?.message ?? "Couldn’t open the conversation" }] },
+      { status: 500 },
+    );
+  }
+  return NextResponse.json({ data: { id: (data as { id: string }).id } });
+}
+
+export const POST = withObservability(handlePost, "POST /api/v1/signal/threads");

--- a/apps/web/src/components/messages/MessagesInbox.tsx
+++ b/apps/web/src/components/messages/MessagesInbox.tsx
@@ -10,11 +10,13 @@ import {
   Bell,
   RefreshCw,
   MessageSquare,
+  PenSquare,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useRealtimeTable } from "@/lib/supabase/realtime";
 import { createClient } from "@/lib/supabase/client";
 import { SignalThreadView } from "./SignalThreadView";
+import { SignalContactPicker } from "./SignalContactPicker";
 
 interface ThreadSummary {
   id: string;
@@ -60,6 +62,7 @@ interface Message {
 export function MessagesInbox() {
   const [threads, setThreads] = useState<ThreadSummary[]>([]);
   const [activeId, setActiveId] = useState<string | null>(null);
+  const [picking, setPicking] = useState(false);
   const [messages, setMessages] = useState<Message[]>([]);
   const [draft, setDraft] = useState("");
   const [sending, setSending] = useState(false);
@@ -228,10 +231,19 @@ export function MessagesInbox() {
   return (
     <div className="flex h-full min-h-0 rounded border border-border bg-bg-1">
       <aside className="w-[260px] flex-shrink-0 border-r border-border">
-        <header className="flex h-9 items-center border-b border-border px-3">
+        <header className="flex h-9 items-center gap-2 border-b border-border px-3">
           <span className="text-xs font-semibold uppercase tracking-wide text-text-3">
             Conversations
           </span>
+          <button
+            type="button"
+            onClick={() => setPicking(true)}
+            title="New Signal message"
+            aria-label="New Signal message"
+            className="ml-auto rounded-sm p-1 text-text-3 hover:bg-bg-2 hover:text-text-0"
+          >
+            <PenSquare className="h-3 w-3" />
+          </button>
         </header>
         {/* Reminders CTA — shows once until the user enables it; the
             refresh endpoint creates the thread + posts pings for the
@@ -289,7 +301,16 @@ export function MessagesInbox() {
       </aside>
 
       <section className="flex min-h-0 flex-1 flex-col">
-        {activeIsSignal && active ? (
+        {picking ? (
+          <SignalContactPicker
+            onClose={() => setPicking(false)}
+            onPick={(id) => {
+              setActiveId(id);
+              setPicking(false);
+              void loadThreads();
+            }}
+          />
+        ) : activeIsSignal && active ? (
           <SignalThreadView
             key={active.id}
             threadId={active.id}

--- a/apps/web/src/components/messages/SignalContactPicker.tsx
+++ b/apps/web/src/components/messages/SignalContactPicker.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { Search, Loader2, X, MessageSquare, Users } from "lucide-react";
+
+interface Contact {
+  signal_id: string;
+  kind: "direct" | "group";
+  name: string | null;
+}
+
+/**
+ * "New Signal message" picker. Lists the user's synced Signal contacts +
+ * groups (from signal_contacts), and on select ensures a thread exists and
+ * hands its id back so the inbox can open the conversation. Kicks a fresh
+ * contact sync on open so the directory is current.
+ */
+export function SignalContactPicker({
+  onClose,
+  onPick,
+}: {
+  onClose: () => void;
+  onPick: (threadId: string) => void;
+}) {
+  const [contacts, setContacts] = useState<Contact[]>([]);
+  const [q, setQ] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [opening, setOpening] = useState<string | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    void (async () => {
+      // Fire a fresh sync (don't block on it), then load whatever's cached.
+      void fetch("/api/v1/signal/sync", {
+        method: "POST",
+        credentials: "include",
+      }).catch(() => {});
+      const r = await fetch("/api/v1/signal/contacts", { credentials: "include" });
+      const b = (await r.json().catch(() => ({}))) as { data?: Contact[] };
+      if (alive) {
+        setContacts(b.data ?? []);
+        setLoading(false);
+      }
+    })();
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  const filtered = useMemo(() => {
+    const s = q.trim().toLowerCase();
+    if (!s) return contacts;
+    return contacts.filter((c) => (c.name ?? c.signal_id).toLowerCase().includes(s));
+  }, [contacts, q]);
+
+  async function pick(c: Contact) {
+    if (opening) return;
+    setOpening(c.signal_id);
+    try {
+      const r = await fetch("/api/v1/signal/threads", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({
+          signalId: c.signal_id,
+          kind: c.kind,
+          title: c.name ?? undefined,
+        }),
+      });
+      const b = (await r.json().catch(() => ({}))) as { data?: { id?: string } };
+      if (b.data?.id) onPick(b.data.id);
+    } finally {
+      setOpening(null);
+    }
+  }
+
+  return (
+    <>
+      <header className="flex h-9 flex-shrink-0 items-center gap-2 border-b border-border bg-bg-0 px-3">
+        <span className="text-xs text-text-1">New Signal message</span>
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close"
+          className="ml-auto rounded-sm p-1 text-text-3 hover:text-text-0"
+        >
+          <X className="h-3 w-3" />
+        </button>
+      </header>
+      <div className="flex flex-shrink-0 items-center gap-1.5 border-b border-border px-3 py-1.5">
+        <Search className="h-3 w-3 text-text-3" />
+        <input
+          autoFocus
+          value={q}
+          onChange={(e) => setQ(e.target.value)}
+          placeholder="Search contacts…"
+          className="flex-1 bg-transparent text-xs text-text-0 outline-none placeholder:text-text-3"
+        />
+      </div>
+      <div className="flex-1 overflow-y-auto">
+        {loading ? (
+          <p className="flex items-center justify-center gap-2 py-10 text-xs text-text-3">
+            <Loader2 className="h-3 w-3 animate-spin" /> Loading contacts…
+          </p>
+        ) : filtered.length === 0 ? (
+          <p className="px-3 py-10 text-center text-xs text-text-3">
+            {contacts.length === 0
+              ? "No Signal contacts synced yet. They appear here once your account finishes syncing."
+              : "No matches."}
+          </p>
+        ) : (
+          <ul>
+            {filtered.map((c) => (
+              <li key={c.signal_id}>
+                <button
+                  type="button"
+                  onClick={() => void pick(c)}
+                  className="flex w-full items-center gap-2 px-3 py-2 text-left text-xs hover:bg-bg-2"
+                >
+                  {c.kind === "group" ? (
+                    <Users className="h-3 w-3 flex-shrink-0 text-text-3" />
+                  ) : (
+                    <MessageSquare className="h-3 w-3 flex-shrink-0 text-text-3" />
+                  )}
+                  <span className="flex-1 truncate text-text-0">
+                    {c.name ?? c.signal_id}
+                  </span>
+                  {opening === c.signal_id ? (
+                    <Loader2 className="h-3 w-3 flex-shrink-0 animate-spin text-text-3" />
+                  ) : null}
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </>
+  );
+}

--- a/apps/web/src/lib/signal/bridge.ts
+++ b/apps/web/src/lib/signal/bridge.ts
@@ -109,3 +109,11 @@ export function bridgeSend(
     { method: "POST", body: payload, timeoutMs: 45_000 },
   );
 }
+
+/** Refresh the user's Signal contact + group directory into signal_contacts. */
+export function bridgeSyncContacts(userId: string): Promise<{ ok: true }> {
+  return bridgeFetch<{ ok: true }>(
+    `/accounts/${encodeURIComponent(userId)}/sync`,
+    { method: "POST", timeoutMs: 30_000 },
+  );
+}

--- a/supabase/migrations/20260617010000_signal_contacts.sql
+++ b/supabase/migrations/20260617010000_signal_contacts.sql
@@ -1,0 +1,41 @@
+-- Signal contacts + group directory.
+--
+-- The bridge pulls the linked account's contacts (signal-cli `listContacts`)
+-- and groups (`listGroups`) into this table so Rokki can (a) show real names
+-- on conversations instead of phone numbers and (b) offer a "new message"
+-- picker to start a chat with anyone in the user's Signal address book — even
+-- before any message has flowed. Signal is the source of truth; this is a
+-- read-through cache the bridge refreshes.
+
+BEGIN;
+
+CREATE TABLE signal_contacts (
+  id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id    UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  signal_id  TEXT NOT NULL,                 -- phone/uuid (direct) OR group id
+  kind       TEXT NOT NULL CHECK (kind IN ('direct', 'group')),
+  name       TEXT,                          -- contact / group display name
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (user_id, signal_id)
+);
+
+CREATE INDEX idx_signal_contacts_user ON signal_contacts(user_id);
+
+ALTER TABLE signal_contacts ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "signal_contacts_owner" ON signal_contacts
+  FOR ALL TO authenticated
+  USING (user_id = auth.uid())
+  WITH CHECK (user_id = auth.uid());
+
+-- Live updates so a freshly-synced directory appears without a refresh.
+ALTER PUBLICATION supabase_realtime ADD TABLE signal_contacts;
+
+COMMIT;
+
+-- ROLLBACK:
+-- BEGIN;
+-- ALTER PUBLICATION supabase_realtime DROP TABLE signal_contacts;
+-- DROP TABLE IF EXISTS signal_contacts CASCADE;
+-- COMMIT;


### PR DESCRIPTION
## What

Your **Signal address book in Rokki.** Conversations now show real **names** instead of phone numbers, and you can **start a chat with anyone** in your Signal contacts — not just people who've already messaged you.

Signal stays the source of truth; this is a read-through refresh (there's no separate Rokki phone-book to push back — that's the honest answer to "vice versa").

## How
- **Migration** `signal_contacts` (user_id, signal_id, kind, name) + RLS + realtime.
- **Bridge** — `syncContacts()` calls the daemon's `listContacts` + `listGroups` over RPC, upserts `signal_contacts`, and back-fills `signal_threads.title` with resolved names. Runs **automatically** when the daemon connects (boot + after link) and on demand via `POST /accounts/:userId/sync`.
- **Web API** — `POST /signal/sync` (trigger), `GET /signal/contacts` (list), `POST /signal/threads` (ensure a thread exists for a contact, returns its id).
- **UI** — a **"New message"** pen button in the Messages sidebar opens a searchable contact/group picker; selecting one opens (creating if needed) the conversation. Thread titles render names.

## Verify
- Web + bridge typecheck clean, lint clean, 18 signal tests pass, migration harness 0 broken.
- Merging applies the migration to sandbox and **auto-deploys the bridge** (contact sync runs on its next boot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)