### PR TITLE
feat(dashboard): reply to conversations from the Messages card

### DIFF
--- a/apps/web/src/components/dashboard/MessagesCard.test.tsx
+++ b/apps/web/src/components/dashboard/MessagesCard.test.tsx
@@ -1,0 +1,174 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  render,
+  screen,
+  cleanup,
+  fireEvent,
+  waitFor,
+} from "@testing-library/react";
+
+// Realtime is a live Supabase subscription — stub it to a no-op so the card
+// renders deterministically in jsdom.
+vi.mock("@/lib/supabase/realtime", () => ({
+  useRealtimeTable: () => {},
+}));
+
+import { MessagesCard } from "./MessagesCard";
+
+const THREADS = [
+  {
+    id: "t-rokki",
+    kind: "dm",
+    source: "rokki",
+    label: "Carlos",
+    last_message_at: "2026-06-17T12:00:00Z",
+  },
+  {
+    id: "t-signal",
+    kind: "signal",
+    source: "signal",
+    label: "Mom",
+    last_message_at: "2026-06-17T13:00:00Z",
+    signal_id: "+13055551212",
+    signal_kind: "direct",
+  },
+];
+
+interface FetchCall {
+  url: string;
+  method: string;
+  body: unknown;
+}
+let calls: FetchCall[];
+
+function jsonRes(data: unknown, ok = true) {
+  return Promise.resolve({
+    ok,
+    json: async () => data,
+  } as Response);
+}
+
+function installFetch() {
+  calls = [];
+  const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    const method = (init?.method ?? "GET").toUpperCase();
+    const body = init?.body ? JSON.parse(String(init.body)) : null;
+    calls.push({ url, method, body });
+
+    if (url === "/api/v1/messages/threads" && method === "GET")
+      return jsonRes({ data: THREADS });
+    if (url === "/api/v1/me") return jsonRes({ data: { user_id: "me" } });
+    if (url === "/api/v1/messages/threads/t-rokki" && method === "GET")
+      return jsonRes({
+        data: [
+          {
+            id: "m1",
+            author_id: "carlos",
+            body: "hey there",
+            created_at: "2026-06-17T12:00:00Z",
+            author_name: "Carlos",
+          },
+          {
+            id: "m2",
+            author_id: "me",
+            body: "yo",
+            created_at: "2026-06-17T12:01:00Z",
+            author_name: "Me",
+          },
+        ],
+      });
+    if (url === "/api/v1/signal/threads/t-signal" && method === "GET")
+      return jsonRes({
+        data: {
+          messages: [
+            {
+              id: "s1",
+              direction: "in",
+              sender: "Mom",
+              body: "call me",
+              sent_at: "2026-06-17T13:00:00Z",
+              attachments: [],
+            },
+          ],
+        },
+      });
+    if (url === "/api/v1/messages/threads/t-rokki" && method === "POST")
+      return jsonRes({ data: { id: "m3", created_at: "now" } }, true);
+    if (url === "/api/v1/signal/send" && method === "POST")
+      return jsonRes({ data: { ok: true } }, true);
+    return jsonRes({ data: [] });
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+beforeEach(() => {
+  installFetch();
+});
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("MessagesCard", () => {
+  it("lists recent conversations", async () => {
+    render(<MessagesCard />);
+    expect(await screen.findByText("Carlos")).toBeTruthy();
+    expect(screen.getByText("Mom")).toBeTruthy();
+  });
+
+  it("opens a native thread and posts a quick reply to /api/v1/messages", async () => {
+    render(<MessagesCard />);
+    fireEvent.click(await screen.findByText("Carlos"));
+
+    // Recent messages load into the quick view.
+    expect(await screen.findByText("hey there")).toBeTruthy();
+
+    const input = screen.getByPlaceholderText(/Reply/i);
+    fireEvent.change(input, { target: { value: "on my way" } });
+    fireEvent.click(screen.getByLabelText("Send reply"));
+
+    await waitFor(() => {
+      const post = calls.find(
+        (c) => c.url === "/api/v1/messages/threads/t-rokki" && c.method === "POST",
+      );
+      expect(post).toBeTruthy();
+      expect((post!.body as { body: string }).body).toBe("on my way");
+    });
+  });
+
+  it("opens a Signal thread and sends through the bridge with the signal target", async () => {
+    render(<MessagesCard />);
+    fireEvent.click(await screen.findByText("Mom"));
+
+    expect(await screen.findByText("call me")).toBeTruthy();
+
+    const input = screen.getByPlaceholderText(/Reply on Signal/i);
+    fireEvent.change(input, { target: { value: "calling now" } });
+    fireEvent.click(screen.getByLabelText("Send reply"));
+
+    await waitFor(() => {
+      const post = calls.find(
+        (c) => c.url === "/api/v1/signal/send" && c.method === "POST",
+      );
+      expect(post).toBeTruthy();
+      const b = post!.body as { signalId: string; kind: string; text: string };
+      expect(b.signalId).toBe("+13055551212");
+      expect(b.kind).toBe("direct");
+      expect(b.text).toBe("calling now");
+    });
+  });
+
+  it("returns to the conversation list via back", async () => {
+    render(<MessagesCard />);
+    fireEvent.click(await screen.findByText("Carlos"));
+    expect(await screen.findByText("hey there")).toBeTruthy();
+
+    fireEvent.click(screen.getByLabelText("Back to conversations"));
+    // Both threads visible again; the composer is gone.
+    expect(await screen.findByText("Mom")).toBeTruthy();
+    expect(screen.queryByPlaceholderText(/Reply/i)).toBeNull();
+  });
+});

--- a/apps/web/src/components/dashboard/MessagesCard.tsx
+++ b/apps/web/src/components/dashboard/MessagesCard.tsx
@@ -1,15 +1,19 @@
 "use client";
 
 import Link from "next/link";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   Hash,
   User as UserIcon,
   MessageSquare,
   MessageSquarePlus,
   Settings2,
+  ChevronLeft,
+  Send,
+  Paperclip,
 } from "lucide-react";
 import { DashboardCard } from "./DashboardCard";
