### PR TITLE
feat(presence): show when Rokki users are online

### DIFF
--- a/apps/web/src/components/DashboardClient.tsx
+++ b/apps/web/src/components/DashboardClient.tsx
@@ -13,6 +13,7 @@ import { MarketsCard } from "./dashboard/MarketsCard";
 import { GoalsCard } from "./dashboard/GoalsCard";
 import { DashboardPanels } from "./dashboard/DashboardPanels";
 import { ModuleVisibilityProvider } from "./dashboard/module-visibility";
+import { PresenceProvider } from "./presence/PresenceProvider";
 import { TerminalScopeFilter } from "./dashboard/TerminalScopeFilter";
 import { TopBar } from "./TopBar";
 import { DensityProvider, type Density } from "@/lib/density";
@@ -199,6 +200,7 @@ export function DashboardClient({
 
   return (
     <DensityProvider initial={initialDensity}>
+      <PresenceProvider>
       <ModuleVisibilityProvider>
       <DashboardShell
         topBar={
@@ -298,6 +300,7 @@ export function DashboardClient({
         />
       ) : null}
       <TimezoneProbe currentTimezone={savedTimezone} />
+      </PresenceProvider>
     </DensityProvider>
   );
 }

--- a/apps/web/src/components/dashboard/MessagesCard.tsx
+++ b/apps/web/src/components/dashboard/MessagesCard.tsx
@@ -15,6 +15,7 @@ import {
 import { DashboardCard } from "./DashboardCard";
 import { cn } from "@/lib/utils";
 import { useRealtimeTable } from "@/lib/supabase/realtime";
+import { PresenceDot, PresenceLabel } from "../presence/PresenceDot";
 
 interface ThreadSummary {
   id: string;
@@ -22,6 +23,8 @@ interface ThreadSummary {
   source?: "rokki" | "signal";
   label: string;
   last_message_at: string;
+  /** Native DM/group — the other participant (drives the presence dot). */
+  other_user_id?: string | null;
   /** Signal-only — the send target + conversation kind. */
   signal_id?: string;
   signal_kind?: "direct" | "group";
@@ -109,6 +112,14 @@ export function MessagesCard() {
                   <Hash className="h-3 w-3 flex-shrink-0 text-text-3" />
                 ) : t.source === "signal" ? (
                   <MessageSquare className="h-3 w-3 flex-shrink-0 text-success" />
+                ) : t.kind === "dm" && t.other_user_id ? (
+                  <span className="relative flex-shrink-0">
+                    <UserIcon className="h-3 w-3 text-text-3" />
+                    <PresenceDot
+                      userId={t.other_user_id}
+                      className="absolute -bottom-0.5 -right-0.5 h-1.5 w-1.5 ring-1 ring-bg-1"
+                    />
+                  </span>
                 ) : (
                   <UserIcon className="h-3 w-3 flex-shrink-0 text-text-3" />
                 )}
@@ -293,6 +304,12 @@ function ThreadQuickView({
           <UserIcon className="h-3 w-3 flex-shrink-0 text-text-3" />
         )}
         <span className="flex-1 truncate text-xs text-text-1">{thread.label}</span>
+        {!isSignal && thread.kind === "dm" && thread.other_user_id ? (
+          <span className="flex flex-shrink-0 items-center gap-1">
+            <PresenceDot userId={thread.other_user_id} />
+            <PresenceLabel userId={thread.other_user_id} />
+          </span>
+        ) : null}
         <Link
           href="/messages"
           aria-label="Open in full inbox"

--- a/apps/web/src/components/messages/MessagesInbox.tsx
+++ b/apps/web/src/components/messages/MessagesInbox.tsx
@@ -17,6 +17,8 @@ import { useRealtimeTable } from "@/lib/supabase/realtime";
 import { createClient } from "@/lib/supabase/client";
 import { SignalThreadView } from "./SignalThreadView";
 import { SignalContactPicker } from "./SignalContactPicker";
+import { PresenceProvider } from "../presence/PresenceProvider";
+import { PresenceDot, PresenceLabel } from "../presence/PresenceDot";
 
 interface ThreadSummary {
   id: string;
@@ -229,6 +231,7 @@ export function MessagesInbox() {
   }
 
   return (
+    <PresenceProvider>
     <div className="flex h-full min-h-0 rounded border border-border bg-bg-1">
       <aside className="w-[260px] flex-shrink-0 border-r border-border">
         <header className="flex h-9 items-center gap-2 border-b border-border px-3">
@@ -286,6 +289,14 @@ export function MessagesInbox() {
                     <Bell className="h-3 w-3 flex-shrink-0 text-accent" />
                   ) : t.source === "signal" ? (
                     <MessageSquare className="h-3 w-3 flex-shrink-0 text-success" />
+                  ) : t.kind === "dm" && t.other_user_id ? (
+                    <span className="relative flex-shrink-0">
+                      <UserIcon className="h-3 w-3 text-text-3" />
+                      <PresenceDot
+                        userId={t.other_user_id}
+                        className="absolute -bottom-0.5 -right-0.5 h-1.5 w-1.5 ring-1 ring-bg-1"
+                      />
+                    </span>
                   ) : (
                     <UserIcon className="h-3 w-3 flex-shrink-0 text-text-3" />
                   )}
@@ -335,6 +346,12 @@ export function MessagesInbox() {
                 <UserIcon className="h-3 w-3 text-text-3" />
               )}
               <span className="text-xs text-text-1">{active.label}</span>
+              {active.kind === "dm" && active.other_user_id ? (
+                <span className="flex items-center gap-1">
+                  <PresenceDot userId={active.other_user_id} />
+                  <PresenceLabel userId={active.other_user_id} />
+                </span>
+              ) : null}
               {active.kind === "reminders" ? (
                 <button
                   type="button"
@@ -516,6 +533,7 @@ export function MessagesInbox() {
         )}
       </section>
     </div>
+    </PresenceProvider>
   );
 }
 

--- a/apps/web/src/components/presence/PresenceDot.tsx
+++ b/apps/web/src/components/presence/PresenceDot.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { useIsOnline } from "./PresenceProvider";
+
+/**
+ * Small online/offline indicator for a Rokki user: a filled green dot when the
+ * user has Rokki open, a hollow muted dot otherwise. Safe to render outside a
+ * PresenceProvider (reads as offline). Designed to overlay an avatar/icon
+ * (pass an absolute-position className) or sit inline.
+ */
+export function PresenceDot({
+  userId,
+  className,
+  title,
+}: {
+  userId?: string | null;
+  className?: string;
+  title?: string;
+}) {
+  const online = useIsOnline(userId);
+  return (
+    <span
+      className={cn(
+        "inline-block h-2 w-2 flex-shrink-0 rounded-full",
+        online ? "bg-success" : "border border-text-3/60 bg-transparent",
+        className,
+      )}
+      title={title ?? (online ? "Online in Rokki" : "Offline")}
+      aria-label={online ? "online" : "offline"}
+    />
+  );
+}
+
+/** Inline "online" / "offline" text for a Rokki user (e.g. a thread header). */
+export function PresenceLabel({
+  userId,
+  className,
+}: {
+  userId?: string | null;
+  className?: string;
+}) {
+  const online = useIsOnline(userId);
+  return (
+    <span
+      className={cn(
+        "text-[10px]",
+        online ? "text-success" : "text-text-3",
+        className,
+      )}
+    >
+      {online ? "online" : "offline"}
+    </span>
+  );
+}

--- a/apps/web/src/components/presence/PresenceProvider.tsx
+++ b/apps/web/src/components/presence/PresenceProvider.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from "react";
+import { createClient } from "@/lib/supabase/client";
+
+/**
+ * Rokki user presence — who currently has Rokki open.
+ *
+ * One global Supabase Presence channel (`presence:online`): every mounted
+ * provider tracks the signed-in user under their own id, and reads the channel
+ * state into a Set of online user ids. Presence is EPHEMERAL — Supabase drops a
+ * user automatically when their last tab closes — so this reflects live "online
+ * now", with no database writes, no migration, and no `last_seen` persistence.
+ * (Signal contacts are NOT Rokki users and never appear here; Signal exposes no
+ * presence of its own.)
+ *
+ * Mount once per page tree (the dashboard shell, the Messages inbox). Consumers
+ * read presence with `useIsOnline(userId)` / `useOnlineUsers()`, which are safe
+ * to call even with no provider mounted (they read as offline).
+ */
+/** The set of online user ids. Exported so tests can inject presence state
+ *  without standing up a live Supabase channel. */
+export const OnlineContext = createContext<Set<string>>(new Set());
+
+export function PresenceProvider({ children }: { children: ReactNode }) {
+  const [online, setOnline] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    const supabase = createClient();
+    let cancelled = false;
+    let channel: ReturnType<typeof supabase.channel> | null = null;
+    void (async () => {
+      const { data } = await supabase.auth.getUser();
+      const me = data.user?.id;
+      if (!me || cancelled) return;
+      channel = supabase.channel("presence:online", {
+        config: { presence: { key: me } },
+      });
+      channel.on("presence", { event: "sync" }, () => {
+        if (!channel) return;
+        // presenceState() is keyed by our presence key = user id.
+        const state = channel.presenceState() as Record<string, unknown[]>;
+        setOnline(new Set(Object.keys(state)));
+      });
+      await channel.subscribe(async (status) => {
+        if (status === "SUBSCRIBED" && channel) {
+          await channel.track({ user_id: me, at: new Date().toISOString() });
+        }
+      });
+    })();
+    return () => {
+      cancelled = true;
+      if (channel) {
+        void channel.unsubscribe();
+        void createClient().removeChannel(channel);
+      }
+    };
+  }, []);
+
+  return (
+    <OnlineContext.Provider value={online}>{children}</OnlineContext.Provider>
+  );
+}
+
+/** The set of Rokki user ids currently online (have Rokki open). */
+export function useOnlineUsers(): Set<string> {
+  return useContext(OnlineContext);
+}
+
+/** True iff the given user currently has Rokki open. */
+export function useIsOnline(userId?: string | null): boolean {
+  const online = useContext(OnlineContext);
+  return userId != null && online.has(userId);
+}

--- a/apps/web/src/components/presence/presence.test.tsx
+++ b/apps/web/src/components/presence/presence.test.tsx
@@ -1,0 +1,53 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { OnlineContext, useIsOnline } from "./PresenceProvider";
+import { PresenceDot, PresenceLabel } from "./PresenceDot";
+
+afterEach(() => cleanup());
+
+function withOnline(ids: string[], ui: React.ReactNode) {
+  return (
+    <OnlineContext.Provider value={new Set(ids)}>{ui}</OnlineContext.Provider>
+  );
+}
+
+describe("PresenceDot / PresenceLabel", () => {
+  it("renders an online dot for a user who has Rokki open", () => {
+    render(withOnline(["u1"], <PresenceDot userId="u1" />));
+    expect(screen.getByLabelText("online")).toBeTruthy();
+  });
+
+  it("renders an offline dot for a user who is not present", () => {
+    render(withOnline(["u1"], <PresenceDot userId="u2" />));
+    expect(screen.getByLabelText("offline")).toBeTruthy();
+  });
+
+  it("labels online/offline text accordingly", () => {
+    const { rerender } = render(
+      withOnline(["u1"], <PresenceLabel userId="u1" />),
+    );
+    expect(screen.getByText("online")).toBeTruthy();
+    rerender(withOnline(["u1"], <PresenceLabel userId="u2" />));
+    expect(screen.getByText("offline")).toBeTruthy();
+  });
+
+  it("treats null/undefined userId and no-provider as offline", () => {
+    render(<PresenceDot userId={null} />); // no provider at all
+    expect(screen.getByLabelText("offline")).toBeTruthy();
+  });
+});
+
+describe("useIsOnline", () => {
+  function Probe({ id }: { id?: string | null }) {
+    return <span>{useIsOnline(id) ? "yes" : "no"}</span>;
+  }
+  it("reflects membership in the online set", () => {
+    render(withOnline(["a", "b"], <Probe id="b" />));
+    expect(screen.getByText("yes")).toBeTruthy();
+  });
+  it("is false for unknown / nullish ids", () => {
+    render(withOnline(["a"], <Probe id="z" />));
+    expect(screen.getByText("no")).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## What

A live **"online" indicator for Rokki users** — answering "can I see if they're online on Rokki?"

A single global Supabase **Presence** channel (`presence:online`) tracks who currently has Rokki open. A green dot shows next to online users (hollow when offline):
- **Messages inbox** — thread-list DM rows (dot overlaid on the avatar) + the conversation header (dot + `online`/`offline`).
- **Dashboard Messages card** — DM rows + the quick-view header.

**Ephemeral by design:** no DB writes, no migration, no `last_seen` column — Supabase drops a user when their last tab closes, so this reflects *online right now*. (Matches the existing `TeamPane`/`TerminalPresence` pattern.)

## Scope notes (important)
- **Signal contacts are not Rokki users**, and Signal exposes no presence of its own — so dots appear only on **native Rokki DMs**, never Signal threads.
- The **left explorer** lists spaces/terminals, not people, so there's no per-person dot there. If you want a "N teammates online" badge on space rows, that's an easy follow-up.

## Test
- `presence.test.tsx`: online dot, offline dot, online/offline label, null/no-provider → offline, `useIsOnline` membership.
- `tsc` green, `eslint` clean, 10/10 presence + dashboard tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)