### PR TITLE
feat(markets): rates ribbon (Treasury + SOFR/Prime/Fed Funds via FRED)

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -92,6 +92,12 @@ FMP_API_KEY=
 # Get a free key at https://console.cloud.google.com/apis/credentials
 YOUTUBE_API_KEY=
 
+# Rates board — Treasury bill/note yields + SOFR, Prime, and Fed Funds from
+# FRED (Federal Reserve Economic Data). Server-only. If blank, the rates ribbon
+# on the Markets panel stays hidden. Crypto quotes (CoinGecko) need no key.
+# Get a free key at https://fred.stlouisfed.org/docs/api/api_key.html
+FRED_API_KEY=
+
 # Misc
 NODE_ENV=development
 LOG_LEVEL=debug

--- a/apps/web/src/app/api/v1/markets/rates/route.ts
+++ b/apps/web/src/app/api/v1/markets/rates/route.ts
@@ -1,0 +1,35 @@
+import { createClient } from "@/lib/supabase/server";
+import { withObservability } from "@/lib/observability";
+import { ok, unauthorized, mapMarketError } from "@/lib/markets/api";
+import { getRatesBoard, ratesAvailable } from "@/lib/markets/rates";
+
+// Reads the FRED key + pulls fresh observations (cached an hour internally).
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/v1/markets/rates
+ *
+ * Auth-gated. Returns the benchmark rates board (Treasury yields + SOFR/Prime/
+ * Fed Funds) from FRED, and whether FRED_API_KEY is configured. Degrades to
+ * `{ configured: false, board: null }` (not an error) when no key is set, so
+ * the UI can show an "add a free key" prompt.
+ */
+async function handleGet() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return unauthorized();
+
+  if (!ratesAvailable()) {
+    return ok({ configured: false, board: null });
+  }
+  try {
+    const board = await getRatesBoard();
+    return ok({ configured: true, board });
+  } catch (e) {
+    return mapMarketError(e);
+  }
+}
+
+export const GET = withObservability(handleGet, "GET /api/v1/markets/rates");

--- a/apps/web/src/components/dashboard/MarketsCard.test.tsx
+++ b/apps/web/src/components/dashboard/MarketsCard.test.tsx
@@ -7,6 +7,7 @@ vi.mock("@/lib/supabase/realtime", () => ({ useRealtimeTable: () => {} }));
 vi.mock("@/modules/markets/lib/client-api", () => ({
   listWatchlists: vi.fn(),
   getQuotes: vi.fn(),
+  getRatesBoard: vi.fn().mockResolvedValue({ configured: false, board: null }),
 }));
 
 import { listWatchlists, getQuotes } from "@/modules/markets/lib/client-api";

--- a/apps/web/src/components/dashboard/MarketsCard.tsx
+++ b/apps/web/src/components/dashboard/MarketsCard.tsx
@@ -12,7 +12,12 @@ import {
   watchingList,
   type MarketsList,
 } from "@/lib/markets/watching";
