### PR TITLE
feat(messages): Signal-only inbox + archive icon

### DIFF
--- a/apps/web/src/components/dashboard/MessagesCard.test.tsx
+++ b/apps/web/src/components/dashboard/MessagesCard.test.tsx
@@ -112,30 +112,10 @@ afterEach(() => {
 });
 
 describe("MessagesCard", () => {
-  it("lists recent conversations", async () => {
+  it("lists only Signal conversations (native/Rokki threads are hidden)", async () => {
     render(<MessagesCard />);
-    expect(await screen.findByText("Carlos")).toBeTruthy();
-    expect(screen.getByText("Mom")).toBeTruthy();
-  });
-
-  it("opens a native thread and posts a quick reply to /api/v1/messages", async () => {
-    render(<MessagesCard />);
-    fireEvent.click(await screen.findByText("Carlos"));
-
-    // Recent messages load into the quick view.
-    expect(await screen.findByText("hey there")).toBeTruthy();
-
-    const input = screen.getByPlaceholderText(/Reply/i);
-    fireEvent.change(input, { target: { value: "on my way" } });
-    fireEvent.click(screen.getByLabelText("Send reply"));
-
-    await waitFor(() => {
-      const post = calls.find(
-        (c) => c.url === "/api/v1/messages/threads/t-rokki" && c.method === "POST",
-      );
-      expect(post).toBeTruthy();
-      expect((post!.body as { body: string }).body).toBe("on my way");
-    });
+    expect(await screen.findByText("Mom")).toBeTruthy();
+    expect(screen.queryByText("Carlos")).toBeNull();
   });
 
   it("opens a Signal thread and sends through the bridge with the signal target", async () => {
@@ -162,11 +142,10 @@ describe("MessagesCard", () => {
 
   it("returns to the conversation list via back", async () => {
     render(<MessagesCard />);
-    fireEvent.click(await screen.findByText("Carlos"));
-    expect(await screen.findByText("hey there")).toBeTruthy();
+    fireEvent.click(await screen.findByText("Mom"));
+    expect(await screen.findByText("call me")).toBeTruthy();
 
     fireEvent.click(screen.getByLabelText("Back to conversations"));
-    // Both threads visible again; the composer is gone.
     expect(await screen.findByText("Mom")).toBeTruthy();
     expect(screen.queryByPlaceholderText(/Reply/i)).toBeNull();
   });

--- a/apps/web/src/components/dashboard/MessagesCard.tsx
+++ b/apps/web/src/components/dashboard/MessagesCard.tsx
@@ -30,10 +30,8 @@ import { uploadSignalMedia } from "@/lib/signal/upload";
 import {
   useInboxView,
   filterThreads,
-  InboxFilterBar,
   InboxSearch,
   UnreadBadge,
-  type InboxFilter,
 } from "../messages/inbox-prefs";
 import { useAutosize, usePersistedDraft, composerKeyDown } from "../messages/composer-utils";
 
@@ -65,7 +63,7 @@ export function MessagesCard() {
   const [loading, setLoading] = useState(true);
   const [open, setOpen] = useState<ThreadSummary | null>(null);
   const [query, setQuery] = useState("");
-  const { filter, setFilter, hidden, hide, clearHidden } = useInboxView();
+  const { hidden, hide, clearHidden } = useInboxView();
   // Measure the card so we can switch to a two-pane (iMessage-style) layout
   // when it's wide enough.
   const [containerRef, width] = useElementWidth<HTMLDivElement>();
@@ -99,9 +97,11 @@ export function MessagesCard() {
     { onInsert: () => void load(), onUpdate: () => void load() },
   );
 
+  // Signal-only: every conversation goes through Signal, so the inbox shows
+  // Signal threads exclusively (no native/Rokki category).
   const { visible, hiddenInFilter } = filterThreads(
     threads,
-    filter,
+    "signal",
     hidden,
     query,
   );
@@ -124,8 +124,6 @@ export function MessagesCard() {
   const list = (
     <ConversationList
       visible={visible}
-      filter={filter}
-      setFilter={setFilter}
       hiddenInFilter={hiddenInFilter}
       clearHidden={clearHidden}
       hide={hide}
@@ -211,8 +209,6 @@ function useElementWidth<T extends HTMLElement>() {
  *  footer link. Used standalone (narrow) and as the left pane (wide). */
 function ConversationList({
   visible,
-  filter,
-  setFilter,
   hiddenInFilter,
   clearHidden,
   hide,
@@ -222,8 +218,6 @@ function ConversationList({
   onSelect,
 }: {
   visible: ThreadSummary[];
-  filter: InboxFilter;
-  setFilter: (f: InboxFilter) => void;
   hiddenInFilter: number;
   clearHidden: () => void;
   hide: (id: string) => void;
@@ -234,13 +228,12 @@ function ConversationList({
 }) {
   return (
     <div className="flex min-h-0 flex-1 flex-col">
-      <InboxFilterBar
-        filter={filter}
-        setFilter={setFilter}
+      <InboxSearch
+        value={query}
+        onChange={setQuery}
         hiddenCount={hiddenInFilter}
         onShowHidden={clearHidden}
       />
-      <InboxSearch value={query} onChange={setQuery} />
       <ul className="min-h-0 flex-1 divide-y divide-border/30 overflow-y-auto">
         {visible.length === 0 ? (
           <li className="px-3 py-6 text-center text-xs text-text-3">
@@ -277,8 +270,8 @@ function ConversationList({
                   e.stopPropagation();
                   hide(t.id);
                 }}
-                aria-label={`Hide ${t.label}`}
-                title="Hide from this list"
+                aria-label={`Archive ${t.label}`}
+                title="Archive"
                 className="absolute right-2 top-1/2 -translate-y-1/2 rounded-sm p-0.5 text-text-3 opacity-0 transition-opacity hover:text-danger group-hover:opacity-100"
               >
                 <X className="h-3 w-3" />

--- a/apps/web/src/components/messages/MessagesInbox.tsx
+++ b/apps/web/src/components/messages/MessagesInbox.tsx
@@ -23,7 +23,6 @@ import { PresenceDot, PresenceLabel } from "../presence/PresenceDot";
 import {
   useInboxView,
   filterThreads,
-  InboxFilterBar,
   InboxSearch,
   UnreadBadge,
 } from "./inbox-prefs";
@@ -95,13 +94,15 @@ export function MessagesInbox() {
   const [refreshingReminders, setRefreshingReminders] = useState(false);
   const scrollerRef = useRef<HTMLDivElement>(null);
   const composerRef = useRef<HTMLTextAreaElement>(null);
-  const { filter, setFilter, hidden, hide, clearHidden } = useInboxView();
+  const { hidden, hide, clearHidden } = useInboxView();
   useAutosize(composerRef, draft);
 
   const active = threads.find((t) => t.id === activeId) ?? null;
+  // Signal-only: everything goes through Signal, so the inbox shows Signal
+  // conversations exclusively (no native/Rokki category).
   const { visible, hiddenInFilter } = filterThreads(
     threads,
-    filter,
+    "signal",
     hidden,
     query,
   );
@@ -272,13 +273,12 @@ export function MessagesInbox() {
             <PenSquare className="h-3 w-3" />
           </button>
         </header>
-        <InboxFilterBar
-          filter={filter}
-          setFilter={setFilter}
+        <InboxSearch
+          value={query}
+          onChange={setQuery}
           hiddenCount={hiddenInFilter}
           onShowHidden={clearHidden}
         />
-        <InboxSearch value={query} onChange={setQuery} />
         {/* Reminders CTA — shows once until the user enables it; the
             refresh endpoint creates the thread + posts pings for the
             user's overdue / due-today tasks. After first run the
@@ -355,8 +355,8 @@ export function MessagesInbox() {
                     e.stopPropagation();
                     hide(t.id);
                   }}
-                  aria-label={`Hide ${t.label}`}
-                  title="Hide from this list"
+                  aria-label={`Archive ${t.label}`}
+                  title="Archive"
                   className="absolute right-2 top-1/2 -translate-y-1/2 rounded-sm p-0.5 text-text-3 opacity-0 transition-opacity hover:text-danger group-hover:opacity-100"
                 >
                   <X className="h-3 w-3" />

--- a/apps/web/src/components/messages/inbox-prefs.tsx
+++ b/apps/web/src/components/messages/inbox-prefs.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
-import { Search, X } from "lucide-react";
+import { Search, X, Archive } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 /**
@@ -151,14 +151,19 @@ export function InboxFilterBar({
   );
 }
 
-/** Compact search input for filtering the conversation list by name. */
+/** Compact search input for the conversation list, with an archive icon that
+ *  restores hidden conversations when there are any. */
 export function InboxSearch({
   value,
   onChange,
+  hiddenCount = 0,
+  onShowHidden,
   className,
 }: {
   value: string;
   onChange: (v: string) => void;
+  hiddenCount?: number;
+  onShowHidden?: () => void;
   className?: string;
 }) {
   return (
@@ -172,7 +177,7 @@ export function InboxSearch({
       <input
         value={value}
         onChange={(e) => onChange(e.target.value)}
-        placeholder="Search conversations"
+        placeholder="Search"
         className="w-full bg-transparent text-xs text-text-0 outline-none placeholder:text-text-3"
       />
       {value ? (
@@ -183,6 +188,18 @@ export function InboxSearch({
           className="flex-shrink-0 text-text-3 hover:text-text-1"
         >
           <X className="h-3 w-3" />
+        </button>
+      ) : null}
+      {hiddenCount > 0 && onShowHidden ? (
+        <button
+          type="button"
+          onClick={onShowHidden}
+          title={`Show ${hiddenCount} archived`}
+          aria-label={`Show ${hiddenCount} archived conversation${hiddenCount === 1 ? "" : "s"}`}
+          className="flex flex-shrink-0 items-center gap-0.5 rounded-sm px-0.5 text-text-3 hover:text-text-1"
+        >
+          <Archive className="h-3 w-3" />
+          <span className="text-[10px]">{hiddenCount}</span>
         </button>
       ) : null}
     </div>


### PR DESCRIPTION
Per your direction: **everything is through Signal — no two categories.**

- The inbox now shows **Signal conversations only** (native/Rokki threads are filtered out) in both the dashboard card and the full inbox.
- **Removed the All / Signal / Rokki filter tabs** entirely.
- **Archive is now an icon** (with a count) in the search bar instead of the "N hidden · show" words; the per-row hide control is relabeled "Archive".

On *"messages aren't sending"*: the Signal send code path is intact (composer → `/api/v1/signal/send` → bridge). Making the inbox Signal-only removes the chance of accidentally landing in a native thread (which posts to a Rokki channel, not Signal) — but if Signal sends are still failing after this deploys, that points at the bridge/link connection, which I'll need the exact on-screen error to diagnose.

`tsc` green, `eslint` clean, 14/14 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)