### PR TITLE
feat(markets): keyless CoinGecko crypto feed (resolves BTC/ETH/XRP/SOL)

### DIFF
--- a/apps/web/src/lib/markets/providers/coingecko.test.ts
+++ b/apps/web/src/lib/markets/providers/coingecko.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+
+// coingecko.ts is server-only; stub the marker so it imports under vitest.
+vi.mock("server-only", () => ({}));
+
+import { coingecko, coingeckoAvailable, cryptoBase, isCryptoSymbol } from "./coingecko";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function jsonRes(body: unknown, ok = true): Response {
+  return {
+    ok,
+    status: ok ? 200 : 500,
+    text: async () => JSON.stringify(body),
+  } as Response;
+}
+
+describe("cryptoBase / isCryptoSymbol", () => {
+  it("recognizes the common symbol shapes", () => {
+    expect(cryptoBase("BTC")).toBe("BTC");
+    expect(cryptoBase("BTC-USD")).toBe("BTC");
+    expect(cryptoBase("btc/usd")).toBe("BTC");
+    expect(cryptoBase("ETHUSD")).toBe("ETH");
+    expect(cryptoBase("SOL-USD")).toBe("SOL");
+    expect(cryptoBase("XRP-USD")).toBe("XRP");
+  });
+
+  it("returns null for equities/ETFs/unknowns", () => {
+    expect(cryptoBase("AAPL")).toBeNull();
+    expect(cryptoBase("GLD")).toBeNull();
+    expect(cryptoBase("USO")).toBeNull();
+    expect(isCryptoSymbol("AAPL")).toBe(false);
+    expect(isCryptoSymbol("BTC-USD")).toBe(true);
+  });
+
+  it("is always available (no key required)", () => {
+    expect(coingeckoAvailable()).toBe(true);
+  });
+});
+
+describe("coingecko.quote", () => {
+  it("maps simple/price into a normalized Quote and echoes the canonical symbol", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        jsonRes({
+          bitcoin: {
+            usd: 101000,
+            usd_24h_change: 2, // +2% over 24h
+            usd_24h_vol: 35_000_000_000,
+            usd_market_cap: 2_000_000_000_000,
+            last_updated_at: 1_700_000_000,
+          },
+        }),
+      ),
+    );
+    const q = await coingecko.quote!("BTC-USD");
+    expect(q.symbol).toBe("BTC-USD"); // canonical echoed, not "bitcoin"
+    expect(q.name).toBe("Bitcoin");
+    expect(q.price).toBe(101000);
+    expect(q.changePct).toBe(2);
+    expect(q.currency).toBe("USD");
+    expect(q.marketState).toBe("open");
+    expect(q.provider).toBe("coingecko");
+    // prevClose derived from the 24h move: 101000 / 1.02
+    expect(q.prevClose).toBeCloseTo(101000 / 1.02, 2);
+    expect(q.change).toBeCloseTo(101000 - 101000 / 1.02, 2);
+    expect(q.volume).toBe(35_000_000_000);
+    expect(q.marketCap).toBe(2_000_000_000_000);
+  });
+
+  it("throws 404 for an unknown crypto symbol (no network call)", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    await expect(coingecko.quote!("AAPL")).rejects.toThrow(/Unknown crypto/);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("throws when the coin is missing from the response", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => jsonRes({})));
+    await expect(coingecko.quote!("ETH-USD")).rejects.toThrow(/No quote/);
+  });
+});