-import { getQuotes, listWatchlists } from "@/modules/markets/lib/client-api";
+import type { RatesBoard, RateRow } from "@/lib/markets/rates";
+import {
+  getQuotes,
+  getRatesBoard,
+  listWatchlists,
+} from "@/modules/markets/lib/client-api";
 
 /** Index/ETF pulse shown at the top of the card (free-feed-friendly proxies). */
 const INDICES = [
@@ -41,6 +46,7 @@ export function MarketsCard() {
   const [userLists, setUserLists] = useState<MarketsList[]>([]);
   const [activeId, setActiveId] = useState<string>(WATCHING_ID);
   const [quotes, setQuotes] = useState<Record<string, Quote>>({});
+  const [rates, setRates] = useState<RatesBoard | null>(null);
 
   // The built-in Watching list always leads; the viewer's own watchlists follow.
   const lists = useMemo(() => [watchingList(), ...userLists], [userLists]);
@@ -62,6 +68,21 @@ export function MarketsCard() {
       })
       .catch(() => {
         /* unconfigured / no access → just the built-in Watching list */
+      });
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  // Benchmark rates (FRED) — degrades silently when no FRED key is configured.
+  useEffect(() => {
+    let alive = true;
+    getRatesBoard()
+      .then((r) => {
+        if (alive && r.configured) setRates(r.board);
+      })
+      .catch(() => {
+        /* unconfigured / no access → ribbon hidden */
       });
     return () => {
       alive = false;
@@ -128,6 +149,7 @@ export function MarketsCard() {
     >
       <div ref={containerRef} className="flex min-h-0 flex-1 flex-col">
         <IndicesStrip quotes={quotes} />
+        <RatesRibbon board={rates} />
         {!active || active.symbols.length === 0 ? (
           <Empty />
         ) : (
@@ -161,6 +183,38 @@ function IndicesStrip({ quotes }: { quotes: Record<string, Quote> }) {
           </div>
         );
       })}
+    </div>
+  );
+}
+
+/** Benchmark rates ribbon — Treasury yields + SOFR/Prime/Fed Funds (FRED).
+ *  Hidden entirely until a FRED key is configured and values are present, so
+ *  it never shows as a broken row of dashes. */
+function RatesRibbon({ board }: { board: RatesBoard | null }) {
+  if (!board) return null;
+  const rows = [...board.treasury, ...board.reference].filter(
+    (r) => r.value !== null,
+  );
+  if (rows.length === 0) return null;
+  return (
+    <div className="flex flex-shrink-0 items-center gap-3 overflow-x-auto border-b border-border/40 px-3 py-1">
+      <span className="text-2xs font-medium uppercase tracking-wide text-text-3">
+        Rates
+      </span>
+      {rows.map((r) => (
+        <RateCell key={r.id} row={r} />
+      ))}
+    </div>
+  );
+}
+
+function RateCell({ row }: { row: RateRow }) {
+  return (
+    <div className="flex items-baseline gap-1 whitespace-nowrap">
+      <span className="text-2xs text-text-2">{row.label}</span>
+      <span className="font-mono text-2xs tabular-nums text-text-0">
+        {row.value!.toFixed(2)}
+      </span>
     </div>
   );
 }

--- a/apps/web/src/lib/markets/rates.test.ts
+++ b/apps/web/src/lib/markets/rates.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+
+// rates.ts is server-only; stub the marker so it imports under vitest.
+vi.mock("server-only", () => ({}));
+
+import {
+  getRatesBoard,
+  ratesAvailable,
+  __resetRatesCache,
+} from "./rates";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  __resetRatesCache();
+  delete process.env.FRED_API_KEY;
+});
+
+function obsRes(latest: string, prev: string): Response {
+  return {
+    ok: true,
+    status: 200,
+    text: async () =>
+      JSON.stringify({
+        observations: [
+          { date: "2026-06-23", value: latest },
+          { date: "2026-06-20", value: prev },
+        ],
+      }),
+  } as Response;
+}
+
+describe("ratesAvailable", () => {
+  it("reflects FRED_API_KEY", () => {
+    delete process.env.FRED_API_KEY;
+    expect(ratesAvailable()).toBe(false);
+    process.env.FRED_API_KEY = "k";
+    expect(ratesAvailable()).toBe(true);
+  });
+});
+
+describe("getRatesBoard", () => {
+  it("throws when no key is configured", async () => {
+    delete process.env.FRED_API_KEY;
+    await expect(getRatesBoard()).rejects.toThrow(/not configured/);
+  });
+
+  it("maps FRED observations into Treasury + reference rows with day change", async () => {
+    process.env.FRED_API_KEY = "k";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => obsRes("4.32", "4.30")),
+    );
+    const board = await getRatesBoard();
+    expect(board.treasury.length).toBeGreaterThan(0);
+    expect(board.reference.length).toBe(3); // SOFR, Prime, Fed Funds
+    const threeM = board.treasury.find((r) => r.label === "3M")!;
+    expect(threeM.value).toBe(4.32);
+    expect(threeM.change).toBeCloseTo(0.02, 3);
+    expect(threeM.asOf).toBe("2026-06-23");
+    const sofr = board.reference.find((r) => r.id === "SOFR");
+    expect(sofr?.label).toBe("SOFR");
+  });
+
+  it("treats '.' as a missing value (null), not a number", async () => {
+    process.env.FRED_API_KEY = "k";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => obsRes(".", ".")),
+    );
+    const board = await getRatesBoard();
+    const anyRow = board.treasury[0];
+    expect(anyRow.value).toBeNull();
+    expect(anyRow.change).toBeNull();
+  });
+
+  it("caches the board (second call makes no new fetches)", async () => {
+    process.env.FRED_API_KEY = "k";
+    const fetchMock = vi.fn(async () => obsRes("5.00", "5.00"));
+    vi.stubGlobal("fetch", fetchMock);
+    await getRatesBoard();
+    const callsAfterFirst = fetchMock.mock.calls.length;
+    await getRatesBoard();
+    expect(fetchMock.mock.calls.length).toBe(callsAfterFirst); // served from cache
+  });
+});