+import { cn } from "@/lib/utils";
 import { useRealtimeTable } from "@/lib/supabase/realtime";
 
 interface ThreadSummary {
@@ -18,15 +22,23 @@ interface ThreadSummary {
   source?: "rokki" | "signal";
   label: string;
   last_message_at: string;
+  /** Signal-only — the send target + conversation kind. */
+  signal_id?: string;
+  signal_kind?: "direct" | "group";
 }
 
 /**
- * Right-rail Messages card. Shows the most recent conversations you can see
- * with their last-touched time. Clicking a row opens /messages.
+ * Right-rail Messages card. Lists your most recent conversations; clicking one
+ * opens an inline quick-reply view (recent messages + a one-line composer) so
+ * you can answer without leaving the dashboard. Native threads post via
+ * /api/v1/messages; Signal threads send through the bridge via
+ * /api/v1/signal/send. The maximize button still opens the full /messages inbox.
  */
 export function MessagesCard() {
   const [threads, setThreads] = useState<ThreadSummary[]>([]);
   const [loading, setLoading] = useState(true);
+  const [open, setOpen] = useState<ThreadSummary | null>(null);
+  const [meId, setMeId] = useState<string | null>(null);
 
   const load = useCallback(async () => {
     try {
@@ -44,12 +56,30 @@ export function MessagesCard() {
     void load();
   }, [load]);
 
+  // One-shot: who am I, so native messages render mine-vs-theirs correctly.
+  useEffect(() => {
+    let alive = true;
+    void fetch("/api/v1/me", { credentials: "include" })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((b: { data?: { user_id?: string } } | null) => {
+        if (alive && b?.data?.user_id) setMeId(b.data.user_id);
+      })
+      .catch(() => {});
+    return () => {
+      alive = false;
+    };
+  }, []);
+
   useRealtimeTable<{ id: string }>(
     { table: "messages", channelKey: "dash:messages" },
     { onInsert: () => void load() },
   );
   useRealtimeTable<{ id: string }>(
     { table: "message_threads", channelKey: "dash:threads" },
+    { onInsert: () => void load(), onUpdate: () => void load() },
+  );
+  useRealtimeTable<{ id: string }>(
+    { table: "signal_messages", channelKey: "dash:sigmsgs" },
     { onInsert: () => void load(), onUpdate: () => void load() },
   );
 
@@ -69,7 +99,16 @@ export function MessagesCard() {
         </Link>
       }
     >
-      {loading && threads.length === 0 ? (
+      {open ? (
+        <ThreadQuickView
+          thread={open}
+          meId={meId}
+          onBack={() => {
+            setOpen(null);
+            void load();
+          }}
+        />
+      ) : loading && threads.length === 0 ? (
         <p className="px-3 py-4 text-center text-xs text-text-3">Loading…</p>
       ) : threads.length === 0 ? (
         <Empty />
@@ -77,9 +116,10 @@ export function MessagesCard() {
         <ul className="divide-y divide-border/40 text-sm">
           {threads.slice(0, 10).map((t) => (
             <li key={t.id}>
-              <Link
-                href="/messages"
-                className="flex items-center gap-2 px-3 py-[var(--rk-row-py)] hover:bg-bg-2"
+              <button
+                type="button"
+                onClick={() => setOpen(t)}
+                className="flex w-full items-center gap-2 px-3 py-[var(--rk-row-py)] text-left hover:bg-bg-2"
               >
                 {t.kind === "terminal" ? (
                   <Hash className="h-3 w-3 flex-shrink-0 text-text-3" />
@@ -92,7 +132,7 @@ export function MessagesCard() {
                 <span className="font-mono text-2xs text-text-3">
                   {formatRelative(t.last_message_at)}
                 </span>
-              </Link>
+              </button>
             </li>
           ))}
         </ul>
@@ -101,13 +141,251 @@ export function MessagesCard() {
   );
 }
 
+/** Normalized message for the compact quick-reply list. */
+interface QuickMessage {
+  id: string;
+  mine: boolean;
+  who: string;
+  body: string;
+  at: string;
+  hasAttachment?: boolean;
+}
+
+function ThreadQuickView({
+  thread,
+  meId,
+  onBack,
+}: {
+  thread: ThreadSummary;
+  meId: string | null;
+  onBack: () => void;
+}) {
+  const isSignal = thread.source === "signal";
+  const [messages, setMessages] = useState<QuickMessage[]>([]);
+  const [draft, setDraft] = useState("");
+  const [sending, setSending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const scrollerRef = useRef<HTMLDivElement>(null);
+
+  const scrollToEnd = useCallback(() => {
+    requestAnimationFrame(() => {
+      const el = scrollerRef.current;
+      // `scrollTo` is absent in jsdom and older engines — guard it.
+      el?.scrollTo?.(0, el.scrollHeight);
+    });
+  }, []);
+
+  const load = useCallback(async () => {
+    if (isSignal) {
+      const r = await fetch(`/api/v1/signal/threads/${thread.id}`, {
+        credentials: "include",
+      });
+      if (!r.ok) return;
+      const b = (await r.json()) as {
+        data?: {
+          messages?: {
+            id: string;
+            direction: "in" | "out";
+            sender: string | null;
+            body: string | null;
+            sent_at: string;
+            attachments?: unknown[];
+          }[];
+        };
+      };
+      setMessages(
+        (b.data?.messages ?? []).map((m) => ({
+          id: m.id,
+          mine: m.direction === "out",
+          who: m.direction === "out" ? "you" : m.sender ?? "them",
+          body: m.body ?? "",
+          at: m.sent_at,
+          hasAttachment: Array.isArray(m.attachments) && m.attachments.length > 0,
+        })),
+      );
+    } else {
+      const r = await fetch(`/api/v1/messages/threads/${thread.id}`, {
+        credentials: "include",
+      });
+      if (!r.ok) return;
+      const b = (await r.json()) as {
+        data?: {
+          id: string;
+          author_id: string;
+          body: string;
+          created_at: string;
+          author_name?: string;
+        }[];
+      };
+      setMessages(
+        (b.data ?? []).map((m) => ({
+          id: m.id,
+          mine: meId != null && m.author_id === meId,
+          who: m.author_name ?? "someone",
+          body: m.body,
+          at: m.created_at,
+        })),
+      );
+    }
+    scrollToEnd();
+  }, [isSignal, thread.id, meId, scrollToEnd]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  useRealtimeTable<{ id: string }>(
+    {
+      table: isSignal ? "signal_messages" : "messages",
+      filter: `thread_id=eq.${thread.id}`,
+      channelKey: `dashqv:${thread.id}`,
+    },
+    { onInsert: () => void load(), onUpdate: () => void load() },
+  );
+
+  async function submit(e?: React.FormEvent) {
+    e?.preventDefault();
+    const text = draft.trim();
+    if (!text || sending) return;
+    // Optimistic bubble so the reply feels instant; realtime reconciles it.
+    const tempId = `temp-${Date.now()}`;
+    setMessages((prev) => [
+      ...prev,
+      { id: tempId, mine: true, who: "you", body: text, at: new Date().toISOString() },
+    ]);
+    setDraft("");
+    setError(null);
+    setSending(true);
+    scrollToEnd();
+    try {
+      const r = isSignal
+        ? await fetch("/api/v1/signal/send", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            credentials: "include",
+            body: JSON.stringify({
+              signalId: thread.signal_id,
+              kind: thread.signal_kind ?? "direct",
+              text,
+            }),
+          })
+        : await fetch(`/api/v1/messages/threads/${thread.id}`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            credentials: "include",
+            body: JSON.stringify({ body: text }),
+          });
+      if (!r.ok) {
+        setMessages((prev) => prev.filter((m) => m.id !== tempId));
+        const b = (await r.json().catch(() => ({}))) as {
+          errors?: { message: string }[];
+        };
+        setError(b.errors?.[0]?.message ?? "Couldn’t send.");
+      } else {
+        void load();
+      }
+    } catch {
+      setMessages((prev) => prev.filter((m) => m.id !== tempId));
+      setError("Couldn’t send.");
+    } finally {
+      setSending(false);
+    }
+  }
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex flex-shrink-0 items-center gap-1.5 border-b border-border bg-bg-1 px-2 py-1.5">
+        <button
+          type="button"
+          onClick={onBack}
+          aria-label="Back to conversations"
+          className="rounded-sm p-0.5 text-text-3 hover:bg-bg-2 hover:text-text-0"
+        >
+          <ChevronLeft className="h-3.5 w-3.5" />
+        </button>
+        {isSignal ? (
+          <MessageSquare className="h-3 w-3 flex-shrink-0 text-success" />
+        ) : thread.kind === "terminal" ? (
+          <Hash className="h-3 w-3 flex-shrink-0 text-text-3" />
+        ) : (
+          <UserIcon className="h-3 w-3 flex-shrink-0 text-text-3" />
+        )}
+        <span className="flex-1 truncate text-xs text-text-1">{thread.label}</span>
+        <Link
+          href="/messages"
+          aria-label="Open in full inbox"
+          title="Open in full inbox"
+          className="rounded-sm p-0.5 text-text-3 hover:bg-bg-2 hover:text-text-0"
+        >
+          <MessageSquare className="h-3 w-3" />
+        </Link>
+      </div>
+
+      <div ref={scrollerRef} className="min-h-0 flex-1 overflow-y-auto px-2 py-1.5">
+        {messages.length === 0 ? (
+          <p className="py-6 text-center text-xs text-text-3">No messages yet.</p>
+        ) : (
+          <ul className="flex flex-col gap-1">
+            {messages.slice(-30).map((m) => (
+              <li
+                key={m.id}
+                className={cn("flex flex-col", m.mine ? "items-end" : "items-start")}
+              >
+                <div
+                  className={cn(
+                    "max-w-[80%] rounded px-2 py-1 text-xs",
+                    m.mine ? "bg-accent text-bg-0" : "bg-bg-2 text-text-0",
+                  )}
+                >
+                  {m.body ? (
+                    <span className="whitespace-pre-wrap break-words">{m.body}</span>
+                  ) : m.hasAttachment ? (
+                    <span className="flex items-center gap-1 italic opacity-80">
+                      <Paperclip className="h-3 w-3" /> Attachment
+                    </span>
+                  ) : null}
+                </div>
+                <span className="mt-0.5 px-1 text-2xs text-text-3">
+                  {m.mine ? "you" : m.who} · {formatRelative(m.at)}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <form
+        onSubmit={submit}
+        className="flex flex-shrink-0 flex-col gap-1 border-t border-border bg-bg-1 p-2"
+      >
+        {error ? (
+          <span className="px-1 text-2xs text-danger">{error}</span>
+        ) : null}
+        <div className="flex gap-1.5">
+          <input
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            placeholder={`Reply${isSignal ? " on Signal" : ""}…`}
+            className="flex-1 rounded-sm border border-border bg-bg-0 px-2 py-1 text-xs text-text-0 outline-none focus:border-border-focus"
+          />
+          <button
+            type="submit"
+            disabled={!draft.trim() || sending}
+            aria-label="Send reply"
+            className="flex items-center rounded-sm bg-accent px-2 text-bg-0 disabled:opacity-40"
+          >
+            <Send className="h-3 w-3" />
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}
+
 function Empty() {
   return (
     <div className="flex flex-col items-center justify-center gap-2 p-6 text-center">
-      <MessageSquarePlus
-        className="h-5 w-5 text-text-3"
-        aria-hidden="true"
-      />
+      <MessageSquarePlus className="h-5 w-5 text-text-3" aria-hidden="true" />
       <p className="text-xs text-text-2">Quiet.</p>
       <p className="text-xs text-text-3">
         Start a DM or post in a terminal channel.


### PR DESCRIPTION
## What

The dashboard **Messages card** was read-only — every row just linked out to `/messages`. Now you can **reply without leaving the dashboard**:

- Click a conversation → inline quick-reply view with its recent messages + a one-line composer.
- Send (optimistic bubble, realtime reconciles) and tab back to the list.
- **Native threads** post via `POST /api/v1/messages/threads/:id`.
- **Signal threads** send through the bridge via `POST /api/v1/signal/send` using the thread's `signal_id` + `signal_kind`.
- `GET /api/v1/me` resolves the current user so native messages render mine-vs-theirs.
- The maximize button still opens the full `/messages` inbox; attachments stay in the full view to keep the card compact (a 📎 indicator shows when a Signal message carries one).

## Test

`MessagesCard.test.tsx` (new) covers: list render, native quick-reply hitting the right endpoint with the right body, Signal send going to the bridge with the correct target/kind/text, and list↔thread back navigation. Realtime is stubbed; `fetch` is routed by a mock.

- `tsc --noEmit` green, `eslint` clean, 4/4 tests pass.

## Notes

Independent of the Signal Phase 2 attachments PR — works against APIs already on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)