### PR TITLE
feat(markets): built-in "Watching" list on the dashboard panel

### DIFF
--- a/apps/web/src/components/dashboard/MarketsCard.test.tsx
+++ b/apps/web/src/components/dashboard/MarketsCard.test.tsx
@@ -22,30 +22,34 @@ function q(symbol: string, price: number, changePct: number): Quote {
 afterEach(cleanup);
 
 describe("MarketsCard", () => {
-  it("renders the active watchlist with live quotes + the indices strip", async () => {
-    mockList.mockResolvedValue([
-      {
-        id: "w1",
-        name: "Watching",
-        symbols: [{ symbol: "AAPL" }, { symbol: "MSFT" }],
-      },
-    ] as unknown as Awaited<ReturnType<typeof listWatchlists>>);
+  it("renders the built-in Watching list + indices strip even with no DB watchlists", async () => {
+    mockList.mockResolvedValue([]);
     mockQuotes.mockResolvedValue({
       AAPL: q("AAPL", 200, 1.5),
-      MSFT: q("MSFT", 400, -0.8),
       SPY: q("SPY", 500, 0.3),
     });
 
     render(<MarketsCard />);
+    // Built-in Watching symbols render immediately (no DB list required).
     expect(await screen.findByText("AAPL")).toBeTruthy();
-    expect(screen.getByText("MSFT")).toBeTruthy();
+    expect(screen.getByText("BTC-USD")).toBeTruthy(); // crypto row present
+    expect(screen.getByText("GLD")).toBeTruthy(); // commodity proxy present
     expect(screen.getByText("S&P 500")).toBeTruthy(); // indices pulse strip
   });
 
-  it("shows an empty state when there are no watchlists", async () => {
-    mockList.mockResolvedValue([]);
-    mockQuotes.mockResolvedValue({});
+  it("offers the watchlist picker (Watching + the viewer's lists) when DB lists exist", async () => {
+    mockList.mockResolvedValue([
+      { id: "w1", name: "My List", symbols: [{ symbol: "TSLA" }] },
+    ] as unknown as Awaited<ReturnType<typeof listWatchlists>>);
+    mockQuotes.mockResolvedValue({ AAPL: q("AAPL", 200, 1.5) });
+
     render(<MarketsCard />);
-    expect(await screen.findByText("No watchlists yet.")).toBeTruthy();
+    // Wait for the DB lists to load and the picker to appear.
+    const picker = await screen.findByRole("combobox", { name: "Watchlist" });
+    const options = Array.from(picker.querySelectorAll("option")).map(
+      (o) => o.textContent,
+    );
+    expect(options).toContain("Watching");
+    expect(options).toContain("My List");
   });
 });

--- a/apps/web/src/components/dashboard/MarketsCard.tsx
+++ b/apps/web/src/components/dashboard/MarketsCard.tsx
@@ -1,17 +1,18 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { TrendingUp, ChevronUp, ChevronDown } from "lucide-react";
 import { DashboardCard } from "./DashboardCard";
 import { useRealtimeTable } from "@/lib/supabase/realtime";
 import { fmtPrice, fmtPct, changeClass } from "@/lib/markets/format";
 import type { Quote } from "@/lib/markets/providers/types";
 import {
-  getQuotes,
-  listWatchlists,
-  type WatchlistWithSymbols,
-} from "@/modules/markets/lib/client-api";
+  WATCHING_ID,
+  watchingList,
+  type MarketsList,
+} from "@/lib/markets/watching";
+import { getQuotes, listWatchlists } from "@/modules/markets/lib/client-api";
 
 /** Index/ETF pulse shown at the top of the card (free-feed-friendly proxies). */
 const INDICES = [
@@ -27,20 +28,23 @@ interface QuoteCacheRow {
 
 /**
  * Dashboard Markets panel — a scale-adaptive, live-quote terminal that renders
- * inline on the dashboard (no need to open the module). An indices pulse strip
- * sits on top; below it the active watchlist streams live quotes. Density
- * adapts to the panel's width: tight (symbol · price · %chg) when narrow, a
- * fuller table (+ change · day range) when wide. The full board (charts,
- * portfolios, screener, news, TV) is one maximize away at /modules/markets.
+ * inline on the dashboard (no need to open the module). The built-in "Watching"
+ * list (Zack's tracked instruments) leads; the viewer's own watchlists follow
+ * in the picker. An indices pulse strip sits on top; below it the active list
+ * streams live quotes. Density adapts to the panel's width: tight
+ * (symbol · price · %chg) when narrow, a fuller table (+ company name) when
+ * wide. The full board (charts, portfolios, screener, news, TV) is one maximize
+ * away at /modules/markets.
  */
 export function MarketsCard() {
   const [containerRef, width] = useElementWidth<HTMLDivElement>();
-  const [watchlists, setWatchlists] = useState<WatchlistWithSymbols[]>([]);
-  const [activeId, setActiveId] = useState<string>("");
+  const [userLists, setUserLists] = useState<MarketsList[]>([]);
+  const [activeId, setActiveId] = useState<string>(WATCHING_ID);
   const [quotes, setQuotes] = useState<Record<string, Quote>>({});
-  const [loading, setLoading] = useState(true);
 
-  const active = watchlists.find((w) => w.id === activeId) ?? watchlists[0];
+  // The built-in Watching list always leads; the viewer's own watchlists follow.
+  const lists = useMemo(() => [watchingList(), ...userLists], [userLists]);
+  const active = lists.find((l) => l.id === activeId) ?? lists[0];
   const wide = width >= 460;
 
   useEffect(() => {
@@ -48,21 +52,23 @@ export function MarketsCard() {
     listWatchlists("user")
       .then((w) => {
         if (!alive) return;
-        setWatchlists(w);
-        setActiveId((cur) => cur || w[0]?.id || "");
+        setUserLists(
+          w.map((wl) => ({
+            id: wl.id,
+            name: wl.name,
+            symbols: wl.symbols.map((s) => ({ symbol: s.symbol })),
+          })),
+        );
       })
       .catch(() => {
-        /* unconfigured / no access → empty state */
-      })
-      .finally(() => {
-        if (alive) setLoading(false);
+        /* unconfigured / no access → just the built-in Watching list */
       });
     return () => {
       alive = false;
     };
   }, []);
 
-  // Quote every symbol on screen: the indices strip + the active watchlist.
+  // Quote every symbol on screen: the indices strip + the active list.
   const symbols = [
     ...INDICES.map((i) => i.symbol),
     ...(active?.symbols.map((s) => s.symbol) ?? []),
@@ -104,16 +110,16 @@ export function MarketsCard() {
       expandHref="/modules/markets"
       bodyClassName="flex min-h-0 flex-col overflow-hidden"
       headerRight={
-        watchlists.length > 1 ? (
+        lists.length > 1 ? (
           <select
-            value={active?.id ?? ""}
+            value={active?.id ?? WATCHING_ID}
             onChange={(e) => setActiveId(e.target.value)}
             aria-label="Watchlist"
             className="rounded-sm border border-border bg-bg-0 px-1.5 py-0.5 text-2xs text-text-1 outline-none focus:border-border-focus"
           >
-            {watchlists.map((w) => (
-              <option key={w.id} value={w.id}>
-                {w.name}
+            {lists.map((l) => (
+              <option key={l.id} value={l.id}>
+                {l.name}
               </option>
             ))}
           </select>
@@ -122,16 +128,15 @@ export function MarketsCard() {
     >
       <div ref={containerRef} className="flex min-h-0 flex-1 flex-col">
         <IndicesStrip quotes={quotes} />
-        {loading && watchlists.length === 0 ? (
-          <p className="px-3 py-4 text-center text-xs text-text-3">Loading…</p>
-        ) : !active || active.symbols.length === 0 ? (
-          <Empty hasLists={watchlists.length > 0} />
+        {!active || active.symbols.length === 0 ? (
+          <Empty />
         ) : (
           <ul className="min-h-0 flex-1 divide-y divide-border/30 overflow-y-auto">
             {active.symbols.map((s) => (
               <QuoteRow
                 key={s.symbol}
                 symbol={s.symbol}
+                label={s.label}
                 quote={quotes[s.symbol]}
                 wide={wide}
               />
@@ -160,13 +165,15 @@ function IndicesStrip({ quotes }: { quotes: Record<string, Quote> }) {
   );
 }
 
-/** One watchlist row — density adapts to the panel width. */
+/** One list row — density adapts to the panel width. */
 function QuoteRow({
   symbol,
+  label,
   quote,
   wide,
 }: {
   symbol: string;
+  label?: string;
   quote: Quote | undefined;
   wide: boolean;
 }) {
@@ -177,12 +184,12 @@ function QuoteRow({
         href={`/modules/markets/quote/${encodeURIComponent(symbol)}`}
         className="flex items-center gap-2 px-3 py-[var(--rk-row-py)] hover:bg-bg-2"
       >
-        <span className="w-14 flex-shrink-0 truncate font-mono text-xs font-semibold text-text-0">
+        <span className="w-16 flex-shrink-0 truncate font-mono text-xs font-semibold text-text-0">
           {symbol}
         </span>
         {wide ? (
           <span className="flex-1 truncate text-2xs text-text-3">
-            {quote?.name ?? ""}
+            {label ?? quote?.name ?? ""}
           </span>
         ) : (
           <span className="flex-1" />
@@ -213,16 +220,11 @@ function cnPct(q: Quote | undefined): string {
   return `font-mono text-2xs tabular-nums ${q ? changeClass(q.changePct) : "text-text-3"}`;
 }
 
-function Empty({ hasLists }: { hasLists: boolean }) {
+function Empty() {
   return (
     <div className="flex flex-1 flex-col items-center justify-center gap-2 p-6 text-center">
       <TrendingUp className="h-5 w-5 text-text-3" aria-hidden="true" />
-      <p className="text-xs text-text-2">
-        {hasLists ? "This watchlist is empty." : "No watchlists yet."}
-      </p>
-      <p className="text-xs text-text-3">
-        Track quotes, charts, portfolios, and alerts.
-      </p>
+      <p className="text-xs text-text-2">This watchlist is empty.</p>
       <Link
         href="/modules/markets"
         className="mt-1 rounded-sm border border-border bg-bg-2 px-2 py-1 text-xs text-text-1 hover:bg-bg-3"

--- a/apps/web/src/lib/markets/watching.test.ts
+++ b/apps/web/src/lib/markets/watching.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { WATCHING, WATCHING_ID, watchingList } from "./watching";
+import { isValidSymbol } from "./symbols";
+
+describe("watching list", () => {
+  it("every tracked symbol is a valid, normalized instrument symbol", () => {
+    for (const w of WATCHING) {
+      expect(isValidSymbol(w.symbol), w.symbol).toBe(true);
+      expect(w.symbol).toBe(w.symbol.toUpperCase());
+      expect(w.label.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("has no duplicate symbols", () => {
+    const seen = new Set(WATCHING.map((w) => w.symbol));
+    expect(seen.size).toBe(WATCHING.length);
+  });
+
+  it("adapts to a builtin MarketsList keyed by WATCHING_ID", () => {
+    const list = watchingList();
+    expect(list.id).toBe(WATCHING_ID);
+    expect(list.builtin).toBe(true);
+    expect(list.symbols).toHaveLength(WATCHING.length);
+    expect(list.symbols[0]).toEqual({
+      symbol: WATCHING[0].symbol,
+      label: WATCHING[0].label,
+    });
+  });
+});

--- a/apps/web/src/lib/markets/watching.ts
+++ b/apps/web/src/lib/markets/watching.ts
@@ -1,0 +1,70 @@
+/**
+ * The built-in "Watching" list.
+ *
+ * A default, always-present set of instruments so the dashboard Markets panel
+ * is useful before anyone creates a custom watchlist — and so the symbols Zack
+ * asked Rokki to track (mega-cap tech, the majors of crypto, and the metal/oil
+ * proxies) are one glance away on the dashboard, no module click required.
+ *
+ * Pure data + a small adapter — no React, no server-only marker — so it can be
+ * imported from a client component, a server route, or a test alike.
+ *
+ * Resolution notes (free-feed reality, see providers/index.ts):
+ *  - equity + commodity rows are plain US-listed tickers/ETFs → resolve on the
+ *    configured stock feed today.
+ *  - crypto rows are canonical `BASE-USD` symbols; they resolve once a crypto
+ *    feed is wired in (providers/coingecko), which needs no API key.
+ */
+
+/** Stable id for the built-in list (distinct from any DB watchlist UUID). */
+export const WATCHING_ID = "__watching";
+
+export type WatchingKind = "equity" | "crypto" | "commodity";
+
+export interface WatchingItem {
+  /** Canonical instrument symbol (what we display and key quotes on). */
+  symbol: string;
+  /** Friendly name shown when the panel is wide enough. */
+  label: string;
+  kind: WatchingKind;
+}
+
+/**
+ * A width-light view of a list the Markets panel can render. Both the built-in
+ * Watching list and the user's DB watchlists are adapted to this shape so the
+ * panel never has to care which one it's showing.
+ */
+export interface MarketsList {
+  id: string;
+  name: string;
+  /** `builtin` lists can't be edited from the panel (no DB row behind them). */
+  builtin?: boolean;
+  symbols: { symbol: string; label?: string }[];
+}
+
+/** The default tracked instruments. Order is intentional (tech → crypto → metals/oil). */
+export const WATCHING: WatchingItem[] = [
+  { symbol: "AAPL", label: "Apple", kind: "equity" },
+  { symbol: "MSFT", label: "Microsoft", kind: "equity" },
+  { symbol: "GOOGL", label: "Alphabet", kind: "equity" },
+  { symbol: "NVDA", label: "NVIDIA", kind: "equity" },
+  { symbol: "META", label: "Meta", kind: "equity" },
+  { symbol: "CRCL", label: "Circle", kind: "equity" },
+  { symbol: "BTC-USD", label: "Bitcoin", kind: "crypto" },
+  { symbol: "ETH-USD", label: "Ethereum", kind: "crypto" },
+  { symbol: "XRP-USD", label: "XRP", kind: "crypto" },
+  { symbol: "SOL-USD", label: "Solana", kind: "crypto" },
+  { symbol: "GLD", label: "Gold (GLD)", kind: "commodity" },
+  { symbol: "SLV", label: "Silver (SLV)", kind: "commodity" },
+  { symbol: "USO", label: "Oil (USO)", kind: "commodity" },
+];
+
+/** The built-in list adapted to the panel's `MarketsList` shape. */
+export function watchingList(): MarketsList {
+  return {
+    id: WATCHING_ID,
+    name: "Watching",
+    builtin: true,
+    symbols: WATCHING.map((w) => ({ symbol: w.symbol, label: w.label })),
+  };
+}


### PR DESCRIPTION
## What
A built-in **Watching** list now leads the dashboard Markets panel — Zack's tracked instruments (AAPL, MSFT, GOOGL, NVDA, META, CRCL · BTC/ETH/XRP/SOL · GLD/SLV/USO), always present, no DB watchlist required. The viewer's own watchlists follow in the picker.

## Why
Phase 2 of the overnight Markets build. Fulfills the explicit "track these symbols on the dashboard" ask: the panel is now useful on first load, streaming live quotes for the default set without anyone creating a watchlist first.

## Notes
- `lib/markets/watching.ts` is pure data + a `MarketsList` adapter shared by the built-in list and DB watchlists.
- Equity + commodity (ETF proxy) rows resolve on the configured free feed today.
- Crypto rows render now and resolve once the **no-key CoinGecko** adapter lands (immediate follow-up PR) — Finnhub returns HTTP 200 zeros for `BTC-USD`, so a dedicated crypto feed is the correct fix, not a fall-through hack.

## Test
- `watching.test.ts` — every tracked symbol is valid/normalized/unique; builtin adapter shape.
- `MarketsCard.test.tsx` — built-in list + indices strip render with no DB lists; picker lists Watching + the viewer's lists.
- tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)