### PR TITLE
feat(messages): browser-tab unread badge

### DIFF
--- a/apps/web/src/components/DashboardClient.tsx
+++ b/apps/web/src/components/DashboardClient.tsx
@@ -14,6 +14,7 @@ import { GoalsCard } from "./dashboard/GoalsCard";
 import { DashboardPanels } from "./dashboard/DashboardPanels";
 import { ModuleVisibilityProvider } from "./dashboard/module-visibility";
 import { PresenceProvider } from "./presence/PresenceProvider";
+import { UnreadTitleBadge } from "./messages/UnreadTitleBadge";
 import { TerminalScopeFilter } from "./dashboard/TerminalScopeFilter";
 import { TopBar } from "./TopBar";
 import { DensityProvider, type Density } from "@/lib/density";
@@ -300,6 +301,7 @@ export function DashboardClient({
         />
       ) : null}
       <TimezoneProbe currentTimezone={savedTimezone} />
+      <UnreadTitleBadge />
       </PresenceProvider>
     </DensityProvider>
   );

--- a/apps/web/src/components/messages/UnreadTitleBadge.tsx
+++ b/apps/web/src/components/messages/UnreadTitleBadge.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useRealtimeTable } from "@/lib/supabase/realtime";
+
+/**
+ * Mirrors total unread message count into the browser tab title, e.g.
+ * "(3) Rokki — …", so you notice new messages from any tab. Renders nothing.
+ * Refreshes on realtime inserts and when the tab regains focus.
+ */
+export function UnreadTitleBadge() {
+  const [count, setCount] = useState(0);
+
+  const load = useCallback(async () => {
+    try {
+      const r = await fetch("/api/v1/messages/threads", {
+        credentials: "include",
+      });
+      if (!r.ok) return;
+      const b = (await r.json()) as { data?: { unread?: number }[] };
+      setCount((b.data ?? []).reduce((s, t) => s + (t.unread ?? 0), 0));
+    } catch {
+      /* leave the count as-is on transient failure */
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  useRealtimeTable<{ id: string }>(
+    { table: "messages", channelKey: "title:messages" },
+    { onInsert: () => void load() },
+  );
+  useRealtimeTable<{ id: string }>(
+    { table: "signal_messages", channelKey: "title:sigmsgs" },
+    { onInsert: () => void load(), onUpdate: () => void load() },
+  );
+
+  useEffect(() => {
+    const onFocus = () => void load();
+    window.addEventListener("focus", onFocus);
+    return () => window.removeEventListener("focus", onFocus);
+  }, [load]);
+
+  // Prefix the existing title with "(N) " when there's unread; strip any
+  // stale prefix first so the count never compounds.
+  useEffect(() => {
+    const base = document.title.replace(/^\(\d+\)\s*/, "");
+    document.title = count > 0 ? `(${count}) ${base}` : base;
+    return () => {
+      document.title = document.title.replace(/^\(\d+\)\s*/, "");
+    };
+  }, [count]);
+
+  return null;
+}


### PR DESCRIPTION
Mirrors total unread message count into the browser **tab title** — `(3) Rokki — …` — so you notice new messages even when Rokki isn't the focused tab. Refreshes on realtime message inserts and on tab focus; strips its own prefix so the count never compounds. Mounted in the dashboard shell (renders nothing).

`tsc` green, `eslint` clean. Part of Wave 2 (notifications); desktop/push notifications with a permission toggle are a deliberate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)