### PR TITLE
feat(signal): Phase 1 reliability — phone-sync, delivery/read status, mark-read

### DIFF
--- a/apps/signal-bridge/src/index.ts
+++ b/apps/signal-bridge/src/index.ts
@@ -128,7 +128,25 @@ interface RawEnvelope {
   timestamp?: number;
   dataMessage?: RawDataMessage;
   syncMessage?: { sentMessage?: RawSentMessage };
+  receiptMessage?: {
+    when?: number;
+    isDelivery?: boolean;
+    isRead?: boolean;
+    isViewed?: boolean;
+    timestamps?: number[];
+  };
 }
+
+type MsgStatus = "sending" | "sent" | "delivered" | "read" | "failed";
+/** Only ever advance a message's status forward — a late delivery receipt must
+ *  not downgrade a row already marked read. `failed` is terminal/separate. */
+const STATUS_RANK: Record<MsgStatus, number> = {
+  sending: 0,
+  sent: 1,
+  delivered: 2,
+  read: 3,
+  failed: 0,
+};
 
 interface InboundMessage {
   userId: string;
@@ -139,6 +157,7 @@ interface InboundMessage {
   body: string;
   externalId: string;
   sentAt: string;
+  status: MsgStatus;
 }
 
 const groupOf = (m: { groupInfo?: RawGroup; groupV2?: { id?: string } }): string | undefined =>
@@ -172,6 +191,7 @@ function toInbound(userId: string, evt: unknown): InboundMessage | null {
       body: dm.message,
       externalId: String(ts ?? now),
       sentAt: iso(ts, now),
+      status: "sent",
     };
   }
 
@@ -190,6 +210,7 @@ function toInbound(userId: string, evt: unknown): InboundMessage | null {
       body: sent.message,
       externalId: String(sent.timestamp ?? env.timestamp ?? now),
       sentAt: iso(sent.timestamp ?? env.timestamp, now),
+      status: "sent",
     };
   }
 
@@ -226,7 +247,36 @@ async function writeInbound(m: InboundMessage): Promise<void> {
     sender: m.sender,
     body: m.body,
     sent_at: m.sentAt,
+    status: m.status,
   });
+}
+
+/**
+ * A delivery/read receipt arrived for one or more outbound messages (keyed by
+ * the original send timestamp). Advance their status forward only.
+ */
+async function applyReceipt(
+  userId: string,
+  r: { isDelivery?: boolean; isRead?: boolean; isViewed?: boolean; timestamps?: number[] },
+): Promise<void> {
+  const target: MsgStatus | null =
+    r.isRead || r.isViewed ? "read" : r.isDelivery ? "delivered" : null;
+  if (!target || !r.timestamps?.length) return;
+  const ids = r.timestamps.map(String);
+  const { data } = await db
+    .from("signal_messages")
+    .select("id, status")
+    .eq("user_id", userId)
+    .eq("direction", "out")
+    .in("external_id", ids);
+  for (const m of (data ?? []) as { id: string; status: MsgStatus }[]) {
+    if (STATUS_RANK[target] > (STATUS_RANK[m.status] ?? 0)) {
+      await db
+        .from("signal_messages")
+        .update({ status: target, status_at: new Date().toISOString() })
+        .eq("id", m.id);
+    }
+  }
 }
 
 // ── contact / group directory sync ────────────────────────────────────────────
@@ -341,9 +391,14 @@ function handleRpcLine(line: string): void {
   }
   // Push notification: an incoming (or sent-elsewhere) message.
   if (msg.method === "receive" && msg.params && typeof msg.params === "object") {
-    const params = msg.params as { account?: string };
+    const params = msg.params as { account?: string; envelope?: RawEnvelope };
     const userId = params.account ? accountToUser.get(params.account) : undefined;
     if (!userId) return;
+    // Delivery/read receipts ride the same "receive" push — handle first.
+    if (params.envelope?.receiptMessage) {
+      void applyReceipt(userId, params.envelope.receiptMessage);
+      return;
+    }
     const inbound = toInbound(userId, msg.params);
     if (inbound) void writeInbound(inbound);
   }
