### PR TITLE
feat(signal): Phase 2 — attachments (send & receive files, images, docs)

### DIFF
--- a/apps/signal-bridge/src/index.ts
+++ b/apps/signal-bridge/src/index.ts
@@ -2,10 +2,9 @@ import { serve } from "@hono/node-server";
 import { Hono } from "hono";
 import { spawn, type ChildProcess } from "node:child_process";
 import { connect, type Socket } from "node:net";
-import { readFile, writeFile, unlink } from "node:fs/promises";
+import { readFile, writeFile, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { randomUUID } from "node:crypto";
 import { createClient } from "@supabase/supabase-js";
 
 /**
@@ -329,6 +328,14 @@ async function uploadSignalAttachments(
     }
   }
   return out;
+}
+
+/** A path-safe basename: strip any directory parts and exotic characters so a
+ *  user-supplied filename can't escape the temp dir or inject path separators. */
+function safeBasename(name: string | null | undefined, fallback: string): string {
+  const base = (name ?? "").split(/[/\\]/).pop() ?? "";
+  const cleaned = base.replace(/[^A-Za-z0-9._-]/g, "_").replace(/^\.+/, "");
+  return cleaned || fallback;
 }
 
 /**
@@ -682,17 +689,25 @@ app.post("/accounts/:userId/send", async (c) => {
 
   // signal-cli's send takes attachment FILE PATHS, so download each from
   // storage to a temp file. (The web pre-uploaded them under the user's key.)
+  // Stage them inside a private per-send dir created with mkdtemp — it lands at
+  // an unpredictable path with 0700 perms, so other local users can't read the
+  // files and there's no predictable-name/symlink race in the shared temp dir.
   const tempPaths: string[] = [];
-  for (const a of atts) {
-    try {
-      const { data, error } = await db.storage.from(MEDIA_BUCKET).download(a.storage_key);
-      if (error || !data) continue;
-      const buf = Buffer.from(await data.arrayBuffer());
-      const tmp = join(tmpdir(), `rokki-signal-${randomUUID()}`);
-      await writeFile(tmp, buf);
-      tempPaths.push(tmp);
-    } catch (e) {
-      console.log(`[media] send download failed ${a.storage_key}: ${String(e)}`);
+  let tempDir: string | null = null;
+  if (atts.length > 0) {
+    tempDir = await mkdtemp(join(tmpdir(), "rokki-signal-"));
+    for (const [i, a] of atts.entries()) {
+      try {
+        const { data, error } = await db.storage.from(MEDIA_BUCKET).download(a.storage_key);
+        if (error || !data) continue;
+        const buf = Buffer.from(await data.arrayBuffer());
+        const name = safeBasename(a.filename, `attachment-${i}`);
+        const p = join(tempDir, name);
+        await writeFile(p, buf);
+        tempPaths.push(p);
+      } catch (e) {
+        console.log(`[media] send download failed ${a.storage_key}: ${String(e)}`);
+      }
     }
   }
 
@@ -730,7 +745,7 @@ app.post("/accounts/:userId/send", async (c) => {
     const status = msg.includes("starting up") ? 503 : 500;
     return c.json({ error: msg }, status);
   } finally {
-    for (const p of tempPaths) await unlink(p).catch(() => {});
+    if (tempDir) await rm(tempDir, { recursive: true, force: true }).catch(() => {});
   }
 });
 

--- a/apps/signal-bridge/src/index.ts
+++ b/apps/signal-bridge/src/index.ts
@@ -2,6 +2,10 @@ import { serve } from "@hono/node-server";
 import { Hono } from "hono";
 import { spawn, type ChildProcess } from "node:child_process";
 import { connect, type Socket } from "node:net";
+import { readFile, writeFile, unlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
 import { createClient } from "@supabase/supabase-js";
 
 /**
@@ -35,6 +39,11 @@ const BRIDGE_SECRET = process.env.BRIDGE_SECRET ?? "";
 const SUPABASE_URL = process.env.SUPABASE_URL ?? "";
 const SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY ?? "";
 const SIGNAL_CLI = process.env.SIGNAL_CLI_PATH ?? "signal-cli";
+// signal-cli auto-downloads received attachments here; the Fly volume is mounted
+// at this path (see fly.toml [mounts]).
+const SIGNAL_DATA_HOME =
+  process.env.SIGNAL_DATA_HOME ?? "/root/.local/share/signal-cli";
+const MEDIA_BUCKET = process.env.SIGNAL_MEDIA_BUCKET ?? "signal-media";
 const RPC_HOST = "127.0.0.1";
 const RPC_PORT = Number(process.env.SIGNAL_RPC_PORT ?? 7583);
 
@@ -106,11 +115,18 @@ async function refreshAccountMap(): Promise<void> {
 interface RawGroup {
   groupId?: string;
 }
+interface RawAttachment {
+  id?: string;
+  contentType?: string;
+  filename?: string;
+  size?: number;
+}
 interface RawDataMessage {
   message?: string;
   timestamp?: number;
   groupInfo?: RawGroup;
   groupV2?: { id?: string };
+  attachments?: RawAttachment[];
 }
 interface RawSentMessage {
   message?: string;
@@ -120,6 +136,7 @@ interface RawSentMessage {
   destinationUuid?: string;
   groupInfo?: RawGroup;
   groupV2?: { id?: string };
+  attachments?: RawAttachment[];
 }
 interface RawEnvelope {
   source?: string;
@@ -148,6 +165,13 @@ const STATUS_RANK: Record<MsgStatus, number> = {
   failed: 0,
 };
 
+interface StoredAttachment {
+  storage_key: string;
+  content_type: string | null;
+  filename: string | null;
+  size: number | null;
+}
+
 interface InboundMessage {
   userId: string;
   signalId: string;
@@ -158,6 +182,10 @@ interface InboundMessage {
   externalId: string;
   sentAt: string;
   status: MsgStatus;
+  /** Already-uploaded attachment metadata (outbound sends). */
+  attachments?: StoredAttachment[];
+  /** signal-cli attachment refs to download from disk + upload (inbound). */
+  signalAttachments?: RawAttachment[];
 }
 
 const groupOf = (m: { groupInfo?: RawGroup; groupV2?: { id?: string } }): string | undefined =>
