### PR TITLE
feat(signal): create new Signal groups

### DIFF
--- a/apps/signal-bridge/src/index.ts
+++ b/apps/signal-bridge/src/index.ts
@@ -912,6 +912,58 @@ app.post("/accounts/:userId/remote-delete", async (c) => {
   }
 });
 
+/**
+ * Create a new Signal group with the given name + members (recipient
+ * numbers/uuids). updateGroup with no group id creates a fresh group and (on
+ * create) returns its groupId; we upsert a signal_thread so it shows up right
+ * away. If signal-cli doesn't return the id, the group still exists and a
+ * contact sync will surface it.
+ */
+app.post("/accounts/:userId/group", async (c) => {
+  const userId = c.req.param("userId");
+  const body = (await c.req.json().catch(() => ({}))) as Partial<{
+    signalNumber: string;
+    name: string;
+    members: string[];
+  }>;
+  const name = body.name?.trim();
+  if (!body.signalNumber || !name || !body.members?.length) {
+    return c.json({ error: "signalNumber, name and members are required" }, 400);
+  }
+  try {
+    const res = await rpcCall<{ groupId?: string; timestamp?: number }>(
+      "updateGroup",
+      { account: body.signalNumber, name, members: body.members },
+    );
+    const groupId = res?.groupId;
+    if (!groupId) {
+      console.log(`[group] created "${name}" but no groupId returned`);
+      return c.json({ ok: true, groupId: null, threadId: null });
+    }
+    const { data: thread } = await db
+      .from("signal_threads")
+      .upsert(
+        {
+          user_id: userId,
+          signal_id: groupId,
+          kind: "group",
+          title: name,
+          last_message_at: new Date().toISOString(),
+        },
+        { onConflict: "user_id,signal_id" },
+      )
+      .select("id")
+      .single();
+    return c.json({
+      ok: true,
+      groupId,
+      threadId: (thread as { id: string } | null)?.id ?? null,
+    });
+  } catch (e) {
+    return c.json({ error: e instanceof Error ? e.message : String(e) }, 500);
+  }
+});
+
 app.post("/accounts/:userId/sync", async (c) => {
   const userId = c.req.param("userId");
   const { data } = await db

--- a/apps/web/src/app/api/v1/signal/groups/route.ts
+++ b/apps/web/src/app/api/v1/signal/groups/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { withObservability } from "@/lib/observability";
+import { bridgeCreateGroup } from "@/lib/signal/bridge";
+import { unauth, bad, bridgeErrorResponse } from "@/lib/signal/responses";
+
+export const maxDuration = 60;
+
+/**
+ * POST /api/v1/signal/groups  { name, members: [signalId, …] }
+ *
+ * Create a new Signal group with the given members (their signal ids / numbers)
+ * via the bridge. Returns the new Rokki thread id when signal-cli reports it
+ * (otherwise the group surfaces on the next contact sync).
+ */
+async function handlePost(request: NextRequest) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return unauth();
+
+  const body = (await request.json().catch(() => ({}))) as {
+    name?: string;
+    members?: string[];
+  };
+  const name = typeof body.name === "string" ? body.name.trim() : "";
+  const members = Array.isArray(body.members)
+    ? body.members.filter((m): m is string => typeof m === "string" && m.length > 0)
+    : [];
+  if (!name) return bad("a group name is required");
+  if (members.length === 0) return bad("pick at least one member");
+  if (members.length > 100) return bad("too many members (max 100)");
+
+  const { data: account } = await supabase
+    .from("signal_accounts")
+    .select("signal_number, status")
+    .eq("user_id", user.id)
+    .maybeSingle();
+  const acct = account as { signal_number?: string; status?: string } | null;
+  if (!acct?.signal_number || acct.status !== "active") {
+    return bad("Signal isn't connected");
+  }
+
+  try {
+    const res = await bridgeCreateGroup(user.id, {
+      signalNumber: acct.signal_number,
+      name,
+      members,
+    });
+    return NextResponse.json({ data: { threadId: res.threadId ?? null } });
+  } catch (e) {
+    return bridgeErrorResponse(e);
+  }
+}
+
+export const POST = withObservability(handlePost, "POST /api/v1/signal/groups");

--- a/apps/web/src/components/messages/SignalContactPicker.tsx
+++ b/apps/web/src/components/messages/SignalContactPicker.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { Search, Loader2, X, MessageSquare, Users } from "lucide-react";
+import { Search, Loader2, X, MessageSquare, Users, Check } from "lucide-react";
+import { cn } from "@/lib/utils";
 
 interface Contact {
   signal_id: string;
@@ -14,6 +15,9 @@ interface Contact {
  * groups (from signal_contacts), and on select ensures a thread exists and
  * hands its id back so the inbox can open the conversation. Kicks a fresh
  * contact sync on open so the directory is current.
+ *
+ * Also supports a "New group" mode: multi-select direct contacts + a name to
+ * create a brand-new Signal group via the bridge.
  */
 export function SignalContactPicker({
   onClose,
@@ -26,6 +30,12 @@ export function SignalContactPicker({
   const [q, setQ] = useState("");
   const [loading, setLoading] = useState(true);
   const [opening, setOpening] = useState<string | null>(null);
+
+  const [groupMode, setGroupMode] = useState(false);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [groupName, setGroupName] = useState("");
+  const [creating, setCreating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     let alive = true;
@@ -47,11 +57,15 @@ export function SignalContactPicker({
     };
   }, []);
 
+  // Group mode only adds direct contacts (you can't nest a group).
+  const source = groupMode
+    ? contacts.filter((c) => c.kind === "direct")
+    : contacts;
   const filtered = useMemo(() => {
     const s = q.trim().toLowerCase();
-    if (!s) return contacts;
-    return contacts.filter((c) => (c.name ?? c.signal_id).toLowerCase().includes(s));
-  }, [contacts, q]);
+    if (!s) return source;
+    return source.filter((c) => (c.name ?? c.signal_id).toLowerCase().includes(s));
+  }, [source, q]);
 
   async function pick(c: Contact) {
     if (opening) return;
@@ -74,19 +88,93 @@ export function SignalContactPicker({
     }
   }
 
+  function toggle(id: string) {
+    setSelected((prev) => {
+      const n = new Set(prev);
+      if (n.has(id)) n.delete(id);
+      else n.add(id);
+      return n;
+    });
+  }
+
+  async function createGroup() {
+    const name = groupName.trim();
+    if (creating || !name || selected.size === 0) return;
+    setCreating(true);
+    setError(null);
+    try {
+      const r = await fetch("/api/v1/signal/groups", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({ name, members: [...selected] }),
+      });
+      const b = (await r.json().catch(() => ({}))) as {
+        data?: { threadId?: string | null };
+        errors?: { message: string }[];
+      };
+      if (!r.ok) {
+        setError(b.errors?.[0]?.message ?? "Couldn’t create the group.");
+        return;
+      }
+      if (b.data?.threadId) onPick(b.data.threadId);
+      else onClose(); // created — it'll appear after the next sync
+    } finally {
+      setCreating(false);
+    }
+  }
+
   return (
     <>
       <header className="flex h-9 flex-shrink-0 items-center gap-2 border-b border-border bg-bg-0 px-3">
-        <span className="text-xs text-text-1">New Signal message</span>
+        <span className="text-xs text-text-1">
+          {groupMode ? "New group" : "New message"}
+        </span>
+        <button
+          type="button"
+          onClick={() => {
+            setGroupMode((v) => !v);
+            setSelected(new Set());
+            setError(null);
+          }}
+          className="ml-auto flex items-center gap-1 rounded-sm border border-border px-1.5 py-0.5 text-[10px] text-text-2 hover:text-text-0"
+        >
+          <Users className="h-3 w-3" />
+          {groupMode ? "Single" : "Group"}
+        </button>
         <button
           type="button"
           onClick={onClose}
           aria-label="Close"
-          className="ml-auto rounded-sm p-1 text-text-3 hover:text-text-0"
+          className="rounded-sm p-1 text-text-3 hover:text-text-0"
         >
           <X className="h-3 w-3" />
         </button>
       </header>
+
+      {groupMode ? (
+        <div className="flex flex-shrink-0 items-center gap-1.5 border-b border-border px-3 py-1.5">
+          <input
+            value={groupName}
+            onChange={(e) => setGroupName(e.target.value)}
+            placeholder="Group name"
+            className="flex-1 rounded-sm border border-border bg-bg-0 px-2 py-1 text-xs text-text-0 outline-none focus:border-border-focus"
+          />
+          <button
+            type="button"
+            onClick={() => void createGroup()}
+            disabled={!groupName.trim() || selected.size === 0 || creating}
+            className="flex items-center gap-1 rounded-sm bg-accent px-2 py-1 text-xs text-bg-0 disabled:opacity-40"
+          >
+            {creating ? (
+              <Loader2 className="h-3 w-3 animate-spin" />
+            ) : (
+              `Create (${selected.size})`
+            )}
+          </button>
+        </div>
+      ) : null}
+
       <div className="flex flex-shrink-0 items-center gap-1.5 border-b border-border px-3 py-1.5">
         <Search className="h-3 w-3 text-text-3" />
         <input
@@ -97,6 +185,11 @@ export function SignalContactPicker({
           className="flex-1 bg-transparent text-xs text-text-0 outline-none placeholder:text-text-3"
         />
       </div>
+
+      {error ? (
+        <span className="flex-shrink-0 px-3 py-1 text-2xs text-danger">{error}</span>
+      ) : null}
+
       <div className="flex-1 overflow-y-auto">
         {loading ? (
           <p className="flex items-center justify-center gap-2 py-10 text-xs text-text-3">
@@ -110,27 +203,53 @@ export function SignalContactPicker({
           </p>
         ) : (
           <ul>
-            {filtered.map((c) => (
-              <li key={c.signal_id}>
-                <button
-                  type="button"
-                  onClick={() => void pick(c)}
-                  className="flex w-full items-center gap-2 px-3 py-2 text-left text-xs hover:bg-bg-2"
-                >
-                  {c.kind === "group" ? (
-                    <Users className="h-3 w-3 flex-shrink-0 text-text-3" />
-                  ) : (
-                    <MessageSquare className="h-3 w-3 flex-shrink-0 text-text-3" />
-                  )}
-                  <span className="flex-1 truncate text-text-0">
-                    {c.name ?? c.signal_id}
-                  </span>
-                  {opening === c.signal_id ? (
-                    <Loader2 className="h-3 w-3 flex-shrink-0 animate-spin text-text-3" />
-                  ) : null}
-                </button>
-              </li>
-            ))}
+            {filtered.map((c) =>
+              groupMode ? (
+                <li key={c.signal_id}>
+                  <button
+                    type="button"
+                    onClick={() => toggle(c.signal_id)}
+                    className="flex w-full items-center gap-2 px-3 py-2 text-left text-xs hover:bg-bg-2"
+                  >
+                    <span
+                      className={cn(
+                        "flex h-4 w-4 flex-shrink-0 items-center justify-center rounded-sm border",
+                        selected.has(c.signal_id)
+                          ? "border-accent bg-accent text-bg-0"
+                          : "border-border",
+                      )}
+                    >
+                      {selected.has(c.signal_id) ? (
+                        <Check className="h-3 w-3" />
+                      ) : null}
+                    </span>
+                    <span className="flex-1 truncate text-text-0">
+                      {c.name ?? c.signal_id}
+                    </span>
+                  </button>
+                </li>
+              ) : (
+                <li key={c.signal_id}>
+                  <button
+                    type="button"
+                    onClick={() => void pick(c)}
+                    className="flex w-full items-center gap-2 px-3 py-2 text-left text-xs hover:bg-bg-2"
+                  >
+                    {c.kind === "group" ? (
+                      <Users className="h-3 w-3 flex-shrink-0 text-text-3" />
+                    ) : (
+                      <MessageSquare className="h-3 w-3 flex-shrink-0 text-text-3" />
+                    )}
+                    <span className="flex-1 truncate text-text-0">
+                      {c.name ?? c.signal_id}
+                    </span>
+                    {opening === c.signal_id ? (
+                      <Loader2 className="h-3 w-3 flex-shrink-0 animate-spin text-text-3" />
+                    ) : null}
+                  </button>
+                </li>
+              ),
+            )}
           </ul>
         )}
       </div>

--- a/apps/web/src/lib/signal/bridge.ts
+++ b/apps/web/src/lib/signal/bridge.ts
@@ -123,6 +123,18 @@ export function bridgeSend(
   );
 }
 
+/** Create a new Signal group with the given name + member signal ids. Returns
+ *  the new group id + the Rokki thread id (when signal-cli reports them). */
+export function bridgeCreateGroup(
+  userId: string,
+  payload: { signalNumber: string; name: string; members: string[] },
+): Promise<{ ok: true; groupId: string | null; threadId: string | null }> {
+  return bridgeFetch<{ ok: true; groupId: string | null; threadId: string | null }>(
+    `/accounts/${encodeURIComponent(userId)}/group`,
+    { method: "POST", body: payload, timeoutMs: 45_000 },
+  );
+}
+
 /** Refresh the user's Signal contact + group directory into signal_contacts. */
 export function bridgeSyncContacts(userId: string): Promise<{ ok: true }> {
   return bridgeFetch<{ ok: true }>(


### PR DESCRIPTION
Create brand-new Signal groups from Rokki.

- **Bridge** `POST /accounts/:id/group` → `signal-cli` `updateGroup` (name + members, no group id = create); upserts a `signal_thread` so the new group shows immediately. Graceful fallback if signal-cli doesn't return the new id (it appears on the next sync).
- **Web** `POST /api/v1/signal/groups` `{ name, members }`.
- **UI** — the contact picker gains a **Group** mode: multi-select direct contacts + a name → **Create**. Reachable from the dashboard ✎ compose button.

⚠️ **Needs your live test** — signal-cli's `updateGroup` create-result shape isn't documented, so the "open the new group immediately" path depends on it returning a `groupId`; otherwise the group still gets created and appears after a contact sync.

Auto-deploys the bridge. `tsc` green (web + bridge), `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)