--- a/apps/web/src/lib/markets/providers/coingecko.ts
+++ b/apps/web/src/lib/markets/providers/coingecko.ts
@@ -1,0 +1,136 @@
+/**
+ * CoinGecko adapter — live crypto quotes, no API key required.
+ *
+ * The keyed feeds (Finnhub/Twelve Data) don't serve canonical crypto symbols
+ * like `BTC-USD` on their free tiers — Finnhub returns an empty quote (which we
+ * treat as 404), so crypto rows would never resolve. CoinGecko's public
+ * `simple/price` endpoint covers the majors with no key, so the facade routes
+ * any recognized crypto symbol here first.
+ *
+ * Free public API: generous but unauthenticated rate limits, so this only fires
+ * for crypto symbols (gated in the facade) and rides the same quote cache as
+ * every other provider. Display requires attribution — surfaced via
+ * configuredProviders() in the footer.
+ *
+ * Docs: https://docs.coingecko.com/reference/simple-price
+ */
+import "server-only";
+import { fetchJson, MarketDataError } from "../http";
+import type { MarketDataProvider, Quote } from "./types";
+
+const BASE = "https://api.coingecko.com/api/v3";
+
+/**
+ * Canonical base ticker → CoinGecko coin id + display name. Covers Zack's
+ * Watching majors (BTC/ETH/XRP/SOL) plus the common large-caps, so a typed
+ * crypto symbol resolves without a lookup round-trip.
+ */
+const CRYPTO: Record<string, { id: string; name: string }> = {
+  BTC: { id: "bitcoin", name: "Bitcoin" },
+  ETH: { id: "ethereum", name: "Ethereum" },
+  XRP: { id: "ripple", name: "XRP" },
+  SOL: { id: "solana", name: "Solana" },
+  ADA: { id: "cardano", name: "Cardano" },
+  DOGE: { id: "dogecoin", name: "Dogecoin" },
+  BNB: { id: "binancecoin", name: "BNB" },
+  LTC: { id: "litecoin", name: "Litecoin" },
+  DOT: { id: "polkadot", name: "Polkadot" },
+  AVAX: { id: "avalanche-2", name: "Avalanche" },
+  MATIC: { id: "matic-network", name: "Polygon" },
+  LINK: { id: "chainlink", name: "Chainlink" },
+  TRX: { id: "tron", name: "TRON" },
+  BCH: { id: "bitcoin-cash", name: "Bitcoin Cash" },
+  USDC: { id: "usd-coin", name: "USD Coin" },
+  USDT: { id: "tether", name: "Tether" },
+};
+
+/**
+ * Reduce a user-entered symbol to its known crypto base, or null if it isn't
+ * one. Accepts the common shapes: `BTC`, `BTC-USD`, `BTC/USD`, `BTCUSD`.
+ */
+export function cryptoBase(symbol: string): string | null {
+  const s = symbol.trim().toUpperCase();
+  const candidates = [
+    s,
+    s.replace(/[-/]USD$/, ""),
+    s.replace(/[-/]USDT$/, ""),
+    s.replace(/USD$/, ""),
+  ];
+  for (const c of candidates) {
+    if (Object.prototype.hasOwnProperty.call(CRYPTO, c)) return c;
+  }
+  return null;
+}
+
+/** Whether the facade should route this symbol to CoinGecko. */
+export function isCryptoSymbol(symbol: string): boolean {
+  return cryptoBase(symbol) !== null;
+}
+
+type CgSimplePrice = Record<
+  string,
+  {
+    usd?: number;
+    usd_24h_change?: number;
+    usd_24h_vol?: number;
+    usd_market_cap?: number;
+    last_updated_at?: number;
+  }
+>;
+
+export const coingecko: MarketDataProvider = {
+  id: "coingecko",
+  attribution: "Crypto data by CoinGecko",
+
+  async quote(symbol) {
+    const base = cryptoBase(symbol);
+    if (!base) {
+      throw new MarketDataError(404, `Unknown crypto symbol: ${symbol}`, "coingecko");
+    }
+    const { id, name } = CRYPTO[base];
+    const url =
+      `${BASE}/simple/price?ids=${encodeURIComponent(id)}` +
+      `&vs_currencies=usd&include_24hr_change=true&include_24hr_vol=true` +
+      `&include_market_cap=true&include_last_updated_at=true`;
+    const data = await fetchJson<CgSimplePrice>(url, { provider: "coingecko" });
+    const row = data[id];
+    if (!row || typeof row.usd !== "number") {
+      throw new MarketDataError(404, `No quote for ${symbol}`, "coingecko");
+    }
+
+    const price = row.usd;
+    const changePct = row.usd_24h_change ?? 0;
+    // Derive the absolute change + prior close from the 24h % move so the row
+    // matches the shape of every other quote (which carries change + prevClose).
+    const prevClose = changePct > -100 ? price / (1 + changePct / 100) : null;
+    const change = prevClose !== null ? price - prevClose : 0;
+
+    const quote: Quote = {
+      symbol, // echo the canonical symbol the caller asked for (e.g. BTC-USD)
+      name,
+      price,
+      change,
+      changePct,
+      open: null,
+      high: null,
+      low: null,
+      prevClose,
+      volume: row.usd_24h_vol ?? null,
+      marketCap: row.usd_market_cap ?? null,
+      peRatio: null,
+      week52High: null,
+      week52Low: null,
+      currency: "USD",
+      exchange: "CoinGecko",
+      marketState: "open", // crypto trades 24/7
+      asOf: row.last_updated_at
+        ? new Date(row.last_updated_at * 1000).toISOString()
+        : new Date().toISOString(),
+      provider: "coingecko",
+    };
+    return quote;
+  },
+};
+
+/** Always available — the public endpoint needs no API key. */
+export const coingeckoAvailable = () => true;

