### PR TITLE
feat(messages): linkify URLs in chat text

### DIFF
--- a/apps/web/src/components/messages/ChatThread.test.tsx
+++ b/apps/web/src/components/messages/ChatThread.test.tsx
@@ -1,4 +1,5 @@
 // @vitest-environment jsdom
+import { type ReactElement } from "react";
 import { describe, it, expect, afterEach, vi } from "vitest";
 import { render, screen, cleanup, fireEvent } from "@testing-library/react";
 import {
@@ -6,6 +7,7 @@ import {
   isEmojiOnly,
   formatBytes,
   formatRelative,
+  linkify,
   type ChatMessage,
 } from "./ChatThread";
 
@@ -221,5 +223,39 @@ describe("ChatMessageList", () => {
       />,
     );
     expect(screen.getByText("Alice")).toBeTruthy();
+  });
+
+  it("turns URLs in message text into safe links", () => {
+    render(
+      <ChatMessageList
+        messages={[
+          msg({ id: "u", body: "see https://rokki.ai/docs for more" }),
+        ]}
+      />,
+    );
+    const link = screen.getByRole("link", {
+      name: "https://rokki.ai/docs",
+    }) as HTMLAnchorElement;
+    expect(link.href).toBe("https://rokki.ai/docs");
+    expect(link.target).toBe("_blank");
+    expect(link.rel).toContain("noopener");
+    // Surrounding text is preserved.
+    expect(screen.getByText(/for more/)).toBeTruthy();
+  });
+
+  it("does not create links for plain text", () => {
+    render(<ChatMessageList messages={[msg({ id: "p", body: "just text" })]} />);
+    expect(screen.queryByRole("link")).toBeNull();
+  });
+});
+
+describe("linkify", () => {
+  it("does not swallow trailing punctuation", () => {
+    const nodes = linkify("go to https://x.com.", false);
+    const link = nodes.find(
+      (n): n is ReactElement<{ href: string }> =>
+        typeof n === "object" && n !== null && "props" in n,
+    );
+    expect(link?.props.href).toBe("https://x.com");
   });
 });

--- a/apps/web/src/components/messages/ChatThread.tsx
+++ b/apps/web/src/components/messages/ChatThread.tsx
@@ -210,7 +210,7 @@ export function ChatMessageList({
                       ) : null}
                       {m.body ? (
                         <div className="whitespace-pre-wrap break-words px-3 py-2 text-xs leading-relaxed">
-                          {m.body}
+                          {linkify(m.body, m.mine)}
                         </div>
                       ) : null}
                     </div>
@@ -411,6 +411,41 @@ export function StatusTick({ status }: { status: SignalStatus }) {
     default:
       return null;
   }
+}
+
+// Matches http(s) URLs, stopping before trailing punctuation so a URL at the
+// end of a sentence ("see https://x.com.") doesn't swallow the period.
+const URL_RE = /https?:\/\/[^\s<]+[^\s<.,!?;:'")\]}]/gi;
+
+/** Turn bare URLs in message text into safe, clickable links (iMessage/WhatsApp
+ *  parity). Builds React nodes by splitting on matches — never innerHTML — so
+ *  there's no injection surface. */
+export function linkify(text: string, mine: boolean): ReactNode[] {
+  const out: ReactNode[] = [];
+  const re = new RegExp(URL_RE); // fresh instance: reset lastIndex per call
+  let last = 0;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text)) !== null) {
+    if (m.index > last) out.push(text.slice(last, m.index));
+    const url = m[0];
+    out.push(
+      <a
+        key={`${m.index}-${url}`}
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer nofollow"
+        className={cn(
+          "break-all underline underline-offset-2",
+          mine ? "text-bg-0" : "text-accent",
+        )}
+      >
+        {url}
+      </a>,
+    );
+    last = m.index + url.length;
+  }
+  if (last < text.length) out.push(text.slice(last));
+  return out;
 }
 
 function isImage(att: ChatAttachment): boolean {


### PR DESCRIPTION
Bare `http(s)` URLs in message text now render as clickable links across **both** chat surfaces (the shared `ChatThread` renderer) — the last "texts" item iMessage/WhatsApp do that we didn't.

- Built as React nodes by splitting on matches — **no `innerHTML`, no injection surface**.
- Opens in a new tab with `rel="noopener noreferrer nofollow"`.
- Tints to read on both bubble sides (mine vs theirs).
- Trailing sentence punctuation (`see https://x.com.`) is excluded from the link.

Unit-tested (link rendered with correct href/target/rel, plain text untouched, trailing-punctuation trim). `tsc` + `eslint` clean; 18 `ChatThread` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)