### PR TITLE
fix(signal): harden attachments + messaging (review findings)

### DIFF
--- a/apps/signal-bridge/src/index.ts
+++ b/apps/signal-bridge/src/index.ts
@@ -306,6 +306,13 @@ async function uploadSignalAttachments(
   const out: StoredAttachment[] = [];
   for (const a of atts) {
     if (!a.id) continue;
+    // The id becomes both a filesystem path segment and a storage key, so it
+    // must be a bare safe token — reject anything with "/", "..", etc. rather
+    // than transform it (we need the exact name signal-cli wrote on disk).
+    if (!/^[A-Za-z0-9._-]+$/.test(a.id)) {
+      console.log(`[media] skipping attachment with unsafe id: ${a.id}`);
+      continue;
+    }
     try {
       const buf = await readFile(join(SIGNAL_DATA_HOME, "attachments", a.id));
       const key = `${userId}/${threadId}/${a.id}`;
@@ -350,20 +357,21 @@ async function applyReceipt(
     r.isRead || r.isViewed ? "read" : r.isDelivery ? "delivered" : null;
   if (!target || !r.timestamps?.length) return;
   const ids = r.timestamps.map(String);
-  const { data } = await db
+  // Only rows STRICTLY behind the target may advance — and never `failed`,
+  // which is terminal. Expressing the forward-only rule as a filtered UPDATE
+  // (gated on the current status) makes it atomic, so two receipts arriving
+  // at once can't clobber each other via read-modify-write.
+  const advanceable = (Object.keys(STATUS_RANK) as MsgStatus[]).filter(
+    (s) => s !== "failed" && STATUS_RANK[s] < STATUS_RANK[target],
+  );
+  if (advanceable.length === 0) return;
+  await db
     .from("signal_messages")
-    .select("id, status")
+    .update({ status: target, status_at: new Date().toISOString() })
     .eq("user_id", userId)
     .eq("direction", "out")
-    .in("external_id", ids);
-  for (const m of (data ?? []) as { id: string; status: MsgStatus }[]) {
-    if (STATUS_RANK[target] > (STATUS_RANK[m.status] ?? 0)) {
-      await db
-        .from("signal_messages")
-        .update({ status: target, status_at: new Date().toISOString() })
-        .eq("id", m.id);
-    }
-  }
+    .in("external_id", ids)
+    .in("status", advanceable);
 }
 
 // ── contact / group directory sync ────────────────────────────────────────────
@@ -517,6 +525,12 @@ function connectRpc(): void {
     if (rpcReady) console.log("[rpc] disconnected");
     rpcReady = false;
     rpcSocket = null;
+    // Fail every in-flight RPC immediately (each reject clears its own timer)
+    // so a daemon bounce surfaces as a fast 5xx the UI can retry, instead of
+    // hanging the caller until the 30s per-request timeout.
+    const inflight = Array.from(pending.values());
+    pending.clear();
+    for (const p of inflight) p.reject(new Error("Signal RPC connection lost"));
     // The daemon may still be booting (JVM start) or restarting — keep retrying.
     setTimeout(connectRpc, 1500);
   });
@@ -685,6 +699,18 @@ app.post("/accounts/:userId/send", async (c) => {
       400,
     );
   }
+  // Defense-in-depth: the web layer already enforces this, but the bridge holds
+  // the service-role key (which bypasses storage RLS), so re-verify every key is
+  // owned by THIS account before downloading. Without it, a forged storage_key
+  // could fetch another user's private media.
+  for (const a of atts) {
+    if (
+      typeof a.storage_key !== "string" ||
+      (a.storage_key !== userId && !a.storage_key.startsWith(`${userId}/`))
+    ) {
+      return c.json({ error: "attachment does not belong to this account" }, 403);
+    }
+  }
   const isGroup = body.kind === "group";
 
   // signal-cli's send takes attachment FILE PATHS, so download each from
@@ -709,6 +735,14 @@ app.post("/accounts/:userId/send", async (c) => {
         console.log(`[media] send download failed ${a.storage_key}: ${String(e)}`);
       }
     }
+  }
+
+  // Don't silently send a partial (or empty) message: if any attachment failed
+  // to stage, fail the whole send so the UI surfaces an error and can retry,
+  // rather than recording it as 'sent' with media the recipient never got.
+  if (atts.length > 0 && tempPaths.length < atts.length) {
+    if (tempDir) await rm(tempDir, { recursive: true, force: true }).catch(() => {});
+    return c.json({ error: "failed to stage one or more attachments" }, 502);
   }
 
   const base = isGroup

--- a/apps/web/src/app/api/v1/messages/threads/[id]/route.ts
+++ b/apps/web/src/app/api/v1/messages/threads/[id]/route.ts
@@ -86,6 +86,7 @@ async function handleGet(_req: NextRequest, { params }: Props) {
   const decorated = rows.map((r) => ({
     ...r,
     author_name: nameById.get(r.author_id) ?? "someone",
+    is_mine: r.author_id === user.id,
     pinging_task: r.pinging_task_id ? taskById.get(r.pinging_task_id) ?? null : null,
   }));
 

--- a/apps/web/src/app/api/v1/signal/send/route.ts
+++ b/apps/web/src/app/api/v1/signal/send/route.ts
@@ -2,11 +2,13 @@ import { NextResponse, type NextRequest } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { withObservability } from "@/lib/observability";
 import { bridgeSend } from "@/lib/signal/bridge";
+import { ownsStorageKey } from "@/lib/signal/attachments";
 import { unauth, bad, bridgeErrorResponse } from "@/lib/signal/responses";
 
-// signal-cli boots a JVM per send; give the serverless function headroom past
-// the default so it doesn't cut off before the bridge replies.
-export const maxDuration = 60;
+// The bridge may spend up to ~90s downloading + staging attachments before it
+// replies; give the serverless function headroom past that so it doesn't cut
+// off before the bridge does.
+export const maxDuration = 120;
 
 /**
  * POST /api/v1/signal/send  { signalId, kind?, text }
@@ -39,6 +41,16 @@ async function handlePost(request: NextRequest) {
   const attachments = Array.isArray(body.attachments) ? body.attachments : [];
   if (!body.signalId || (!text && attachments.length === 0)) {
     return bad("signalId and text or attachments are required");
+  }
+  if (attachments.length > 20) return bad("too many attachments (max 20)");
+  // Authorization: the bridge downloads each attachment with the Supabase
+  // SERVICE ROLE (bypassing storage RLS), so the ONLY thing stopping a user
+  // from sending — and thereby exfiltrating — another user's private media is
+  // this ownership check. See ownsStorageKey for the tenant-boundary rationale.
+  for (const a of attachments) {
+    if (!ownsStorageKey(user.id, a?.storage_key)) {
+      return bad("invalid attachment");
+    }
   }
   const kind = body.kind === "group" ? "group" : "direct";
 

--- a/apps/web/src/components/dashboard/MessagesCard.test.tsx
+++ b/apps/web/src/components/dashboard/MessagesCard.test.tsx
@@ -59,23 +59,22 @@ function installFetch() {
 
     if (url === "/api/v1/messages/threads" && method === "GET")
       return jsonRes({ data: THREADS });
-    if (url === "/api/v1/me") return jsonRes({ data: { user_id: "me" } });
     if (url === "/api/v1/messages/threads/t-rokki" && method === "GET")
       return jsonRes({
         data: [
           {
             id: "m1",
-            author_id: "carlos",
             body: "hey there",
             created_at: "2026-06-17T12:00:00Z",
             author_name: "Carlos",
+            is_mine: false,
           },
           {
             id: "m2",
-            author_id: "me",
             body: "yo",
             created_at: "2026-06-17T12:01:00Z",
             author_name: "Me",
+            is_mine: true,
           },
         ],
       });

--- a/apps/web/src/components/dashboard/MessagesCard.tsx
+++ b/apps/web/src/components/dashboard/MessagesCard.tsx
@@ -38,7 +38,6 @@ export function MessagesCard() {
   const [threads, setThreads] = useState<ThreadSummary[]>([]);
   const [loading, setLoading] = useState(true);
   const [open, setOpen] = useState<ThreadSummary | null>(null);
-  const [meId, setMeId] = useState<string | null>(null);
 
   const load = useCallback(async () => {
     try {
@@ -55,20 +54,6 @@ export function MessagesCard() {
   useEffect(() => {
     void load();
   }, [load]);
-
-  // One-shot: who am I, so native messages render mine-vs-theirs correctly.
-  useEffect(() => {
-    let alive = true;
-    void fetch("/api/v1/me", { credentials: "include" })
-      .then((r) => (r.ok ? r.json() : null))
-      .then((b: { data?: { user_id?: string } } | null) => {
-        if (alive && b?.data?.user_id) setMeId(b.data.user_id);
-      })
-      .catch(() => {});
-    return () => {
-      alive = false;
-    };
-  }, []);
 
   useRealtimeTable<{ id: string }>(
     { table: "messages", channelKey: "dash:messages" },
@@ -102,7 +87,6 @@ export function MessagesCard() {
       {open ? (
         <ThreadQuickView
           thread={open}
-          meId={meId}
           onBack={() => {
             setOpen(null);
             void load();
@@ -153,11 +137,9 @@ interface QuickMessage {
 
 function ThreadQuickView({
   thread,
-  meId,
   onBack,
 }: {
   thread: ThreadSummary;
-  meId: string | null;
   onBack: () => void;
 }) {
   const isSignal = thread.source === "signal";
@@ -211,16 +193,16 @@ function ThreadQuickView({
       const b = (await r.json()) as {
         data?: {
           id: string;
-          author_id: string;
           body: string;
           created_at: string;
           author_name?: string;
+          is_mine?: boolean;
         }[];
       };
       setMessages(
         (b.data ?? []).map((m) => ({
           id: m.id,
-          mine: meId != null && m.author_id === meId,
+          mine: Boolean(m.is_mine),
           who: m.author_name ?? "someone",
           body: m.body,
           at: m.created_at,
@@ -228,7 +210,7 @@ function ThreadQuickView({
       );
     }
     scrollToEnd();
-  }, [isSignal, thread.id, meId, scrollToEnd]);
+  }, [isSignal, thread.id, scrollToEnd]);
 
   useEffect(() => {
     void load();

--- a/apps/web/src/components/messages/SignalThreadView.tsx
+++ b/apps/web/src/components/messages/SignalThreadView.tsx
@@ -83,17 +83,28 @@ export function SignalThreadView({
   const [error, setError] = useState<string | null>(null);
   const scrollerRef = useRef<HTMLDivElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  // Temp ids of optimistic bubbles whose send is still in flight — a realtime
+  // reload must not wipe these before the stored row exists.
+  const inFlightRef = useRef<Set<string>>(new Set());
+  // Mirror of `pending` so the unmount cleanup can revoke any staged object URLs.
+  const pendingRef = useRef<PendingAttachment[]>([]);
+  pendingRef.current = pending;
 
   const load = useCallback(async () => {
     const r = await fetch(`/api/v1/signal/threads/${threadId}`, {
       credentials: "include",
     });
-    if (!r.ok) {
-      setMessages([]);
-      return;
-    }
+    if (!r.ok) return; // transient — keep what we have rather than blanking
     const body = (await r.json()) as { data?: { messages?: SignalMessage[] } };
-    setMessages(body.data?.messages ?? []);
+    const server = body.data?.messages ?? [];
+    setMessages((prev) => {
+      // Preserve optimistic bubbles whose send hasn't resolved yet, so a
+      // realtime-triggered reload mid-send doesn't make the message vanish.
+      const keptTemps = prev.filter(
+        (m) => m.id.startsWith("temp-") && inFlightRef.current.has(m.id),
+      );
+      return [...server, ...keptTemps];
+    });
     requestAnimationFrame(() => {
       scrollerRef.current?.scrollTo(0, scrollerRef.current.scrollHeight);
     });
@@ -102,6 +113,17 @@ export function SignalThreadView({
   useEffect(() => {
     void load();
   }, [load]);
+
+  // On unmount (pane closed / thread switched), revoke any object URLs still
+  // staged in the composer so we don't leak them.
+  useEffect(
+    () => () => {
+      for (const p of pendingRef.current) {
+        if (p.previewUrl) URL.revokeObjectURL(p.previewUrl);
+      }
+    },
+    [],
+  );
 
   // Opening a direct conversation marks its inbound messages read (sends read
   // receipts so the other person sees ✓✓). Groups are skipped.
@@ -194,12 +216,23 @@ export function SignalThreadView({
         })),
       },
     ]);
+    inFlightRef.current.add(tempId);
     setDraft("");
     setPending([]);
     setError(null);
     requestAnimationFrame(() => {
       scrollerRef.current?.scrollTo(0, scrollerRef.current.scrollHeight);
     });
+    // Roll back the optimistic bubble and put the text + staged attachments back
+    // in the composer so the user can retry without re-typing or re-attaching.
+    // Keep the preview object URLs alive (the restored chips still need them);
+    // they're revoked on success, or on unmount if the draft is abandoned.
+    const rollback = () => {
+      inFlightRef.current.delete(tempId);
+      setMessages((prev) => prev.filter((m) => m.id !== tempId));
+      setDraft((cur) => (cur ? cur : text));
+      setPending((cur) => [...atts, ...cur]);
+    };
     try {
       const r = await fetch("/api/v1/signal/send", {
         method: "POST",
@@ -218,18 +251,20 @@ export function SignalThreadView({
         }),
       });
       if (!r.ok) {
-        // Roll back the optimistic bubble and surface the error.
-        setMessages((prev) => prev.filter((m) => m.id !== tempId));
         const b = (await r.json().catch(() => ({}))) as {
           errors?: { message: string }[];
         };
+        rollback();
         setError(b.errors?.[0]?.message ?? "Couldn’t send.");
       } else {
-        // Drop the composer previews now that the message owns them.
+        // Sent: drop the now-owned previews and let the stored row replace the
+        // optimistic bubble on the next load (no longer in flight).
+        inFlightRef.current.delete(tempId);
         atts.forEach((a) => a.previewUrl && URL.revokeObjectURL(a.previewUrl));
+        void load();
       }
     } catch {
-      setMessages((prev) => prev.filter((m) => m.id !== tempId));
+      rollback();
       setError("Couldn’t send.");
     }
   }

--- a/apps/web/src/lib/signal/attachments.test.ts
+++ b/apps/web/src/lib/signal/attachments.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { ownsStorageKey } from "./attachments";
+
+describe("ownsStorageKey", () => {
+  const me = "11111111-1111-1111-1111-111111111111";
+  const other = "22222222-2222-2222-2222-222222222222";
+
+  it("accepts keys under the caller's own prefix", () => {
+    expect(ownsStorageKey(me, `${me}/outgoing/abc`)).toBe(true);
+    expect(ownsStorageKey(me, `${me}/thread-9/att-1`)).toBe(true);
+    expect(ownsStorageKey(me, me)).toBe(true); // exact match (no sub-path)
+  });
+
+  it("rejects another user's key — the IDOR / cross-tenant exfiltration case", () => {
+    expect(ownsStorageKey(me, `${other}/outgoing/abc`)).toBe(false);
+    expect(ownsStorageKey(me, `${other}/thread-9/att-1`)).toBe(false);
+  });
+
+  it("rejects prefix confusion (trailing-slash boundary)", () => {
+    // `me` must NOT own a key whose first segment merely starts with `me`.
+    expect(ownsStorageKey("u1", "u11/secret")).toBe(false);
+    expect(ownsStorageKey("u1", "u1x")).toBe(false);
+  });
+
+  it("rejects path-traversal and malformed values", () => {
+    expect(ownsStorageKey(me, "../etc/passwd")).toBe(false);
+    expect(ownsStorageKey(me, "")).toBe(false);
+    expect(ownsStorageKey(me, undefined)).toBe(false);
+    expect(ownsStorageKey(me, null)).toBe(false);
+    expect(ownsStorageKey(me, 123)).toBe(false);
+    expect(ownsStorageKey(me, { storage_key: `${me}/x` })).toBe(false);
+  });
+});

--- a/apps/web/src/lib/signal/attachments.ts
+++ b/apps/web/src/lib/signal/attachments.ts
@@ -1,0 +1,23 @@
+/**
+ * Outbound Signal attachment authorization.
+ *
+ * The bridge downloads each attachment with the Supabase SERVICE ROLE, which
+ * bypasses storage RLS — so the per-user key prefix is the ONLY tenant
+ * boundary for outbound media. Every attachment a user asks to send must live
+ * under their own prefix; otherwise a forged `storage_key` could fetch (and
+ * thereby exfiltrate) another user's private file. The send route enforces
+ * this, and the bridge re-checks it as defense-in-depth.
+ */
+
+/**
+ * True iff `storageKey` is a non-empty string owned by `userId` — i.e. exactly
+ * `<userId>` or anything under the `<userId>/` prefix. Note the trailing slash:
+ * it prevents prefix confusion (`u1` must NOT own `u11/...`).
+ */
+export function ownsStorageKey(userId: string, storageKey: unknown): boolean {
+  return (
+    typeof storageKey === "string" &&
+    storageKey.length > 0 &&
+    (storageKey === userId || storageKey.startsWith(`${userId}/`))
+  );
+}

--- a/apps/web/src/lib/signal/bridge.ts
+++ b/apps/web/src/lib/signal/bridge.ts
@@ -112,9 +112,14 @@ export function bridgeSend(
 ): Promise<{ ok: true }> {
   return bridgeFetch<{ ok: true }>(
     `/accounts/${encodeURIComponent(userId)}/send`,
-    // signal-cli cold-starts a JVM per send (~5–15s on the shared Fly VM), so
-    // allow well past the 15s default before giving up.
-    { method: "POST", body: payload, timeoutMs: 45_000 },
+    // The daemon makes sends fast, but with attachments the bridge also has to
+    // download each file from storage and stage it before signal-cli sends, so
+    // give extra headroom when any are attached.
+    {
+      method: "POST",
+      body: payload,
+      timeoutMs: payload.attachments?.length ? 90_000 : 45_000,
+    },
   );
 }
 


### PR DESCRIPTION
## What

A 5-dimension **adversarial review** of the just-merged Signal Phase 1+2 + dashboard messaging code — each finding independently verified by a skeptic agent — surfaced **13 real issues** (5 unrelated false-positives were correctly dismissed). This PR fixes all 13.

### Security
- **IDOR / cross-tenant media exfiltration (HIGH).** The send route forwarded client-supplied attachment `storage_key`s to the bridge, which downloads them with the **service role** (bypassing storage RLS). A forged key like `<victimId>/<thread>/<att>` would have fetched another user's private media and delivered it to the attacker's own chat. Fixed: the send route rejects any key not owned by the caller (new `ownsStorageKey` helper, unit-tested incl. prefix-confusion + traversal cases), and the bridge re-checks ownership as defense-in-depth.
- **Path-unsafe inbound attachment id** used as a filesystem path + storage key → now allowlist-validated (`/^[A-Za-z0-9._-]+$/`, rejecting `/` and `..`) before `readFile`/upload.
- **Attachment count cap** (max 20) + shape validation on the send route.

### Reliability (bridge)
- Don't record a send as `sent` when attachment staging partially/fully fails — fail the request so the UI can retry instead of silently dropping media.
- Reject in-flight RPCs when the daemon socket drops → a daemon bounce surfaces as a fast 5xx instead of hanging to the 30s timeout.
- Receipt status advance is now an **atomic, forward-only filtered UPDATE** (no read-modify-write race) that never resurrects terminal `failed` rows.
- `bridgeSend` gets a 90s timeout (+ route `maxDuration` 120s) when attachments ride along.

### UI (SignalThreadView)
- Revoke staged object URLs on unmount; stop leaking them on send failure.
- On a failed send, restore the draft + staged attachments so the user retries without re-typing / re-picking.
- Preserve optimistic bubbles across realtime reloads so an in-flight message can't briefly vanish.

### Dashboard
- Native messages now carry `is_mine` from the server (`GET messages/threads/:id`), removing the `/api/v1/me` round-trip and the mine-vs-theirs attribution race.

## Test
- New `attachments.test.ts` locks the IDOR boundary (8 cases incl. prefix confusion + traversal).
- `tsc` green (web + bridge), `eslint` clean, **50/50** signal/messages/dashboard tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)