### PR TITLE
docs(signal): document the Signal API surface + ADR 0006

### DIFF
--- a/docs/02_API.md
+++ b/docs/02_API.md
@@ -653,7 +653,89 @@ Others are optional but recommended for write retries.
 - Deprecations: old endpoint returns `Deprecation: date` header and `Sunset: date`
 - Minimum deprecation window: 12 months for public APIs, 3 months for internal-only
 
-## 2.23 Common pitfalls
+## 2.23 Signal messaging
+
+Signal is integrated as a per-user **linked (secondary) device**. Rokki never
+holds the user's Signal identity keys; a separate **bridge** service
+(`apps/signal-bridge`, deployed to Fly.io) runs `signal-cli` and is the only
+component that talks to Signal. The web app calls the bridge **server-side** over
+HTTPS, authenticated by a shared secret (`x-bridge-secret`); browsers only ever
+hit our own `/v1/signal/*` routes. See `docs/adr/0006-signal-linked-device.md`.
+
+### 2.23.1 Account & linking
+
+```
+POST   /v1/signal/link        → { uri }            // sgnl:// device-link URI to render as a QR
+GET    /v1/signal/account     → { status, signal_number? }
+DELETE /v1/signal/account                          // unlink this device + purge local data
+```
+
+Linking starts a JVM in the bridge, so `POST /link` can take ~30–60s.
+
+### 2.23.2 Contacts & sync
+
+```
+GET    /v1/signal/contacts    → { data: [{ signal_id, kind, name }] }   // kind ∈ direct | group
+POST   /v1/signal/sync                             // refresh contacts + groups from the device
+```
+
+### 2.23.3 Threads & messages
+
+```
+POST   /v1/signal/threads          { signalId, kind, title? } → { data: { id } }   // ensure a thread exists
+GET    /v1/signal/threads/:id      → { data: { messages: [...] } }
+DELETE /v1/signal/threads/:id                       // remove Rokki's local copy of the conversation
+POST   /v1/signal/threads/:id/read                  // send read receipts for inbound messages (direct only)
+```
+
+Inbox listing is unified — Signal threads surface in `GET /v1/messages/threads`
+alongside everything else (`source: "signal"`). A message row:
+`{ id, direction: "in"|"out", sender, body, sent_at, status?, attachments? }`,
+where `status` ∈ `sending | sent | delivered | read | failed`.
+
+### 2.23.4 Sending & attachments
+
+```
+POST   /v1/signal/media   (multipart: file) → { data: { storage_key, content_type, filename, size } }
+POST   /v1/signal/send    { signalId, kind, text, attachments?: [{ storage_key, content_type, filename, size }] }
+```
+
+Attachments are uploaded to staging first (`/media`), then referenced by
+`storage_key` on `/send`; the bridge downloads each from storage before handing
+it to `signal-cli`. `/send` re-checks the caller owns every `storage_key` — an
+IDOR guard, because the bridge uses a service-role key that bypasses RLS.
+
+### 2.23.5 Deleting (synced both ways)
+
+```
+DELETE /v1/signal/messages/:id                      // "delete for me" — Rokki-local only
+POST   /v1/signal/messages/:id/remote-delete        // "delete for everyone" — Signal remote-delete (own messages only)
+```
+
+A remote-delete performed in the Signal app (from the phone) is reflected in
+Rokki, and vice-versa — best-effort, since the inbound `remoteDelete` envelope
+field is undocumented in `signal-cli`.
+
+### 2.23.6 Groups
+
+```
+POST   /v1/signal/groups   { name, members: [signalId, …] } → { data: { threadId } }
+```
+
+### 2.23.7 Hard protocol limits (not bugs)
+
+A linked device fundamentally cannot do these, so the UI never promises them:
+
+- **No history backfill** — messages predating the link don't sync; a thread
+  starts empty in Rokki.
+- **No presence/online status** for Signal contacts.
+- **No calls** — `signal-cli` can neither place nor receive Signal calls.
+
+**Parity note:** the Signal surface is currently **REST + UI only**; MCP tools
+are not yet exposed (tracked separately), which is a known exception to the
+API+MCP-parity rule for this in-progress feature.
+
+## 2.24 Common pitfalls
 
 - **404 vs 403:** `not_found` is returned for BOTH missing and forbidden resources. Never return 403 for a resource the caller can't see — that leaks existence. Only return 403 for resources they can see but can't mutate.
 - **Rate limit on magic link:** 5/min per IP is aggressive. For legitimate bulk invites, the admin endpoint bypasses this — use `POST /v1/orgs/:slug/members` with server-side session, not `POST /v1/auth/magic-link` in a loop.

