### PR TITLE
feat(messages): inbox management — filters, hide channels, unread badges (Wave 1)

### DIFF
--- a/apps/web/src/app/api/v1/messages/threads/route.ts
+++ b/apps/web/src/app/api/v1/messages/threads/route.ts
@@ -218,8 +218,26 @@ async function handleGet() {
     signalThreadToInbox,
   );
 
+  const merged = mergeInboxThreads(nativeThreads, signalThreads);
+
+  // Per-thread unread counts via two RLS-scoped RPCs (native + Signal), so the
+  // inbox can badge unread without a query per thread.
+  type UnreadRow = { thread_id: string; unread: number };
+  const rpcUnread = async (fn: string): Promise<UnreadRow[]> => {
+    const { data } = await supabase.rpc(fn);
+    return (data ?? []) as UnreadRow[];
+  };
+  const [nativeUnread, signalUnread] = await Promise.all([
+    rpcUnread("rokki_unread_counts"),
+    rpcUnread("rokki_signal_unread_counts"),
+  ]);
+  const unreadMap = new Map<string, number>();
+  for (const r of [...nativeUnread, ...signalUnread]) {
+    unreadMap.set(r.thread_id, Number(r.unread) || 0);
+  }
+
   return NextResponse.json({
-    data: mergeInboxThreads(nativeThreads, signalThreads),
+    data: merged.map((t) => ({ ...t, unread: unreadMap.get(t.id) ?? 0 })),
   });
 }
 

--- a/apps/web/src/app/api/v1/signal/threads/[id]/route.ts
+++ b/apps/web/src/app/api/v1/signal/threads/[id]/route.ts
@@ -66,6 +66,13 @@ async function handleGet(_req: NextRequest, { params }: Props) {
     }),
   );
 
+  // Best-effort: mark this Signal thread read so its unread badge clears.
+  await supabase
+    .from("signal_threads")
+    // @ts-expect-error generic update collapses to never
+    .update({ last_read_at: new Date().toISOString() })
+    .eq("id", id);
+
   return NextResponse.json({
     data: { thread: thread ?? null, messages: enriched },
   });

--- a/apps/web/src/components/dashboard/MessagesCard.tsx
+++ b/apps/web/src/components/dashboard/MessagesCard.tsx
@@ -21,6 +21,12 @@ import { cn } from "@/lib/utils";
 import { useRealtimeTable } from "@/lib/supabase/realtime";
 import { PresenceDot, PresenceLabel } from "../presence/PresenceDot";
 import { uploadSignalMedia } from "@/lib/signal/upload";
