### PR TITLE
a11y(messages): keyboard divider, focus traps, dialog + menu semantics

### DIFF
--- a/apps/web/src/components/dashboard/MessagesCard.tsx
+++ b/apps/web/src/components/dashboard/MessagesCard.tsx
@@ -117,6 +117,24 @@ export function MessagesCard() {
     window.addEventListener("mousemove", onMove);
     window.addEventListener("mouseup", onUp);
   };
+  // Keyboard equivalent of the drag handle (WCAG 2.1.1): ← / → nudge the list
+  // width and persist it like the mouse path does.
+  const resizeByKey = (e: React.KeyboardEvent) => {
+    if (e.key !== "ArrowLeft" && e.key !== "ArrowRight") return;
+    e.preventDefault();
+    setListWidth((w) => {
+      const next = Math.max(
+        180,
+        Math.min(460, w + (e.key === "ArrowLeft" ? -16 : 16)),
+      );
+      try {
+        localStorage.setItem("rokki:msg:listw", String(next));
+      } catch {
+        /* ignore */
+      }
+      return next;
+    });
+  };
 
   const load = useCallback(async () => {
     try {
@@ -217,10 +235,16 @@ export function MessagesCard() {
             adds no width); shows accent on hover to signal it's draggable. */}
         <div
           onMouseDown={startResize}
+          onKeyDown={resizeByKey}
           role="separator"
-          aria-label="Drag to resize the conversation list"
-          title="Drag to resize"
-          className="z-10 -ml-1 w-2 flex-shrink-0 cursor-col-resize transition-colors hover:bg-accent/30"
+          tabIndex={0}
+          aria-orientation="vertical"
+          aria-label="Resize the conversation list"
+          aria-valuemin={180}
+          aria-valuemax={460}
+          aria-valuenow={Math.round(listWidth)}
+          title="Drag, or focus and use ← / → to resize"
+          className="z-10 -ml-1 w-2 flex-shrink-0 cursor-col-resize transition-colors hover:bg-accent/30 focus-visible:bg-accent/40 focus-visible:outline-none"
         />
         <div className="flex min-h-0 flex-1 flex-col">
           {open ? (

--- a/apps/web/src/components/messages/ChatThread.tsx
+++ b/apps/web/src/components/messages/ChatThread.tsx
@@ -79,14 +79,19 @@ export function ChatMessageList({
 }) {
   const [menuFor, setMenuFor] = useState<string | null>(null);
 
-  // Close an open per-message menu on any outside click.
+  // Close an open per-message menu on any outside click or Escape.
   useEffect(() => {
     if (!menuFor) return;
     const close = () => setMenuFor(null);
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setMenuFor(null);
+    };
     const t = setTimeout(() => window.addEventListener("mousedown", close), 0);
+    window.addEventListener("keydown", onKey);
     return () => {
       clearTimeout(t);
       window.removeEventListener("mousedown", close);
+      window.removeEventListener("keydown", onKey);
     };
   }, [menuFor]);
 
@@ -165,7 +170,9 @@ export function ChatMessageList({
                         setMenuFor((cur) => (cur === m.id ? null : m.id))
                       }
                       aria-label="Message options"
-                      className="flex-shrink-0 rounded-sm p-0.5 text-text-3 opacity-0 transition-opacity hover:text-text-0 group-hover/msg:opacity-100"
+                      aria-haspopup="menu"
+                      aria-expanded={menuFor === m.id}
+                      className="flex-shrink-0 rounded-sm p-0.5 text-text-3 opacity-0 transition-opacity hover:text-text-0 group-hover/msg:opacity-100 focus-visible:opacity-100"
                     >
                       <MoreHorizontal className="h-3.5 w-3.5" />
                     </button>
@@ -221,6 +228,8 @@ export function ChatMessageList({
                 </div>
                 {menuFor === m.id ? (
                   <div
+                    role="menu"
+                    aria-label="Message options"
                     onMouseDown={(e) => e.stopPropagation()}
                     className={cn(
                       "absolute top-6 z-20 flex flex-col rounded-md border border-border bg-bg-1 py-1 text-2xs shadow-lg",
@@ -230,6 +239,7 @@ export function ChatMessageList({
                     {hasBody ? (
                       <button
                         type="button"
+                        role="menuitem"
                         onClick={() => {
                           setMenuFor(null);
                           void navigator.clipboard?.writeText(m.body);
@@ -242,6 +252,7 @@ export function ChatMessageList({
                     {canDelete ? (
                       <button
                         type="button"
+                        role="menuitem"
                         onClick={() => {
                           setMenuFor(null);
                           onDeleteForMe?.(m.id);
@@ -254,6 +265,7 @@ export function ChatMessageList({
                     {canDelete && m.mine && onDeleteForEveryone ? (
                       <button
                         type="button"
+                        role="menuitem"
                         onClick={() => {
                           setMenuFor(null);
                           onDeleteForEveryone(m.id);

--- a/apps/web/src/components/messages/EmojiPicker.tsx
+++ b/apps/web/src/components/messages/EmojiPicker.tsx
@@ -142,6 +142,7 @@ export function EmojiPicker({
               key={`${e}-${i}`}
               type="button"
               onClick={() => pick(e)}
+              aria-label={e}
               className="flex h-6 w-6 items-center justify-center rounded text-base hover:bg-bg-2"
             >
               {e}
@@ -154,6 +155,7 @@ export function EmojiPicker({
           type="button"
           onClick={() => setCat("recent")}
           title="Recent"
+          aria-label="Recent emojis"
           className={cn(
             "flex h-6 w-6 items-center justify-center rounded hover:bg-bg-2",
             cat === "recent" ? "text-accent" : "text-text-3",
@@ -167,6 +169,7 @@ export function EmojiPicker({
             type="button"
             onClick={() => setCat(c.key)}
             title={c.label}
+            aria-label={c.label}
             className={cn(
               "flex h-6 w-6 items-center justify-center rounded text-sm hover:bg-bg-2",
               cat === c.key ? "bg-bg-2" : "",

--- a/apps/web/src/components/messages/Lightbox.tsx
+++ b/apps/web/src/components/messages/Lightbox.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { X, ChevronLeft, ChevronRight, Download } from "lucide-react";
 import type { ChatAttachment } from "./ChatThread";
+import { useFocusTrap } from "@/lib/use-focus-trap";
 
 /**
  * Full-screen image viewer with prev/next + keyboard nav (Esc / ← / →), shared
@@ -20,28 +21,33 @@ export function Lightbox({
   onClose: () => void;
   onNav: (i: number) => void;
 }) {
+  const panelRef = useRef<HTMLDivElement>(null);
   const current = items[index];
   const go = useCallback(
     (delta: number) => onNav((index + delta + items.length) % items.length),
     [index, items.length, onNav],
   );
+  // Escape + Tab-trap + focus-in/-restore (consistent with the Dialog primitive).
+  useFocusTrap(panelRef, true, onClose);
+  // Arrow keys page through the gallery.
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
-      else if (e.key === "ArrowLeft") go(-1);
+      if (e.key === "ArrowLeft") go(-1);
       else if (e.key === "ArrowRight") go(1);
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [go, onClose]);
+  }, [go]);
   if (!current?.url) return null;
   const stop = (e: React.MouseEvent) => e.stopPropagation();
   return (
     <div
+      ref={panelRef}
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/85 p-8"
       onClick={onClose}
       role="dialog"
       aria-modal="true"
+      aria-label="Image viewer"
     >
       <button
         type="button"

--- a/apps/web/src/components/messages/SignalContactPicker.tsx
+++ b/apps/web/src/components/messages/SignalContactPicker.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Search, Loader2, X, MessageSquare, Users, Check } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { useFocusTrap } from "@/lib/use-focus-trap";
 
 interface Contact {
   signal_id: string;
@@ -36,6 +37,10 @@ export function SignalContactPicker({
   const [groupName, setGroupName] = useState("");
   const [creating, setCreating] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  // Treat the picker as a modal dialog: Escape closes it, Tab is trapped, and
+  // focus returns to the trigger on close.
+  useFocusTrap(panelRef, true, onClose);
 
   useEffect(() => {
     let alive = true;
@@ -145,7 +150,13 @@ export function SignalContactPicker({
   }
 
   return (
-    <>
+    <div
+      ref={panelRef}
+      role="dialog"
+      aria-modal="true"
+      aria-label={groupMode ? "New group" : "New message"}
+      className="flex min-h-0 flex-1 flex-col"
+    >
       <header className="flex h-9 flex-shrink-0 items-center gap-2 border-b border-border bg-bg-0 px-3">
         <span className="text-xs text-text-1">
           {groupMode ? "New group" : "New message"}
@@ -273,6 +284,6 @@ export function SignalContactPicker({
           </ul>
         )}
       </div>
-    </>
+    </div>
   );
 }

--- a/apps/web/src/lib/use-focus-trap.ts
+++ b/apps/web/src/lib/use-focus-trap.ts
@@ -1,0 +1,80 @@
+import { useEffect, type RefObject } from "react";
+
+/** Elements that participate in a focus trap (excludes tabindex="-1"). */
+const FOCUSABLE_SELECTOR = [
+  "a[href]",
+  "button:not([disabled])",
+  "input:not([disabled]):not([type='hidden'])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  "[tabindex]:not([tabindex='-1'])",
+  "[contenteditable='true']",
+].join(",");
+
+function getFocusables(root: HTMLElement): HTMLElement[] {
+  return Array.from(
+    root.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
+  ).filter((el) => !el.hasAttribute("aria-hidden"));
+}
+
+/**
+ * Trap keyboard focus within `panelRef` while `active`. Moves focus into the
+ * panel on activate (unless a child already grabbed it via autoFocus), traps
+ * Tab / Shift+Tab inside it, calls `onClose` on Escape, and restores focus to
+ * the previously-focused element on deactivate. Mirrors the behavior of the
+ * repo's Dialog primitive so overlays (Lightbox, pickers) behave consistently.
+ */
+export function useFocusTrap(
+  panelRef: RefObject<HTMLElement | null>,
+  active: boolean,
+  onClose: () => void,
+): void {
+  useEffect(() => {
+    if (!active) return;
+    const previouslyFocused =
+      document.activeElement instanceof HTMLElement
+        ? document.activeElement
+        : null;
+
+    // Defer a tick so the panel is in the DOM; leave an autoFocus'd child alone.
+    const t = setTimeout(() => {
+      const panel = panelRef.current;
+      if (!panel || panel.contains(document.activeElement)) return;
+      (getFocusables(panel)[0] ?? panel).focus?.();
+    }, 0);
+
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onClose();
+        return;
+      }
+      if (e.key !== "Tab") return;
+      const panel = panelRef.current;
+      if (!panel) return;
+      const focusables = getFocusables(panel);
+      if (focusables.length === 0) {
+        e.preventDefault();
+        return;
+      }
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      const activeEl = document.activeElement;
+      if (e.shiftKey) {
+        if (activeEl === first || !panel.contains(activeEl)) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else if (activeEl === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => {
+      clearTimeout(t);
+      window.removeEventListener("keydown", onKey);
+      previouslyFocused?.focus({ preventScroll: true });
+    };
+  }, [active, onClose, panelRef]);
+}


### PR DESCRIPTION
Final batch from the messaging-quality audit — verified accessibility findings:

- **Keyboard-operable divider (HIGH, WCAG 2.1.1):** the split-layout resize handle was mouse-only. Now focusable, exposes `aria-orientation` + `aria-valuemin/max/now`, and `←`/`→` nudge + persist the width, with a focus-visible affordance.
- **Modal focus management (HIGH/MED):** new shared `useFocusTrap` hook (mirrors the repo's `Dialog` primitive) wires the image **Lightbox** and the **contact/new-message picker** as real modals — focus moves in, Tab/Shift+Tab trapped, Escape closes, focus returns to the trigger. Picker is now `role="dialog"` + `aria-modal` + `aria-label`.
- **⋯ menu semantics (LOW):** closes on Escape; `aria-haspopup`/`aria-expanded` on the trigger, `role="menu"`/`menuitem` on the popup.
- **Emoji grid (LOW):** emoji + category buttons get accessible names.

`tsc` + `eslint` clean; 28 messaging tests pass (the Lightbox's Escape test now exercises the new trap). No behavior change for mouse users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)