### PR TITLE
feat(messages): visible inbox↔chat divider + copy-text + timestamp tooltip

### DIFF
--- a/apps/web/src/components/dashboard/MessagesCard.tsx
+++ b/apps/web/src/components/dashboard/MessagesCard.tsx
@@ -201,21 +201,24 @@ export function MessagesCard() {
   } else if (split) {
     body = (
       <div className="flex min-h-0 flex-1">
+        {/* The list pane's right border IS the divider line — a real 1px
+            border paints reliably at any DPI (a standalone w-px flex child can
+            wash out on HiDPI), so the faint line between inbox and chat is
+            always visible. */}
         <div
           style={{ width: Math.min(listWidth, Math.max(180, width - 300)) }}
-          className="flex flex-shrink-0 flex-col"
+          className="flex flex-shrink-0 flex-col border-r border-border"
         >
           {list}
         </div>
-        {/* A crisp, always-visible hairline between the list and the chat
-            (like the Mac Messages sidebar rule), with a wider invisible grab
-            zone so it's still easy to drag. */}
+        {/* A transparent grab strip straddling that border (pulled left so it
+            adds no width); shows accent on hover to signal it's draggable. */}
         <div
           onMouseDown={startResize}
           role="separator"
           aria-label="Drag to resize the conversation list"
           title="Drag to resize"
-          className="relative w-px flex-shrink-0 cursor-col-resize bg-border transition-colors before:absolute before:inset-y-0 before:-left-1.5 before:-right-1.5 before:content-[''] hover:bg-accent"
+          className="z-10 -ml-1 w-2 flex-shrink-0 cursor-col-resize transition-colors hover:bg-accent/30"
         />
         <div className="flex min-h-0 flex-1 flex-col">
           {open ? (

--- a/apps/web/src/components/messages/ChatThread.test.tsx
+++ b/apps/web/src/components/messages/ChatThread.test.tsx
@@ -191,6 +191,31 @@ describe("ChatMessageList", () => {
     expect(screen.queryByText("Delete for everyone")).toBeNull();
   });
 
+  it("offers Copy text and writes the body to the clipboard", () => {
+    const writeText = vi.fn();
+    Object.assign(navigator, { clipboard: { writeText } });
+    render(
+      <ChatMessageList
+        messages={[msg({ id: "c", body: "hello world" })]}
+        onDeleteForMe={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByLabelText("Message options"));
+    fireEvent.click(screen.getByText("Copy text"));
+    expect(writeText).toHaveBeenCalledWith("hello world");
+  });
+
+  it("lets you copy any message even with no delete handlers", () => {
+    render(
+      <ChatMessageList
+        messages={[msg({ id: "x", mine: false, body: "copy me" })]}
+      />,
+    );
+    fireEvent.click(screen.getByLabelText("Message options"));
+    expect(screen.getByText("Copy text")).toBeTruthy();
+    expect(screen.queryByText("Delete for me")).toBeNull();
+  });
+
   it("calls onOpenImage instead of navigating when provided", () => {
     const onOpenImage = vi.fn();
     render(

--- a/apps/web/src/components/messages/ChatThread.tsx
+++ b/apps/web/src/components/messages/ChatThread.tsx
@@ -126,6 +126,9 @@ export function ChatMessageList({
             m.attachments.length === 0 && isEmojiOnly(m.body);
           const canDelete =
             Boolean(onDeleteForMe) && !m.id.startsWith("temp-");
+          const hasBody = m.body.trim().length > 0;
+          // The ⋯ menu is worth showing if there's text to copy or an action.
+          const showMenu = hasBody || canDelete;
           const showName =
             showSender && !m.mine && firstInGroup && Boolean(m.sender);
           return (
@@ -155,7 +158,7 @@ export function ChatMessageList({
                     m.mine ? "flex-row" : "flex-row-reverse",
                   )}
                 >
-                  {canDelete ? (
+                  {showMenu ? (
                     <button
                       type="button"
                       onClick={() =>
@@ -224,17 +227,31 @@ export function ChatMessageList({
                       m.mine ? "right-5" : "left-5",
                     )}
                   >
-                    <button
-                      type="button"
-                      onClick={() => {
-                        setMenuFor(null);
-                        onDeleteForMe?.(m.id);
-                      }}
-                      className="whitespace-nowrap px-3 py-1 text-left text-text-1 hover:bg-bg-2"
-                    >
-                      Delete for me
-                    </button>
-                    {m.mine && onDeleteForEveryone ? (
+                    {hasBody ? (
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setMenuFor(null);
+                          void navigator.clipboard?.writeText(m.body);
+                        }}
+                        className="whitespace-nowrap px-3 py-1 text-left text-text-1 hover:bg-bg-2"
+                      >
+                        Copy text
+                      </button>
+                    ) : null}
+                    {canDelete ? (
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setMenuFor(null);
+                          onDeleteForMe?.(m.id);
+                        }}
+                        className="whitespace-nowrap px-3 py-1 text-left text-text-1 hover:bg-bg-2"
+                      >
+                        Delete for me
+                      </button>
+                    ) : null}
+                    {canDelete && m.mine && onDeleteForEveryone ? (
                       <button
                         type="button"
                         onClick={() => {
@@ -249,7 +266,10 @@ export function ChatMessageList({
                   </div>
                 ) : null}
                 {lastInGroup ? (
-                  <span className="mt-0.5 flex items-center gap-1 px-1 text-2xs text-text-3">
+                  <span
+                    title={new Date(m.at).toLocaleString()}
+                    className="mt-0.5 flex items-center gap-1 px-1 text-2xs text-text-3"
+                  >
                     {formatRelative(m.at)}
                     {m.mine && m.status ? <StatusTick status={m.status} /> : null}
                   </span>


### PR DESCRIPTION
Addresses Zack's note that there's **no visible line between the inbox and the chat** in the split layout, plus two small polish wins.

## Divider (the fix)
The separator was a standalone `w-px` flex child — that washes out on HiDPI displays (you could see the horizontal conversation-row dividers but *not* the vertical one). Replaced with a real **`border-r border-border` on the list pane** (a true 1px border paints reliably at any DPI), plus a transparent grab strip over it that highlights `accent` on hover so it stays draggable without adding width.

> Tip: if the line still doesn't show on sandbox, hard-refresh — the PWA service worker can serve a stale bundle.

## Copy text
The ⋯ message menu now offers **Copy text** for any message with a body — including incoming messages and messages with no delete handlers wired.

## Timestamp tooltip
The per-run time label now shows a full localized date/time on hover (`title`).

`tsc` + `eslint` clean; 23 messages tests pass (incl. copy-text coverage). Pure presentational/UX — no API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)