### PR TITLE
fix(messages): surface failures in the contact + GIF pickers

### DIFF
--- a/apps/web/src/components/messages/GifPicker.tsx
+++ b/apps/web/src/components/messages/GifPicker.tsx
@@ -22,11 +22,13 @@ function GifGrid({
   const [results, setResults] = useState<Gif[]>([]);
   const [loading, setLoading] = useState(true);
   const [unconfigured, setUnconfigured] = useState(false);
+  const [error, setError] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     let alive = true;
     setLoading(true);
+    setError(false);
     const t = setTimeout(() => {
       fetch(`/api/v1/gif/search?q=${encodeURIComponent(q)}`, {
         credentials: "include",
@@ -36,13 +38,21 @@ function GifGrid({
             if (alive) setUnconfigured(true);
             return { data: [] };
           }
-          return r.ok ? r.json() : { data: [] };
+          if (!r.ok) {
+            // A server/proxy error is NOT an empty result — surface it.
+            if (alive) setError(true);
+            return { data: [] };
+          }
+          return r.json();
         })
         .then((b: { data?: Gif[] }) => {
           if (alive) setResults(b.data ?? []);
         })
         .catch(() => {
-          if (alive) setResults([]);
+          if (alive) {
+            setError(true);
+            setResults([]);
+          }
         })
         .finally(() => {
           if (alive) setLoading(false);
@@ -86,6 +96,10 @@ function GifGrid({
           <p className="col-span-2 px-2 py-6 text-center text-2xs text-text-3">
             GIF search isn’t set up yet — add a Tenor API key.
           </p>
+        ) : error ? (
+          <p className="col-span-2 py-6 text-center text-2xs text-text-3">
+            Couldn’t reach GIF search.
+          </p>
         ) : loading && results.length === 0 ? (
           <p className="col-span-2 py-6 text-center text-2xs text-text-3">
             Searching…
@@ -100,6 +114,7 @@ function GifGrid({
               key={g.id}
               type="button"
               onClick={() => onPick(g)}
+              aria-label={g.description || "Insert GIF"}
               className="aspect-square overflow-hidden rounded-sm bg-bg-2 hover:opacity-80"
             >
               {/* eslint-disable-next-line @next/next/no-img-element */}

--- a/apps/web/src/components/messages/SignalContactPicker.tsx
+++ b/apps/web/src/components/messages/SignalContactPicker.tsx
@@ -45,11 +45,20 @@ export function SignalContactPicker({
         method: "POST",
         credentials: "include",
       }).catch(() => {});
-      const r = await fetch("/api/v1/signal/contacts", { credentials: "include" });
-      const b = (await r.json().catch(() => ({}))) as { data?: Contact[] };
-      if (alive) {
-        setContacts(b.data ?? []);
-        setLoading(false);
+      try {
+        const r = await fetch("/api/v1/signal/contacts", {
+          credentials: "include",
+        });
+        const b = (await r.json().catch(() => ({}))) as { data?: Contact[] };
+        if (alive) {
+          setContacts(b.data ?? []);
+          if (!r.ok) setError("Couldn’t load contacts.");
+        }
+      } catch {
+        // Network failure (offline / bridge down) — don't hang on the spinner.
+        if (alive) setError("Couldn’t load contacts.");
+      } finally {
+        if (alive) setLoading(false);
       }
     })();
     return () => {
@@ -70,6 +79,7 @@ export function SignalContactPicker({
   async function pick(c: Contact) {
     if (opening) return;
     setOpening(c.signal_id);
+    setError(null);
     try {
       const r = await fetch("/api/v1/signal/threads", {
         method: "POST",
@@ -81,8 +91,18 @@ export function SignalContactPicker({
           title: c.name ?? undefined,
         }),
       });
-      const b = (await r.json().catch(() => ({}))) as { data?: { id?: string } };
-      if (b.data?.id) onPick(b.data.id);
+      const b = (await r.json().catch(() => ({}))) as {
+        data?: { id?: string };
+        errors?: { message: string }[];
+      };
+      if (!r.ok || !b.data?.id) {
+        // Don't leave the user staring at the picker with no feedback.
+        setError(b.errors?.[0]?.message ?? "Couldn’t open that conversation.");
+        return;
+      }
+      onPick(b.data.id);
+    } catch {
+      setError("Couldn’t open that conversation.");
     } finally {
       setOpening(null);
     }


### PR DESCRIPTION
From the messaging-quality audit (adversarially verified findings):

- **Contact picker — silent failure starting a chat:** `pick()` never checked `r.ok` and only acted on a present id, so a 4xx/5xx or bridge-down left the user staring at the picker with no feedback. Now branches on failure (uses the existing error banner) and catches network throws.
- **Contact picker — infinite "Loading contacts…":** the fetch had no `try/catch` (only `r.json()` was guarded), so a network rejection skipped `setLoading(false)` and hung forever. Now wrapped in `try/catch/finally` with an error message.
- **GIF search — errors looked like empty results:** a 500 from the Tenor proxy or an offline client rendered the same "No GIFs found" as a genuinely empty query. Now a non-OK/thrown fetch shows "Couldn’t reach GIF search."
- **GIF tiles — no accessible name** when Tenor returns an empty description; added `aria-label` fallback.

`tsc` + `eslint` clean. Pure resilience/a11y, no behavior change on the happy path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)