### PR TITLE
feat(messages): GIF support via Tenor

### DIFF
--- a/apps/web/src/app/api/v1/gif/proxy/route.ts
+++ b/apps/web/src/app/api/v1/gif/proxy/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { withObservability } from "@/lib/observability";
+
+export const maxDuration = 20;
+
+// Only Tenor media hosts — prevents this from being an open SSRF proxy.
+const TENOR_HOST = /^https:\/\/([a-z0-9-]+\.)?tenor\.com\//i;
+
+/**
+ * GET /api/v1/gif/proxy?url=…  — stream a Tenor GIF through our origin so the
+ * client can turn it into a File for the attachment pipeline without CORS
+ * trouble. The url MUST be a tenor.com media URL.
+ */
+async function handleGet(req: NextRequest) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json(
+      { errors: [{ code: "unauthenticated", message: "Sign in required" }] },
+      { status: 401 },
+    );
+  }
+
+  const url = req.nextUrl.searchParams.get("url") ?? "";
+  if (!TENOR_HOST.test(url)) {
+    return NextResponse.json(
+      { errors: [{ message: "only tenor.com media is allowed" }] },
+      { status: 400 },
+    );
+  }
+
+  const r = await fetch(url, { cache: "no-store" });
+  if (!r.ok) {
+    return NextResponse.json(
+      { errors: [{ message: "couldn't fetch the GIF" }] },
+      { status: 502 },
+    );
+  }
+  const buf = await r.arrayBuffer();
+  return new NextResponse(buf, {
+    headers: {
+      "content-type": r.headers.get("content-type") ?? "image/gif",
+      "cache-control": "private, max-age=3600",
+    },
+  });
+}
+
+export const GET = withObservability(handleGet, "GET /api/v1/gif/proxy");

--- a/apps/web/src/app/api/v1/gif/search/route.ts
+++ b/apps/web/src/app/api/v1/gif/search/route.ts
@@ -1,0 +1,76 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { withObservability } from "@/lib/observability";
+
+export const maxDuration = 15;
+
+/**
+ * GET /api/v1/gif/search?q=…  — proxy Tenor GIF search behind our key.
+ *
+ * Requires auth (so the key + quota aren't exposed to the open internet).
+ * Returns a slim shape: { id, description, preview, url }. Empty query returns
+ * Tenor's featured GIFs. Set TENOR_API_KEY in the environment to enable.
+ */
+async function handleGet(req: NextRequest) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json(
+      { errors: [{ code: "unauthenticated", message: "Sign in required" }] },
+      { status: 401 },
+    );
+  }
+
+  const key = process.env.TENOR_API_KEY;
+  if (!key) {
+    return NextResponse.json(
+      { errors: [{ message: "GIF search isn't configured (set TENOR_API_KEY)" }] },
+      { status: 503 },
+    );
+  }
+
+  const q = req.nextUrl.searchParams.get("q")?.trim() ?? "";
+  const base = q
+    ? "https://tenor.googleapis.com/v2/search"
+    : "https://tenor.googleapis.com/v2/featured";
+  const params = new URLSearchParams({
+    key,
+    client_key: "rokki",
+    limit: "24",
+    media_filter: "gif,tinygif",
+    contentfilter: "medium",
+  });
+  if (q) params.set("q", q);
+
+  const r = await fetch(`${base}?${params.toString()}`, { cache: "no-store" });
+  if (!r.ok) {
+    return NextResponse.json(
+      { errors: [{ message: "GIF search failed" }] },
+      { status: 502 },
+    );
+  }
+  const body = (await r.json()) as {
+    results?: {
+      id: string;
+      content_description?: string;
+      media_formats?: {
+        gif?: { url: string };
+        tinygif?: { url: string };
+      };
+    }[];
+  };
+  const data = (body.results ?? [])
+    .map((g) => ({
+      id: g.id,
+      description: g.content_description ?? "GIF",
+      preview: g.media_formats?.tinygif?.url ?? g.media_formats?.gif?.url ?? "",
+      url: g.media_formats?.gif?.url ?? "",
+    }))
+    .filter((g) => g.url && g.preview);
+
+  return NextResponse.json({ data });
+}
+
+export const GET = withObservability(handleGet, "GET /api/v1/gif/search");

--- a/apps/web/src/components/dashboard/MessagesCard.tsx
+++ b/apps/web/src/components/dashboard/MessagesCard.tsx
@@ -40,6 +40,7 @@ import {
 } from "../messages/inbox-prefs";
 import { useAutosize, usePersistedDraft, composerKeyDown } from "../messages/composer-utils";
 import { EmojiButton } from "../messages/EmojiPicker";
+import { GifButton } from "../messages/GifPicker";
 
 interface ThreadSummary {
   id: string;
@@ -583,6 +584,23 @@ function ThreadQuickView({
     });
   }
 
