### PR TITLE
feat(signal): delete for me / for everyone, two-way Signal sync

### DIFF
--- a/apps/signal-bridge/src/index.ts
+++ b/apps/signal-bridge/src/index.ts
@@ -120,12 +120,16 @@ interface RawAttachment {
   filename?: string;
   size?: number;
 }
+interface RawRemoteDelete {
+  timestamp?: number;
+}
 interface RawDataMessage {
   message?: string;
   timestamp?: number;
   groupInfo?: RawGroup;
   groupV2?: { id?: string };
   attachments?: RawAttachment[];
+  remoteDelete?: RawRemoteDelete;
 }
 interface RawSentMessage {
   message?: string;
@@ -136,6 +140,7 @@ interface RawSentMessage {
   groupInfo?: RawGroup;
   groupV2?: { id?: string };
   attachments?: RawAttachment[];
+  remoteDelete?: RawRemoteDelete;
 }
 interface RawEnvelope {
   source?: string;
@@ -388,6 +393,27 @@ async function applyReceipt(
     .in("status", advanceable);
 }
 
+/**
+ * A message was deleted "for everyone" (on Signal). Reflect it in Rokki by
+ * soft-deleting the matching row (external_id == the deleted message's send
+ * timestamp). Works for both an incoming delete and our own phone-side delete.
+ */
+async function applyRemoteDelete(
+  userId: string,
+  targetTimestamp: number,
+): Promise<void> {
+  const { error } = await db
+    .from("signal_messages")
+    .update({ deleted_at: new Date().toISOString() })
+    .eq("user_id", userId)
+    .eq("external_id", String(targetTimestamp));
+  if (error) {
+    console.log(`[remoteDelete] reflect failed: ${error.message}`);
+  } else {
+    console.log(`[remoteDelete] reflected delete of ${targetTimestamp}`);
+  }
+}
+
 // ── contact / group directory sync ────────────────────────────────────────────
 
 interface RawContact {
@@ -506,6 +532,16 @@ function handleRpcLine(line: string): void {
     // Delivery/read receipts ride the same "receive" push — handle first.
     if (params.envelope?.receiptMessage) {
       void applyReceipt(userId, params.envelope.receiptMessage);
+      return;
+    }
+    // Remote delete ("delete for everyone") — either the other party deleting
+    // their message (dataMessage.remoteDelete) or our own delete syncing from
+    // the phone (syncMessage.sentMessage.remoteDelete). Mark the row deleted.
+    const remoteDelete =
+      params.envelope?.dataMessage?.remoteDelete ??
+      params.envelope?.syncMessage?.sentMessage?.remoteDelete;
+    if (remoteDelete?.timestamp) {
+      void applyRemoteDelete(userId, remoteDelete.timestamp);
       return;
     }
     const inbound = toInbound(userId, msg.params);
@@ -826,6 +862,50 @@ app.post("/accounts/:userId/read", async (c) => {
       targetTimestamps: body.timestamps,
       type: "read",
     });
+    return c.json({ ok: true });
+  } catch (e) {
+    return c.json({ error: e instanceof Error ? e.message : String(e) }, 500);
+  }
+});
+
+/**
+ * Delete a message for EVERYONE (Signal remote delete). Only valid for messages
+ * we sent. targetTimestamp is the original send timestamp (our external_id).
+ */
+app.post("/accounts/:userId/remote-delete", async (c) => {
+  const userId = c.req.param("userId");
+  const body = (await c.req.json().catch(() => ({}))) as Partial<{
+    signalNumber: string;
+    signalId: string;
+    kind: "direct" | "group";
+    targetTimestamp: number;
+  }>;
+  if (!body.signalNumber || !body.signalId || !body.targetTimestamp) {
+    return c.json(
+      { error: "signalNumber, signalId and targetTimestamp are required" },
+      400,
+    );
+  }
+  const params =
+    body.kind === "group"
+      ? {
+          account: body.signalNumber,
+          groupId: body.signalId,
+          targetTimestamp: body.targetTimestamp,
+        }
+      : {
+          account: body.signalNumber,
+          recipient: [body.signalId],
+          targetTimestamp: body.targetTimestamp,
+        };
+  try {
+    await rpcCall("remoteDelete", params);
+    // Reflect locally immediately (don't wait for the sync transcript).
+    await db
+      .from("signal_messages")
+      .update({ deleted_at: new Date().toISOString() })
+      .eq("user_id", userId)
+      .eq("external_id", String(body.targetTimestamp));
     return c.json({ ok: true });
   } catch (e) {
     return c.json({ error: e instanceof Error ? e.message : String(e) }, 500);

--- a/apps/web/src/app/api/v1/signal/messages/[id]/remote-delete/route.ts
+++ b/apps/web/src/app/api/v1/signal/messages/[id]/remote-delete/route.ts
@@ -1,0 +1,81 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { withObservability } from "@/lib/observability";
+import { bridgeRemoteDelete } from "@/lib/signal/bridge";
+import { unauth, bad, bridgeErrorResponse } from "@/lib/signal/responses";
+
+export const maxDuration = 30;
+
+interface Props {
+  params: Promise<{ id: string }>;
+}
+
+/**
+ * POST /api/v1/signal/messages/:id/remote-delete — delete a message for
+ * EVERYONE on Signal (remote delete). Only your own (direction=out) messages
+ * qualify. The bridge issues the Signal remote-delete and soft-deletes the row;
+ * the other party's device removes it too.
+ */
+async function handlePost(_req: NextRequest, { params }: Props) {
+  const { id } = await params;
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return unauth();
+
+  const { data: message } = await supabase
+    .from("signal_messages")
+    .select("external_id, direction, thread_id")
+    .eq("id", id)
+    .maybeSingle();
+  const m = message as {
+    external_id?: string;
+    direction?: string;
+    thread_id?: string;
+  } | null;
+  if (!m) return bad("message not found");
+  if (m.direction !== "out") {
+    return bad("you can only delete-for-everyone messages you sent");
+  }
+  if (!m.external_id || !m.thread_id) {
+    return bad("this message can't be remote-deleted");
+  }
+  const targetTimestamp = Number(m.external_id);
+  if (!Number.isFinite(targetTimestamp)) return bad("invalid message timestamp");
+
+  const { data: thread } = await supabase
+    .from("signal_threads")
+    .select("signal_id, kind")
+    .eq("id", m.thread_id)
+    .maybeSingle();
+  const t = thread as { signal_id?: string; kind?: string } | null;
+  if (!t?.signal_id) return bad("conversation not found");
+
+  const { data: account } = await supabase
+    .from("signal_accounts")
+    .select("signal_number, status")
+    .eq("user_id", user.id)
+    .maybeSingle();
+  const acct = account as { signal_number?: string; status?: string } | null;
+  if (!acct?.signal_number || acct.status !== "active") {
+    return bad("Signal isn't connected");
+  }
+
+  try {
+    await bridgeRemoteDelete(user.id, {
+      signalNumber: acct.signal_number,
+      signalId: t.signal_id,
+      kind: t.kind === "group" ? "group" : "direct",
+      targetTimestamp,
+    });
+    return NextResponse.json({ data: { ok: true } });
+  } catch (e) {
+    return bridgeErrorResponse(e);
+  }
+}
+
+export const POST = withObservability(
+  handlePost,
+  "POST /api/v1/signal/messages/:id/remote-delete",
+);

--- a/apps/web/src/components/dashboard/MessagesCard.tsx
+++ b/apps/web/src/components/dashboard/MessagesCard.tsx
@@ -27,6 +27,7 @@ import {
   AlertCircle,
   Archive,
   ArchiveRestore,
+  MoreHorizontal,
 } from "lucide-react";
 import { DashboardCard } from "./DashboardCard";
 import { cn } from "@/lib/utils";
@@ -471,6 +472,7 @@ function ThreadQuickView({
   const [sending, setSending] = useState(false);
   const [dragging, setDragging] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [menuFor, setMenuFor] = useState<string | null>(null);
   const scrollerRef = useRef<HTMLDivElement>(null);
   const composerRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -567,6 +569,17 @@ function ThreadQuickView({
     { onInsert: () => void load(), onUpdate: () => void load() },
   );
 
+  // Close an open per-message menu on any outside click.
+  useEffect(() => {
+    if (!menuFor) return;
+    const close = () => setMenuFor(null);
+    const t = setTimeout(() => window.addEventListener("mousedown", close), 0);
+    return () => {
+      clearTimeout(t);
+      window.removeEventListener("mousedown", close);
+    };
+  }, [menuFor]);
+
   // ── attachments (Signal only) ──────────────────────────────────────────────
   async function uploadFiles(files: File[]) {
     if (!isSignal || files.length === 0) return;
@@ -633,6 +646,33 @@ function ThreadQuickView({
       await uploadFiles([new File([blob], name, { type: blob.type || "image/gif" })]);
     } catch {
       setError("Couldn’t load that GIF.");
+    }
+  }
+
+  // Per-message delete: "for me" (Rokki-local) and "for everyone" (Signal
+  // remote delete — only your own messages).
+  async function deleteForMe(id: string) {
+    setMenuFor(null);
+    setMessages((prev) => prev.filter((mm) => mm.id !== id));
+    const r = await fetch(`/api/v1/signal/messages/${id}`, {
+      method: "DELETE",
+      credentials: "include",
+    });
+    if (!r.ok) void load();
+  }
+  async function deleteForEveryone(id: string) {
+    setMenuFor(null);
+    setMessages((prev) => prev.filter((mm) => mm.id !== id));
+    const r = await fetch(`/api/v1/signal/messages/${id}/remote-delete`, {
+      method: "POST",
+      credentials: "include",
+    });
+    if (!r.ok) {
+      void load();
+      const b = (await r.json().catch(() => ({}))) as {
+        errors?: { message: string }[];
+      };
+      setError(b.errors?.[0]?.message ?? "Couldn’t delete for everyone.");
     }
   }
 
@@ -783,35 +823,85 @@ function ThreadQuickView({
           <p className="py-6 text-center text-xs text-text-3">No messages yet.</p>
         ) : (
           <ul className="flex flex-col gap-2.5">
-            {messages.map((m) => (
-              <li
-                key={m.id}
-                className={cn(
-                  "flex flex-col gap-0.5",
-                  m.mine ? "items-end" : "items-start",
-                )}
-              >
-                <div
+            {messages.map((m) => {
+              const deletable = !m.id.startsWith("temp-");
+              return (
+                <li
+                  key={m.id}
                   className={cn(
-                    "flex max-w-[78%] flex-col gap-1.5 rounded-2xl px-3 py-2 text-xs leading-relaxed shadow-sm",
-                    m.mine
-                      ? "rounded-br-md bg-accent text-bg-0"
-                      : "rounded-bl-md bg-bg-2 text-text-0",
+                    "group/msg relative flex flex-col gap-0.5",
+                    m.mine ? "items-end" : "items-start",
                   )}
                 >
-                  {m.attachments.map((a, i) => (
-                    <BubbleAttachment key={i} att={a} />
-                  ))}
-                  {m.body ? (
-                    <span className="whitespace-pre-wrap break-words">{m.body}</span>
+                  <div
+                    className={cn(
+                      "flex items-center gap-1",
+                      m.mine ? "flex-row" : "flex-row-reverse",
+                    )}
+                  >
+                    {deletable ? (
+                      <button
+                        type="button"
+                        onClick={() =>
+                          setMenuFor((cur) => (cur === m.id ? null : m.id))
+                        }
+                        aria-label="Message options"
+                        className="rounded-sm p-0.5 text-text-3 opacity-0 transition-opacity hover:text-text-0 group-hover/msg:opacity-100"
+                      >
+                        <MoreHorizontal className="h-3.5 w-3.5" />
+                      </button>
+                    ) : null}
+                    <div
+                      className={cn(
+                        "flex max-w-[78%] flex-col gap-1.5 rounded-2xl px-3 py-2 text-xs leading-relaxed shadow-sm",
+                        m.mine
+                          ? "rounded-br-md bg-accent text-bg-0"
+                          : "rounded-bl-md bg-bg-2 text-text-0",
+                      )}
+                    >
+                      {m.attachments.map((a, i) => (
+                        <BubbleAttachment key={i} att={a} />
+                      ))}
+                      {m.body ? (
+                        <span className="whitespace-pre-wrap break-words">
+                          {m.body}
+                        </span>
+                      ) : null}
+                    </div>
+                  </div>
+                  {menuFor === m.id ? (
+                    <div
+                      onMouseDown={(e) => e.stopPropagation()}
+                      className={cn(
+                        "absolute top-6 z-20 flex flex-col rounded-md border border-border bg-bg-1 py-1 text-2xs shadow-lg",
+                        m.mine ? "right-5" : "left-5",
+                      )}
+                    >
+                      <button
+                        type="button"
+                        onClick={() => void deleteForMe(m.id)}
+                        className="whitespace-nowrap px-3 py-1 text-left text-text-1 hover:bg-bg-2"
+                      >
+                        Delete for me
+                      </button>
+                      {m.mine ? (
+                        <button
+                          type="button"
+                          onClick={() => void deleteForEveryone(m.id)}
+                          className="whitespace-nowrap px-3 py-1 text-left text-danger hover:bg-bg-2"
+                        >
+                          Delete for everyone
+                        </button>
+                      ) : null}
+                    </div>
                   ) : null}
-                </div>
-                <span className="flex items-center gap-1 px-1 text-2xs text-text-3">
-                  {formatRelative(m.at)}
-                  {m.mine && m.status ? <StatusTick status={m.status} /> : null}
-                </span>
-              </li>
-            ))}
+                  <span className="flex items-center gap-1 px-1 text-2xs text-text-3">
+                    {formatRelative(m.at)}
+                    {m.mine && m.status ? <StatusTick status={m.status} /> : null}
+                  </span>
+                </li>
+              );
+            })}
           </ul>
         )}
       </div>

--- a/apps/web/src/lib/signal/bridge.ts
+++ b/apps/web/src/lib/signal/bridge.ts
@@ -131,6 +131,23 @@ export function bridgeSyncContacts(userId: string): Promise<{ ok: true }> {
   );
 }
 
+/** Delete a message for EVERYONE on Signal (remote delete). Only valid for
+ *  messages the user sent; targetTimestamp is that message's external_id. */
+export function bridgeRemoteDelete(
+  userId: string,
+  payload: {
+    signalNumber: string;
+    signalId: string;
+    kind: "direct" | "group";
+    targetTimestamp: number;
+  },
+): Promise<{ ok: true }> {
+  return bridgeFetch<{ ok: true }>(
+    `/accounts/${encodeURIComponent(userId)}/remote-delete`,
+    { method: "POST", body: payload, timeoutMs: 30_000 },
+  );
+}
+
 /** Send read receipts for the given inbound message timestamps (direct chats). */
 export function bridgeMarkRead(
   userId: string,


### PR DESCRIPTION
Delete + undo-send that syncs both ways with Signal.

- **Delete for everyone** (Signal remote delete) — bridge endpoint calls `signal-cli`'s `remoteDelete` (recipient/groupId + `targetTimestamp` = our `external_id`); web route `POST /api/v1/signal/messages/:id/remote-delete` (only your own out messages, owner-scoped, active account). The recipient's device removes it too.
- **Two-way sync** — the bridge receive handler now reflects remote deletes: `dataMessage.remoteDelete` (the other party deletes their message) and `syncMessage.sentMessage.remoteDelete` (you delete from your phone) → soft-deletes the matching `external_id`. So a delete on Signal shows in Rokki, and vice-versa.
- **UI** — hover a message in the dashboard thread → ⋯ → **Delete for me** (Rokki-local) / **Delete for everyone** (your messages only), optimistic.

⚠️ **Needs your live test.** signal-cli doesn't document the *receive*-side `remoteDelete` field, so the inbound reflection is best-effort and logs `[remoteDelete] reflected …` on each hit. Test: (a) send a message from Rokki → ⋯ → Delete for everyone → confirm it vanishes on the recipient's phone; (b) delete one of your messages *on your phone* → confirm it disappears in Rokki. If (b) doesn't work, the field path needs adjusting and the bridge logs will tell us.

Auto-deploys the bridge on merge. `tsc` green (web + bridge), `eslint` clean, tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)