--- a/docs/adr/0006-signal-linked-device.md
+++ b/docs/adr/0006-signal-linked-device.md
@@ -1,0 +1,87 @@
+# ADR 0006 — Signal as a linked device via a bridge service
+
+**Date:** 2026-06-19
+**Status:** Accepted
+
+## Context
+
+Zack wanted to send and receive his real Signal messages from inside Rokki —
+not a separate inbox, but his actual conversations, alongside the rest of the
+dashboard. Signal has no public server API: the only supported way for a
+third party to participate is `signal-cli`, the community CLI/daemon that
+implements the protocol.
+
+Two questions had to be answered:
+
+1. **How does Rokki hold a Signal identity** without becoming a custodian of
+   the user's primary account or their identity keys?
+2. **Where does `signal-cli` run?** It needs a long-lived process, a JVM, and
+   local state on disk — none of which fit Vercel's serverless model.
+
+## Decision
+
+**Integrate Signal as a per-user _secondary linked device_, behind a standalone
+bridge service.**
+
+- **Linked device, not primary.** Rokki links to the user's existing Signal
+  account the same way Signal Desktop does — by scanning a QR
+  (`sgnl://linkdevice?...`). The phone stays the primary. Rokki never holds the
+  primary identity; unlinking from the phone instantly revokes Rokki's access.
+
+- **A dedicated bridge** (`apps/signal-bridge`, a Hono app on Fly.io) runs the
+  `signal-cli` JSON-RPC daemon. It is the **only** component that talks to
+  Signal, and the only place that holds both the Signal session **and** the
+  Supabase **service-role** key. It auto-deploys from CI on changes to
+  `apps/signal-bridge/**`.
+
+- **Server-to-server only.** The web app calls the bridge over HTTPS,
+  authenticated by a shared secret (`x-bridge-secret`). Browsers never touch the
+  bridge — they hit our own `/api/v1/signal/*` routes, which call the bridge
+  server-side. `SIGNAL_BRIDGE_SECRET` is never shipped to the client.
+
+- **Persistence + realtime.** Inbound/outbound messages, threads, contacts and
+  account state live in `signal_*` Postgres tables with owner-only RLS;
+  Supabase realtime drives live UI updates. The unified inbox lists Signal
+  threads alongside native ones via `source: "signal"`.
+
+- **One shared renderer.** Both chat surfaces — the dashboard Messages card and
+  the full-page `/messages` view — render through a single component
+  (`components/messages/ChatThread.tsx`, plus a shared `Lightbox`), so they
+  stay pixel-identical and can't drift.
+
+## Consequences
+
+**Good**
+
+- The user's identity keys never leave their phone; Rokki is a revocable,
+  least-privilege linked device.
+- Standard `signal-cli` — no bespoke protocol implementation to maintain.
+- The bridge is the single trust boundary: one secret, one service-role key,
+  one place to audit.
+- Shared rendering means messaging UX improvements land on both surfaces at
+  once.
+
+**Limits (protocol, not implementation — surfaced honestly in the UI)**
+
+- **No history backfill.** Linked devices don't receive messages sent before
+  the link; threads start empty in Rokki.
+- **No presence** for Signal contacts, and **no calls** (`signal-cli` can't
+  place or receive them).
+- Some `signal-cli` behaviours are **undocumented** and handled best-effort:
+  the inbound `remoteDelete` reflection (delete-sync) and the `updateGroup`
+  create-result shape (group creation). Both are flagged for live verification.
+
+**Costs**
+
+- A separate always-on service to operate (Fly.io), distinct from the Vercel
+  web deploy.
+- An IDOR risk was designed out: because the bridge bypasses RLS with the
+  service-role key, `/send` re-checks that the caller owns every attachment
+  `storage_key` before the bridge fetches it.
+
+## Notes
+
+- Bridge secrets (`SIGNAL_BRIDGE_SECRET`, `SUPABASE_*`) are set by Zack only;
+  Claude never enters them. The bridge's `FLY_API_TOKEN` lives in CI.
+- Never apply production migrations for `signal_*` tables without explicit
+  approval.


### PR DESCRIPTION
The Signal feature shipped UI+API first and was **undocumented** — a gap against the CLAUDE.md "update docs for changes you made" non-negotiable. This reconciles the docs.

- **`02_API.md` §2.23 Signal messaging** — every `/v1/signal/*` endpoint (link/account, contacts/sync, threads/messages, media/send, delete + remote-delete, groups) with request shapes, the IDOR guard on attachment `storage_key`s, and the hard protocol limits (no backfill / presence / calls). Honestly notes the REST+UI-only MCP-parity gap.
- **ADR 0006 — Signal as a linked device** — why the keys stay on the phone, why the Fly.io bridge is the sole trust boundary (Signal session + service-role key), the shared `ChatThread` renderer, and the documented protocol limits.

Docs-only; prettier-clean. No code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)