### PR TITLE
feat(messages): emoji picker + draggable list/chat divider

### DIFF
--- a/apps/web/src/components/dashboard/MessagesCard.tsx
+++ b/apps/web/src/components/dashboard/MessagesCard.tsx
@@ -39,6 +39,7 @@ import {
   UnreadBadge,
 } from "../messages/inbox-prefs";
 import { useAutosize, usePersistedDraft, composerKeyDown } from "../messages/composer-utils";
+import { EmojiButton } from "../messages/EmojiPicker";
 
 interface ThreadSummary {
   id: string;
@@ -73,6 +74,41 @@ export function MessagesCard() {
   // Measure the card so we can switch to a two-pane (iMessage-style) layout
   // when it's wide enough.
   const [containerRef, width] = useElementWidth<HTMLDivElement>();
+  // Draggable width of the conversation list (left pane) in the split layout.
+  const [listWidth, setListWidth] = useState(240);
+  useEffect(() => {
+    try {
+      const w = Number(localStorage.getItem("rokki:msg:listw"));
+      if (w >= 180 && w <= 460) setListWidth(w);
+    } catch {
+      /* ignore */
+    }
+  }, []);
+  const startResize = (e: React.MouseEvent) => {
+    e.preventDefault();
+    const startX = e.clientX;
+    const startW = listWidth;
+    document.body.style.userSelect = "none";
+    const onMove = (ev: MouseEvent) => {
+      const w = Math.max(180, Math.min(460, startW + (ev.clientX - startX)));
+      setListWidth(w);
+    };
+    const onUp = () => {
+      window.removeEventListener("mousemove", onMove);
+      window.removeEventListener("mouseup", onUp);
+      document.body.style.userSelect = "";
+      setListWidth((w) => {
+        try {
+          localStorage.setItem("rokki:msg:listw", String(w));
+        } catch {
+          /* ignore */
+        }
+        return w;
+      });
+    };
+    window.addEventListener("mousemove", onMove);
+    window.addEventListener("mouseup", onUp);
+  };
 
   const load = useCallback(async () => {
     try {
@@ -149,9 +185,19 @@ export function MessagesCard() {
   } else if (split) {
     body = (
       <div className="flex min-h-0 flex-1">
-        <div className="flex w-[240px] flex-shrink-0 flex-col border-r border-border">
+        <div
+          style={{ width: Math.min(listWidth, Math.max(180, width - 300)) }}
+          className="flex flex-shrink-0 flex-col"
+        >
           {list}
         </div>
+        <div
+          onMouseDown={startResize}
+          role="separator"
+          aria-label="Drag to resize the conversation list"
+          title="Drag to resize"
+          className="w-1 flex-shrink-0 cursor-col-resize bg-border/60 transition-colors hover:bg-accent"
+        />
         <div className="flex min-h-0 flex-1 flex-col">
           {open ? (
             <ThreadQuickView
@@ -793,6 +839,7 @@ function ThreadQuickView({
               </button>
             </>
           ) : null}
+          <EmojiButton onPick={(emoji) => setDraft((d) => d + emoji)} />
           <textarea
             ref={composerRef}
             value={draft}

--- a/apps/web/src/components/messages/EmojiPicker.tsx
+++ b/apps/web/src/components/messages/EmojiPicker.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { Smile, Clock } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+/**
+ * Dependency-free emoji picker: category tabs + a "recent" row (localStorage),
+ * click to insert. Sending an emoji is just unicode text, so the composer
+ * appends the character to the draft — Signal renders it natively.
+ */
+
+const RECENTS_KEY = "rokki:emoji:recent";
+
+const CATEGORIES: { key: string; label: string; emoji: string; items: string[] }[] = [
+  {
+    key: "smileys",
+    label: "Smileys",
+    emoji: "😀",
+    items: "😀 😃 😄 😁 😆 😅 😂 🤣 🥲 ☺️ 😊 😇 🙂 🙃 😉 😌 😍 🥰 😘 😗 😙 😚 😋 😛 😝 😜 🤪 🤨 🧐 🤓 😎 🥸 🤩 🥳 😏 😒 😞 😔 😟 😕 🙁 ☹️ 😣 😖 😫 😩 🥺 😢 😭 😤 😠 😡 🤬 🤯 😳 🥵 🥶 😱 😨 😰 😥 😓 🤗 🤔 🤭 🤫 🤥 😶 😐 😑 😬 🙄 😯 😦 😧 😮 😲 🥱 😴 🤤 😪 😵 🤐 🥴 🤢 🤮 🤧 😷 🤒 🤕".split(" "),
+  },
+  {
+    key: "gestures",
+    label: "Gestures",
+    emoji: "👍",
+    items: "👍 👎 👊 ✊ 🤛 🤜 👏 🙌 👐 🤲 🤝 🙏 ✍️ 💅 🤳 💪 👈 👉 👆 👇 ☝️ ✋ 🤚 🖐️ 🖖 👋 🤙 🤟 🤘 👌 🤌 🤏 ✌️ 🤞 🫰 🫶 🫵 👆 🖕 ❤️ 🧡 💛 💚 💙 💜 🖤 🤍 🤎 💔 ❣️ 💕 💞 💓 💗 💖 💘 💝".split(" "),
+  },
+  {
+    key: "people",
+    label: "People",
+    emoji: "🧑",
+    items: "👶 🧒 👦 👧 🧑 👨 👩 🧓 👴 👵 🧔 👮 🕵️ 💂 👷 🤴 👸 👳 👲 🧕 🤵 👰 🤰 🤱 👼 🎅 🤶 🦸 🦹 🧙 🧚 🧛 🧜 🧝 🧞 🧟 💆 💇 🚶 🏃 💃 🕺 🧗 🤺 🏇 ⛷️ 🏂 🏌️ 🏄 🚣 🏊 ⛹️ 🏋️ 🚴 🤸 🤼 🤽 🤾 🤹 🧘".split(" "),
+  },
+  {
+    key: "animals",
+    label: "Animals",
+    emoji: "🐶",
+    items: "🐶 🐱 🐭 🐹 🐰 🦊 🐻 🐼 🐨 🐯 🦁 🐮 🐷 🐽 🐸 🐵 🙈 🙉 🙊 🐒 🐔 🐧 🐦 🐤 🦆 🦅 🦉 🦇 🐺 🐗 🐴 🦄 🐝 🐛 🦋 🐌 🐞 🐜 🦂 🐢 🐍 🦎 🐙 🦑 🦐 🦀 🐡 🐠 🐟 🐬 🐳 🐋 🦈 🐊 🐅 🐆 🦓 🦍 🐘 🦛 🐪 🐫 🦒 🐃 🐂 🐄 🐎 🐖 🐏 🐑 🐐 🦌 🐕 🐩 🐈 🐓 🦃 🕊️ 🐇 🐁 🐀 🐿️ 🌵 🎄 🌲 🌳 🌴 🌱 🌿 ☘️ 🍀 🎍 🌾 🌷 🌹 🥀 🌺 🌸 🌼 🌻".split(" "),
+  },
+  {
+    key: "food",
+    label: "Food",
+    emoji: "🍎",
+    items: "🍏 🍎 🍐 🍊 🍋 🍌 🍉 🍇 🍓 🫐 🍈 🍒 🍑 🥭 🍍 🥥 🥝 🍅 🍆 🥑 🥦 🥬 🥒 🌶️ 🌽 🥕 🧄 🧅 🥔 🍠 🥐 🍞 🥖 🥨 🧀 🥚 🍳 🧈 🥞 🧇 🥓 🥩 🍗 🍖 🌭 🍔 🍟 🍕 🥪 🌮 🌯 🥗 🥘 🍝 🍜 🍲 🍛 🍣 🍱 🥟 🍤 🍙 🍚 🍘 🍥 🥮 🍢 🍡 🍧 🍨 🍦 🥧 🧁 🍰 🎂 🍮 🍭 🍬 🍫 🍿 🍩 🍪 🌰 🥜 🍯 🥛 🍼 ☕ 🍵 🧃 🥤 🍶 🍺 🍻 🥂 🍷 🥃 🍸 🍹 🍾".split(" "),
+  },
+  {
+    key: "activities",
+    label: "Activities",
+    emoji: "⚽",
+    items: "⚽ 🏀 🏈 ⚾ 🥎 🎾 🏐 🏉 🥏 🎱 🪀 🏓 🏸 🏒 🏑 🥍 🏏 ⛳ 🪁 🏹 🎣 🤿 🥊 🥋 🎽 🛹 🛼 🛷 ⛸️ 🥌 🎿 ⛷️ 🏂 🏋️ 🤼 🤸 ⛹️ 🤺 🤾 🏌️ 🏇 🧘 🏄 🏊 🤽 🚣 🧗 🚵 🚴 🏆 🥇 🥈 🥉 🏅 🎖️ 🏵️ 🎗️ 🎫 🎟️ 🎪 🤹 🎭 🩰 🎨 🎬 🎤 🎧 🎼 🎹 🥁 🎷 🎺 🎸 🪕 🎻 🎲 ♟️ 🎯 🎳 🎮 🎰 🧩".split(" "),
+  },
+  {
+    key: "travel",
+    label: "Travel",
+    emoji: "🚗",
+    items: "🚗 🚕 🚙 🚌 🚎 🏎️ 🚓 🚑 🚒 🚐 🚚 🚛 🚜 🛴 🚲 🛵 🏍️ 🚨 🚔 🚍 🚘 🚖 🚡 🚠 🚟 🚃 🚋 🚞 🚝 🚄 🚅 🚈 🚂 🚆 🚇 🚊 🚉 ✈️ 🛫 🛬 🛩️ 💺 🚁 🚀 🛸 🛶 ⛵ 🚤 🛥️ 🛳️ ⛴️ 🚢 ⚓ 🗺️ 🗽 🗿 🗼 🏰 🏯 🏟️ 🎡 🎢 🎠 ⛲ ⛱️ 🏖️ 🏝️ 🏜️ 🌋 ⛰️ 🏔️ 🗻 🏕️ ⛺ 🏠 🏡 🏘️ 🏢 🏬 🏣 🏤 🏥 🏦 🏨 🏪 🏫 🏩 💒 🏛️ ⛪ 🕌 🕍 🛕 🌁 🌃 🏙️ 🌄 🌅 🌆 🌇 🌉".split(" "),
+  },
+  {
+    key: "objects",
+    label: "Objects",
+    emoji: "💡",
+    items: "⌚ 📱 💻 ⌨️ 🖥️ 🖨️ 🖱️ 💽 💾 💿 📀 📷 📸 📹 🎥 📞 ☎️ 📟 📠 📺 📻 🎙️ ⏰ ⏱️ ⏲️ 🕰️ 🔋 🔌 💡 🔦 🕯️ 🧯 🛢️ 💸 💵 💴 💶 💷 💰 💳 💎 ⚖️ 🧰 🔧 🔨 ⚒️ 🛠️ ⛏️ 🔩 ⚙️ 🧱 ⛓️ 🧲 🔫 💣 🔪 🗡️ ⚔️ 🛡️ 🚬 ⚰️ 🏺 🔮 📿 🧿 💈 🔭 🔬 🕳️ 💊 💉 🩸 🌡️ 🧹 🧺 🧻 🚽 🚿 🛁 🧼 🪥 🧽 🔑 🗝️ 🚪 🛋️ 🛏️ 🖼️ 🛍️ 🎁 🎈 🎏 🎀 🎊 🎉 🧧 ✉️ 📩 📨 📧 📦 📫 📪 📬 📭 📮 📯 📜 📃 📄 📑 📊 📈 📉 🗒️ 📅 📆 📇 🗃️ 🗳️ 🗄️ 📋 📁 📂 🗂️ 📰 📓 📔 📒 📕 📗 📘 📙 📚 📖 🔖 ✏️ ✒️ 🖋️ 🖊️ 🖌️ 🖍️ 📝 ✂️ 📌 📍 📎 🖇️ 📏 📐".split(" "),
+  },
+  {
+    key: "symbols",
+    label: "Symbols",
+    emoji: "✅",
+    items: "✅ ❌ ❎ ✔️ ☑️ 🔘 ⭕ 🚫 ⛔ 📛 💯 ❗ ❓ ❕ ❔ ‼️ ⁉️ 🔅 🔆 ⚠️ 🚸 🔱 ⚜️ 🔰 ♻️ ✳️ ❇️ ✴️ 💠 Ⓜ️ 🌐 💢 🔥 ✨ 💫 ⭐ 🌟 ⚡ ☄️ 💥 🌈 ☀️ 🌤️ ⛅ 🌥️ ☁️ 🌦️ 🌧️ ⛈️ 🌩️ ❄️ ☃️ ⛄ 💨 💧 💦 ☔ ☂️ 🌊 ❤️ 🧡 💛 💚 💙 💜 🖤 🤍 🤎 💔 ❣️ 💕 💞 💓 💗 💖 💘 💝 💟 🔞 📵 🚭 ❎ 🆎 🆑 🆘 ⛎ ♈ ♉ ♊ ♋ ♌ ♍ ♎ ♏ ♐ ♑ ♒ ♓ 🆔 ⚛️ 🉑 ☢️ ☣️ 🈶 🈚 🈸 🈺 🈷️ ✴️ 🆚 💮 🉐 ㊙️ ㊗️ 🈴 🈵 🈹 🈲 🅰️ 🅱️ 🆎 🆑 🅾️ 🆘 🔠 🔡 🔢 🔣 🔤 🅰️ 🆎".split(" "),
+  },
+];
+
+export function EmojiPicker({
+  onPick,
+  onClose,
+}: {
+  onPick: (emoji: string) => void;
+  onClose: () => void;
+}) {
+  const [cat, setCat] = useState("smileys");
+  const [recent, setRecent] = useState<string[]>([]);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    try {
+      const r = JSON.parse(localStorage.getItem(RECENTS_KEY) ?? "[]") as string[];
+      setRecent(Array.isArray(r) ? r.slice(0, 24) : []);
+    } catch {
+      setRecent([]);
+    }
+  }, []);
+
+  // Close on outside click / Escape.
+  useEffect(() => {
+    const onDown = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) onClose();
+    };
+    const onKey = (e: KeyboardEvent) => e.key === "Escape" && onClose();
+    window.addEventListener("mousedown", onDown);
+    window.addEventListener("keydown", onKey);
+    return () => {
+      window.removeEventListener("mousedown", onDown);
+      window.removeEventListener("keydown", onKey);
+    };
+  }, [onClose]);
+
+  const pick = (emoji: string) => {
+    onPick(emoji);
+    setRecent((prev) => {
+      const next = [emoji, ...prev.filter((e) => e !== emoji)].slice(0, 24);
+      try {
+        localStorage.setItem(RECENTS_KEY, JSON.stringify(next));
+      } catch {
+        /* ignore */
+      }
+      return next;
+    });
+  };
+
+  const active = CATEGORIES.find((c) => c.key === cat) ?? CATEGORIES[0];
+  const items =
+    cat === "recent" ? recent : active.items;
+
+  return (
+    <div
+      ref={ref}
+      className="absolute bottom-full left-0 z-20 mb-1 w-64 overflow-hidden rounded-md border border-border bg-bg-1 shadow-lg"
+    >
+      <div className="grid max-h-48 grid-cols-8 gap-0.5 overflow-y-auto p-2">
+        {items.length === 0 ? (
+          <p className="col-span-8 py-6 text-center text-2xs text-text-3">
+            No recent emojis yet.
+          </p>
+        ) : (
+          items.map((e, i) => (
+            <button
+              key={`${e}-${i}`}
+              type="button"
+              onClick={() => pick(e)}
+              className="flex h-6 w-6 items-center justify-center rounded text-base hover:bg-bg-2"
+            >
+              {e}
+            </button>
+          ))
+        )}
+      </div>
+      <div className="flex items-center gap-0.5 border-t border-border bg-bg-0 px-1 py-1">
+        <button
+          type="button"
+          onClick={() => setCat("recent")}
+          title="Recent"
+          className={cn(
+            "flex h-6 w-6 items-center justify-center rounded hover:bg-bg-2",
+            cat === "recent" ? "text-accent" : "text-text-3",
+          )}
+        >
+          <Clock className="h-3.5 w-3.5" />
+        </button>
+        {CATEGORIES.map((c) => (
+          <button
+            key={c.key}
+            type="button"
+            onClick={() => setCat(c.key)}
+            title={c.label}
+            className={cn(
+              "flex h-6 w-6 items-center justify-center rounded text-sm hover:bg-bg-2",
+              cat === c.key ? "bg-bg-2" : "",
+            )}
+          >
+            {c.emoji}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/** The trigger button + popover wrapper. */
+export function EmojiButton({ onPick }: { onPick: (emoji: string) => void }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="relative flex-shrink-0">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        title="Emoji"
+        aria-label="Insert emoji"
+        className="flex h-full items-center rounded-sm border border-border bg-bg-0 px-2 text-text-2 hover:text-text-0"
+      >
+        <Smile className="h-3.5 w-3.5" />
+      </button>
+      {open ? (
+        <EmojiPicker
+          onPick={(e) => onPick(e)}
+          onClose={() => setOpen(false)}
+        />
+      ) : null}
+    </div>
+  );
+}


### PR DESCRIPTION
- **Emoji** — a 😊 button in the composer opens a categorized, dependency-free emoji picker (9 categories + a "recents" row), click to insert. Emoji is just unicode text so Signal renders it natively, no protocol work.
- **Draggable divider** — grab the bar between the conversation list and the chat (split layout) to resize the list (180–460px); your size is saved.
- **Smoother resize** — the list width is clamped to always leave the chat ≥300px, so resizing flexes the chat instead of squishing it.

GIF is deferred — it needs a Tenor or Giphy API key set as a secret (no good keyless option). Online-presence for Signal contacts is not possible (Signal exposes none to linked devices).

`tsc` green, `eslint` clean, tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)