@@ -179,7 +207,11 @@ function toInbound(userId: string, evt: unknown): InboundMessage | null {
   const source = env.sourceNumber ?? env.source ?? env.sourceUuid ?? "unknown";
 
   const dm = env.dataMessage;
-  if (dm && typeof dm.message === "string" && dm.message.length > 0) {
+  const dmHasContent =
+    !!dm &&
+    ((typeof dm.message === "string" && dm.message.length > 0) ||
+      (dm.attachments?.length ?? 0) > 0);
+  if (dm && dmHasContent) {
     const groupId = groupOf(dm);
     const ts = dm.timestamp ?? env.timestamp;
     return {
@@ -188,15 +220,20 @@ function toInbound(userId: string, evt: unknown): InboundMessage | null {
       kind: groupId ? "group" : "direct",
       direction: "in",
       sender: source,
-      body: dm.message,
+      body: dm.message ?? "",
       externalId: String(ts ?? now),
       sentAt: iso(ts, now),
       status: "sent",
+      signalAttachments: dm.attachments,
     };
   }
 
   const sent = env.syncMessage?.sentMessage;
-  if (sent && typeof sent.message === "string" && sent.message.length > 0) {
+  const sentHasContent =
+    !!sent &&
+    ((typeof sent.message === "string" && sent.message.length > 0) ||
+      (sent.attachments?.length ?? 0) > 0);
+  if (sent && sentHasContent) {
     const groupId = groupOf(sent);
     const dest = sent.destinationNumber ?? sent.destination ?? sent.destinationUuid;
     const signalId = groupId ?? dest;
@@ -207,10 +244,11 @@ function toInbound(userId: string, evt: unknown): InboundMessage | null {
       kind: groupId ? "group" : "direct",
       direction: "out",
       sender: null,
-      body: sent.message,
+      body: sent.message ?? "",
       externalId: String(sent.timestamp ?? env.timestamp ?? now),
       sentAt: iso(sent.timestamp ?? env.timestamp, now),
       status: "sent",
+      signalAttachments: sent.attachments,
     };
   }
 
@@ -239,6 +277,14 @@ async function writeInbound(m: InboundMessage): Promise<void> {
     .maybeSingle();
   if (existing) return;
 
+  // Outbound sends arrive with attachments already uploaded; inbound receives
+  // carry signal-cli refs we read off disk + upload now.
+  const attachments =
+    m.attachments ??
+    (m.signalAttachments?.length
+      ? await uploadSignalAttachments(m.userId, threadId, m.signalAttachments)
+      : []);
+
   await db.from("signal_messages").insert({
     thread_id: threadId,
     user_id: m.userId,
@@ -248,7 +294,41 @@ async function writeInbound(m: InboundMessage): Promise<void> {
     body: m.body,
     sent_at: m.sentAt,
     status: m.status,
+    attachments,
   });
+}
+
+/** Read each received attachment off signal-cli's disk + upload to storage. */
+async function uploadSignalAttachments(
+  userId: string,
+  threadId: string,
+  atts: RawAttachment[],
+): Promise<StoredAttachment[]> {
+  const out: StoredAttachment[] = [];
+  for (const a of atts) {
+    if (!a.id) continue;
+    try {
+      const buf = await readFile(join(SIGNAL_DATA_HOME, "attachments", a.id));
+      const key = `${userId}/${threadId}/${a.id}`;
+      const { error } = await db.storage.from(MEDIA_BUCKET).upload(key, buf, {
+        contentType: a.contentType ?? "application/octet-stream",
+        upsert: true,
+      });
+      if (error) {
+        console.log(`[media] upload failed ${a.id}: ${error.message}`);
+        continue;
+      }
+      out.push({
+        storage_key: key,
+        content_type: a.contentType ?? null,
+        filename: a.filename ?? null,
+        size: a.size ?? buf.length,
+      });
+    } catch (e) {
+      console.log(`[media] read failed ${a.id}: ${String(e)}`);
+    }
+  }
+  return out;
 }
 
 /**
@@ -588,14 +668,39 @@ app.post("/accounts/:userId/send", async (c) => {
     signalId: string;
     kind: "direct" | "group";
     text: string;
+    attachments: StoredAttachment[];
   }>;
-  if (!body.signalNumber || !body.signalId || !body.text) {
-    return c.json({ error: "signalNumber, signalId and text are required" }, 400);
+  const text = body.text ?? "";
+  const atts = body.attachments ?? [];
+  if (!body.signalNumber || !body.signalId || (!text && atts.length === 0)) {
+    return c.json(
+      { error: "signalNumber, signalId and text or attachments are required" },
+      400,
+    );
   }
   const isGroup = body.kind === "group";
-  const params = isGroup
-    ? { account: body.signalNumber, groupId: body.signalId, message: body.text }
-    : { account: body.signalNumber, recipient: [body.signalId], message: body.text };
+
+  // signal-cli's send takes attachment FILE PATHS, so download each from
+  // storage to a temp file. (The web pre-uploaded them under the user's key.)
+  const tempPaths: string[] = [];
+  for (const a of atts) {
+    try {
+      const { data, error } = await db.storage.from(MEDIA_BUCKET).download(a.storage_key);
+      if (error || !data) continue;
+      const buf = Buffer.from(await data.arrayBuffer());
+      const tmp = join(tmpdir(), `rokki-signal-${randomUUID()}`);
+      await writeFile(tmp, buf);
+      tempPaths.push(tmp);
+    } catch (e) {
+      console.log(`[media] send download failed ${a.storage_key}: ${String(e)}`);
+    }
+  }
+
+  const base = isGroup
+    ? { account: body.signalNumber, groupId: body.signalId, message: text }
+    : { account: body.signalNumber, recipient: [body.signalId], message: text };
+  const params = tempPaths.length ? { ...base, attachments: tempPaths } : base;
+
   try {
     // The send result carries signal-cli's message timestamp — the id that
     // delivery/read receipts reference. Storing the REAL timestamp (not a
@@ -612,10 +717,11 @@ app.post("/accounts/:userId/send", async (c) => {
       kind: isGroup ? "group" : "direct",
       direction: "out",
       sender: null,
-      body: body.text,
+      body: text,
       externalId,
       sentAt: new Date().toISOString(),
       status: anyFail ? "failed" : "sent",
+      attachments: atts,
     });
     return c.json({ ok: true });
   } catch (e) {
@@ -623,6 +729,8 @@ app.post("/accounts/:userId/send", async (c) => {
     // "starting up" is transient (daemon booting) → 503 so the UI can retry.
     const status = msg.includes("starting up") ? 503 : 500;
     return c.json({ error: msg }, status);
+  } finally {
+    for (const p of tempPaths) await unlink(p).catch(() => {});
   }
 });
 

--- a/apps/web/src/app/api/v1/signal/media/route.ts
+++ b/apps/web/src/app/api/v1/signal/media/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { randomUUID } from "node:crypto";
+import { createClient } from "@/lib/supabase/server";
+import { withObservability } from "@/lib/observability";
+import { unauth, bad } from "@/lib/signal/responses";
+
+// Allow a comfortable window for larger files to stream up.
+export const maxDuration = 60;
+
+const MEDIA_BUCKET = "signal-media";
+const MAX_BYTES = 100 * 1024 * 1024; // 100 MB — Signal's own attachment ceiling.
+
+/**
+ * POST /api/v1/signal/media  (multipart/form-data, field `file`)
+ *
+ * Stage an outbound attachment in Supabase Storage before sending. Returns the
+ * storage metadata the caller then passes to /api/v1/signal/send as one of
+ * `attachments[]`. Files land under `<userId>/outgoing/<uuid>` so the
+ * per-user storage RLS policy authorizes the write.
+ */
+async function handlePost(request: NextRequest) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return unauth();
+
+  const form = await request.formData().catch(() => null);
+  const file = form?.get("file");
+  if (!(file instanceof File)) return bad("file is required");
+  if (file.size === 0) return bad("file is empty");
+  if (file.size > MAX_BYTES) return bad("file too large (max 100 MB)");
+
+  const key = `${user.id}/outgoing/${randomUUID()}`;
+  const bytes = new Uint8Array(await file.arrayBuffer());
+  const contentType = file.type || "application/octet-stream";
+
+  const { error } = await supabase.storage
+    .from(MEDIA_BUCKET)
+    .upload(key, bytes, { contentType, upsert: true });
+  if (error) {
+    return NextResponse.json(
+      { errors: [{ message: error.message }] },
+      { status: 502 },
+    );
+  }
+
+  return NextResponse.json({
+    data: {
+      storage_key: key,
+      content_type: contentType,
+      filename: file.name || null,
+      size: file.size,
+    },
+  });
+}
+
+export const POST = withObservability(handlePost, "POST /api/v1/signal/media");

--- a/apps/web/src/app/api/v1/signal/send/route.ts
+++ b/apps/web/src/app/api/v1/signal/send/route.ts
@@ -28,9 +28,18 @@ async function handlePost(request: NextRequest) {
     signalId?: string;
     kind?: "direct" | "group";
     text?: string;
+    attachments?: {
+      storage_key: string;
+      content_type: string | null;
+      filename: string | null;
+      size: number | null;
+    }[];
   };
   const text = typeof body.text === "string" ? body.text.trim() : "";
-  if (!body.signalId || !text) return bad("signalId and text are required");
+  const attachments = Array.isArray(body.attachments) ? body.attachments : [];
+  if (!body.signalId || (!text && attachments.length === 0)) {
+    return bad("signalId and text or attachments are required");
+  }
   const kind = body.kind === "group" ? "group" : "direct";
 
   const { data: account } = await supabase
@@ -52,6 +61,7 @@ async function handlePost(request: NextRequest) {
       signalId: body.signalId,
       kind,
       text,
+      attachments,
     });
     return NextResponse.json({ data: { ok: true } });
   } catch (e) {

--- a/apps/web/src/app/api/v1/signal/threads/[id]/route.ts
+++ b/apps/web/src/app/api/v1/signal/threads/[id]/route.ts
@@ -35,8 +35,39 @@ async function handleGet(_req: NextRequest, { params }: Props) {
     .is("deleted_at", null)
     .order("sent_at", { ascending: true });
 
+  // Mint short-lived signed URLs so the client can render image previews /
+  // download files without the bucket being public. Stored attachments carry a
+  // `storage_key`; rows without attachments pass through untouched.
+  type StoredAttachment = {
+    storage_key?: string;
+    content_type?: string | null;
+    filename?: string | null;
+    size?: number | null;
+  };
+  type Row = {
+    attachments?: StoredAttachment[] | null;
+    [k: string]: unknown;
+  };
+  const rows = (messages ?? []) as Row[];
+  const enriched = await Promise.all(
+    rows.map(async (m) => {
+      const atts = Array.isArray(m.attachments) ? m.attachments : [];
+      if (atts.length === 0) return m;
+      const withUrls = await Promise.all(
+        atts.map(async (a) => {
+          if (!a.storage_key) return { ...a, url: null };
+          const { data: signed } = await supabase.storage
+            .from("signal-media")
+            .createSignedUrl(a.storage_key, 60 * 60);
+          return { ...a, url: signed?.signedUrl ?? null };
+        }),
+      );
+      return { ...m, attachments: withUrls };
+    }),
+  );
+
   return NextResponse.json({
-    data: { thread: thread ?? null, messages: messages ?? [] },
+    data: { thread: thread ?? null, messages: enriched },
   });
 }
 

--- a/apps/web/src/components/messages/SignalThreadView.tsx
+++ b/apps/web/src/components/messages/SignalThreadView.tsx
@@ -11,11 +11,24 @@ import {
   CheckCheck,
   Clock,
   AlertCircle,
+  Paperclip,
+  FileText,
+  Download,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useRealtimeTable } from "@/lib/supabase/realtime";
 
 type SignalStatus = "sending" | "sent" | "delivered" | "read" | "failed";
+
+interface MessageAttachment {
+  storage_key?: string;
+  content_type: string | null;
+  filename: string | null;
+  size: number | null;
+  /** Short-lived signed URL minted by the GET route, or a local object URL on
+   *  an optimistic bubble before the stored row arrives. */
+  url?: string | null;
+}
 
 interface SignalMessage {
   id: string;
@@ -24,6 +37,17 @@ interface SignalMessage {
   body: string | null;
   sent_at: string;
   status?: SignalStatus;
+  attachments?: MessageAttachment[];
+}
+
+/** A file already uploaded to staging and ready to ride the next send. */
+interface PendingAttachment {
+  storage_key: string;
+  content_type: string | null;
+  filename: string | null;
+  size: number | null;
+  /** Object URL for the composer thumbnail; revoked once sent. */
+  previewUrl?: string;
 }
 
 /**
@@ -53,9 +77,12 @@ export function SignalThreadView({
 }) {
   const [messages, setMessages] = useState<SignalMessage[]>([]);
   const [draft, setDraft] = useState("");
+  const [pending, setPending] = useState<PendingAttachment[]>([]);
+  const [uploading, setUploading] = useState(false);
   const [deletingConvo, setDeletingConvo] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const scrollerRef = useRef<HTMLDivElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   const load = useCallback(async () => {
     const r = await fetch(`/api/v1/signal/threads/${threadId}`, {
@@ -98,10 +125,54 @@ export function SignalThreadView({
     { onInsert: () => void load(), onUpdate: () => void load() },
   );
 
+  async function onPickFiles(e: React.ChangeEvent<HTMLInputElement>) {
+    const files = Array.from(e.target.files ?? []);
+    // Let the same file be picked again later.
+    e.target.value = "";
+    if (files.length === 0) return;
+    setError(null);
+    setUploading(true);
+    try {
+      for (const file of files) {
+        const form = new FormData();
+        form.append("file", file);
+        const r = await fetch("/api/v1/signal/media", {
+          method: "POST",
+          credentials: "include",
+          body: form,
+        });
+        if (!r.ok) {
+          const b = (await r.json().catch(() => ({}))) as {
+            errors?: { message: string }[];
+          };
+          setError(b.errors?.[0]?.message ?? `Couldn’t attach ${file.name}.`);
+          continue;
+        }
+        const b = (await r.json()) as { data?: PendingAttachment };
+        if (!b.data) continue;
+        const previewUrl = file.type.startsWith("image/")
+          ? URL.createObjectURL(file)
+          : undefined;
+        setPending((prev) => [...prev, { ...b.data!, previewUrl }]);
+      }
+    } finally {
+      setUploading(false);
+    }
+  }
+
+  function removePending(key: string) {
+    setPending((prev) => {
+      const hit = prev.find((p) => p.storage_key === key);
+      if (hit?.previewUrl) URL.revokeObjectURL(hit.previewUrl);
+      return prev.filter((p) => p.storage_key !== key);
+    });
+  }
+
   async function submit(e?: React.FormEvent) {
     e?.preventDefault();
     const text = draft.trim();
-    if (!text) return;
+    const atts = pending;
+    if (!text && atts.length === 0) return;
     // Optimistic: drop the bubble in and clear the box immediately so sending
     // feels instant. The bridge persists it and the realtime insert reconciles
     // this temp row to the stored one on the next load().
@@ -115,9 +186,16 @@ export function SignalThreadView({
         body: text,
         sent_at: new Date().toISOString(),
         status: "sending",
+        attachments: atts.map((a) => ({
+          content_type: a.content_type,
+          filename: a.filename,
+          size: a.size,
+          url: a.previewUrl ?? null,
+        })),
       },
     ]);
     setDraft("");
+    setPending([]);
     setError(null);
     requestAnimationFrame(() => {
       scrollerRef.current?.scrollTo(0, scrollerRef.current.scrollHeight);
@@ -127,7 +205,17 @@ export function SignalThreadView({
         method: "POST",
         headers: { "Content-Type": "application/json" },
         credentials: "include",
-        body: JSON.stringify({ signalId, kind: signalKind, text }),
+        body: JSON.stringify({
+          signalId,
+          kind: signalKind,
+          text,
+          attachments: atts.map((a) => ({
+            storage_key: a.storage_key,
+            content_type: a.content_type,
+            filename: a.filename,
+            size: a.size,
+          })),
+        }),
       });
       if (!r.ok) {
         // Roll back the optimistic bubble and surface the error.
@@ -136,6 +224,9 @@ export function SignalThreadView({
           errors?: { message: string }[];
         };
         setError(b.errors?.[0]?.message ?? "Couldn’t send.");
+      } else {
+        // Drop the composer previews now that the message owns them.
+        atts.forEach((a) => a.previewUrl && URL.revokeObjectURL(a.previewUrl));
       }
     } catch {
       setMessages((prev) => prev.filter((m) => m.id !== tempId));
@@ -235,11 +326,18 @@ export function SignalThreadView({
                     </button>
                     <div
                       className={cn(
-                        "max-w-[75%] rounded px-2 py-1 text-xs",
+                        "flex max-w-[75%] flex-col gap-1 rounded px-2 py-1 text-xs",
                         mine ? "bg-accent text-bg-0" : "bg-bg-2 text-text-0",
                       )}
                     >
-                      {m.body}
+                      {m.attachments && m.attachments.length > 0 ? (
+                        <div className="flex flex-col gap-1">
+                          {m.attachments.map((a, i) => (
+                            <AttachmentView key={i} att={a} mine={mine} />
+                          ))}
+                        </div>
+                      ) : null}
+                      {m.body ? <span>{m.body}</span> : null}
                     </div>
                   </div>
                   <div className="mt-0.5 flex items-center gap-1 text-[10px] text-text-3">
@@ -261,7 +359,60 @@ export function SignalThreadView({
         {error ? (
           <span className="px-1 text-[10px] text-danger">{error}</span>
         ) : null}
+        {pending.length > 0 ? (
+          <ul className="flex flex-wrap gap-1.5 px-1 pb-0.5">
+            {pending.map((p) => (
+              <li
+                key={p.storage_key}
+                className="flex items-center gap-1.5 rounded-sm border border-border bg-bg-0 py-1 pl-1 pr-1.5"
+              >
+                {p.previewUrl ? (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img
+                    src={p.previewUrl}
+                    alt={p.filename ?? "attachment"}
+                    className="h-7 w-7 rounded-sm object-cover"
+                  />
+                ) : (
+                  <FileText className="h-4 w-4 text-text-3" />
+                )}
+                <span className="max-w-[10rem] truncate text-[10px] text-text-1">
+                  {p.filename ?? "file"}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => removePending(p.storage_key)}
+                  aria-label={`Remove ${p.filename ?? "attachment"}`}
+                  className="rounded-sm p-0.5 text-text-3 hover:text-danger"
+                >
+                  <X className="h-3 w-3" />
+                </button>
+              </li>
+            ))}
+          </ul>
+        ) : null}
         <div className="flex gap-2">
+          <input
+            ref={fileInputRef}
+            type="file"
+            multiple
+            onChange={onPickFiles}
+            className="hidden"
+          />
+          <button
+            type="button"
+            onClick={() => fileInputRef.current?.click()}
+            disabled={uploading}
+            title="Attach files"
+            aria-label="Attach files"
+            className="flex items-center rounded-sm border border-border bg-bg-0 px-2 text-text-2 hover:text-text-0 disabled:opacity-40"
+          >
+            {uploading ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            ) : (
+              <Paperclip className="h-3.5 w-3.5" />
+            )}
+          </button>
           <input
             value={draft}
             onChange={(e) => setDraft(e.target.value)}
@@ -270,7 +421,7 @@ export function SignalThreadView({
           />
           <button
             type="submit"
-            disabled={!draft.trim()}
+            disabled={(!draft.trim() && pending.length === 0) || uploading}
             className="flex items-center gap-1 rounded-sm bg-accent px-2 py-1 text-xs text-bg-0 disabled:opacity-40"
           >
             <Send className="h-3 w-3" />
@@ -297,6 +448,63 @@ function StatusIndicator({ status }: { status: SignalStatus }) {
     default:
       return null;
   }
+}
+
+function AttachmentView({
+  att,
+  mine,
+}: {
+  att: MessageAttachment;
+  mine: boolean;
+}) {
+  const isImage = (att.content_type ?? "").startsWith("image/");
+  const name = att.filename ?? "file";
+
+  if (isImage && att.url) {
+    return (
+      <a href={att.url} target="_blank" rel="noopener noreferrer">
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={att.url}
+          alt={name}
+          className="max-h-48 max-w-full rounded object-cover"
+        />
+      </a>
+    );
+  }
+
+  // Non-image (or an image still missing its signed URL) → compact file card.
+  const card = (
+    <span
+      className={cn(
+        "flex items-center gap-2 rounded border px-2 py-1.5",
+        mine ? "border-bg-0/30" : "border-border bg-bg-0",
+      )}
+    >
+      <FileText className="h-4 w-4 flex-shrink-0 opacity-80" />
+      <span className="flex flex-col overflow-hidden">
+        <span className="truncate text-[11px]">{name}</span>
+        {att.size ? (
+          <span className="text-[10px] opacity-60">{formatBytes(att.size)}</span>
+        ) : null}
+      </span>
+      {att.url ? <Download className="ml-1 h-3 w-3 flex-shrink-0 opacity-70" /> : null}
+    </span>
+  );
+
+  return att.url ? (
+    <a href={att.url} target="_blank" rel="noopener noreferrer" download={name}>
+      {card}
+    </a>
+  ) : (
+    card
+  );
+}
+
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(0)} KB`;
+  return `${(n / (1024 * 1024)).toFixed(1)} MB`;
 }
 
 function formatRelative(iso: string): string {

--- a/apps/web/src/lib/signal/bridge.ts
+++ b/apps/web/src/lib/signal/bridge.ts
@@ -93,6 +93,13 @@ export function bridgeStartLink(userId: string): Promise<{ uri: string }> {
 }
 
 /** Send a message on the user's behalf through their linked Signal account. */
+export interface SignalAttachmentRef {
+  storage_key: string;
+  content_type: string | null;
+  filename: string | null;
+  size: number | null;
+}
+
 export function bridgeSend(
   userId: string,
   payload: {
@@ -100,6 +107,7 @@ export function bridgeSend(
     signalId: string;
     kind: "direct" | "group";
     text: string;
+    attachments?: SignalAttachmentRef[];
   },
 ): Promise<{ ok: true }> {
   return bridgeFetch<{ ok: true }>(

--- a/supabase/migrations/20260618020000_signal_media_bucket.sql
+++ b/supabase/migrations/20260618020000_signal_media_bucket.sql
@@ -1,0 +1,37 @@
+-- Storage bucket for Signal attachments (images, documents, any file).
+--
+-- The bridge uploads received attachments here via the service role (bypasses
+-- storage RLS); outbound files the user attaches are uploaded by the web app
+-- under the same per-user key prefix. Keys are `<userId>/<threadId>/<name>`.
+-- The SELECT policy lets a user sign download URLs for their own media only.
+
+BEGIN;
+
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('signal-media', 'signal-media', false)
+ON CONFLICT (id) DO NOTHING;
+
+DROP POLICY IF EXISTS "signal_media_owner_read" ON storage.objects;
+CREATE POLICY "signal_media_owner_read" ON storage.objects
+  FOR SELECT TO authenticated
+  USING (
+    bucket_id = 'signal-media'
+    AND (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+DROP POLICY IF EXISTS "signal_media_owner_write" ON storage.objects;
+CREATE POLICY "signal_media_owner_write" ON storage.objects
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    bucket_id = 'signal-media'
+    AND (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+COMMIT;
+
+-- ROLLBACK:
+-- BEGIN;
+-- DROP POLICY IF EXISTS "signal_media_owner_read" ON storage.objects;
+-- DROP POLICY IF EXISTS "signal_media_owner_write" ON storage.objects;
+-- DELETE FROM storage.buckets WHERE id = 'signal-media';
+-- COMMIT;


### PR DESCRIPTION
## What

Phase 2 of the Signal messaging suite: **send and receive attachments** — images, documents, any file — with iMessage-style inline previews.

### Bridge (`apps/signal-bridge`)
- Received attachments (already auto-downloaded by signal-cli to the Fly volume) are uploaded to the private `signal-media` Supabase Storage bucket under `<userId>/<threadId>/<id>`.
- Outbound sends download the staged file(s) from storage to temp paths and pass them to signal-cli's `send` (which takes file **paths**, not base64); temp files are cleaned up in `finally`.
- Messages that carry only attachments (empty body) are no longer silently dropped.

### Web (`apps/web`)
- **`POST /api/v1/signal/media`** — multipart upload that stages a file under `<userId>/outgoing/<uuid>` and returns its storage metadata.
- **`POST /api/v1/signal/send`** — now accepts `attachments[]` and allows attachment-only sends (text optional).
- **`GET /api/v1/signal/threads/:id`** — mints short-lived (1h) signed URLs per attachment so the client renders previews/downloads without a public bucket.
- **`SignalThreadView`** — paperclip attach button, pending-attachment chips with image thumbnails + remove, optimistic previews on send, and inline image / file-card rendering with download.

### DB
- New migration `20260618020000_signal_media_bucket.sql`: private `signal-media` bucket + owner-only read/write storage RLS policies keyed on the leading `<userId>` path segment.

## Test
- `tsc --noEmit` green for both `apps/web` and `apps/signal-bridge`.
- `eslint` clean on all changed files.
- Storage RLS: keys are prefixed with the owner's `auth.uid()`, so both inbound (`<uid>/<thread>/…`) and outbound (`<uid>/outgoing/…`) objects are readable/writable only by that user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)