+  // Picking a GIF: download it through our Tenor proxy and stage it as a
+  // pending image attachment, so it sends like any other media.
+  async function stageGif(g: { url: string; description: string }) {
+    setError(null);
+    try {
+      const r = await fetch(`/api/v1/gif/proxy?url=${encodeURIComponent(g.url)}`, {
+        credentials: "include",
+      });
+      if (!r.ok) throw new Error("fetch failed");
+      const blob = await r.blob();
+      const name = `${(g.description || "gif").replace(/[^a-z0-9]+/gi, "-").slice(0, 40) || "gif"}.gif`;
+      await uploadFiles([new File([blob], name, { type: blob.type || "image/gif" })]);
+    } catch {
+      setError("Couldn’t load that GIF.");
+    }
+  }
+
   function onPickFiles(e: React.ChangeEvent<HTMLInputElement>) {
     const files = Array.from(e.target.files ?? []);
     e.target.value = "";
@@ -840,6 +858,7 @@ function ThreadQuickView({
             </>
           ) : null}
           <EmojiButton onPick={(emoji) => setDraft((d) => d + emoji)} />
+          {isSignal ? <GifButton onPick={(g) => void stageGif(g)} /> : null}
           <textarea
             ref={composerRef}
             value={draft}

--- a/apps/web/src/components/messages/GifPicker.tsx
+++ b/apps/web/src/components/messages/GifPicker.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+export interface Gif {
+  id: string;
+  description: string;
+  preview: string;
+  url: string;
+}
+
+/** Searchable Tenor GIF grid. Picking a GIF hands its media URL back to the
+ *  composer, which downloads it (via our proxy) and sends it as an image. */
+function GifGrid({
+  onPick,
+  onClose,
+}: {
+  onPick: (g: Gif) => void;
+  onClose: () => void;
+}) {
+  const [q, setQ] = useState("");
+  const [results, setResults] = useState<Gif[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [unconfigured, setUnconfigured] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    let alive = true;
+    setLoading(true);
+    const t = setTimeout(() => {
+      fetch(`/api/v1/gif/search?q=${encodeURIComponent(q)}`, {
+        credentials: "include",
+      })
+        .then(async (r) => {
+          if (r.status === 503) {
+            if (alive) setUnconfigured(true);
+            return { data: [] };
+          }
+          return r.ok ? r.json() : { data: [] };
+        })
+        .then((b: { data?: Gif[] }) => {
+          if (alive) setResults(b.data ?? []);
+        })
+        .catch(() => {
+          if (alive) setResults([]);
+        })
+        .finally(() => {
+          if (alive) setLoading(false);
+        });
+    }, 350);
+    return () => {
+      alive = false;
+      clearTimeout(t);
+    };
+  }, [q]);
+
+  useEffect(() => {
+    const onDown = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) onClose();
+    };
+    const onKey = (e: KeyboardEvent) => e.key === "Escape" && onClose();
+    window.addEventListener("mousedown", onDown);
+    window.addEventListener("keydown", onKey);
+    return () => {
+      window.removeEventListener("mousedown", onDown);
+      window.removeEventListener("keydown", onKey);
+    };
+  }, [onClose]);
+
+  return (
+    <div
+      ref={ref}
+      className="absolute bottom-full left-0 z-20 mb-1 w-72 overflow-hidden rounded-md border border-border bg-bg-1 shadow-lg"
+    >
+      <div className="border-b border-border p-1.5">
+        <input
+          autoFocus
+          value={q}
+          onChange={(e) => setQ(e.target.value)}
+          placeholder="Search GIFs"
+          className="w-full rounded-sm border border-border bg-bg-0 px-2 py-1 text-xs text-text-0 outline-none focus:border-border-focus"
+        />
+      </div>
+      <div className="grid max-h-56 grid-cols-2 gap-1 overflow-y-auto p-1.5">
+        {unconfigured ? (
+          <p className="col-span-2 px-2 py-6 text-center text-2xs text-text-3">
+            GIF search isn’t set up yet — add a Tenor API key.
+          </p>
+        ) : loading && results.length === 0 ? (
+          <p className="col-span-2 py-6 text-center text-2xs text-text-3">
+            Searching…
+          </p>
+        ) : results.length === 0 ? (
+          <p className="col-span-2 py-6 text-center text-2xs text-text-3">
+            No GIFs found.
+          </p>
+        ) : (
+          results.map((g) => (
+            <button
+              key={g.id}
+              type="button"
+              onClick={() => onPick(g)}
+              className="aspect-square overflow-hidden rounded-sm bg-bg-2 hover:opacity-80"
+            >
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={g.preview}
+                alt={g.description}
+                loading="lazy"
+                className="h-full w-full object-cover"
+              />
+            </button>
+          ))
+        )}
+      </div>
+      <div className="border-t border-border bg-bg-0 px-2 py-0.5 text-right text-[9px] text-text-3">
+        via Tenor
+      </div>
+    </div>
+  );
+}
+
+/** The GIF trigger button + popover. */
+export function GifButton({ onPick }: { onPick: (g: Gif) => void }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="relative flex-shrink-0">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        title="GIF"
+        aria-label="Insert GIF"
+        className="flex h-full items-center rounded-sm border border-border bg-bg-0 px-1.5 text-2xs font-bold text-text-2 hover:text-text-0"
+      >
+        GIF
+      </button>
+      {open ? (
+        <GifGrid
+          onPick={(g) => {
+            onPick(g);
+            setOpen(false);
+          }}
+          onClose={() => setOpen(false)}
+        />
+      ) : null}
+    </div>
+  );
+}


### PR DESCRIPTION
A **GIF** button in the composer opens a searchable Tenor grid; picking one downloads it (through an authenticated, Tenor-host-locked proxy to dodge CORS/SSRF) and stages it as an image attachment, so it sends like any other media on Signal.

- `GET /api/v1/gif/search?q=` — auth'd Tenor search proxy (slim result shape; falls back to Tenor "featured" for an empty query).
- `GET /api/v1/gif/proxy?url=` — streams a `tenor.com` media URL through our origin (host-locked, auth'd).
- `GifPicker` (search + grid) wired into the composer next to the emoji button.

**Needs `TENOR_API_KEY`** set in the environment to work; until then the picker shows a clear "not set up yet" message. Free key at developers.google.com/tenor (Tenor / Google Cloud).

`tsc` green, `eslint` clean, tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)