--- a/apps/web/src/lib/markets/providers/index.ts
+++ b/apps/web/src/lib/markets/providers/index.ts
@@ -12,6 +12,7 @@ import { MarketDataError } from "../http";
 import { finnhub, finnhubAvailable } from "./finnhub";
 import { twelvedata, twelvedataAvailable } from "./twelvedata";
 import { fmp, fmpAvailable } from "./fmp";
+import { coingecko, coingeckoAvailable, isCryptoSymbol } from "./coingecko";
 import type {
   Candle,
   CompanyProfile,
@@ -55,6 +56,12 @@ async function firstOf<T>(cls: string, attempts: Attempt<T>[]): Promise<T> {
 
 export function getQuote(symbol: string): Promise<Quote> {
   return firstOf("quote", [
+    // Crypto resolves via CoinGecko (no key); the keyed feeds don't serve
+    // canonical crypto symbols on their free tiers. Non-crypto skips this.
+    {
+      available: coingeckoAvailable() && isCryptoSymbol(symbol) && !!coingecko.quote,
+      run: () => coingecko.quote!(symbol),
+    },
     { available: finnhubAvailable() && !!finnhub.quote, run: () => finnhub.quote!(symbol) },
     { available: twelvedataAvailable() && !!twelvedata.quote, run: () => twelvedata.quote!(symbol) },
   ]);
@@ -121,6 +128,8 @@ export function configuredProviders(): { id: string; attribution: string }[] {
   if (finnhubAvailable()) out.push({ id: finnhub.id, attribution: finnhub.attribution });
   if (twelvedataAvailable()) out.push({ id: twelvedata.id, attribution: twelvedata.attribution });
   if (fmpAvailable()) out.push({ id: fmp.id, attribution: fmp.attribution });
+  // Always available (no key) — credit it whenever crypto can be shown.
+  if (coingeckoAvailable()) out.push({ id: coingecko.id, attribution: coingecko.attribution });
   return out;
 }
 


### PR DESCRIPTION
## What
A **keyless CoinGecko adapter** for live crypto quotes, routed first in the facade for any recognized crypto symbol. Completes the dashboard "Watching" list's crypto rows (BTC/ETH/XRP/SOL).

## Why
Finnhub/Twelve Data free tiers don't serve canonical crypto symbols like `BTC-USD` — Finnhub returns an empty quote (treated as 404), so crypto rows never resolved. CoinGecko's public `simple/price` needs no API key, so it's the correct fix (not a fall-through hack). Rides the existing quote cache + realtime; non-crypto symbols skip it entirely.

## Notes
- `providers/coingecko.ts`: `simple/price` → normalized `Quote`; `cryptoBase()` parses `BTC` / `BTC-USD` / `BTC/USD` / `BTCUSD`; covers the majors + common large-caps. 24h % move → derived `change`/`prevClose` so crypto rows match every other quote's shape.
- `providers/index.ts`: `getQuote` routes crypto → CoinGecko first; credited in the attribution footer via `configuredProviders()`.
- No env var (keyless). Free public tier; only fires for crypto, so rate limits aren't a concern at watchlist scale.

## Test
- `coingecko.test.ts` — symbol parsing, quote mapping (incl. derived change/prevClose/volume/marketCap), unknown-symbol short-circuit (no network call).
- `availability.test.ts` unchanged (keyless provider surfaced via attribution, not the keyed-availability maps).
- tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)