### PR TITLE
feat(messages): conversation search + multiline composer with saved drafts (Wave 2)

### DIFF
--- a/apps/web/src/components/dashboard/MessagesCard.tsx
+++ b/apps/web/src/components/dashboard/MessagesCard.tsx
@@ -31,9 +31,11 @@ import {
   useInboxView,
   filterThreads,
   InboxFilterBar,
+  InboxSearch,
   UnreadBadge,
   type InboxFilter,
 } from "../messages/inbox-prefs";
+import { useAutosize, usePersistedDraft, composerKeyDown } from "../messages/composer-utils";
 
 interface ThreadSummary {
   id: string;
@@ -62,6 +64,7 @@ export function MessagesCard() {
   const [threads, setThreads] = useState<ThreadSummary[]>([]);
   const [loading, setLoading] = useState(true);
   const [open, setOpen] = useState<ThreadSummary | null>(null);
+  const [query, setQuery] = useState("");
   const { filter, setFilter, hidden, hide, clearHidden } = useInboxView();
   // Measure the card so we can switch to a two-pane (iMessage-style) layout
   // when it's wide enough.
@@ -96,7 +99,12 @@ export function MessagesCard() {
     { onInsert: () => void load(), onUpdate: () => void load() },
   );
 
-  const { visible, hiddenInFilter } = filterThreads(threads, filter, hidden);
+  const { visible, hiddenInFilter } = filterThreads(
+    threads,
+    filter,
+    hidden,
+    query,
+  );
   // Two-pane (list + open chat side by side) once the card is wide enough,
   // like Messages on a Mac; below that, the single-pane list↔thread flow.
   const split = width >= 560;
@@ -121,6 +129,8 @@ export function MessagesCard() {
       hiddenInFilter={hiddenInFilter}
       clearHidden={clearHidden}
       hide={hide}
+      query={query}
+      setQuery={setQuery}
       activeId={split ? open?.id ?? null : null}
       onSelect={selectThread}
     />
@@ -206,6 +216,8 @@ function ConversationList({
   hiddenInFilter,
   clearHidden,
   hide,
+  query,
+  setQuery,
   activeId,
   onSelect,
 }: {
@@ -215,6 +227,8 @@ function ConversationList({
   hiddenInFilter: number;
   clearHidden: () => void;
   hide: (id: string) => void;
+  query: string;
+  setQuery: (v: string) => void;
   activeId: string | null;
   onSelect: (t: ThreadSummary) => void;
 }) {
@@ -226,6 +240,7 @@ function ConversationList({
         hiddenCount={hiddenInFilter}
         onShowHidden={clearHidden}
       />
+      <InboxSearch value={query} onChange={setQuery} />
       <ul className="min-h-0 flex-1 divide-y divide-border/30 overflow-y-auto">
         {visible.length === 0 ? (
           <li className="px-3 py-6 text-center text-xs text-text-3">
@@ -352,16 +367,18 @@ function ThreadQuickView({
 }) {
   const isSignal = thread.source === "signal";
   const [messages, setMessages] = useState<QuickMessage[]>([]);
-  const [draft, setDraft] = useState("");
+  const [draft, setDraft] = usePersistedDraft(thread.id);
   const [pending, setPending] = useState<PendingItem[]>([]);
   const [sending, setSending] = useState(false);
   const [dragging, setDragging] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const scrollerRef = useRef<HTMLDivElement>(null);
+  const composerRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const dragDepth = useRef(0);
   const pendingRef = useRef<PendingItem[]>([]);
   pendingRef.current = pending;
+  useAutosize(composerRef, draft);
 
   const scrollToEnd = useCallback(() => {
     requestAnimationFrame(() => {
@@ -771,11 +788,14 @@ function ThreadQuickView({
               </button>
             </>
           ) : null}
-          <input
+          <textarea
+            ref={composerRef}
             value={draft}
             onChange={(e) => setDraft(e.target.value)}
+            onKeyDown={(e) => composerKeyDown(e, () => void submit())}
+            rows={1}
             placeholder={`Reply${isSignal ? " on Signal" : ""}…`}
-            className="flex-1 rounded-sm border border-border bg-bg-0 px-2 py-1 text-xs text-text-0 outline-none focus:border-border-focus"
+            className="max-h-[120px] flex-1 resize-none rounded-sm border border-border bg-bg-0 px-2 py-1 text-xs text-text-0 outline-none focus:border-border-focus"
           />
           <button
             type="submit"

--- a/apps/web/src/components/messages/MessagesInbox.tsx
+++ b/apps/web/src/components/messages/MessagesInbox.tsx
@@ -24,8 +24,14 @@ import {
   useInboxView,
   filterThreads,
   InboxFilterBar,
+  InboxSearch,
   UnreadBadge,
 } from "./inbox-prefs";
+import {
+  useAutosize,
+  usePersistedDraft,
+  composerKeyDown,
+} from "./composer-utils";
 
 interface ThreadSummary {
   id: string;
@@ -74,7 +80,8 @@ export function MessagesInbox() {
   const [activeId, setActiveId] = useState<string | null>(null);
   const [picking, setPicking] = useState(false);
   const [messages, setMessages] = useState<Message[]>([]);
-  const [draft, setDraft] = useState("");
+  const [draft, setDraft] = usePersistedDraft(activeId ?? "none");
+  const [query, setQuery] = useState("");
   const [sending, setSending] = useState(false);
   const [meId, setMeId] = useState<string | null>(null);
   /**
@@ -87,10 +94,17 @@ export function MessagesInbox() {
   const [statusSending, setStatusSending] = useState<string | null>(null);
   const [refreshingReminders, setRefreshingReminders] = useState(false);
   const scrollerRef = useRef<HTMLDivElement>(null);
+  const composerRef = useRef<HTMLTextAreaElement>(null);
   const { filter, setFilter, hidden, hide, clearHidden } = useInboxView();
+  useAutosize(composerRef, draft);
 
   const active = threads.find((t) => t.id === activeId) ?? null;
-  const { visible, hiddenInFilter } = filterThreads(threads, filter, hidden);
+  const { visible, hiddenInFilter } = filterThreads(
+    threads,
+    filter,
+    hidden,
+    query,
+  );
   // Signal threads load + send through a different pipeline (the bridge), so
   // the native message-load and realtime below skip them.
   const activeIsSignal = active?.source === "signal";
@@ -264,6 +278,7 @@ export function MessagesInbox() {
           hiddenCount={hiddenInFilter}
           onShowHidden={clearHidden}
         />
+        <InboxSearch value={query} onChange={setQuery} />
         {/* Reminders CTA — shows once until the user enables it; the
             refresh endpoint creates the thread + posts pings for the
             user's overdue / due-today tasks. After first run the
@@ -554,11 +569,14 @@ export function MessagesInbox() {
             onSubmit={submit}
             className="flex gap-2 border-t border-border bg-bg-1 p-2"
           >
-            <input
+            <textarea
+              ref={composerRef}
               value={draft}
               onChange={(e) => setDraft(e.target.value)}
+              onKeyDown={(e) => composerKeyDown(e, () => void submit())}
+              rows={1}
               placeholder={`Message ${active.label}`}
-              className="flex-1 rounded-sm border border-border bg-bg-0 px-2 py-1.5 text-xs text-text-0 outline-none focus:border-border-focus"
+              className="max-h-[140px] flex-1 resize-none rounded-sm border border-border bg-bg-0 px-2 py-1.5 text-xs text-text-0 outline-none focus:border-border-focus"
               disabled={sending}
             />
             <button

--- a/apps/web/src/components/messages/SignalThreadView.tsx
+++ b/apps/web/src/components/messages/SignalThreadView.tsx
@@ -22,6 +22,11 @@ import {
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useRealtimeTable } from "@/lib/supabase/realtime";
+import {
+  useAutosize,
+  usePersistedDraft,
+  composerKeyDown,
+} from "./composer-utils";
 
 type SignalStatus = "sending" | "sent" | "delivered" | "read" | "failed";
 
@@ -81,7 +86,7 @@ export function SignalThreadView({
   onDeleted?: () => void;
 }) {
   const [messages, setMessages] = useState<SignalMessage[]>([]);
-  const [draft, setDraft] = useState("");
+  const [draft, setDraft] = usePersistedDraft(threadId);
   const [pending, setPending] = useState<PendingAttachment[]>([]);
   const [uploading, setUploading] = useState(false);
   const [dragging, setDragging] = useState(false);
@@ -90,6 +95,7 @@ export function SignalThreadView({
   const [view, setView] = useState<"chat" | "media">("chat");
   const [lightbox, setLightbox] = useState<number | null>(null);
   const scrollerRef = useRef<HTMLDivElement>(null);
+  const composerRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   // dragenter/dragleave fire for every child element; count depth so the drop
   // overlay only clears when the cursor truly leaves the pane.
@@ -100,6 +106,7 @@ export function SignalThreadView({
   // Mirror of `pending` so the unmount cleanup can revoke any staged object URLs.
   const pendingRef = useRef<PendingAttachment[]>([]);
   pendingRef.current = pending;
+  useAutosize(composerRef, draft);
 
   const load = useCallback(async () => {
     const r = await fetch(`/api/v1/signal/threads/${threadId}`, {
@@ -537,11 +544,14 @@ export function SignalThreadView({
               <Paperclip className="h-3.5 w-3.5" />
             )}
           </button>
-          <input
+          <textarea
+            ref={composerRef}
             value={draft}
             onChange={(e) => setDraft(e.target.value)}
+            onKeyDown={(e) => composerKeyDown(e, () => void submit())}
+            rows={1}
             placeholder={`Message ${label} on Signal`}
-            className="flex-1 rounded-sm border border-border bg-bg-0 px-2 py-1.5 text-xs text-text-0 outline-none focus:border-border-focus"
+            className="max-h-[140px] flex-1 resize-none rounded-sm border border-border bg-bg-0 px-2 py-1.5 text-xs text-text-0 outline-none focus:border-border-focus"
           />
           <button
             type="submit"

--- a/apps/web/src/components/messages/composer-utils.test.ts
+++ b/apps/web/src/components/messages/composer-utils.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import type { KeyboardEvent } from "react";
+import { composerKeyDown } from "./composer-utils";
+
+type KE = KeyboardEvent<HTMLTextAreaElement>;
+
+function evt(key: string, shiftKey: boolean) {
+  let prevented = false;
+  const e = {
+    key,
+    shiftKey,
+    preventDefault: () => {
+      prevented = true;
+    },
+  } as unknown as KE;
+  return { e, wasPrevented: () => prevented };
+}
+
+describe("composerKeyDown", () => {
+  it("Enter without shift submits and prevents the newline", () => {
+    let submitted = false;
+    const { e, wasPrevented } = evt("Enter", false);
+    composerKeyDown(e, () => {
+      submitted = true;
+    });
+    expect(submitted).toBe(true);
+    expect(wasPrevented()).toBe(true);
+  });
+
+  it("Shift+Enter inserts a newline (no submit)", () => {
+    let submitted = false;
+    const { e, wasPrevented } = evt("Enter", true);
+    composerKeyDown(e, () => {
+      submitted = true;
+    });
+    expect(submitted).toBe(false);
+    expect(wasPrevented()).toBe(false);
+  });
+
+  it("other keys do nothing", () => {
+    let submitted = false;
+    const { e } = evt("a", false);
+    composerKeyDown(e, () => {
+      submitted = true;
+    });
+    expect(submitted).toBe(false);
+  });
+});

--- a/apps/web/src/components/messages/composer-utils.ts
+++ b/apps/web/src/components/messages/composer-utils.ts
@@ -1,0 +1,71 @@
+"use client";
+
+import {
+  useEffect,
+  useState,
+  type Dispatch,
+  type RefObject,
+  type SetStateAction,
+} from "react";
+
+/**
+ * Grow a textarea to fit its content up to a max height, then scroll. Call with
+ * the textarea ref and its current value so it re-measures on every change.
+ */
+export function useAutosize(
+  ref: RefObject<HTMLTextAreaElement | null>,
+  value: string,
+  maxPx = 120,
+) {
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    el.style.height = "auto";
+    el.style.height = `${Math.min(el.scrollHeight, maxPx)}px`;
+  }, [ref, value, maxPx]);
+}
+
+const DRAFT_PREFIX = "rokki:draft:";
+
+/**
+ * A composer draft persisted per conversation in localStorage, so an unsent
+ * message survives switching threads / reloading. Returns [draft, setDraft,
+ * clearDraft]. Hydrates on mount and whenever the key (thread id) changes.
+ */
+export function usePersistedDraft(
+  key: string,
+): [string, Dispatch<SetStateAction<string>>, () => void] {
+  const [draft, setDraft] = useState("");
+
+  // Hydrate when the conversation changes.
+  useEffect(() => {
+    try {
+      setDraft(localStorage.getItem(DRAFT_PREFIX + key) ?? "");
+    } catch {
+      setDraft("");
+    }
+  }, [key]);
+
+  // Persist on every change (clears the entry when empty).
+  useEffect(() => {
+    try {
+      if (draft) localStorage.setItem(DRAFT_PREFIX + key, draft);
+      else localStorage.removeItem(DRAFT_PREFIX + key);
+    } catch {
+      /* ignore unavailable storage */
+    }
+  }, [draft, key]);
+
+  return [draft, setDraft, () => setDraft("")];
+}
+
+/** Enter submits, Shift+Enter inserts a newline. Use on a composer textarea. */
+export function composerKeyDown(
+  e: React.KeyboardEvent<HTMLTextAreaElement>,
+  submit: () => void,
+) {
+  if (e.key === "Enter" && !e.shiftKey) {
+    e.preventDefault();
+    submit();
+  }
+}

--- a/apps/web/src/components/messages/inbox-prefs.test.tsx
+++ b/apps/web/src/components/messages/inbox-prefs.test.tsx
@@ -43,6 +43,34 @@ describe("filterThreads", () => {
   });
 });
 
+describe("filterThreads search", () => {
+  const labeled = [
+    { id: "a", source: "rokki" as const, label: "Carlos" },
+    { id: "b", source: "signal" as const, label: "Mom" },
+    { id: "c", source: "rokki" as const, label: "Maria" },
+  ];
+  it("filters by label substring, case-insensitive", () => {
+    const { visible } = filterThreads(labeled, "all", new Set(), "MAR");
+    expect(visible.map((t) => t.id)).toEqual(["c"]);
+  });
+  it("combines with the source filter", () => {
+    const { visible } = filterThreads(labeled, "rokki", new Set(), "ca");
+    expect(visible.map((t) => t.id)).toEqual(["a"]);
+  });
+  it("an empty query returns everything in the filter", () => {
+    expect(filterThreads(labeled, "all", new Set(), "").visible.length).toBe(3);
+  });
+  it("hiddenInFilter is independent of the query", () => {
+    const { hiddenInFilter } = filterThreads(
+      labeled,
+      "all",
+      new Set(["a"]),
+      "zzz",
+    );
+    expect(hiddenInFilter).toBe(1);
+  });
+});
+
 describe("UnreadBadge", () => {
   it("renders the count when > 0", () => {
     render(<UnreadBadge count={5} />);

--- a/apps/web/src/components/messages/inbox-prefs.tsx
+++ b/apps/web/src/components/messages/inbox-prefs.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
+import { Search, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 /**
@@ -70,19 +71,26 @@ export function useInboxView() {
   return { filter, setFilter, hidden, hide, unhide, clearHidden };
 }
 
-/** Apply a filter + hide list to a thread array. */
+/** Apply a source filter + hide list + (optional) search query to a thread
+ *  array. `hiddenInFilter` reflects hidden conversations within the active
+ *  source filter, independent of the search query. */
 export function filterThreads<
-  T extends { id: string; source?: "rokki" | "signal" },
+  T extends { id: string; source?: "rokki" | "signal"; label?: string },
 >(
   threads: T[],
   filter: InboxFilter,
   hidden: Set<string>,
+  query = "",
 ): { visible: T[]; hiddenInFilter: number } {
   const bySource = threads.filter((t) =>
     filter === "all" ? true : (t.source ?? "rokki") === filter,
   );
-  const visible = bySource.filter((t) => !hidden.has(t.id));
-  return { visible, hiddenInFilter: bySource.length - visible.length };
+  const afterHidden = bySource.filter((t) => !hidden.has(t.id));
+  const q = query.trim().toLowerCase();
+  const visible = q
+    ? afterHidden.filter((t) => (t.label ?? "").toLowerCase().includes(q))
+    : afterHidden;
+  return { visible, hiddenInFilter: bySource.length - afterHidden.length };
 }
 
 const FILTERS: { key: InboxFilter; label: string }[] = [
@@ -137,6 +145,44 @@ export function InboxFilterBar({
           title="Restore hidden conversations"
         >
           {hiddenCount} hidden · show
+        </button>
+      ) : null}
+    </div>
+  );
+}
+
+/** Compact search input for filtering the conversation list by name. */
+export function InboxSearch({
+  value,
+  onChange,
+  className,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-1.5 border-b border-border/60 px-2 py-1",
+        className,
+      )}
+    >
+      <Search className="h-3 w-3 flex-shrink-0 text-text-3" />
+      <input
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder="Search conversations"
+        className="w-full bg-transparent text-xs text-text-0 outline-none placeholder:text-text-3"
+      />
+      {value ? (
+        <button
+          type="button"
+          onClick={() => onChange("")}
+          aria-label="Clear search"
+          className="flex-shrink-0 text-text-3 hover:text-text-1"
+        >
+          <X className="h-3 w-3" />
         </button>
       ) : null}
     </div>


### PR DESCRIPTION
## Wave 2 — part 1

- **Search.** A search box filters the conversation list by name — in both the dashboard card and the full inbox. Combines with the Signal/Rokki filter and works alongside hide.
- **Real composer.** The reply box is now a multiline textarea: **Enter sends, Shift+Enter adds a newline**, and it **auto-grows** up to a cap. **Drafts are saved per conversation** (localStorage), so an unsent message survives switching threads / reloading — and carries between the dashboard and full views (they key off the same thread id).

Shared `composer-utils` (`useAutosize`, `usePersistedDraft`, `composerKeyDown`) wired into the dashboard thread view, the full Signal thread view, and the native inbox composer.

## Test
`tsc` green, `eslint` clean, 42/42 messaging/dashboard tests pass (new coverage: `filterThreads` search + `composerKeyDown`).

Still queued in Wave 2: notifications (desktop + tab badge), reactions/reply, presence "last seen". Reactions/reply touch the bridge + DB so they'll be their own focused PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)