--- a/apps/web/src/lib/markets/rates.ts
+++ b/apps/web/src/lib/markets/rates.ts
@@ -1,0 +1,129 @@
+/**
+ * Rates board — benchmark interest rates from FRED (Federal Reserve Economic
+ * Data). Server-only: carries the FRED API key.
+ *
+ * FRED is the authoritative, free source for the rates Zack tracks: Treasury
+ * bill/note yields (the constant-maturity series), SOFR, the bank Prime rate,
+ * and the effective Fed Funds rate. A FRED key is free (instant signup at
+ * fred.stlouisfed.org) — when `FRED_API_KEY` is unset the board degrades to a
+ * "add a key" prompt, exactly like Markets TV without a YouTube key.
+ *
+ * Each series is one cheap observations call; we pull the latest two points to
+ * show the value and its day-over-day change. The whole board is cached for an
+ * hour since these update at most daily.
+ *
+ * Docs: https://fred.stlouisfed.org/docs/api/fred/series_observations.html
+ */
+import "server-only";
+import { fetchJson, hasKey, requireKey, MarketDataError } from "./http";
+
+const KEY_ENV = "FRED_API_KEY";
+const BASE = "https://api.stlouisfed.org/fred";
+
+export interface RateRow {
+  /** FRED series id (stable key). */
+  id: string;
+  label: string;
+  /** Latest value in percent, or null when unavailable. */
+  value: number | null;
+  /** Day-over-day change in percentage points, or null. */
+  change: number | null;
+  /** ISO date of the latest observation, or null. */
+  asOf: string | null;
+}
+
+export interface RatesBoard {
+  /** Treasury constant-maturity yields, short → long. */
+  treasury: RateRow[];
+  /** Reference/overnight rates: SOFR, Prime, Fed Funds. */
+  reference: RateRow[];
+}
+
+interface SeriesDef {
+  id: string;
+  label: string;
+}
+
+// Treasury constant-maturity yields. The bills (≤1Y) are what "T-bills" means;
+// 2Y/10Y/30Y give the curve context a professional board shows alongside.
+const TREASURY: SeriesDef[] = [
+  { id: "DGS1MO", label: "1M" },
+  { id: "DGS3MO", label: "3M" },
+  { id: "DGS6MO", label: "6M" },
+  { id: "DGS1", label: "1Y" },
+  { id: "DGS2", label: "2Y" },
+  { id: "DGS10", label: "10Y" },
+  { id: "DGS30", label: "30Y" },
+];
+
+const REFERENCE: SeriesDef[] = [
+  { id: "SOFR", label: "SOFR" },
+  { id: "DPRIME", label: "Prime" },
+  { id: "DFF", label: "Fed Funds" },
+];
+
+/** Whether the rates board can be served (FRED key present). */
+export function ratesAvailable(): boolean {
+  return hasKey(KEY_ENV);
+}
+
+interface FredObsResponse {
+  observations?: { date: string; value: string }[];
+}
+
+/** Parse a FRED value string ("." means missing). */
+function parseVal(v: string | undefined): number | null {
+  if (!v || v === ".") return null;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : null;
+}
+
+async function fetchSeries(def: SeriesDef, key: string): Promise<RateRow> {
+  try {
+    const url =
+      `${BASE}/series/observations?series_id=${encodeURIComponent(def.id)}` +
+      `&api_key=${encodeURIComponent(key)}&file_type=json` +
+      `&sort_order=desc&limit=2`;
+    const data = await fetchJson<FredObsResponse>(url, { provider: "fred" });
+    const obs = (data.observations ?? []).filter((o) => parseVal(o.value) !== null);
+    const latest = obs[0];
+    const prev = obs[1];
+    const value = latest ? parseVal(latest.value) : null;
+    const prevValue = prev ? parseVal(prev.value) : null;
+    const change =
+      value !== null && prevValue !== null
+        ? Math.round((value - prevValue) * 1000) / 1000
+        : null;
+    return { id: def.id, label: def.label, value, change, asOf: latest?.date ?? null };
+  } catch {
+    // One bad series shouldn't blank the board.
+    return { id: def.id, label: def.label, value: null, change: null, asOf: null };
+  }
+}
+
+let cache: { board: RatesBoard; at: number } | null = null;
+const TTL_MS = 60 * 60_000;
+
+/**
+ * The full rates board, cached for an hour. Throws MarketDataError(503) when
+ * FRED_API_KEY is missing — the route maps that to a "not configured" payload.
+ */
+export async function getRatesBoard(): Promise<RatesBoard> {
+  const key = requireKey(KEY_ENV, "FRED");
+  if (cache && Date.now() - cache.at < TTL_MS) return cache.board;
+
+  const [treasury, reference] = await Promise.all([
+    Promise.all(TREASURY.map((d) => fetchSeries(d, key))),
+    Promise.all(REFERENCE.map((d) => fetchSeries(d, key))),
+  ]);
+  const board: RatesBoard = { treasury, reference };
+  cache = { board, at: Date.now() };
+  return board;
+}
+
+/** Test seam — drop the in-memory cache. */
+export function __resetRatesCache(): void {
+  cache = null;
+}
+
+export { MarketDataError };

