### PR TITLE
feat(markets): report rates + crypto feed status in /api/v1/health

### DIFF
--- a/apps/web/src/app/api/v1/health/route.ts
+++ b/apps/web/src/app/api/v1/health/route.ts
@@ -6,6 +6,7 @@ import {
   dataClassAvailability,
 } from "@/lib/markets/providers";
 import { tvAvailable } from "@/lib/markets/tv";
+import { ratesAvailable } from "@/lib/markets/rates";
 
 import { withObservability } from "@/lib/observability";
 
@@ -42,6 +43,8 @@ async function handleGet() {
         classes: dataClassAvailability(),
         attribution: configuredProviders(),
         tv: tvAvailable(), // YOUTUBE_API_KEY present (Markets TV embed)
+        rates: ratesAvailable(), // FRED_API_KEY present (rates ribbon)
+        crypto: true, // CoinGecko — keyless, always available
       },
     },
     { status: allOk ? 200 : 503 },


### PR DESCRIPTION
## What
Extends `/api/v1/health`'s `markets` section so a deploy's market-data wiring can be verified at a glance (booleans only, never key values):
- `rates`: `FRED_API_KEY` present (powers the rates ribbon)
- `crypto`: CoinGecko — keyless, always available

## Why
Answers Zack's "are my feeds actually working?" without signing in — `curl /api/v1/health` now shows every market feed's status. Not part of `status` (missing market keys aren't a system failure).

## Test
- No health-route test exists; trivial boolean additions. tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)