### PR TITLE
fix(markets): target Bloomberg Television (@markets), resolve by handle

### DIFF
--- a/apps/web/src/app/api/v1/markets/tv/route.ts
+++ b/apps/web/src/app/api/v1/markets/tv/route.ts
@@ -37,7 +37,7 @@ async function handleGet(request: NextRequest) {
     id: channel.id,
     name: channel.name,
     attribution: channel.attribution,
-    youtubeChannelId: channel.youtubeChannelId,
+    handle: channel.handle,
   };
 
   if (!tvAvailable()) {
@@ -45,7 +45,7 @@ async function handleGet(request: NextRequest) {
   }
 
   try {
-    const videoId = await resolveLiveVideoId(channel.youtubeChannelId);
+    const videoId = await resolveLiveVideoId(channel);
     return ok({ configured: true, videoId, channel: meta, channels });
   } catch (e) {
     return mapMarketError(e);

--- a/apps/web/src/lib/markets/tv.test.ts
+++ b/apps/web/src/lib/markets/tv.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, afterEach, vi } from "vitest";
 // tv.ts is server-only; stub the marker so it imports under vitest.
 vi.mock("server-only", () => ({}));
 
-import { tvAvailable, findChannel, resolveLiveVideoId } from "./tv";
+import { tvAvailable, findChannel, resolveLiveVideoId, type TvChannel } from "./tv";
 
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -18,6 +18,23 @@ function jsonRes(body: unknown, ok = true): Response {
   } as Response;
 }
 