+import {
+  useInboxView,
+  filterThreads,
+  InboxFilterBar,
+  UnreadBadge,
+} from "../messages/inbox-prefs";
 
 interface ThreadSummary {
   id: string;
@@ -30,6 +36,8 @@ interface ThreadSummary {
   last_message_at: string;
   /** Native DM/group — the other participant (drives the presence dot). */
   other_user_id?: string | null;
+  /** Count of unread messages since I last opened the thread. */
+  unread?: number;
   /** Signal-only — the send target + conversation kind. */
   signal_id?: string;
   signal_kind?: "direct" | "group";
@@ -47,6 +55,7 @@ export function MessagesCard() {
   const [threads, setThreads] = useState<ThreadSummary[]>([]);
   const [loading, setLoading] = useState(true);
   const [open, setOpen] = useState<ThreadSummary | null>(null);
+  const { filter, setFilter, hidden, hide, clearHidden } = useInboxView();
 
   const load = useCallback(async () => {
     try {
@@ -77,10 +86,12 @@ export function MessagesCard() {
     { onInsert: () => void load(), onUpdate: () => void load() },
   );
 
+  const { visible, hiddenInFilter } = filterThreads(threads, filter, hidden);
+
   return (
     <DashboardCard
       title="Messages"
-      count={threads.length}
+      count={visible.length}
       expandHref="/messages"
       bodyClassName="flex min-h-0 flex-col overflow-hidden"
       headerRight={
@@ -108,22 +119,62 @@ export function MessagesCard() {
         <Empty />
       ) : (
         <div className="flex min-h-0 flex-1 flex-col">
+          <InboxFilterBar
+            filter={filter}
+            setFilter={setFilter}
+            hiddenCount={hiddenInFilter}
+            onShowHidden={clearHidden}
+          />
           <ul className="min-h-0 flex-1 divide-y divide-border/30 overflow-y-auto">
-            {threads.map((t) => (
-              <li key={t.id}>
-                <button
-                  type="button"
-                  onClick={() => setOpen(t)}
-                  className="flex w-full items-center gap-2.5 px-3 py-2 text-left text-sm hover:bg-bg-2"
-                >
-                  <ThreadIcon thread={t} />
-                  <span className="flex-1 truncate text-text-0">{t.label}</span>
-                  <span className="flex-shrink-0 font-mono text-2xs text-text-3">
-                    {formatRelative(t.last_message_at)}
-                  </span>
-                </button>
+            {visible.length === 0 ? (
+              <li className="px-3 py-6 text-center text-xs text-text-3">
+                Nothing here.
               </li>
-            ))}
+            ) : (
+              visible.map((t) => (
+                <li key={t.id} className="group relative">
+                  <button
+                    type="button"
+                    onClick={() => {
+                      // Optimistically clear the badge; the server marks it read.
+                      setThreads((prev) =>
+                        prev.map((x) =>
+                          x.id === t.id ? { ...x, unread: 0 } : x,
+                        ),
+                      );
+                      setOpen(t);
+                    }}
+                    className="flex w-full items-center gap-2.5 px-3 py-2 text-left text-sm hover:bg-bg-2"
+                  >
+                    <ThreadIcon thread={t} />
+                    <span
+                      className={cn(
+                        "flex-1 truncate",
+                        t.unread ? "font-semibold text-text-0" : "text-text-0",
+                      )}
+                    >
+                      {t.label}
+                    </span>
+                    <UnreadBadge count={t.unread} />
+                    <span className="flex-shrink-0 font-mono text-2xs text-text-3 group-hover:opacity-0">
+                      {formatRelative(t.last_message_at)}
+                    </span>
+                  </button>
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      hide(t.id);
+                    }}
+                    aria-label={`Hide ${t.label}`}
+                    title="Hide from this list"
+                    className="absolute right-2 top-1/2 -translate-y-1/2 rounded-sm p-0.5 text-text-3 opacity-0 transition-opacity hover:text-danger group-hover:opacity-100"
+                  >
+                    <X className="h-3 w-3" />
+                  </button>
+                </li>
+              ))
+            )}
           </ul>
           <Link
             href="/messages"

--- a/apps/web/src/components/messages/MessagesInbox.tsx
+++ b/apps/web/src/components/messages/MessagesInbox.tsx
@@ -11,6 +11,7 @@ import {
   RefreshCw,
   MessageSquare,
   PenSquare,
+  X,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useRealtimeTable } from "@/lib/supabase/realtime";
@@ -19,6 +20,12 @@ import { SignalThreadView } from "./SignalThreadView";
 import { SignalContactPicker } from "./SignalContactPicker";
 import { PresenceProvider } from "../presence/PresenceProvider";
 import { PresenceDot, PresenceLabel } from "../presence/PresenceDot";
+import {
+  useInboxView,
+  filterThreads,
+  InboxFilterBar,
+  UnreadBadge,
+} from "./inbox-prefs";
 
 interface ThreadSummary {
   id: string;
@@ -28,6 +35,7 @@ interface ThreadSummary {
   last_message_at: string;
   href_ticker?: string | null;
   other_user_id?: string | null;
+  unread?: number;
   signal_id?: string;
   signal_kind?: "direct" | "group";
 }
@@ -79,8 +87,10 @@ export function MessagesInbox() {
   const [statusSending, setStatusSending] = useState<string | null>(null);
   const [refreshingReminders, setRefreshingReminders] = useState(false);
   const scrollerRef = useRef<HTMLDivElement>(null);
+  const { filter, setFilter, hidden, hide, clearHidden } = useInboxView();
 
   const active = threads.find((t) => t.id === activeId) ?? null;
+  const { visible, hiddenInFilter } = filterThreads(threads, filter, hidden);
   // Signal threads load + send through a different pipeline (the bridge), so
   // the native message-load and realtime below skip them.
   const activeIsSignal = active?.source === "signal";
@@ -248,6 +258,12 @@ export function MessagesInbox() {
             <PenSquare className="h-3 w-3" />
           </button>
         </header>
+        <InboxFilterBar
+          filter={filter}
+          setFilter={setFilter}
+          hiddenCount={hiddenInFilter}
+          onShowHidden={clearHidden}
+        />
         {/* Reminders CTA — shows once until the user enables it; the
             refresh endpoint creates the thread + posts pings for the
             user's overdue / due-today tasks. After first run the
@@ -269,15 +285,20 @@ export function MessagesInbox() {
           </button>
         ) : null}
         <ul className="overflow-y-auto">
-          {threads.length === 0 ? (
+          {visible.length === 0 ? (
             <li className="px-3 py-6 text-center text-xs text-text-3">
-              No conversations yet.
+              {threads.length === 0 ? "No conversations yet." : "Nothing here."}
             </li>
           ) : (
-            threads.map((t) => (
-              <li key={t.id}>
+            visible.map((t) => (
+              <li key={t.id} className="group relative">
                 <button
-                  onClick={() => setActiveId(t.id)}
+                  onClick={() => {
+                    setThreads((prev) =>
+                      prev.map((x) => (x.id === t.id ? { ...x, unread: 0 } : x)),
+                    );
+                    setActiveId(t.id);
+                  }}
                   className={cn(
                     "flex w-full items-center gap-2 px-3 py-2 text-left text-xs hover:bg-bg-2",
                     activeId === t.id && "bg-bg-2 text-text-0",
@@ -300,10 +321,30 @@ export function MessagesInbox() {
                   ) : (
                     <UserIcon className="h-3 w-3 flex-shrink-0 text-text-3" />
                   )}
-                  <span className="flex-1 truncate">{t.label}</span>
-                  <span className="font-mono text-[10px] text-text-3">
+                  <span
+                    className={cn(
+                      "flex-1 truncate",
+                      t.unread ? "font-semibold text-text-0" : undefined,
+                    )}
+                  >
+                    {t.label}
+                  </span>
+                  <UnreadBadge count={t.unread} />
+                  <span className="font-mono text-[10px] text-text-3 group-hover:opacity-0">
                     {formatRelative(t.last_message_at)}
                   </span>
+                </button>
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    hide(t.id);
+                  }}
+                  aria-label={`Hide ${t.label}`}
+                  title="Hide from this list"
+                  className="absolute right-2 top-1/2 -translate-y-1/2 rounded-sm p-0.5 text-text-3 opacity-0 transition-opacity hover:text-danger group-hover:opacity-100"
+                >
+                  <X className="h-3 w-3" />
                 </button>
               </li>
             ))

--- a/apps/web/src/components/messages/inbox-prefs.test.tsx
+++ b/apps/web/src/components/messages/inbox-prefs.test.tsx
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { filterThreads, UnreadBadge } from "./inbox-prefs";
+
+afterEach(() => cleanup());
+
+const threads = [
+  { id: "a", source: "rokki" as const },
+  { id: "b", source: "signal" as const },
+  { id: "c", source: "rokki" as const },
+];
+
+describe("filterThreads", () => {
+  it("'all' returns everything except hidden, and counts the hidden", () => {
+    const { visible, hiddenInFilter } = filterThreads(
+      threads,
+      "all",
+      new Set(["c"]),
+    );
+    expect(visible.map((t) => t.id)).toEqual(["a", "b"]);
+    expect(hiddenInFilter).toBe(1);
+  });
+
+  it("'signal' returns only Signal threads", () => {
+    const { visible } = filterThreads(threads, "signal", new Set());
+    expect(visible.map((t) => t.id)).toEqual(["b"]);
+  });
+
+  it("'rokki' treats a missing source as native", () => {
+    const { visible } = filterThreads(
+      [{ id: "x" }, { id: "y", source: "signal" as const }],
+      "rokki",
+      new Set(),
+    );
+    expect(visible.map((t) => t.id)).toEqual(["x"]);
+  });
+
+  it("hiddenInFilter counts only hidden items within the active filter", () => {
+    // 'a' is a rokki thread, hidden — but the signal filter doesn't include it.
+    const { hiddenInFilter } = filterThreads(threads, "signal", new Set(["a"]));
+    expect(hiddenInFilter).toBe(0);
+  });
+});
+
+describe("UnreadBadge", () => {
+  it("renders the count when > 0", () => {
+    render(<UnreadBadge count={5} />);
+    expect(screen.getByText("5")).toBeTruthy();
+  });
+  it("caps at 99+", () => {
+    render(<UnreadBadge count={250} />);
+    expect(screen.getByText("99+")).toBeTruthy();
+  });
+  it("renders nothing at 0 / undefined", () => {
+    const { container } = render(<UnreadBadge count={0} />);
+    expect(container.textContent).toBe("");
+  });
+});

--- a/apps/web/src/components/messages/inbox-prefs.tsx
+++ b/apps/web/src/components/messages/inbox-prefs.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { cn } from "@/lib/utils";
+
+/**
+ * Client-side inbox view preferences: a source filter (All / Signal / Rokki)
+ * and a per-conversation hide list. Stored in localStorage so the board stays
+ * the way you left it (per device) with no extra backend — the filter alone
+ * lets you drop every terminal/space channel with one tap ("Signal only"), and
+ * hide handles the odd one-off.
+ */
+export type InboxFilter = "all" | "signal" | "rokki";
+
+const FILTER_KEY = "rokki:inbox:filter";
+const HIDDEN_KEY = "rokki:inbox:hidden";
+
+export function useInboxView() {
+  const [filter, setFilterState] = useState<InboxFilter>("all");
+  const [hidden, setHidden] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    try {
+      const f = localStorage.getItem(FILTER_KEY);
+      if (f === "signal" || f === "rokki" || f === "all") setFilterState(f);
+      const h = localStorage.getItem(HIDDEN_KEY);
+      if (h) setHidden(new Set(JSON.parse(h) as string[]));
+    } catch {
+      /* ignore unavailable/corrupt storage */
+    }
+  }, []);
+
+  const setFilter = useCallback((f: InboxFilter) => {
+    setFilterState(f);
+    try {
+      localStorage.setItem(FILTER_KEY, f);
+    } catch {
+      /* ignore */
+    }
+  }, []);
+
+  const persist = (s: Set<string>) => {
+    try {
+      localStorage.setItem(HIDDEN_KEY, JSON.stringify([...s]));
+    } catch {
+      /* ignore */
+    }
+  };
+  const hide = useCallback((id: string) => {
+    setHidden((prev) => {
+      const n = new Set(prev);
+      n.add(id);
+      persist(n);
+      return n;
+    });
+  }, []);
+  const unhide = useCallback((id: string) => {
+    setHidden((prev) => {
+      const n = new Set(prev);
+      n.delete(id);
+      persist(n);
+      return n;
+    });
+  }, []);
+  const clearHidden = useCallback(() => {
+    setHidden(new Set());
+    persist(new Set());
+  }, []);
+
+  return { filter, setFilter, hidden, hide, unhide, clearHidden };
+}
+
+/** Apply a filter + hide list to a thread array. */
+export function filterThreads<
+  T extends { id: string; source?: "rokki" | "signal" },
+>(
+  threads: T[],
+  filter: InboxFilter,
+  hidden: Set<string>,
+): { visible: T[]; hiddenInFilter: number } {
+  const bySource = threads.filter((t) =>
+    filter === "all" ? true : (t.source ?? "rokki") === filter,
+  );
+  const visible = bySource.filter((t) => !hidden.has(t.id));
+  return { visible, hiddenInFilter: bySource.length - visible.length };
+}
+
+const FILTERS: { key: InboxFilter; label: string }[] = [
+  { key: "all", label: "All" },
+  { key: "signal", label: "Signal" },
+  { key: "rokki", label: "Rokki" },
+];
+
+/** Segmented source filter + a "show hidden" affordance. */
+export function InboxFilterBar({
+  filter,
+  setFilter,
+  hiddenCount,
+  onShowHidden,
+  className,
+}: {
+  filter: InboxFilter;
+  setFilter: (f: InboxFilter) => void;
+  hiddenCount: number;
+  onShowHidden?: () => void;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-1 border-b border-border/60 px-2 py-1.5",
+        className,
+      )}
+    >
+      <div className="flex rounded-sm border border-border bg-bg-0 p-0.5">
+        {FILTERS.map((f) => (
+          <button
+            key={f.key}
+            type="button"
+            onClick={() => setFilter(f.key)}
+            className={cn(
+              "rounded-[3px] px-2 py-0.5 text-2xs font-medium transition-colors",
+              filter === f.key
+                ? "bg-accent text-bg-0"
+                : "text-text-3 hover:text-text-1",
+            )}
+          >
+            {f.label}
+          </button>
+        ))}
+      </div>
+      {hiddenCount > 0 && onShowHidden ? (
+        <button
+          type="button"
+          onClick={onShowHidden}
+          className="ml-auto text-2xs text-text-3 hover:text-text-1"
+          title="Restore hidden conversations"
+        >
+          {hiddenCount} hidden · show
+        </button>
+      ) : null}
+    </div>
+  );
+}
+
+/** Blue unread-count pill, iMessage-style. Renders nothing when count is 0. */
+export function UnreadBadge({ count }: { count?: number }) {
+  if (!count || count <= 0) return null;
+  return (
+    <span className="flex h-4 min-w-[1rem] flex-shrink-0 items-center justify-center rounded-full bg-accent px-1 text-[10px] font-semibold leading-none text-bg-0">
+      {count > 99 ? "99+" : count}
+    </span>
+  );
+}

--- a/apps/web/src/lib/signal/inbox.ts
+++ b/apps/web/src/lib/signal/inbox.ts
@@ -20,6 +20,8 @@ export interface InboxThread {
   signal_kind?: "direct" | "group";
   href_ticker?: string | null;
   other_user_id?: string | null;
+  /** Count of unread messages (not from me, since I last opened the thread). */
+  unread?: number;
 }
 
 /** Shape selected from the `signal_threads` table. */

--- a/supabase/migrations/20260618030000_signal_thread_read_unread.sql
+++ b/supabase/migrations/20260618030000_signal_thread_read_unread.sql
@@ -1,0 +1,58 @@
+-- Unread tracking for the unified inbox.
+--
+-- Native threads already track per-user read state via
+-- thread_participants.last_read_at. Signal threads had no read marker, so add
+-- one. Two SECURITY INVOKER functions (RLS-respecting) return per-thread unread
+-- counts for the current user, so the inbox can show unread badges without N
+-- round-trips.
+
+BEGIN;
+
+ALTER TABLE signal_threads
+  ADD COLUMN IF NOT EXISTS last_read_at TIMESTAMPTZ;
+
+-- Unread native messages per thread: messages newer than my last_read_at that
+-- I didn't send. Joins thread_participants so it's scoped to my threads; RLS on
+-- messages further scopes it. epoch fallback = "never read → all unread".
+CREATE OR REPLACE FUNCTION rokki_unread_counts()
+  RETURNS TABLE (thread_id UUID, unread BIGINT)
+  LANGUAGE sql
+  STABLE
+  SECURITY INVOKER
+AS $$
+  SELECT m.thread_id, COUNT(*)::BIGINT
+  FROM messages m
+  JOIN thread_participants tp
+    ON tp.thread_id = m.thread_id AND tp.user_id = auth.uid()
+  WHERE m.deleted_at IS NULL
+    AND m.author_id <> auth.uid()
+    AND m.created_at > COALESCE(tp.last_read_at, 'epoch'::timestamptz)
+  GROUP BY m.thread_id;
+$$;
+
+-- Unread Signal messages per thread: inbound messages newer than the thread's
+-- last_read_at. Scoped to my own Signal threads.
+CREATE OR REPLACE FUNCTION rokki_signal_unread_counts()
+  RETURNS TABLE (thread_id UUID, unread BIGINT)
+  LANGUAGE sql
+  STABLE
+  SECURITY INVOKER
+AS $$
+  SELECT sm.thread_id, COUNT(*)::BIGINT
+  FROM signal_messages sm
+  JOIN signal_threads st
+    ON st.id = sm.thread_id AND st.user_id = auth.uid()
+  WHERE sm.direction = 'in'
+    AND sm.deleted_at IS NULL
+    AND sm.sent_at > COALESCE(st.last_read_at, 'epoch'::timestamptz)
+  GROUP BY sm.thread_id;
+$$;
+
+COMMIT;
+
+-- ROLLBACK:
+-- BEGIN;
+-- DROP FUNCTION IF EXISTS rokki_signal_unread_counts();
+-- DROP FUNCTION IF EXISTS rokki_unread_counts();
+-- ALTER TABLE signal_threads DROP COLUMN IF EXISTS last_read_at;
+-- COMMIT;


### PR DESCRIPTION
## Wave 1 cont'd — inbox you control.

Addresses: *"group chats for terminals/spaces I can't remove from the message board"* and *"I don't see if I have any unread messages."*

### Filters + hide
- **Source filter (All / Signal / Rokki).** One tap = "Signal only" drops every terminal/space channel from the board. Persisted per device.
- **Per-conversation hide** (hover the ×) with an "N hidden · show" restore. In **both** the dashboard card and the full inbox.

### Unread
- **Blue unread-count pill + bold row** for conversations with unread messages, in both surfaces. Opening a thread clears it (optimistic + server-side mark-read).
- New migration: `signal_threads.last_read_at` + two **RLS-scoped RPCs** (`rokki_unread_counts`, `rokki_signal_unread_counts`) so the threads API returns per-thread unread without a query per thread. The Signal thread GET now stamps `last_read_at`; native threads already use `thread_participants.last_read_at`.

## Test
`filterThreads` + `UnreadBadge` unit coverage; `tsc` green, `eslint` clean, 11/11 relevant tests pass.

Stacked after #263 (rebased onto main, contains only its own changes). Next: WhatsApp-style media gallery + rich attachment rendering + history divider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)