### PR TITLE
perf(messages): reuse one Intl.Segmenter + memoize media lists

### DIFF
--- a/apps/web/src/components/dashboard/MessagesCard.tsx
+++ b/apps/web/src/components/dashboard/MessagesCard.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import {
   useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
   type ReactNode,
@@ -791,9 +792,14 @@ function ThreadQuickView({
   }
 
   // Every image in this thread (with a usable URL) powers the lightbox.
-  const imageItems = messages
-    .flatMap((m) => m.attachments)
-    .filter((a) => (a.content_type ?? "").startsWith("image/") && a.url);
+  // Memoized — this view re-renders on each composer keystroke.
+  const imageItems = useMemo(
+    () =>
+      messages
+        .flatMap((m) => m.attachments)
+        .filter((a) => (a.content_type ?? "").startsWith("image/") && a.url),
+    [messages],
+  );
   const openLightbox = (url: string) => {
     const idx = imageItems.findIndex((a) => a.url === url);
     if (idx >= 0) setLightbox(idx);

--- a/apps/web/src/components/messages/ChatThread.tsx
+++ b/apps/web/src/components/messages/ChatThread.tsx
@@ -481,12 +481,16 @@ function withinRun(a: string, b: string): boolean {
   return Math.abs(new Date(b).getTime() - new Date(a).getTime()) < 5 * 60_000;
 }
 
+// One Segmenter for the whole module — constructing it is comparatively
+// expensive and graphemes() runs for every message on every list render.
+let _segmenter: Intl.Segmenter | null = null;
+
 /** Split into user-perceived characters (grapheme clusters) so emoji ZWJ
  *  sequences (👨‍👩‍👧), flags (🇺🇸) and keycaps (1️⃣) each count as one. */
 function graphemes(s: string): string[] {
   if (typeof Intl !== "undefined" && "Segmenter" in Intl) {
-    const seg = new Intl.Segmenter(undefined, { granularity: "grapheme" });
-    return Array.from(seg.segment(s), (g) => g.segment);
+    _segmenter ??= new Intl.Segmenter(undefined, { granularity: "grapheme" });
+    return Array.from(_segmenter.segment(s), (g) => g.segment);
   }
   return Array.from(s); // fallback: code points (imperfect for ZWJ runs)
 }

--- a/apps/web/src/components/messages/SignalThreadView.tsx
+++ b/apps/web/src/components/messages/SignalThreadView.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   Send,
   MessageSquare,
@@ -381,12 +381,21 @@ export function SignalThreadView({
   }
 
   // All attachments with a usable URL, flattened across messages — powers the
-  // media gallery + lightbox.
-  const mediaItems = messages
-    .flatMap((m) => (m.attachments ?? []).map((att) => ({ att, at: m.sent_at })))
-    .filter((x) => Boolean(x.att.url));
-  const imageItems = mediaItems.filter((x) =>
-    (x.att.content_type ?? "").startsWith("image/"),
+  // media gallery + lightbox. Memoized so it isn't recomputed on every render
+  // (this component re-renders on each composer keystroke).
+  const mediaItems = useMemo(
+    () =>
+      messages
+        .flatMap((m) =>
+          (m.attachments ?? []).map((att) => ({ att, at: m.sent_at })),
+        )
+        .filter((x) => Boolean(x.att.url)),
+    [messages],
+  );
+  const imageItems = useMemo(
+    () =>
+      mediaItems.filter((x) => (x.att.content_type ?? "").startsWith("image/")),
+    [mediaItems],
   );
   const openLightbox = (url: string) => {
     const idx = imageItems.findIndex((x) => x.att.url === url);


### PR DESCRIPTION
Verified runtime-perf findings from the messaging-quality audit:

- **`Intl.Segmenter` per message per render (HIGH):** `graphemes()` constructed a new `Intl.Segmenter` on every call — and it runs (via `isEmojiOnly`/`emojiSize`) for every message on every list render, which re-renders on each composer keystroke. Now a single lazily-initialized module-level Segmenter is reused.
- **Media lists recomputed every render (MED):** `mediaItems`/`imageItems` in `SignalThreadView` and `imageItems` in `ThreadQuickView` ran `O(messages × attachments)` flatMap/filter passes on every render (incl. keystrokes). Now wrapped in `useMemo` keyed on `messages`.

Pure runtime perf, no behavior change. `tsc` + `eslint` clean; 21 tests pass.

> Deferred (noted for a careful pass): code-splitting the EmojiPicker/GifPicker/Lightbox via `next/dynamic` (bundle-size MED) — needs a small file split + build verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)