+function ch(handle: string): TvChannel {
+  return { id: handle, name: handle, handle, attribution: "" };
+}
+
+/** Mock that answers both calls: /channels (handle→id) and /search (live). */
+function ytMock(searchBody: unknown, channelsBody?: unknown) {
+  return vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input);
+    if (url.includes("/channels")) {
+      if (channelsBody) return jsonRes(channelsBody);
+      const handle = new URL(url).searchParams.get("forHandle") ?? "x";
+      return jsonRes({ items: [{ id: `UC_${handle}` }] });
+    }
+    return jsonRes(searchBody);
+  });
+}
+
 describe("tvAvailable", () => {
   it("reflects YOUTUBE_API_KEY", () => {
     delete process.env.YOUTUBE_API_KEY;
@@ -28,41 +45,51 @@ describe("tvAvailable", () => {
 });
 
 describe("findChannel", () => {
-  it("finds bloomberg and is undefined for unknown ids", () => {
-    expect(findChannel("bloomberg")?.name).toBe("Bloomberg TV");
+  it("finds bloomberg (Bloomberg Television, @markets) and is undefined for unknown", () => {
+    const c = findChannel("bloomberg");
+    expect(c?.name).toBe("Bloomberg Television");
+    expect(c?.handle).toBe("markets");
     expect(findChannel("nope")).toBeUndefined();
   });
 });
 
 describe("resolveLiveVideoId", () => {
-  it("extracts the live video id (11-char) and caches it", async () => {
+  it("resolves the channel by handle then extracts + caches the live id", async () => {
     process.env.YOUTUBE_API_KEY = "k";
-    const fetchMock = vi.fn(async () =>
-      jsonRes({ items: [{ id: { videoId: "LIVEvid1234" } }] }),
-    );
+    const fetchMock = ytMock({ items: [{ id: { videoId: "LIVEvid1234" } }] });
     vi.stubGlobal("fetch", fetchMock);
-    expect(await resolveLiveVideoId("UC_cacheA")).toBe("LIVEvid1234");
-    expect(await resolveLiveVideoId("UC_cacheA")).toBe("LIVEvid1234"); // cached
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(await resolveLiveVideoId(ch("h_extract"))).toBe("LIVEvid1234");
+    expect(fetchMock).toHaveBeenCalledTimes(2); // channels + search
+    // Second call: both lookups cached → no new fetches.
+    expect(await resolveLiveVideoId(ch("h_extract"))).toBe("LIVEvid1234");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
   it("rejects a malformed video id (wrong length / chars)", async () => {
     process.env.YOUTUBE_API_KEY = "k";
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async () => jsonRes({ items: [{ id: { videoId: "not a real id!" } }] })),
-    );
-    expect(await resolveLiveVideoId("UC_cacheBad")).toBeNull();
+    vi.stubGlobal("fetch", ytMock({ items: [{ id: { videoId: "not a real id!" } }] }));
+    expect(await resolveLiveVideoId(ch("h_bad"))).toBeNull();
   });
 
   it("returns null when the channel isn't live", async () => {
     process.env.YOUTUBE_API_KEY = "k";
-    vi.stubGlobal("fetch", vi.fn(async () => jsonRes({ items: [] })));
-    expect(await resolveLiveVideoId("UC_cacheB")).toBeNull();
+    vi.stubGlobal("fetch", ytMock({ items: [] }));
+    expect(await resolveLiveVideoId(ch("h_notlive"))).toBeNull();
+  });
+
+  it("returns null when the handle can't be resolved", async () => {
+    process.env.YOUTUBE_API_KEY = "k";
+    vi.stubGlobal(
+      "fetch",
+      ytMock({ items: [{ id: { videoId: "LIVEvid1234" } }] }, { items: [] }),
+    );
+    expect(await resolveLiveVideoId(ch("h_missing"))).toBeNull();
   });
 
   it("throws when no key is configured", async () => {
     delete process.env.YOUTUBE_API_KEY;
-    await expect(resolveLiveVideoId("UC_cacheC")).rejects.toThrow(/not configured/);
+    await expect(resolveLiveVideoId(ch("h_nokey"))).rejects.toThrow(
+      /not configured/,
+    );
   });
 });

--- a/apps/web/src/lib/markets/tv.ts
+++ b/apps/web/src/lib/markets/tv.ts
@@ -3,14 +3,17 @@
  * on YouTube so it can be embedded inline. Server-only: it carries the YouTube
  * Data API key and must never run in the browser.
  *
- * Why a resolver: YouTube assigns a fresh video id to each live broadcast, so
- * we ask the Data API "what is this channel live with right now?" (cached, since
- * that search call costs 100 quota units). The client then embeds the returned
- * video id via youtube-nocookie.com — no key needed on the client.
+ * We target channels by their @handle (not a raw channel id) and resolve the
+ * id at request time, so we always hit the right channel — e.g. Bloomberg
+ * Television is youtube.com/@markets, which is distinct from Bloomberg News
+ * (@Bloomberg-News) and Bloomberg Originals (@business). Then we ask the Data
+ * API "what is this channel live with right now?" (each broadcast gets a fresh
+ * video id). Both lookups are cached since the live search costs 100 quota
+ * units. The client embeds the returned id via youtube-nocookie.com — no key
+ * needed on the client.
  *
- * Embeds the OFFICIAL public live streams only. We never proxy or re-host the
- * feed (that would cross into ToS/copyright); the iframe points straight at
- * YouTube.
+ * Embeds the OFFICIAL public live stream only; we never proxy or re-host the
+ * feed (that would cross into ToS/copyright).
  */
 import "server-only";
 import { fetchJson, hasKey, requireKey } from "./http";
@@ -21,19 +24,22 @@ export interface TvChannel {
   /** Our stable slug (used in the API query + UI). */
   id: string;
   name: string;
-  /** The channel's YouTube channel id (UC…). */
-  youtubeChannelId: string;
+  /** The channel's YouTube @handle, without the leading @. */
+  handle: string;
   attribution: string;
 }
 
 /** Curated free, official finance-news live channels. Bloomberg first. Add
- *  more here once their channel id is verified — the UI picks them up. */
+ *  more here by @handle — the UI picks them up. */
 export const TV_CHANNELS: TvChannel[] = [
   {
     id: "bloomberg",
-    name: "Bloomberg TV",
-    youtubeChannelId: "UCIALMKvObZNtJ6AmdCLP7Lg",
-    attribution: "Bloomberg Television — official live stream on YouTube",
+    name: "Bloomberg Television",
+    // youtube.com/@markets IS Bloomberg Television (the markets TV simulcast) —
+    // NOT Bloomberg News (@Bloomberg-News) or Bloomberg Originals (@business).
+    handle: "markets",
+    attribution:
+      "Bloomberg Television (@markets) — official live stream on YouTube",
   },
 ];
 
@@ -45,39 +51,69 @@ export function findChannel(id: string): TvChannel | undefined {
   return TV_CHANNELS.find((c) => c.id === id);
 }
 
+interface YtChannelsResponse {
+  items?: { id?: string }[];
+}
 interface YtSearchResponse {
   items?: { id?: { videoId?: string } }[];
 }
 
+const VIDEO_ID_RE = /^[\w-]{11}$/;
+
+// @handle → channel id rarely changes, so cache it long. Costs 1 quota unit.
+const channelIdCache = new Map<string, { id: string | null; at: number }>();
+const CHANNEL_TTL_MS = 12 * 60 * 60_000;
+
+async function resolveChannelId(handle: string): Promise<string | null> {
+  const key = requireKey(KEY_ENV, "YouTube");
+  const hit = channelIdCache.get(handle);
+  if (hit && Date.now() - hit.at < CHANNEL_TTL_MS) return hit.id;
+  const url =
+    `https://www.googleapis.com/youtube/v3/channels?part=id` +
+    `&forHandle=${encodeURIComponent(handle)}&key=${encodeURIComponent(key)}`;
+  const data = await fetchJson<YtChannelsResponse>(url, {
+    provider: "YouTube",
+    timeoutMs: 8_000,
+  });
+  const id = data.items?.[0]?.id ?? null;
+  channelIdCache.set(handle, { id, at: Date.now() });
+  return id;
+}
+
 // The live video id is stable across a broadcast and the search call is
-// quota-expensive (100 units), so cache per channel. In-process + short TTL is
-// plenty: worst case a warm instance refetches every few minutes.
-const cache = new Map<string, { videoId: string | null; at: number }>();
-const TTL_MS = 5 * 60_000;
+// quota-expensive (100 units), so cache per channel.
+const liveCache = new Map<string, { videoId: string | null; at: number }>();
+const LIVE_TTL_MS = 5 * 60_000;
 
 /**
- * The channel's current live video id, or null when it isn't live. Cached.
- * Throws MarketDataError(503) when YOUTUBE_API_KEY is missing.
+ * The channel's current live video id, or null when it isn't live. Resolves the
+ * channel by its @handle first (so we always target the right channel), then
+ * finds its live broadcast. Both lookups cached. Throws MarketDataError(503)
+ * when YOUTUBE_API_KEY is missing.
  */
 export async function resolveLiveVideoId(
-  youtubeChannelId: string,
+  channel: TvChannel,
 ): Promise<string | null> {
-  const key = requireKey(KEY_ENV, "YouTube");
-  const hit = cache.get(youtubeChannelId);
-  if (hit && Date.now() - hit.at < TTL_MS) return hit.videoId;
+  requireKey(KEY_ENV, "YouTube");
+  const channelId = await resolveChannelId(channel.handle);
+  if (!channelId) return null;
 
+  const hit = liveCache.get(channelId);
+  if (hit && Date.now() - hit.at < LIVE_TTL_MS) return hit.videoId;
+
+  const key = requireKey(KEY_ENV, "YouTube");
   const url =
     `https://www.googleapis.com/youtube/v3/search?part=snippet` +
-    `&channelId=${encodeURIComponent(youtubeChannelId)}` +
+    `&channelId=${encodeURIComponent(channelId)}` +
     `&eventType=live&type=video&maxResults=1&key=${encodeURIComponent(key)}`;
   const data = await fetchJson<YtSearchResponse>(url, {
     provider: "YouTube",
     timeoutMs: 8_000,
   });
   const raw = data.items?.[0]?.id?.videoId ?? null;
-  // Only accept a well-formed YouTube id so nothing unexpected can be
-  // interpolated into the iframe src downstream.
-  const videoId = raw && /^[\w-]{11}$/.test(raw) ? raw : null;
-  cache.set(youtubeChannelId, { videoId, at: Date.now() });
+  // Only accept a well-formed YouTube id so nothing unexpected reaches the
+  // iframe src downstream.
+  const videoId = raw && VIDEO_ID_RE.test(raw) ? raw : null;
+  liveCache.set(channelId, { videoId, at: Date.now() });
   return videoId;
 }

--- a/apps/web/src/modules/markets/components/MarketsTV.tsx
+++ b/apps/web/src/modules/markets/components/MarketsTV.tsx
@@ -17,7 +17,7 @@ interface TvData {
     id: string;
     name: string;
     attribution: string;
-    youtubeChannelId: string;
+    handle: string;
   };
   channels: { id: string; name: string }[];
 }
@@ -66,8 +66,8 @@ export function MarketsTV() {
 
   const channel = data?.channel;
   const youtubeLiveUrl = channel
-    ? `https://www.youtube.com/channel/${channel.youtubeChannelId}/live`
-    : "https://www.youtube.com/results?search_query=bloomberg+tv+live";
+    ? `https://www.youtube.com/@${channel.handle}/live`
+    : "https://www.youtube.com/@markets/live";
   const embedSrc = data?.videoId
     ? `https://www.youtube-nocookie.com/embed/${data.videoId}?autoplay=1&mute=${
         muted ? 1 : 0


### PR DESCRIPTION
Zack flagged that **Bloomberg Television** ≠ Bloomberg Business News — and he's right. The TV panel hardcoded a raw channel id I couldn't fully verify, so this makes it **correct by construction**.

- Targets channels by **@handle** and resolves the channel id at request time. **Bloomberg Television = `youtube.com/@markets`** (the markets TV simulcast) — distinct from Bloomberg News (`@Bloomberg-News`) and Bloomberg Originals (`@business`).
- `resolveChannelId(handle)` via the Data API `channels?forHandle` (1 quota unit, cached 12h) → then the existing live search; the live id is still format-validated + cached 5 min.
- The route now returns the channel `handle`; the "Watch on YouTube" fallback links to `youtube.com/@<handle>/live`.

`tsc` + `eslint` clean; 7 tests pass (handle→id resolve, live extract+cache, malformed reject, not-live, unresolved-handle, no-key).

🤖 Generated with [Claude Code](https://claude.com/claude-code)