### PR TITLE
feat(markets): provider config in /api/v1/health for deploy verification

### DIFF
--- a/apps/web/src/app/api/v1/health/route.ts
+++ b/apps/web/src/app/api/v1/health/route.ts
@@ -1,7 +1,16 @@
 import { NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
+import {
+  configuredProviders,
+  providerAvailability,
+  dataClassAvailability,
+} from "@/lib/markets/providers";
 
 import { withObservability } from "@/lib/observability";
+
+// Read API-key env vars at request time, never a build-time snapshot.
+export const dynamic = "force-dynamic";
+
 async function handleGet() {
   const checks: Record<string, { ok: boolean; error?: string }> = {};
 
@@ -24,6 +33,14 @@ async function handleGet() {
       version: process.env.VERCEL_GIT_COMMIT_SHA ?? "local",
       time: new Date().toISOString(),
       checks,
+      // Informational only — which market-data feeds are wired (booleans, never
+      // key values or market data). Lets a deploy be verified without signing
+      // in. NOT part of `status`: missing market keys aren't a system failure.
+      markets: {
+        providers: providerAvailability(),
+        classes: dataClassAvailability(),
+        attribution: configuredProviders(),
+      },
     },
     { status: allOk ? 200 : 503 },
   );

--- a/apps/web/src/lib/markets/providers/availability.test.ts
+++ b/apps/web/src/lib/markets/providers/availability.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// The facade is server-only; stub the marker so the module imports under vitest.
+vi.mock("server-only", () => ({}));
+
+import { providerAvailability, dataClassAvailability } from "./index";
+
+const KEYS = ["FINNHUB_API_KEY", "TWELVEDATA_API_KEY", "FMP_API_KEY"];
+
+beforeEach(() => {
+  for (const k of KEYS) delete process.env[k];
+});
+
+describe("providerAvailability", () => {
+  it("reflects which API keys are set (booleans only)", () => {
+    expect(providerAvailability()).toEqual({
+      finnhub: false,
+      twelvedata: false,
+      fmp: false,
+    });
+    process.env.FINNHUB_API_KEY = "k";
+    process.env.FMP_API_KEY = "k";
+    expect(providerAvailability()).toEqual({
+      finnhub: true,
+      twelvedata: false,
+      fmp: true,
+    });
+  });
+});
+
+describe("dataClassAvailability", () => {
+  it("maps each feature to the providers that can serve it", () => {
+    process.env.FINNHUB_API_KEY = "k";
+    const c = dataClassAvailability();
+    // Finnhub-served classes light up; twelvedata/fmp-only classes don't.
+    expect(c.quote).toBe(true); // finnhub OR twelvedata
+    expect(c.profile).toBe(true); // finnhub only
+    expect(c.news).toBe(true); // finnhub only
+    expect(c.candles).toBe(false); // twelvedata only
+    expect(c.fx).toBe(false); // twelvedata only
+    expect(c.financials).toBe(false); // fmp only
+    expect(c.movers).toBe(false); // fmp only
+  });
+
+  it("twelvedata unlocks charts + fx, fmp unlocks fundamentals + movers", () => {
+    process.env.TWELVEDATA_API_KEY = "k";
+    process.env.FMP_API_KEY = "k";
+    const c = dataClassAvailability();
+    expect(c.candles).toBe(true);
+    expect(c.fx).toBe(true);
+    expect(c.financials).toBe(true);
+    expect(c.movers).toBe(true);
+    expect(c.news).toBe(false); // still finnhub-only
+  });
+});

--- a/apps/web/src/lib/markets/providers/index.ts
+++ b/apps/web/src/lib/markets/providers/index.ts
@@ -123,3 +123,35 @@ export function configuredProviders(): { id: string; attribution: string }[] {
   if (fmpAvailable()) out.push({ id: fmp.id, attribution: fmp.attribution });
   return out;
 }
+
+/** Per-provider "is an API key configured" booleans (no key values). */
+export function providerAvailability(): {
+  finnhub: boolean;
+  twelvedata: boolean;
+  fmp: boolean;
+} {
+  return {
+    finnhub: finnhubAvailable(),
+    twelvedata: twelvedataAvailable(),
+    fmp: fmpAvailable(),
+  };
+}
+
+/** Whether each data class has at least one configured provider — i.e. which
+ *  Markets features will actually return data. Mirrors the dispatch above. */
+export function dataClassAvailability(): Record<string, boolean> {
+  const fh = finnhubAvailable();
+  const td = twelvedataAvailable();
+  const f = fmpAvailable();
+  return {
+    quote: fh || td,
+    search: fh || td,
+    candles: td,
+    profile: fh,
+    news: fh,
+    financials: f,
+    calendar: fh,
+    movers: f,
+    fx: td,
+  };
+}


### PR DESCRIPTION
Supports connecting the Markets data feeds: once the three provider keys are set in Vercel and a deploy lands, you can verify **which feeds lit up without signing in**.

The public `/api/v1/health` route now includes a `markets` section:
```json
"markets": {
  "providers": { "finnhub": true, "twelvedata": false, "fmp": false },
  "classes":   { "quote": true, "candles": false, "news": true, "financials": false, ... },
  "attribution": [{ "id": "finnhub", "attribution": "Data by Finnhub" }]
}
```
- **Booleans only** — never key values, never market data.
- **Informational** — NOT part of the pass/fail `status`, so missing market keys never flip the app to "degraded".
- Wires up the previously-orphaned `configuredProviders()`; adds `providerAvailability()` + `dataClassAvailability()` (mirror the dispatch table) with unit tests.
- Folded into the **existing public** health route — the auth middleware needs no change (a new `/markets/health` route would've been 401'd by the gate).

`tsc` + `eslint` clean; 3 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)