### PR TITLE
feat(messages): image lightbox in the dashboard chat (shared)

### DIFF
--- a/apps/web/src/components/dashboard/MessagesCard.tsx
+++ b/apps/web/src/components/dashboard/MessagesCard.tsx
@@ -45,6 +45,7 @@ import {
   type SignalStatus,
 } from "../messages/ChatThread";
 import { SignalContactPicker } from "../messages/SignalContactPicker";
+import { Lightbox } from "../messages/Lightbox";
 
 interface ThreadSummary {
   id: string;
@@ -470,6 +471,7 @@ function ThreadQuickView({
   const [sending, setSending] = useState(false);
   const [dragging, setDragging] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [lightbox, setLightbox] = useState<number | null>(null);
   const scrollerRef = useRef<HTMLDivElement>(null);
   const composerRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -776,6 +778,15 @@ function ThreadQuickView({
     }
   }
 
+  // Every image in this thread (with a usable URL) powers the lightbox.
+  const imageItems = messages
+    .flatMap((m) => m.attachments)
+    .filter((a) => (a.content_type ?? "").startsWith("image/") && a.url);
+  const openLightbox = (url: string) => {
+    const idx = imageItems.findIndex((a) => a.url === url);
+    if (idx >= 0) setLightbox(idx);
+  };
+
   return (
     <div
       className="relative flex min-h-0 flex-1 flex-col"
@@ -818,6 +829,7 @@ function ThreadQuickView({
           showSender={thread.signal_kind === "group"}
           onDeleteForMe={isSignal ? deleteForMe : undefined}
           onDeleteForEveryone={isSignal ? deleteForEveryone : undefined}
+          onOpenImage={openLightbox}
         />
       </div>
 
@@ -926,6 +938,15 @@ function ThreadQuickView({
             <span className="text-xs font-medium">Drop to attach</span>
           </div>
         </div>
+      ) : null}
+
+      {lightbox !== null && imageItems[lightbox] ? (
+        <Lightbox
+          items={imageItems}
+          index={lightbox}
+          onClose={() => setLightbox(null)}
+          onNav={setLightbox}
+        />
       ) : null}
     </div>
   );

--- a/apps/web/src/components/messages/Lightbox.test.tsx
+++ b/apps/web/src/components/messages/Lightbox.test.tsx
@@ -1,0 +1,46 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import { Lightbox } from "./Lightbox";
+import type { ChatAttachment } from "./ChatThread";
+
+afterEach(cleanup);
+
+const items: ChatAttachment[] = [
+  { url: "https://x/a.jpg", content_type: "image/jpeg", filename: "a.jpg", size: 1 },
+  { url: "https://x/b.jpg", content_type: "image/jpeg", filename: "b.jpg", size: 1 },
+];
+
+describe("Lightbox", () => {
+  it("renders the current image", () => {
+    render(<Lightbox items={items} index={0} onClose={vi.fn()} onNav={vi.fn()} />);
+    const img = screen.getByAltText("a.jpg") as HTMLImageElement;
+    expect(img.src).toContain("a.jpg");
+  });
+
+  it("closes on Escape", () => {
+    const onClose = vi.fn();
+    render(<Lightbox items={items} index={0} onClose={onClose} onNav={vi.fn()} />);
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("navigates with the next button (wrapping)", () => {
+    const onNav = vi.fn();
+    render(<Lightbox items={items} index={1} onClose={vi.fn()} onNav={onNav} />);
+    fireEvent.click(screen.getByLabelText("Next"));
+    expect(onNav).toHaveBeenCalledWith(0); // wraps from last to first
+  });
+
+  it("renders nothing when the item has no url", () => {
+    const { container } = render(
+      <Lightbox
+        items={[{ url: null, content_type: "image/jpeg", filename: "x", size: 1 }]}
+        index={0}
+        onClose={vi.fn()}
+        onNav={vi.fn()}
+      />,
+    );
+    expect(container.querySelector("img")).toBeNull();
+  });
+});

--- a/apps/web/src/components/messages/Lightbox.tsx
+++ b/apps/web/src/components/messages/Lightbox.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { useCallback, useEffect } from "react";
+import { X, ChevronLeft, ChevronRight, Download } from "lucide-react";
+import type { ChatAttachment } from "./ChatThread";
+
+/**
+ * Full-screen image viewer with prev/next + keyboard nav (Esc / ← / →), shared
+ * by the dashboard Messages card and the full-page Signal view so tapping an
+ * image behaves identically on both surfaces.
+ */
+export function Lightbox({
+  items,
+  index,
+  onClose,
+  onNav,
+}: {
+  items: ChatAttachment[];
+  index: number;
+  onClose: () => void;
+  onNav: (i: number) => void;
+}) {
+  const current = items[index];
+  const go = useCallback(
+    (delta: number) => onNav((index + delta + items.length) % items.length),
+    [index, items.length, onNav],
+  );
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+      else if (e.key === "ArrowLeft") go(-1);
+      else if (e.key === "ArrowRight") go(1);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [go, onClose]);
+  if (!current?.url) return null;
+  const stop = (e: React.MouseEvent) => e.stopPropagation();
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/85 p-8"
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+    >
+      <button
+        type="button"
+        onClick={onClose}
+        aria-label="Close"
+        className="absolute right-4 top-4 rounded-full bg-white/10 p-2 text-white hover:bg-white/20"
+      >
+        <X className="h-5 w-5" />
+      </button>
+      {items.length > 1 ? (
+        <button
+          type="button"
+          onClick={(e) => {
+            stop(e);
+            go(-1);
+          }}
+          aria-label="Previous"
+          className="absolute left-4 rounded-full bg-white/10 p-2 text-white hover:bg-white/20"
+        >
+          <ChevronLeft className="h-6 w-6" />
+        </button>
+      ) : null}
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
+        src={current.url}
+        alt={current.filename ?? "image"}
+        onClick={stop}
+        className="max-h-full max-w-full rounded object-contain"
+      />
+      {items.length > 1 ? (
+        <button
+          type="button"
+          onClick={(e) => {
+            stop(e);
+            go(1);
+          }}
+          aria-label="Next"
+          className="absolute right-4 rounded-full bg-white/10 p-2 text-white hover:bg-white/20"
+        >
+          <ChevronRight className="h-6 w-6" />
+        </button>
+      ) : null}
+      <a
+        href={current.url}
+        download={current.filename ?? "image"}
+        onClick={stop}
+        className="absolute bottom-4 flex items-center gap-1.5 rounded-sm bg-white/10 px-3 py-1.5 text-xs text-white hover:bg-white/20"
+      >
+        <Download className="h-3.5 w-3.5" /> Download
+      </a>
+    </div>
+  );
+}

--- a/apps/web/src/components/messages/SignalThreadView.tsx
+++ b/apps/web/src/components/messages/SignalThreadView.tsx
@@ -12,7 +12,6 @@ import {
   Download,
   Images,
   ChevronLeft,
-  ChevronRight,
   Film,
   Music,
 } from "lucide-react";
@@ -24,6 +23,7 @@ import {
   composerKeyDown,
 } from "./composer-utils";
 import { ChatMessageList, formatBytes } from "./ChatThread";
+import { Lightbox } from "./Lightbox";
 
 type SignalStatus = "sending" | "sent" | "delivered" | "read" | "failed";
 
@@ -652,94 +652,6 @@ function MediaGallery({
           ) : null}
         </>
       )}
-    </div>
-  );
-}
-
-/** Full-screen image viewer with prev/next + keyboard nav. */
-function Lightbox({
-  items,
-  index,
-  onClose,
-  onNav,
-}: {
-  items: MessageAttachment[];
-  index: number;
-  onClose: () => void;
-  onNav: (i: number) => void;
-}) {
-  const current = items[index];
-  const go = useCallback(
-    (delta: number) => onNav((index + delta + items.length) % items.length),
-    [index, items.length, onNav],
-  );
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
-      else if (e.key === "ArrowLeft") go(-1);
-      else if (e.key === "ArrowRight") go(1);
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [go, onClose]);
-  if (!current?.url) return null;
-  const stop = (e: React.MouseEvent) => e.stopPropagation();
-  return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/85 p-8"
-      onClick={onClose}
-      role="dialog"
-      aria-modal="true"
-    >
-      <button
-        type="button"
-        onClick={onClose}
-        aria-label="Close"
-        className="absolute right-4 top-4 rounded-full bg-white/10 p-2 text-white hover:bg-white/20"
-      >
-        <X className="h-5 w-5" />
-      </button>
-      {items.length > 1 ? (
-        <button
-          type="button"
-          onClick={(e) => {
-            stop(e);
-            go(-1);
-          }}
-          aria-label="Previous"
-          className="absolute left-4 rounded-full bg-white/10 p-2 text-white hover:bg-white/20"
-        >
-          <ChevronLeft className="h-6 w-6" />
-        </button>
-      ) : null}
-      {/* eslint-disable-next-line @next/next/no-img-element */}
-      <img
-        src={current.url}
-        alt={current.filename ?? "image"}
-        onClick={stop}
-        className="max-h-full max-w-full rounded object-contain"
-      />
-      {items.length > 1 ? (
-        <button
-          type="button"
-          onClick={(e) => {
-            stop(e);
-            go(1);
-          }}
-          aria-label="Next"
-          className="absolute right-4 rounded-full bg-white/10 p-2 text-white hover:bg-white/20"
-        >
-          <ChevronRight className="h-6 w-6" />
-        </button>
-      ) : null}
-      <a
-        href={current.url}
-        download={current.filename ?? "image"}
-        onClick={stop}
-        className="absolute bottom-4 flex items-center gap-1.5 rounded-sm bg-white/10 px-3 py-1.5 text-xs text-white hover:bg-white/20"
-      >
-        <Download className="h-3.5 w-3.5" /> Download
-      </a>
     </div>
   );
 }


### PR DESCRIPTION
Tapping an image in the **dashboard** Messages card opened a new browser tab, while the full-page view had a proper full-screen **lightbox** (prev/next, `Esc`/`←`/`→`, download). This unifies them.

- Extracted the lightbox into a shared `components/messages/Lightbox.tsx`.
- Wired the dashboard `ThreadQuickView` to it via the shared renderer's `onOpenImage` hook (gathers all images in the thread for prev/next).
- `SignalThreadView` now imports the shared `Lightbox` instead of its local copy — keeps the two surfaces identical.

`tsc` + `eslint` clean; 4 new `Lightbox` tests + 23 messaging tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)