@@ -388,8 +443,11 @@ function startDaemon(): void {
     "daemon",
     "--tcp",
     `${RPC_HOST}:${RPC_PORT}`,
+    // on-connection (vs on-start): the daemon ties receive to our persistent
+    // RPC connection. Leading hypothesis for "Rokki sends don't appear on the
+    // phone" — needs live verification.
     "--receive-mode",
-    "on-start",
+    "on-connection",
   ]);
   daemon.stdout?.on("data", (d: Buffer) =>
     console.log(`[daemon] ${d.toString().trim().slice(0, 200)}`),
@@ -539,7 +597,15 @@ app.post("/accounts/:userId/send", async (c) => {
     ? { account: body.signalNumber, groupId: body.signalId, message: body.text }
     : { account: body.signalNumber, recipient: [body.signalId], message: body.text };
   try {
-    await rpcCall("send", params); // fast: persistent daemon, no JVM start
+    // The send result carries signal-cli's message timestamp — the id that
+    // delivery/read receipts reference. Storing the REAL timestamp (not a
+    // fabricated Date.now()) is what lets receipts correlate back to this row.
+    const res = await rpcCall<{ timestamp?: number; results?: Array<{ type?: string }> }>(
+      "send",
+      params,
+    );
+    const externalId = String(res?.timestamp ?? Date.now());
+    const anyFail = (res?.results ?? []).some((r) => r.type && r.type !== "SUCCESS");
     await writeInbound({
       userId,
       signalId: body.signalId,
@@ -547,8 +613,9 @@ app.post("/accounts/:userId/send", async (c) => {
       direction: "out",
       sender: null,
       body: body.text,
-      externalId: String(Date.now()),
+      externalId,
       sentAt: new Date().toISOString(),
+      status: anyFail ? "failed" : "sent",
     });
     return c.json({ ok: true });
   } catch (e) {
@@ -556,6 +623,28 @@ app.post("/accounts/:userId/send", async (c) => {
     // "starting up" is transient (daemon booting) → 503 so the UI can retry.
     const status = msg.includes("starting up") ? 503 : 500;
     return c.json({ error: msg }, status);
+  }
+});
+
+app.post("/accounts/:userId/read", async (c) => {
+  const body = (await c.req.json().catch(() => ({}))) as Partial<{
+    signalNumber: string;
+    recipient: string;
+    timestamps: number[];
+  }>;
+  if (!body.signalNumber || !body.recipient || !body.timestamps?.length) {
+    return c.json({ error: "signalNumber, recipient and timestamps are required" }, 400);
+  }
+  try {
+    await rpcCall("sendReceipt", {
+      account: body.signalNumber,
+      recipient: body.recipient,
+      targetTimestamps: body.timestamps,
+      type: "read",
+    });
+    return c.json({ ok: true });
+  } catch (e) {
+    return c.json({ error: e instanceof Error ? e.message : String(e) }, 500);
   }
 });
 

--- a/apps/web/src/app/api/v1/signal/threads/[id]/read/route.ts
+++ b/apps/web/src/app/api/v1/signal/threads/[id]/read/route.ts
@@ -1,0 +1,73 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { withObservability } from "@/lib/observability";
+import { bridgeMarkRead } from "@/lib/signal/bridge";
+import { unauth, bridgeErrorResponse } from "@/lib/signal/responses";
+
+interface Props {
+  params: Promise<{ id: string }>;
+}
+
+/**
+ * POST /api/v1/signal/threads/:id/read — send read receipts for the inbound
+ * messages in a direct thread (so the other person's app shows ✓✓). Fired when
+ * the user opens the conversation. Groups are skipped (Signal doesn't do
+ * per-message group read receipts). RLS scopes the thread/messages to the owner.
+ */
+async function handlePost(_req: NextRequest, { params }: Props) {
+  const { id } = await params;
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return unauth();
+
+  const { data: acct } = await supabase
+    .from("signal_accounts")
+    .select("signal_number, status")
+    .eq("user_id", user.id)
+    .maybeSingle();
+  const a = acct as { signal_number?: string | null; status?: string } | null;
+  if (!a?.signal_number || a.status !== "active") {
+    return NextResponse.json({ data: { ok: false } });
+  }
+
+  const { data: thread } = await supabase
+    .from("signal_threads")
+    .select("signal_id, kind")
+    .eq("id", id)
+    .maybeSingle();
+  const t = thread as { signal_id?: string; kind?: string } | null;
+  // Direct chats only — no per-message read receipts for groups.
+  if (!t?.signal_id || t.kind !== "direct") {
+    return NextResponse.json({ data: { ok: true } });
+  }
+
+  const { data: msgs } = await supabase
+    .from("signal_messages")
+    .select("external_id")
+    .eq("thread_id", id)
+    .eq("direction", "in")
+    .order("sent_at", { ascending: false })
+    .limit(100);
+  const timestamps = ((msgs ?? []) as { external_id: string | null }[])
+    .map((m) => Number(m.external_id))
+    .filter((n) => Number.isFinite(n));
+  if (timestamps.length === 0) return NextResponse.json({ data: { ok: true } });
+
+  try {
+    await bridgeMarkRead(user.id, {
+      signalNumber: a.signal_number,
+      recipient: t.signal_id,
+      timestamps,
+    });
+    return NextResponse.json({ data: { ok: true } });
+  } catch (e) {
+    return bridgeErrorResponse(e);
+  }
+}
+
+export const POST = withObservability(
+  handlePost,
+  "POST /api/v1/signal/threads/:id/read",
+);

--- a/apps/web/src/app/api/v1/signal/threads/[id]/route.ts
+++ b/apps/web/src/app/api/v1/signal/threads/[id]/route.ts
@@ -29,7 +29,7 @@ async function handleGet(_req: NextRequest, { params }: Props) {
   const { data: messages } = await supabase
     .from("signal_messages")
     .select(
-      "id, direction, sender, body, attachments, sent_at, edited_at, deleted_at",
+      "id, direction, sender, body, attachments, status, sent_at, edited_at, deleted_at",
     )
     .eq("thread_id", id)
     .is("deleted_at", null)

--- a/apps/web/src/components/messages/SignalThreadView.tsx
+++ b/apps/web/src/components/messages/SignalThreadView.tsx
@@ -1,9 +1,21 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Send, MessageSquare, Loader2, Trash2, X } from "lucide-react";
+import {
+  Send,
+  MessageSquare,
+  Loader2,
+  Trash2,
+  X,
+  Check,
+  CheckCheck,
+  Clock,
+  AlertCircle,
+} from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useRealtimeTable } from "@/lib/supabase/realtime";
+
+type SignalStatus = "sending" | "sent" | "delivered" | "read" | "failed";
 
 interface SignalMessage {
   id: string;
@@ -11,6 +23,7 @@ interface SignalMessage {
   sender: string | null;
   body: string | null;
   sent_at: string;
+  status?: SignalStatus;
 }
 
 /**
@@ -63,6 +76,19 @@ export function SignalThreadView({
     void load();
   }, [load]);
 
+  // Opening a direct conversation marks its inbound messages read (sends read
+  // receipts so the other person sees ✓✓). Groups are skipped.
+  useEffect(() => {
+    if (signalKind !== "direct") return;
+    const t = setTimeout(() => {
+      void fetch(`/api/v1/signal/threads/${threadId}/read`, {
+        method: "POST",
+        credentials: "include",
+      }).catch(() => {});
+    }, 500);
+    return () => clearTimeout(t);
+  }, [threadId, signalKind]);
+
   useRealtimeTable<{ id: string; thread_id: string }>(
     {
       table: "signal_messages",
@@ -88,6 +114,7 @@ export function SignalThreadView({
         sender: null,
         body: text,
         sent_at: new Date().toISOString(),
+        status: "sending",
       },
     ]);
     setDraft("");
@@ -219,6 +246,7 @@ export function SignalThreadView({
                     <span>{mine ? "you" : (m.sender ?? "them")}</span>
                     <span>·</span>
                     <span>{formatRelative(m.sent_at)}</span>
+                    {mine && m.status ? <StatusIndicator status={m.status} /> : null}
                   </div>
                 </li>
               );
@@ -252,6 +280,23 @@ export function SignalThreadView({
       </form>
     </>
   );
+}
+
+function StatusIndicator({ status }: { status: SignalStatus }) {
+  switch (status) {
+    case "sending":
+      return <Clock className="h-2.5 w-2.5" aria-label="sending" />;
+    case "sent":
+      return <Check className="h-2.5 w-2.5" aria-label="sent" />;
+    case "delivered":
+      return <CheckCheck className="h-2.5 w-2.5" aria-label="delivered" />;
+    case "read":
+      return <CheckCheck className="h-2.5 w-2.5 text-accent" aria-label="read" />;
+    case "failed":
+      return <AlertCircle className="h-2.5 w-2.5 text-danger" aria-label="failed to send" />;
+    default:
+      return null;
+  }
 }
 
 function formatRelative(iso: string): string {

--- a/apps/web/src/lib/signal/bridge.ts
+++ b/apps/web/src/lib/signal/bridge.ts
@@ -117,3 +117,14 @@ export function bridgeSyncContacts(userId: string): Promise<{ ok: true }> {
     { method: "POST", timeoutMs: 30_000 },
   );
 }
+
+/** Send read receipts for the given inbound message timestamps (direct chats). */
+export function bridgeMarkRead(
+  userId: string,
+  payload: { signalNumber: string; recipient: string; timestamps: number[] },
+): Promise<{ ok: true }> {
+  return bridgeFetch<{ ok: true }>(
+    `/accounts/${encodeURIComponent(userId)}/read`,
+    { method: "POST", body: payload, timeoutMs: 20_000 },
+  );
+}

--- a/supabase/migrations/20260618010000_signal_message_status.sql
+++ b/supabase/migrations/20260618010000_signal_message_status.sql
@@ -1,0 +1,29 @@
+-- Signal message delivery/read status.
+--
+-- Tracks the send lifecycle of outbound messages: sending → sent → delivered
+-- (✓✓) → read, plus a terminal `failed`. The bridge captures the real
+-- signal-cli send timestamp as `external_id`, then maps incoming
+-- `receiptMessage` events (delivery/read) back to the row by that timestamp,
+-- advancing status forward only. Inbound messages keep the default 'sent'
+-- (the UI only renders status ticks on outbound bubbles).
+
+BEGIN;
+
+ALTER TABLE signal_messages
+  ADD COLUMN status TEXT NOT NULL DEFAULT 'sent'
+    CHECK (status IN ('sending', 'sent', 'delivered', 'read', 'failed')),
+  ADD COLUMN status_at TIMESTAMPTZ;
+
+-- Fast lookup of an outbound row by its signal timestamp during receipt handling.
+CREATE INDEX signal_messages_out_ext_idx
+  ON signal_messages (user_id, external_id)
+  WHERE direction = 'out';
+
+COMMIT;
+
+-- ROLLBACK:
+-- BEGIN;
+-- DROP INDEX IF EXISTS signal_messages_out_ext_idx;
+-- ALTER TABLE signal_messages DROP COLUMN IF EXISTS status_at;
+-- ALTER TABLE signal_messages DROP COLUMN IF EXISTS status;
+-- COMMIT;


### PR DESCRIPTION
## Phase 1 of the Signal → iMessage roadmap (`docs/SIGNAL_ROADMAP.md`)

Source-confirmed against signal-cli internals via parallel research.

### The linchpin — capture the real send timestamp
The bridge wrote a fabricated `Date.now()` as `external_id`, so receipts (keyed by signal-cli's send timestamp) could **never** correlate. `/send` now captures the `send` RPC result's `timestamp` as `external_id` + the per-recipient result type as initial status (SUCCESS→sent, failure→failed). This unlocks everything below.

### Delivery/read status (sending → sent → delivered ✓✓ → read → failed)
- Migration: `signal_messages.status` (CHECK) + `status_at` + partial index on `(user_id, external_id) WHERE direction='out'`.
- Bridge: receipts ride the same `receive` push → `applyReceipt()` maps delivery/read, **forward-only** (a late delivery receipt can't downgrade a read row).
- UI: ticks on outbound bubbles (clock/✓/✓✓/✓✓-accent/alert); optimistic rows show "sending".

### Mark-as-read
Bridge `POST /accounts/:userId/read` → `sendReceipt` RPC; web `/api/v1/signal/threads/:id/read` (direct only); fired on thread open so the other person sees ✓✓.

### Phone-sync (your #1 complaint)
Changed daemon `--receive-mode on-start → on-connection` — the source-informed leading hypothesis for why Rokki sends weren't appearing on your phone. **⚠️ NEEDS YOUR LIVE TEST** — clearly flagged; a one-line iterate if it's not the cause. The timestamp fix also removes the duplicate-out-row risk from the phone's sync echo.

Merging applies the migration + auto-deploys the bridge. web+bridge typecheck, migration 0-broken, lint, tests all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)