### PR TITLE
refactor(messages): one shared chat renderer for dashboard + full page

### DIFF
--- a/apps/web/src/components/dashboard/MessagesCard.tsx
+++ b/apps/web/src/components/dashboard/MessagesCard.tsx
@@ -505,7 +505,9 @@ function ThreadQuickView({
         (b.data?.messages ?? []).map((m) => ({
           id: m.id,
           mine: m.direction === "out",
-          who: m.direction === "out" ? "you" : m.sender ?? "them",
+          // Empty (not "them") when the sender is unknown, so the shared
+          // renderer shows no group label — matching the full-page view.
+          who: m.direction === "out" ? "you" : m.sender ?? "",
           body: m.body ?? "",
           at: m.sent_at,
           attachments: Array.isArray(m.attachments) ? m.attachments : [],

--- a/apps/web/src/components/dashboard/MessagesCard.tsx
+++ b/apps/web/src/components/dashboard/MessagesCard.tsx
@@ -2,7 +2,6 @@
 
 import Link from "next/link";
 import {
-  Fragment,
   useCallback,
   useEffect,
   useRef,
@@ -22,13 +21,8 @@ import {
   X,
   FileText,
   Loader2,
-  Check,
-  CheckCheck,
-  Clock,
-  AlertCircle,
   Archive,
   ArchiveRestore,
-  MoreHorizontal,
 } from "lucide-react";
 import { DashboardCard } from "./DashboardCard";
 import { cn } from "@/lib/utils";
@@ -44,6 +38,12 @@ import {
 import { useAutosize, usePersistedDraft, composerKeyDown } from "../messages/composer-utils";
 import { EmojiButton } from "../messages/EmojiPicker";
 import { GifButton } from "../messages/GifPicker";
+import {
+  ChatMessageList,
+  formatRelative,
+  type ChatAttachment,
+  type SignalStatus,
+} from "../messages/ChatThread";
 import { SignalContactPicker } from "../messages/SignalContactPicker";
 
 interface ThreadSummary {
@@ -428,15 +428,6 @@ function ThreadIcon({ thread: t }: { thread: ThreadSummary }) {
   return <UserIcon className="h-3.5 w-3.5 flex-shrink-0 text-text-3" />;
 }
 
-interface MsgAttachment {
-  url?: string | null;
-  content_type: string | null;
-  filename: string | null;
-  size: number | null;
-}
-
-type SignalStatus = "sending" | "sent" | "delivered" | "read" | "failed";
-
 /** Normalized message for the thread view. */
 interface QuickMessage {
   id: string;
@@ -444,7 +435,7 @@ interface QuickMessage {
   who: string;
   body: string;
   at: string;
-  attachments: MsgAttachment[];
+  attachments: ChatAttachment[];
   status?: SignalStatus;
 }
 
@@ -476,7 +467,6 @@ function ThreadQuickView({
   const [sending, setSending] = useState(false);
   const [dragging, setDragging] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [menuFor, setMenuFor] = useState<string | null>(null);
   const scrollerRef = useRef<HTMLDivElement>(null);
   const composerRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -507,7 +497,7 @@ function ThreadQuickView({
             body: string | null;
             sent_at: string;
             status?: SignalStatus;
-            attachments?: MsgAttachment[];
+            attachments?: ChatAttachment[];
           }[];
         };
       };
@@ -572,17 +562,6 @@ function ThreadQuickView({
     },
     { onInsert: () => void load(), onUpdate: () => void load() },
   );
-
-  // Close an open per-message menu on any outside click.
-  useEffect(() => {
-    if (!menuFor) return;
-    const close = () => setMenuFor(null);
-    const t = setTimeout(() => window.addEventListener("mousedown", close), 0);
-    return () => {
-      clearTimeout(t);
-      window.removeEventListener("mousedown", close);
-    };
-  }, [menuFor]);
 
   // ── attachments (Signal only) ──────────────────────────────────────────────
   async function uploadFiles(files: File[]) {
@@ -656,7 +635,6 @@ function ThreadQuickView({
   // Per-message delete: "for me" (Rokki-local) and "for everyone" (Signal
   // remote delete — only your own messages).
   async function deleteForMe(id: string) {
-    setMenuFor(null);
     setMessages((prev) => prev.filter((mm) => mm.id !== id));
     const r = await fetch(`/api/v1/signal/messages/${id}`, {
       method: "DELETE",
@@ -665,7 +643,6 @@ function ThreadQuickView({
     if (!r.ok) void load();
   }
   async function deleteForEveryone(id: string) {
-    setMenuFor(null);
     setMessages((prev) => prev.filter((mm) => mm.id !== id));
     const r = await fetch(`/api/v1/signal/messages/${id}/remote-delete`, {
       method: "POST",
@@ -823,137 +800,20 @@ function ThreadQuickView({
       ) : null}
 
       <div ref={scrollerRef} className="min-h-0 flex-1 overflow-y-auto px-3 py-3">
-        {messages.length === 0 ? (
-          <p className="py-6 text-center text-xs text-text-3">No messages yet.</p>
-        ) : (
-          <ul className="flex flex-col">
-            {messages.map((m, i) => {
-              // iMessage/WhatsApp-style grouping: consecutive messages from the
-              // same side within a short window are one "run" — tight spacing,
-              // a tail (the cut corner) only on the last bubble, and a single
-              // timestamp under the run.
-              const prev = messages[i - 1];
-              const next = messages[i + 1];
-              const firstInGroup =
-                !prev || prev.mine !== m.mine || !withinRun(prev.at, m.at);
-              const lastInGroup =
-                !next || next.mine !== m.mine || !withinRun(m.at, next.at);
-              const bigGap =
-                !prev ||
-                new Date(m.at).getTime() - new Date(prev.at).getTime() >
-                  60 * 60_000;
-              const imgs = m.attachments.filter((a) => isImageAtt(a));
-              const files = m.attachments.filter((a) => !isImageAtt(a));
-              const emojiOnly =
-                imgs.length === 0 && files.length === 0 && isEmojiOnly(m.body);
-              const deletable = !m.id.startsWith("temp-");
-              return (
-                <Fragment key={m.id}>
-                  {bigGap ? (
-                    <li className="my-2 flex justify-center">
-                      <span className="rounded-full bg-bg-2/70 px-2 py-0.5 text-[10px] font-medium text-text-3">
-                        {formatStamp(m.at)}
-                      </span>
-                    </li>
-                  ) : null}
-                  <li
-                    className={cn(
-                      "group/msg relative flex flex-col",
-                      m.mine ? "items-end" : "items-start",
-                      firstInGroup ? "mt-2" : "mt-0.5",
-                    )}
-                  >
-                    <div
-                      className={cn(
-                        "flex max-w-[82%] items-center gap-1",
-                        m.mine ? "flex-row" : "flex-row-reverse",
-                      )}
-                    >
-                      {deletable ? (
-                        <button
-                          type="button"
-                          onClick={() =>
-                            setMenuFor((cur) => (cur === m.id ? null : m.id))
-                          }
-                          aria-label="Message options"
-                          className="flex-shrink-0 rounded-sm p-0.5 text-text-3 opacity-0 transition-opacity hover:text-text-0 group-hover/msg:opacity-100"
-                        >
-                          <MoreHorizontal className="h-3.5 w-3.5" />
-                        </button>
-                      ) : null}
-                      {emojiOnly ? (
-                        <div className={cn("px-1 py-0.5 leading-none", emojiSize(m.body))}>
-                          {m.body}
-                        </div>
-                      ) : (
-                        <div
-                          className={cn(
-                            "relative overflow-hidden rounded-[18px] shadow-sm",
-                            m.mine
-                              ? "bg-accent text-bg-0"
-                              : "bg-bg-2 text-text-0",
-                            lastInGroup &&
-                              (m.mine
-                                ? "rounded-br-[5px]"
-                                : "rounded-bl-[5px]"),
-                          )}
-                        >
-                          {imgs.length > 0 ? <ImageGroup imgs={imgs} /> : null}
-                          {files.length > 0 ? (
-                            <div className="flex flex-col gap-1 p-1.5">
-                              {files.map((a, k) => (
-                                <FileCard key={k} att={a} mine={m.mine} />
-                              ))}
-                            </div>
-                          ) : null}
-                          {m.body ? (
-                            <div className="whitespace-pre-wrap break-words px-3 py-2 text-xs leading-relaxed">
-                              {m.body}
-                            </div>
-                          ) : null}
-                        </div>
-                      )}
-                    </div>
-                    {menuFor === m.id ? (
-                      <div
-                        onMouseDown={(e) => e.stopPropagation()}
-                        className={cn(
-                          "absolute top-6 z-20 flex flex-col rounded-md border border-border bg-bg-1 py-1 text-2xs shadow-lg",
-                          m.mine ? "right-5" : "left-5",
-                        )}
-                      >
-                        <button
-                          type="button"
-                          onClick={() => void deleteForMe(m.id)}
-                          className="whitespace-nowrap px-3 py-1 text-left text-text-1 hover:bg-bg-2"
-                        >
-                          Delete for me
-                        </button>
-                        {m.mine ? (
-                          <button
-                            type="button"
-                            onClick={() => void deleteForEveryone(m.id)}
-                            className="whitespace-nowrap px-3 py-1 text-left text-danger hover:bg-bg-2"
-                          >
-                            Delete for everyone
-                          </button>
-                        ) : null}
-                      </div>
-                    ) : null}
-                    {lastInGroup ? (
-                      <span className="mt-0.5 flex items-center gap-1 px-1 text-2xs text-text-3">
-                        {formatRelative(m.at)}
-                        {m.mine && m.status ? (
-                          <StatusTick status={m.status} />
-                        ) : null}
-                      </span>
-                    ) : null}
-                  </li>
-                </Fragment>
-              );
-            })}
-          </ul>
-        )}
+        <ChatMessageList
+          messages={messages.map((m) => ({
+            id: m.id,
+            mine: m.mine,
+            sender: m.who,
+            body: m.body,
+            at: m.at,
+            status: m.status,
+            attachments: m.attachments,
+          }))}
+          showSender={thread.signal_kind === "group"}
+          onDeleteForMe={isSignal ? deleteForMe : undefined}
+          onDeleteForEveryone={isSignal ? deleteForEveryone : undefined}
+        />
       </div>
 
       <form
@@ -1066,156 +926,6 @@ function ThreadQuickView({
   );
 }
 
-function isImageAtt(att: MsgAttachment): boolean {
-  return (att.content_type ?? "").startsWith("image/");
-}
-
-/** Render a message's image attachment(s) flush inside the bubble — a single
- *  image fills the bubble (image *is* the bubble, à la iMessage/WhatsApp);
- *  multiple images become a 2-up collage with a "+N" overlay. GIFs get a
- *  small badge and loop on their own (animated <img>). */
-function ImageGroup({ imgs }: { imgs: MsgAttachment[] }) {
-  if (imgs.length === 1) {
-    const a = imgs[0];
-    const gif = (a.content_type ?? "") === "image/gif";
-    const inner = (
-      <span className="relative block">
-        {/* eslint-disable-next-line @next/next/no-img-element */}
-        <img
-          src={a.url ?? undefined}
-          alt={a.filename ?? "image"}
-          className="block max-h-60 max-w-[260px] object-cover"
-        />
-        {gif ? (
-          <span className="absolute bottom-1 left-1 rounded bg-black/55 px-1 py-px text-[9px] font-semibold uppercase tracking-wide text-white">
-            GIF
-          </span>
-        ) : null}
-      </span>
-    );
-    return a.url ? (
-      <a href={a.url} target="_blank" rel="noopener noreferrer">
-        {inner}
-      </a>
-    ) : (
-      inner
-    );
-  }
-  const shown = imgs.slice(0, 4);
-  const extra = imgs.length - shown.length;
-  return (
-    <div className="grid w-[238px] grid-cols-2 gap-0.5">
-      {shown.map((a, i) => {
-        const last = i === shown.length - 1 && extra > 0;
-        const tile = (
-          <span className="relative block">
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img
-              src={a.url ?? undefined}
-              alt={a.filename ?? "image"}
-              className="aspect-square w-full object-cover"
-            />
-            {last ? (
-              <span className="absolute inset-0 flex items-center justify-center bg-black/50 text-sm font-semibold text-white">
-                +{extra}
-              </span>
-            ) : null}
-          </span>
-        );
-        return a.url ? (
-          <a key={i} href={a.url} target="_blank" rel="noopener noreferrer">
-            {tile}
-          </a>
-        ) : (
-          <Fragment key={i}>{tile}</Fragment>
-        );
-      })}
-    </div>
-  );
-}
-
-/** A non-image attachment: a tidy card with an icon, filename and size that
- *  inherits the bubble's text color so it reads on both sides. */
-function FileCard({ att, mine }: { att: MsgAttachment; mine: boolean }) {
-  const name = att.filename ?? "file";
-  const card = (
-    <span
-      className={cn(
-        "flex items-center gap-2 rounded-lg px-2 py-1.5",
-        mine ? "bg-black/10" : "bg-black/15",
-      )}
-    >
-      <FileText className="h-4 w-4 flex-shrink-0 opacity-80" />
-      <span className="min-w-0">
-        <span className="block max-w-[180px] truncate text-xs">{name}</span>
-        {att.size ? (
-          <span className="block text-[10px] opacity-70">
-            {formatSize(att.size)}
-          </span>
-        ) : null}
-      </span>
-    </span>
-  );
-  return att.url ? (
-    <a href={att.url} target="_blank" rel="noopener noreferrer" download={name}>
-      {card}
-    </a>
-  ) : (
-    card
-  );
-}
-
-/** Two messages are in the same "run" when from the same side within 5 min. */
-function withinRun(a: string, b: string): boolean {
-  return Math.abs(new Date(b).getTime() - new Date(a).getTime()) < 5 * 60_000;
-}
-
-/** Count emoji in a string (over-counts ZWJ sequences slightly — fine for
- *  sizing). */
-function emojiCount(s: string): number {
-  const m = s.match(/\p{Extended_Pictographic}/gu);
-  return m ? m.length : 0;
-}
-
-/** True when a message is nothing but emoji (+ whitespace) — iMessage/WhatsApp
- *  render those big and bubble-less. */
-function isEmojiOnly(s: string): boolean {
-  const t = (s ?? "").trim();
-  if (!t) return false;
-  const stripped = t.replace(
-    /[\p{Extended_Pictographic}\u{1F3FB}-\u{1F3FF}\u{1F1E6}-\u{1F1FF}‍️⃣\s]/gu,
-    "",
-  );
-  return stripped === "" && emojiCount(t) <= 6;
-}
-
-/** Jumbo size for an emoji-only message — biggest for a lone emoji. */
-function emojiSize(s: string): string {
-  const n = emojiCount(s);
-  if (n <= 1) return "text-5xl";
-  if (n === 2) return "text-4xl";
-  return "text-3xl";
-}
-
-function formatSize(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-}
-
-/** Date/time chip shown between messages with a big time gap (iMessage-style).*/
-function formatStamp(iso: string): string {
-  const d = new Date(iso);
-  const now = new Date();
-  const sameDay = d.toDateString() === now.toDateString();
-  const time = d.toLocaleTimeString(undefined, {
-    hour: "numeric",
-    minute: "2-digit",
-  });
-  if (sameDay) return time;
-  return `${d.toLocaleDateString(undefined, { month: "short", day: "numeric" })}, ${time}`;
-}
-
 function Empty() {
   return (
     <div className="flex flex-col items-center justify-center gap-2 p-6 text-center">
@@ -1234,46 +944,10 @@ function Empty() {
   );
 }
 
-/** Sent / delivered / read ticks under an outgoing message. */
-function StatusTick({ status }: { status: SignalStatus }) {
-  switch (status) {
-    case "sending":
-      return <Clock className="h-2.5 w-2.5" aria-label="sending" />;
-    case "sent":
-      return <Check className="h-2.5 w-2.5" aria-label="sent" />;
-    case "delivered":
-      return <CheckCheck className="h-2.5 w-2.5" aria-label="delivered" />;
-    case "read":
-      return <CheckCheck className="h-2.5 w-2.5 text-accent" aria-label="read" />;
-    case "failed":
-      return (
-        <AlertCircle className="h-2.5 w-2.5 text-danger" aria-label="failed to send" />
-      );
-    default:
-      return null;
-  }
-}
-
 const UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 /** Don't surface a raw Signal UUID as a conversation name. */
 function displayLabel(label: string): string {
   return UUID_RE.test((label ?? "").trim()) ? "Unknown" : label;
-}
-
-function formatRelative(iso: string): string {
-  const ms = Date.now() - new Date(iso).getTime();
-  const s = Math.floor(ms / 1000);
-  if (s < 60) return "now";
-  const m = Math.floor(s / 60);
-  if (m < 60) return `${m}m`;
-  const h = Math.floor(m / 60);
-  if (h < 24) return `${h}h`;
-  const d = Math.floor(h / 24);
-  if (d < 7) return `${d}d`;
-  return new Date(iso).toLocaleDateString(undefined, {
-    month: "short",
-    day: "numeric",
-  });
 }

--- a/apps/web/src/components/messages/ChatThread.test.tsx
+++ b/apps/web/src/components/messages/ChatThread.test.tsx
@@ -33,6 +33,13 @@ describe("isEmojiOnly", () => {
     expect(isEmojiOnly("")).toBe(false);
     expect(isEmojiOnly("😀😀😀😀😀😀😀")).toBe(false); // 7 > cap
   });
+  it("handles flags, ZWJ sequences and keycaps as single graphemes", () => {
+    expect(isEmojiOnly("🇺🇸")).toBe(true); // one flag
+    expect(isEmojiOnly("👨‍👩‍👧‍👦")).toBe(true); // family ZWJ → one grapheme
+    expect(isEmojiOnly("👨‍👩‍👧‍👦👨‍👩‍👧‍👦")).toBe(true); // two graphemes
+    expect(isEmojiOnly("1️⃣")).toBe(true); // keycap
+    expect(isEmojiOnly("🇺🇸🇺🇸🇺🇸🇺🇸🇺🇸🇺🇸🇺🇸")).toBe(false); // 7 flags > cap
+  });
 });
 
 describe("formatBytes", () => {

--- a/apps/web/src/components/messages/ChatThread.test.tsx
+++ b/apps/web/src/components/messages/ChatThread.test.tsx
@@ -1,0 +1,218 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import {
+  ChatMessageList,
+  isEmojiOnly,
+  formatBytes,
+  formatRelative,
+  type ChatMessage,
+} from "./ChatThread";
+
+afterEach(cleanup);
+
+function msg(over: Partial<ChatMessage> & { id: string }): ChatMessage {
+  return {
+    mine: false,
+    body: "",
+    at: "2026-06-17T12:00:00Z",
+    attachments: [],
+    ...over,
+  };
+}
+
+describe("isEmojiOnly", () => {
+  it("is true for pure-emoji messages (up to 6)", () => {
+    expect(isEmojiOnly("😀")).toBe(true);
+    expect(isEmojiOnly("😀🎉🔥")).toBe(true);
+    expect(isEmojiOnly("  😀  ")).toBe(true);
+  });
+  it("is false for text, mixed, empty, or too many", () => {
+    expect(isEmojiOnly("nope")).toBe(false);
+    expect(isEmojiOnly("😀 hi")).toBe(false);
+    expect(isEmojiOnly("")).toBe(false);
+    expect(isEmojiOnly("😀😀😀😀😀😀😀")).toBe(false); // 7 > cap
+  });
+});
+
+describe("formatBytes", () => {
+  it("renders B / KB / MB", () => {
+    expect(formatBytes(500)).toBe("500 B");
+    expect(formatBytes(2048)).toBe("2 KB");
+    expect(formatBytes(1_572_864)).toBe("1.5 MB");
+  });
+});
+
+describe("formatRelative", () => {
+  it("renders compact relative times", () => {
+    expect(formatRelative(new Date(Date.now() - 30_000).toISOString())).toBe(
+      "now",
+    );
+    expect(formatRelative(new Date(Date.now() - 5 * 60_000).toISOString())).toBe(
+      "5m",
+    );
+    expect(
+      formatRelative(new Date(Date.now() - 3 * 3600_000).toISOString()),
+    ).toBe("3h");
+  });
+});
+
+describe("ChatMessageList", () => {
+  it("shows the empty state", () => {
+    render(<ChatMessageList messages={[]} emptyText="Nothing here." />);
+    expect(screen.getByText("Nothing here.")).toBeTruthy();
+  });
+
+  it("renders message bodies", () => {
+    render(
+      <ChatMessageList
+        messages={[
+          msg({ id: "a", body: "hello" }),
+          msg({ id: "b", mine: true, body: "hi back" }),
+        ]}
+      />,
+    );
+    expect(screen.getByText("hello")).toBeTruthy();
+    expect(screen.getByText("hi back")).toBeTruthy();
+  });
+
+  it("renders an emoji-only message jumbo (no bubble)", () => {
+    render(<ChatMessageList messages={[msg({ id: "e", body: "😀" })]} />);
+    const el = screen.getByText("😀");
+    expect(el.className).toContain("text-5xl");
+  });
+
+  it("groups a run and shows one timestamp/status for the last bubble only", () => {
+    render(
+      <ChatMessageList
+        messages={[
+          msg({
+            id: "g1",
+            mine: true,
+            body: "one",
+            at: "2026-06-17T12:00:00Z",
+            status: "read",
+          }),
+          msg({
+            id: "g2",
+            mine: true,
+            body: "two",
+            at: "2026-06-17T12:01:00Z",
+            status: "read",
+          }),
+        ]}
+      />,
+    );
+    // Both are "mine" within a minute → one run → exactly one status tick.
+    expect(screen.getAllByLabelText("read")).toHaveLength(1);
+  });
+
+  it("renders an image attachment and tags GIFs", () => {
+    render(
+      <ChatMessageList
+        messages={[
+          msg({
+            id: "img",
+            attachments: [
+              {
+                url: "https://x/test.gif",
+                content_type: "image/gif",
+                filename: "test.gif",
+                size: 1000,
+              },
+            ],
+          }),
+        ]}
+      />,
+    );
+    const img = screen.getByAltText("test.gif") as HTMLImageElement;
+    expect(img.src).toContain("test.gif");
+    expect(screen.getByText("GIF")).toBeTruthy();
+  });
+
+  it("renders a non-image file as a card with name + size", () => {
+    render(
+      <ChatMessageList
+        messages={[
+          msg({
+            id: "f",
+            attachments: [
+              {
+                url: "https://x/deck.pdf",
+                content_type: "application/pdf",
+                filename: "deck.pdf",
+                size: 2048,
+              },
+            ],
+          }),
+        ]}
+      />,
+    );
+    expect(screen.getByText("deck.pdf")).toBeTruthy();
+    expect(screen.getByText("2 KB")).toBeTruthy();
+  });
+
+  it("opens the delete menu and calls the right handler", () => {
+    const onMe = vi.fn();
+    const onAll = vi.fn();
+    render(
+      <ChatMessageList
+        messages={[msg({ id: "d", mine: true, body: "secret" })]}
+        onDeleteForMe={onMe}
+        onDeleteForEveryone={onAll}
+      />,
+    );
+    fireEvent.click(screen.getByLabelText("Message options"));
+    expect(screen.getByText("Delete for me")).toBeTruthy();
+    fireEvent.click(screen.getByText("Delete for everyone"));
+    expect(onAll).toHaveBeenCalledWith("d");
+    expect(onMe).not.toHaveBeenCalled();
+  });
+
+  it("does not offer 'delete for everyone' on incoming messages", () => {
+    render(
+      <ChatMessageList
+        messages={[msg({ id: "in", mine: false, body: "theirs" })]}
+        onDeleteForMe={vi.fn()}
+        onDeleteForEveryone={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByLabelText("Message options"));
+    expect(screen.getByText("Delete for me")).toBeTruthy();
+    expect(screen.queryByText("Delete for everyone")).toBeNull();
+  });
+
+  it("calls onOpenImage instead of navigating when provided", () => {
+    const onOpenImage = vi.fn();
+    render(
+      <ChatMessageList
+        onOpenImage={onOpenImage}
+        messages={[
+          msg({
+            id: "lb",
+            attachments: [
+              {
+                url: "https://x/p.jpg",
+                content_type: "image/jpeg",
+                filename: "p.jpg",
+                size: 10,
+              },
+            ],
+          }),
+        ]}
+      />,
+    );
+    fireEvent.click(screen.getByAltText("p.jpg"));
+    expect(onOpenImage).toHaveBeenCalledWith("https://x/p.jpg");
+  });
+
+  it("shows the sender name above incoming group chats", () => {
+    render(
+      <ChatMessageList
+        showSender
+        messages={[msg({ id: "s", mine: false, sender: "Alice", body: "hi" })]}
+      />,
+    );
+    expect(screen.getByText("Alice")).toBeTruthy();
+  });
+});

--- a/apps/web/src/components/messages/ChatThread.tsx
+++ b/apps/web/src/components/messages/ChatThread.tsx
@@ -425,28 +425,40 @@ function withinRun(a: string, b: string): boolean {
   return Math.abs(new Date(b).getTime() - new Date(a).getTime()) < 5 * 60_000;
 }
 
-/** Count emoji in a string (over-counts ZWJ sequences slightly — fine for
- *  sizing). */
-function emojiCount(s: string): number {
-  const m = s.match(/\p{Extended_Pictographic}/gu);
-  return m ? m.length : 0;
+/** Split into user-perceived characters (grapheme clusters) so emoji ZWJ
+ *  sequences (👨‍👩‍👧), flags (🇺🇸) and keycaps (1️⃣) each count as one. */
+function graphemes(s: string): string[] {
+  if (typeof Intl !== "undefined" && "Segmenter" in Intl) {
+    const seg = new Intl.Segmenter(undefined, { granularity: "grapheme" });
+    return Array.from(seg.segment(s), (g) => g.segment);
+  }
+  return Array.from(s); // fallback: code points (imperfect for ZWJ runs)
 }
 
-/** True when a message is nothing but emoji (+ whitespace) — iMessage/WhatsApp
- *  render those big and bubble-less. */
-export function isEmojiOnly(s: string): boolean {
-  const t = (s ?? "").trim();
-  if (!t) return false;
-  const stripped = t.replace(
-    /[\p{Extended_Pictographic}\u{1F3FB}-\u{1F3FF}\u{1F1E6}-\u{1F1FF}‍️⃣\s]/gu,
-    "",
+/** True when a grapheme reads as an emoji — pictographic, flag, or keycap. */
+function isEmojiGrapheme(g: string): boolean {
+  return (
+    /[0-9#*]️?⃣/u.test(g) || // keycap: 1️⃣ #️⃣
+    /\p{Regional_Indicator}/u.test(g) || // flag: two regional indicators
+    /\p{Extended_Pictographic}/u.test(g) // most emoji, incl. ZWJ sequences
   );
-  return stripped === "" && emojiCount(t) <= 6;
+}
+
+/** Visible (non-space) grapheme clusters of a trimmed string. */
+function visibleGraphemes(s: string): string[] {
+  return graphemes((s ?? "").trim()).filter((g) => g.trim() !== "");
+}
+
+/** True when a message is nothing but emoji (≤6) — iMessage/WhatsApp render
+ *  those big and bubble-less. */
+export function isEmojiOnly(s: string): boolean {
+  const gs = visibleGraphemes(s);
+  return gs.length > 0 && gs.length <= 6 && gs.every(isEmojiGrapheme);
 }
 
 /** Jumbo size for an emoji-only message — biggest for a lone emoji. */
 function emojiSize(s: string): string {
-  const n = emojiCount(s);
+  const n = visibleGraphemes(s).length;
   if (n <= 1) return "text-5xl";
   if (n === 2) return "text-4xl";
   return "text-3xl";

--- a/apps/web/src/components/messages/ChatThread.tsx
+++ b/apps/web/src/components/messages/ChatThread.tsx
@@ -1,0 +1,489 @@
+"use client";
+
+import {
+  Fragment,
+  useEffect,
+  useState,
+  type ReactNode,
+} from "react";
+import {
+  FileText,
+  MoreHorizontal,
+  Check,
+  CheckCheck,
+  Clock,
+  AlertCircle,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+
+/**
+ * Shared chat rendering used by BOTH the dashboard Messages card
+ * (ThreadQuickView) and the full-page Signal conversation (SignalThreadView),
+ * so the two surfaces stay pixel-identical and never drift again.
+ *
+ * It matches iMessage / WhatsApp conventions: consecutive messages from the
+ * same side are grouped (tight spacing, tail only on the last bubble, one
+ * timestamp per run); emoji-only messages render jumbo and bubble-less; images
+ * are full-bleed (the image *is* the bubble) with a 2-up collage for several
+ * and a "GIF" badge on GIFs; videos play inline; audio gets a player; other
+ * files render as a tidy card. A big time gap drops a centered date/time chip.
+ */
+
+export type SignalStatus = "sending" | "sent" | "delivered" | "read" | "failed";
+
+export interface ChatAttachment {
+  /** Signed URL (or a local object URL on an optimistic bubble). */
+  url?: string | null;
+  content_type: string | null;
+  filename: string | null;
+  size: number | null;
+}
+
+export interface ChatMessage {
+  id: string;
+  /** True for outgoing messages (right side, accent bubble). */
+  mine: boolean;
+  /** Display name for an incoming message — shown above group runs. */
+  sender?: string | null;
+  body: string;
+  /** ISO timestamp. */
+  at: string;
+  status?: SignalStatus;
+  attachments: ChatAttachment[];
+}
+
+/** Render a thread's messages as grouped, iMessage/WhatsApp-style bubbles.
+ *  The caller owns the scroll container; this renders the optional header and
+ *  the message list (or an empty state). */
+export function ChatMessageList({
+  messages,
+  showSender = false,
+  onDeleteForMe,
+  onDeleteForEveryone,
+  onOpenImage,
+  header,
+  emptyText = "No messages yet.",
+}: {
+  messages: ChatMessage[];
+  /** Show the sender's name above incoming group runs (group chats). */
+  showSender?: boolean;
+  /** When set, messages get a ⋯ menu with "Delete for me". */
+  onDeleteForMe?: (id: string) => void;
+  /** When set, your own messages also get "Delete for everyone". */
+  onDeleteForEveryone?: (id: string) => void;
+  /** When set, tapping an image calls this (lightbox) instead of opening a
+   *  new tab. */
+  onOpenImage?: (url: string) => void;
+  header?: ReactNode;
+  emptyText?: string;
+}) {
+  const [menuFor, setMenuFor] = useState<string | null>(null);
+
+  // Close an open per-message menu on any outside click.
+  useEffect(() => {
+    if (!menuFor) return;
+    const close = () => setMenuFor(null);
+    const t = setTimeout(() => window.addEventListener("mousedown", close), 0);
+    return () => {
+      clearTimeout(t);
+      window.removeEventListener("mousedown", close);
+    };
+  }, [menuFor]);
+
+  if (messages.length === 0) {
+    return (
+      <>
+        {header}
+        <p className="py-6 text-center text-xs text-text-3">{emptyText}</p>
+      </>
+    );
+  }
+
+  return (
+    <>
+      {header}
+      <ul className="flex flex-col">
+        {messages.map((m, i) => {
+          const prev = messages[i - 1];
+          const next = messages[i + 1];
+          const firstInGroup =
+            !prev || prev.mine !== m.mine || !withinRun(prev.at, m.at);
+          const lastInGroup =
+            !next || next.mine !== m.mine || !withinRun(m.at, next.at);
+          const bigGap =
+            !prev ||
+            new Date(m.at).getTime() - new Date(prev.at).getTime() >
+              60 * 60_000;
+          // Visual media needs a URL to render; anything without one (an
+          // optimistic video, or an image whose signed URL failed) falls back
+          // to a file card so we always show *something* (the filename).
+          const imgs = m.attachments.filter((a) => isImage(a) && a.url);
+          const vids = m.attachments.filter((a) => isVideo(a) && a.url);
+          const docs = m.attachments.filter(
+            (a) => !((isImage(a) || isVideo(a)) && a.url),
+          );
+          const emojiOnly =
+            m.attachments.length === 0 && isEmojiOnly(m.body);
+          const canDelete =
+            Boolean(onDeleteForMe) && !m.id.startsWith("temp-");
+          const showName =
+            showSender && !m.mine && firstInGroup && Boolean(m.sender);
+          return (
+            <Fragment key={m.id}>
+              {bigGap ? (
+                <li className="my-2 flex justify-center">
+                  <span className="rounded-full bg-bg-2/70 px-2 py-0.5 text-[10px] font-medium text-text-3">
+                    {formatStamp(m.at)}
+                  </span>
+                </li>
+              ) : null}
+              <li
+                className={cn(
+                  "group/msg relative flex flex-col",
+                  m.mine ? "items-end" : "items-start",
+                  firstInGroup ? "mt-2" : "mt-0.5",
+                )}
+              >
+                {showName ? (
+                  <span className="mb-0.5 px-1 text-2xs font-medium text-text-2">
+                    {m.sender}
+                  </span>
+                ) : null}
+                <div
+                  className={cn(
+                    "flex max-w-[82%] items-center gap-1",
+                    m.mine ? "flex-row" : "flex-row-reverse",
+                  )}
+                >
+                  {canDelete ? (
+                    <button
+                      type="button"
+                      onClick={() =>
+                        setMenuFor((cur) => (cur === m.id ? null : m.id))
+                      }
+                      aria-label="Message options"
+                      className="flex-shrink-0 rounded-sm p-0.5 text-text-3 opacity-0 transition-opacity hover:text-text-0 group-hover/msg:opacity-100"
+                    >
+                      <MoreHorizontal className="h-3.5 w-3.5" />
+                    </button>
+                  ) : null}
+                  {emojiOnly ? (
+                    <div
+                      className={cn(
+                        "px-1 py-0.5 leading-none",
+                        emojiSize(m.body),
+                      )}
+                    >
+                      {m.body}
+                    </div>
+                  ) : (
+                    <div
+                      className={cn(
+                        "relative overflow-hidden rounded-[18px] shadow-sm",
+                        m.mine
+                          ? "bg-accent text-bg-0"
+                          : "bg-bg-2 text-text-0",
+                        lastInGroup &&
+                          (m.mine ? "rounded-br-[5px]" : "rounded-bl-[5px]"),
+                      )}
+                    >
+                      {imgs.length > 0 ? (
+                        <ImageGroup imgs={imgs} onOpenImage={onOpenImage} />
+                      ) : null}
+                      {vids.map((a, k) =>
+                        a.url ? (
+                          <video
+                            key={`v${k}`}
+                            src={a.url}
+                            controls
+                            preload="metadata"
+                            className="block max-h-60 max-w-[260px]"
+                          />
+                        ) : null,
+                      )}
+                      {docs.length > 0 ? (
+                        <div className="flex flex-col gap-1 p-1.5">
+                          {docs.map((a, k) => (
+                            <DocAttachment key={k} att={a} mine={m.mine} />
+                          ))}
+                        </div>
+                      ) : null}
+                      {m.body ? (
+                        <div className="whitespace-pre-wrap break-words px-3 py-2 text-xs leading-relaxed">
+                          {m.body}
+                        </div>
+                      ) : null}
+                    </div>
+                  )}
+                </div>
+                {menuFor === m.id ? (
+                  <div
+                    onMouseDown={(e) => e.stopPropagation()}
+                    className={cn(
+                      "absolute top-6 z-20 flex flex-col rounded-md border border-border bg-bg-1 py-1 text-2xs shadow-lg",
+                      m.mine ? "right-5" : "left-5",
+                    )}
+                  >
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setMenuFor(null);
+                        onDeleteForMe?.(m.id);
+                      }}
+                      className="whitespace-nowrap px-3 py-1 text-left text-text-1 hover:bg-bg-2"
+                    >
+                      Delete for me
+                    </button>
+                    {m.mine && onDeleteForEveryone ? (
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setMenuFor(null);
+                          onDeleteForEveryone(m.id);
+                        }}
+                        className="whitespace-nowrap px-3 py-1 text-left text-danger hover:bg-bg-2"
+                      >
+                        Delete for everyone
+                      </button>
+                    ) : null}
+                  </div>
+                ) : null}
+                {lastInGroup ? (
+                  <span className="mt-0.5 flex items-center gap-1 px-1 text-2xs text-text-3">
+                    {formatRelative(m.at)}
+                    {m.mine && m.status ? <StatusTick status={m.status} /> : null}
+                  </span>
+                ) : null}
+              </li>
+            </Fragment>
+          );
+        })}
+      </ul>
+    </>
+  );
+}
+
+/** Image attachment(s) rendered flush inside the bubble — a single image fills
+ *  the bubble (image *is* the bubble); multiple become a 2-up collage with a
+ *  "+N" overlay. GIFs get a badge and loop on their own (animated <img>). When
+ *  onOpenImage is provided the tile opens a lightbox; otherwise a new tab. */
+function ImageGroup({
+  imgs,
+  onOpenImage,
+}: {
+  imgs: ChatAttachment[];
+  onOpenImage?: (url: string) => void;
+}) {
+  if (imgs.length === 1) {
+    const a = imgs[0];
+    const gif = (a.content_type ?? "") === "image/gif";
+    const inner = (
+      <span className="relative block">
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={a.url ?? undefined}
+          alt={a.filename ?? "image"}
+          className="block max-h-60 max-w-[260px] object-cover"
+        />
+        {gif ? (
+          <span className="absolute bottom-1 left-1 rounded bg-black/55 px-1 py-px text-[9px] font-semibold uppercase tracking-wide text-white">
+            GIF
+          </span>
+        ) : null}
+      </span>
+    );
+    if (!a.url) return inner;
+    return onOpenImage ? (
+      <button
+        type="button"
+        onClick={() => onOpenImage(a.url as string)}
+        className="block cursor-zoom-in"
+      >
+        {inner}
+      </button>
+    ) : (
+      <a href={a.url} target="_blank" rel="noopener noreferrer">
+        {inner}
+      </a>
+    );
+  }
+  const shown = imgs.slice(0, 4);
+  const extra = imgs.length - shown.length;
+  return (
+    <div className="grid w-[238px] grid-cols-2 gap-0.5">
+      {shown.map((a, i) => {
+        const last = i === shown.length - 1 && extra > 0;
+        const tile = (
+          <span className="relative block">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={a.url ?? undefined}
+              alt={a.filename ?? "image"}
+              className="aspect-square w-full object-cover"
+            />
+            {last ? (
+              <span className="absolute inset-0 flex items-center justify-center bg-black/50 text-sm font-semibold text-white">
+                +{extra}
+              </span>
+            ) : null}
+          </span>
+        );
+        if (!a.url) return <Fragment key={i}>{tile}</Fragment>;
+        return onOpenImage ? (
+          <button
+            key={i}
+            type="button"
+            onClick={() => onOpenImage(a.url as string)}
+            className="block cursor-zoom-in"
+          >
+            {tile}
+          </button>
+        ) : (
+          <a key={i} href={a.url} target="_blank" rel="noopener noreferrer">
+            {tile}
+          </a>
+        );
+      })}
+    </div>
+  );
+}
+
+/** Audio gets an inline player; any other non-visual file gets a tidy card
+ *  (icon + filename + human size) that inherits the bubble's text color. */
+function DocAttachment({ att, mine }: { att: ChatAttachment; mine: boolean }) {
+  const type = att.content_type ?? "";
+  if (type.startsWith("audio/") && att.url) {
+    return (
+      <audio
+        src={att.url}
+        controls
+        preload="metadata"
+        className="w-full min-w-[180px]"
+      />
+    );
+  }
+  const name = att.filename ?? "file";
+  const card = (
+    <span
+      className={cn(
+        "flex items-center gap-2 rounded-lg px-2 py-1.5",
+        mine ? "bg-black/10" : "bg-black/15",
+      )}
+    >
+      <FileText className="h-4 w-4 flex-shrink-0 opacity-80" />
+      <span className="min-w-0">
+        <span className="block max-w-[180px] truncate text-xs">{name}</span>
+        {att.size ? (
+          <span className="block text-[10px] opacity-70">
+            {formatBytes(att.size)}
+          </span>
+        ) : null}
+      </span>
+    </span>
+  );
+  return att.url ? (
+    <a href={att.url} target="_blank" rel="noopener noreferrer" download={name}>
+      {card}
+    </a>
+  ) : (
+    card
+  );
+}
+
+/** Sent / delivered / read ticks under an outgoing message. */
+export function StatusTick({ status }: { status: SignalStatus }) {
+  switch (status) {
+    case "sending":
+      return <Clock className="h-2.5 w-2.5" aria-label="sending" />;
+    case "sent":
+      return <Check className="h-2.5 w-2.5" aria-label="sent" />;
+    case "delivered":
+      return <CheckCheck className="h-2.5 w-2.5" aria-label="delivered" />;
+    case "read":
+      return <CheckCheck className="h-2.5 w-2.5 text-accent" aria-label="read" />;
+    case "failed":
+      return (
+        <AlertCircle
+          className="h-2.5 w-2.5 text-danger"
+          aria-label="failed to send"
+        />
+      );
+    default:
+      return null;
+  }
+}
+
+function isImage(att: ChatAttachment): boolean {
+  return (att.content_type ?? "").startsWith("image/");
+}
+function isVideo(att: ChatAttachment): boolean {
+  return (att.content_type ?? "").startsWith("video/");
+}
+
+/** Two messages are in the same "run" when from the same side within 5 min. */
+function withinRun(a: string, b: string): boolean {
+  return Math.abs(new Date(b).getTime() - new Date(a).getTime()) < 5 * 60_000;
+}
+
+/** Count emoji in a string (over-counts ZWJ sequences slightly — fine for
+ *  sizing). */
+function emojiCount(s: string): number {
+  const m = s.match(/\p{Extended_Pictographic}/gu);
+  return m ? m.length : 0;
+}
+
+/** True when a message is nothing but emoji (+ whitespace) — iMessage/WhatsApp
+ *  render those big and bubble-less. */
+export function isEmojiOnly(s: string): boolean {
+  const t = (s ?? "").trim();
+  if (!t) return false;
+  const stripped = t.replace(
+    /[\p{Extended_Pictographic}\u{1F3FB}-\u{1F3FF}\u{1F1E6}-\u{1F1FF}‍️⃣\s]/gu,
+    "",
+  );
+  return stripped === "" && emojiCount(t) <= 6;
+}
+
+/** Jumbo size for an emoji-only message — biggest for a lone emoji. */
+function emojiSize(s: string): string {
+  const n = emojiCount(s);
+  if (n <= 1) return "text-5xl";
+  if (n === 2) return "text-4xl";
+  return "text-3xl";
+}
+
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+/** Date/time chip shown between messages with a big time gap (iMessage-style).*/
+function formatStamp(iso: string): string {
+  const d = new Date(iso);
+  const now = new Date();
+  const sameDay = d.toDateString() === now.toDateString();
+  const time = d.toLocaleTimeString(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+  });
+  if (sameDay) return time;
+  return `${d.toLocaleDateString(undefined, { month: "short", day: "numeric" })}, ${time}`;
+}
+
+/** Compact relative timestamp (now / 5m / 3h / 2d / Jun 4). */
+export function formatRelative(iso: string): string {
+  const ms = Date.now() - new Date(iso).getTime();
+  const s = Math.floor(ms / 1000);
+  if (s < 60) return "now";
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h`;
+  const d = Math.floor(h / 24);
+  if (d < 7) return `${d}d`;
+  return new Date(iso).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+  });
+}

--- a/apps/web/src/components/messages/SignalThreadView.tsx
+++ b/apps/web/src/components/messages/SignalThreadView.tsx
@@ -7,10 +7,6 @@ import {
   Loader2,
   Trash2,
   X,
-  Check,
-  CheckCheck,
-  Clock,
-  AlertCircle,
   Paperclip,
   FileText,
   Download,
@@ -27,6 +23,7 @@ import {
   usePersistedDraft,
   composerKeyDown,
 } from "./composer-utils";
+import { ChatMessageList, formatBytes } from "./ChatThread";
 
 type SignalStatus = "sending" | "sent" | "delivered" | "read" | "failed";
 
@@ -353,6 +350,22 @@ export function SignalThreadView({
     if (!r.ok) void load(); // restore on failure
   }
 
+  // Delete for EVERYONE on Signal (remote delete) — only your own messages.
+  async function deleteForEveryone(id: string) {
+    setMessages((prev) => prev.filter((m) => m.id !== id));
+    const r = await fetch(`/api/v1/signal/messages/${id}/remote-delete`, {
+      method: "POST",
+      credentials: "include",
+    });
+    if (!r.ok) {
+      void load();
+      const b = (await r.json().catch(() => ({}))) as {
+        errors?: { message: string }[];
+      };
+      setError(b.errors?.[0]?.message ?? "Couldn’t delete for everyone.");
+    }
+  }
+
   // All attachments with a usable URL, flattened across messages — powers the
   // media gallery + lightbox.
   const mediaItems = messages
@@ -418,70 +431,23 @@ export function SignalThreadView({
       ) : (
         <>
       <div ref={scrollerRef} className="flex-1 overflow-y-auto px-3 py-2 text-xs">
-        <HistoryNotice />
-        {messages.length === 0 ? (
-          <p className="py-10 text-center text-text-3">
-            No messages yet in this Signal chat.
-          </p>
-        ) : (
-          <ul className="flex flex-col gap-2">
-            {messages.map((m) => {
-              const mine = m.direction === "out";
-              return (
-                <li
-                  key={m.id}
-                  className={cn(
-                    "group flex flex-col rounded-sm px-2 py-1",
-                    mine ? "items-end" : "items-start",
-                  )}
-                >
-                  <div
-                    className={cn(
-                      "flex items-center gap-1",
-                      mine ? "flex-row" : "flex-row-reverse",
-                    )}
-                  >
-                    <button
-                      type="button"
-                      onClick={() => void deleteMessage(m.id)}
-                      title="Delete this message from Rokki"
-                      aria-label="Delete message"
-                      className="rounded-sm p-0.5 text-text-3 opacity-0 transition-opacity hover:text-danger group-hover:opacity-100"
-                    >
-                      <X className="h-3 w-3" />
-                    </button>
-                    <div
-                      className={cn(
-                        "flex max-w-[75%] flex-col gap-1 rounded px-2 py-1 text-xs",
-                        mine ? "bg-accent text-bg-0" : "bg-bg-2 text-text-0",
-                      )}
-                    >
-                      {m.attachments && m.attachments.length > 0 ? (
-                        <div className="flex flex-col gap-1">
-                          {m.attachments.map((a, i) => (
-                            <AttachmentView
-                              key={i}
-                              att={a}
-                              mine={mine}
-                              onOpenImage={openLightbox}
-                            />
-                          ))}
-                        </div>
-                      ) : null}
-                      {m.body ? <span>{m.body}</span> : null}
-                    </div>
-                  </div>
-                  <div className="mt-0.5 flex items-center gap-1 text-[10px] text-text-3">
-                    <span>{mine ? "you" : (m.sender ?? "them")}</span>
-                    <span>·</span>
-                    <span>{formatRelative(m.sent_at)}</span>
-                    {mine && m.status ? <StatusIndicator status={m.status} /> : null}
-                  </div>
-                </li>
-              );
-            })}
-          </ul>
-        )}
+        <ChatMessageList
+          header={<HistoryNotice />}
+          emptyText="No messages yet in this Signal chat."
+          showSender={signalKind === "group"}
+          onDeleteForMe={deleteMessage}
+          onDeleteForEveryone={deleteForEveryone}
+          onOpenImage={openLightbox}
+          messages={messages.map((m) => ({
+            id: m.id,
+            mine: m.direction === "out",
+            sender: m.sender,
+            body: m.body ?? "",
+            at: m.sent_at,
+            status: m.status,
+            attachments: m.attachments ?? [],
+          }))}
+        />
       </div>
       <form
         onSubmit={submit}
@@ -582,90 +548,6 @@ export function SignalThreadView({
         />
       ) : null}
     </div>
-  );
-}
-
-function StatusIndicator({ status }: { status: SignalStatus }) {
-  switch (status) {
-    case "sending":
-      return <Clock className="h-2.5 w-2.5" aria-label="sending" />;
-    case "sent":
-      return <Check className="h-2.5 w-2.5" aria-label="sent" />;
-    case "delivered":
-      return <CheckCheck className="h-2.5 w-2.5" aria-label="delivered" />;
-    case "read":
-      return <CheckCheck className="h-2.5 w-2.5 text-accent" aria-label="read" />;
-    case "failed":
-      return <AlertCircle className="h-2.5 w-2.5 text-danger" aria-label="failed to send" />;
-    default:
-      return null;
-  }
-}
-
-function AttachmentView({
-  att,
-  mine,
-  onOpenImage,
-}: {
-  att: MessageAttachment;
-  mine: boolean;
-  onOpenImage?: (url: string) => void;
-}) {
-  const type = att.content_type ?? "";
-  const name = att.filename ?? "file";
-
-  if (type.startsWith("image/") && att.url) {
-    const url = att.url;
-    return (
-      <button type="button" onClick={() => onOpenImage?.(url)} className="block">
-        {/* eslint-disable-next-line @next/next/no-img-element */}
-        <img
-          src={url}
-          alt={name}
-          className="max-h-56 max-w-full cursor-zoom-in rounded object-cover"
-        />
-      </button>
-    );
-  }
-  if (type.startsWith("video/") && att.url) {
-    return (
-      <video
-        src={att.url}
-        controls
-        className="max-h-56 max-w-full rounded"
-        preload="metadata"
-      />
-    );
-  }
-  if (type.startsWith("audio/") && att.url) {
-    return <audio src={att.url} controls className="w-full" preload="metadata" />;
-  }
-
-  // Non-media (or a file still missing its signed URL) → compact file card.
-  const card = (
-    <span
-      className={cn(
-        "flex items-center gap-2 rounded border px-2 py-1.5",
-        mine ? "border-bg-0/30" : "border-border bg-bg-0",
-      )}
-    >
-      <FileText className="h-4 w-4 flex-shrink-0 opacity-80" />
-      <span className="flex flex-col overflow-hidden">
-        <span className="truncate text-[11px]">{name}</span>
-        {att.size ? (
-          <span className="text-[10px] opacity-60">{formatBytes(att.size)}</span>
-        ) : null}
-      </span>
-      {att.url ? <Download className="ml-1 h-3 w-3 flex-shrink-0 opacity-70" /> : null}
-    </span>
-  );
-
-  return att.url ? (
-    <a href={att.url} target="_blank" rel="noopener noreferrer" download={name}>
-      {card}
-    </a>
-  ) : (
-    card
   );
 }
 
@@ -870,23 +752,4 @@ function HistoryNotice() {
       phone — Signal doesn’t sync history to linked devices.
     </div>
   );
-}
-
-function formatBytes(n: number): string {
-  if (n < 1024) return `${n} B`;
-  if (n < 1024 * 1024) return `${(n / 1024).toFixed(0)} KB`;
-  return `${(n / (1024 * 1024)).toFixed(1)} MB`;
-}
-
-function formatRelative(iso: string): string {
-  const ms = Date.now() - new Date(iso).getTime();
-  const s = Math.floor(ms / 1000);
-  if (s < 60) return "now";
-  const m = Math.floor(s / 60);
-  if (m < 60) return `${m}m`;
-  const h = Math.floor(m / 60);
-  if (h < 24) return `${h}h`;
-  const d = Math.floor(h / 24);
-  if (d < 7) return `${d}d`;
-  return new Date(iso).toLocaleDateString();
 }


### PR DESCRIPTION
Mirrors the new iMessage/WhatsApp chat formatting (shipped for the dashboard in #277) to the **full-page `/messages` Signal view** — and does it the drift-proof way: by extracting the bubble rendering into **one shared module both surfaces consume**, instead of copy-pasting.

## New: `components/messages/ChatThread.tsx`
`ChatMessageList` + `ImageGroup` + `DocAttachment` + `StatusTick` + format/emoji helpers. Fully unit-tested (`ChatThread.test.tsx`, 14 tests): emoji-only detection, byte/relative formatting, run grouping, GIF tag, file card, delete menu (incl. incoming gets no "delete for everyone"), lightbox callback, group sender label.

## Both surfaces now render through `ChatMessageList`
- **Dashboard `ThreadQuickView`** drops its inline bubble block + local helpers (−245 lines).
- **Full-page `SignalThreadView`** *gains*: message grouping, emoji-jumbo, image collage + "+N", GIF badges, inline video/audio, and **delete-for-everyone** (it previously only had delete-for-me). Keeps its media gallery, lightbox, and history notice.

## Robustness
Any attachment without a usable URL (an optimistic video, or an image whose signed URL failed) now falls back to a file card showing the filename — instead of a broken `<img>` (old dashboard) or nothing (old full page).

## Verification
- `tsc` + `eslint` clean.
- **31 messages tests pass** (14 new `ChatThread` + 3 `MessagesCard` integration + 14 `inbox-prefs`). The existing `MessagesCard` tests passing unchanged confirms the dashboard still renders/sends correctly through the shared component.
- Visual-regression snapshots will change on purpose (non-blocking).

🤖 Generated with [Claude Code](https://claude.com/claude-code)