--- a/apps/web/src/modules/markets/lib/client-api.ts
+++ b/apps/web/src/modules/markets/lib/client-api.ts
@@ -28,6 +28,7 @@ import type {
   ScopeKind,
 } from "@/lib/markets/db";
 import type { PortfolioPerformance } from "@/lib/markets/portfolio";
+import type { RatesBoard } from "@/lib/markets/rates";
 
 async function req<T>(url: string, init?: RequestInit): Promise<T> {
   const res = await fetch(url, {
@@ -95,6 +96,9 @@ export const getOverview = () =>
 
 export const getMovers = (type: MoverKind) =>
   req<{ movers: Mover[] }>(`${B}/movers?type=${type}`).then((d) => d.movers);
+
+export const getRatesBoard = () =>
+  req<{ configured: boolean; board: RatesBoard | null }>(`${B}/rates`);
 
 export const getCalendar = (from: string, to: string) =>
   req<{ events: EarningsEvent[] }>(`${B}/calendar?from=${from}&to=${to}`).then(


### PR DESCRIPTION
## What
A benchmark-rates ribbon on the dashboard Markets panel — the rates Zack asked to track (T-bills + SOFR + Prime), plus the curve context and Fed Funds, sourced from **FRED**.

- Treasury constant-maturity yields: 1M · 3M · 6M · 1Y · 2Y · 10Y · 30Y
- Reference rates: SOFR · Prime · Fed Funds

## Why
Phase 2 of the overnight Markets build, last of the explicit "data" asks. FRED is the authoritative free source for all of these (Finnhub/TD/FMP free tiers don't cover SOFR/Prime cleanly). One cheap observations call per series; whole board cached 1h (these move at most daily).

## Notes
- `lib/markets/rates.ts`: FRED observations → `RatesBoard` (latest value + day-over-day change per series). Gated on `FRED_API_KEY`.
- `/api/v1/markets/rates`: auth-gated; degrades to `{ configured:false, board:null }` (not an error) when no key — like Markets TV.
- `MarketsCard`: thin scrollable Rates ribbon under the indices strip, **hidden entirely** until a key is set and values exist (never a broken row of dashes).
- `.env.example`: documents the free `FRED_API_KEY`.

## Action for Zack
Add a free `FRED_API_KEY` (1-min signup: https://fred.stlouisfed.org/docs/api/api_key.html) in Vercel to light up the ribbon.

## Test
- `rates.test.ts` — `ratesAvailable`, FRED mapping (value + day change), `.`-missing handling, 1h cache, no-key throw.
- `MarketsCard.test.tsx` — mock updated for the new `getRatesBoard` call.
- tsc + eslint clean.

## Follow-up
- MCP/OpenAPI parity for `/markets/rates` (endpoint is dormant until the key is set).

🤖 Generated with [Claude Code](https://claude.com/claude-code)