### PR TITLE
fix(markets): harden crypto routing + rates reliability (overnight review)

### DIFF
--- a/apps/web/src/components/dashboard/MarketsCard.tsx
+++ b/apps/web/src/components/dashboard/MarketsCard.tsx
@@ -118,14 +118,17 @@ export function MarketsCard() {
   useEffect(() => {
     if (symbols.length === 0) return;
     let cancelled = false;
+    // Re-show the skeleton whenever the symbol set changes (e.g. switching
+    // watchlists) so the new list reads as "loading", not a flash of "—".
+    setLoaded(false);
     getQuotes(symbols)
       .then((q) => {
         if (!cancelled) setQuotes((prev) => ({ ...prev, ...q }));
       })
       .catch(() => {})
       .finally(() => {
-        // Flip out of the skeleton once the first batch settles — even on
-        // failure, so missing-key states show "—" rows, not a perpetual pulse.
+        // Flip out of the skeleton once the batch settles — even on failure,
+        // so missing-key states show "—" rows, not a perpetual pulse.
         if (!cancelled) setLoaded(true);
       });
     return () => {

--- a/apps/web/src/lib/markets/providers/coingecko.test.ts
+++ b/apps/web/src/lib/markets/providers/coingecko.test.ts
@@ -25,6 +25,20 @@ describe("cryptoBase / isCryptoSymbol", () => {
     expect(cryptoBase("ETHUSD")).toBe("ETH");
     expect(cryptoBase("SOL-USD")).toBe("SOL");
     expect(cryptoBase("XRP-USD")).toBe("XRP");
+    expect(cryptoBase("BTCUSDT")).toBe("BTC"); // separator-less USDT pair
+    expect(cryptoBase("BTC-USDT")).toBe("BTC");
+  });
+
+  it("does NOT hijack bare equity-collision tickers, but honors explicit -USD", () => {
+    // LINK/DOT/ADA/BCH are also real/plausible equity tickers — bare form must
+    // stay equity so a watchlist's LINK isn't silently shown as Chainlink.
+    expect(cryptoBase("LINK")).toBeNull();
+    expect(cryptoBase("DOT")).toBeNull();
+    expect(cryptoBase("ADA")).toBeNull();
+    expect(isCryptoSymbol("LINK")).toBe(false);
+    // …but an explicit fiat suffix signals crypto intent and resolves.
+    expect(cryptoBase("LINK-USD")).toBe("LINK");
+    expect(cryptoBase("DOT/USD")).toBe("DOT");
   });
 
   it("returns null for equities/ETFs/unknowns", () => {

--- a/apps/web/src/lib/markets/providers/coingecko.ts
+++ b/apps/web/src/lib/markets/providers/coingecko.ts
@@ -45,19 +45,30 @@ const CRYPTO: Record<string, { id: string; name: string }> = {
 };
 
 /**
+ * Bare bases we'll treat as crypto WITHOUT an explicit fiat suffix. These have
+ * no real US-equity ticker collision. Everything else in CRYPTO (LINK, DOT,
+ * ADA, BCH, …) is also a plausible equity ticker, so it only counts as crypto
+ * when the symbol carries an explicit -USD/USD/USDT quote — otherwise a
+ * watchlist's `LINK` equity would be silently hijacked to the Chainlink price.
+ */
+const BARE_SAFE = new Set(["BTC", "ETH", "XRP", "SOL", "DOGE", "USDT", "USDC"]);
+
+/**
  * Reduce a user-entered symbol to its known crypto base, or null if it isn't
- * one. Accepts the common shapes: `BTC`, `BTC-USD`, `BTC/USD`, `BTCUSD`.
+ * one. Accepts the fiat-quoted shapes `BTC-USD`, `BTC/USD`, `BTCUSD`,
+ * `BTC-USDT`, `BTCUSDT` for any known base; a bare ticker (`BTC`) only resolves
+ * for the unambiguous coins in BARE_SAFE so equity tickers aren't hijacked.
  */
 export function cryptoBase(symbol: string): string | null {
   const s = symbol.trim().toUpperCase();
-  const candidates = [
-    s,
-    s.replace(/[-/]USD$/, ""),
-    s.replace(/[-/]USDT$/, ""),
-    s.replace(/USD$/, ""),
-  ];
-  for (const c of candidates) {
-    if (Object.prototype.hasOwnProperty.call(CRYPTO, c)) return c;
+  // Strip an explicit fiat quote (separator optional): USDT first, then USD.
+  const stripped = s.replace(/[-/]?USDT$/, "").replace(/[-/]?USD$/, "");
+  if (stripped !== s && Object.prototype.hasOwnProperty.call(CRYPTO, stripped)) {
+    return stripped; // explicit crypto intent (e.g. LINK-USD) is always honored
+  }
+  // Bare ticker, no fiat suffix: only the collision-free coins count as crypto.
+  if (BARE_SAFE.has(s) && Object.prototype.hasOwnProperty.call(CRYPTO, s)) {
+    return s;
   }
   return null;
 }

--- a/apps/web/src/lib/markets/providers/getquote.test.ts
+++ b/apps/web/src/lib/markets/providers/getquote.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Quote } from "./types";
+
+// All provider modules are server-only; stub the marker so index imports.
+vi.mock("server-only", () => ({}));
+
+// Hoisted mock fns so the vi.mock factories (hoisted above imports) can use them.
+const { fhQuote, tdQuote, cgQuote } = vi.hoisted(() => ({
+  fhQuote: vi.fn(),
+  tdQuote: vi.fn(),
+  cgQuote: vi.fn(),
+}));
+
+vi.mock("./finnhub", () => ({
+  finnhub: { id: "finnhub", attribution: "", quote: fhQuote },
+  finnhubAvailable: () => true,
+}));
+vi.mock("./twelvedata", () => ({
+  twelvedata: { id: "twelvedata", attribution: "", quote: tdQuote },
+  twelvedataAvailable: () => true,
+}));
+vi.mock("./fmp", () => ({
+  fmp: { id: "fmp", attribution: "" },
+  fmpAvailable: () => false,
+}));
+vi.mock("./coingecko", () => ({
+  coingecko: { id: "coingecko", attribution: "", quote: cgQuote },
+  coingeckoAvailable: () => true,
+  // Real-ish gate: crypto symbols only.
+  isCryptoSymbol: (s: string) => s.includes("BTC") || s.includes("ETH"),
+}));
+
+import { getQuote } from "./index";
+
+const q = (provider: string) =>
+  ({ symbol: "X", price: 1, provider }) as unknown as Quote;
+
+beforeEach(() => {
+  fhQuote.mockReset();
+  tdQuote.mockReset();
+  cgQuote.mockReset();
+});
+
+describe("getQuote provider routing", () => {
+  it("routes a crypto symbol to CoinGecko first and never touches the equity feeds", async () => {
+    cgQuote.mockResolvedValue(q("coingecko"));
+    const out = await getQuote("BTC-USD");
+    expect(out.provider).toBe("coingecko");
+    expect(cgQuote).toHaveBeenCalledTimes(1);
+    expect(fhQuote).not.toHaveBeenCalled();
+    expect(tdQuote).not.toHaveBeenCalled();
+  });
+
+  it("routes an equity symbol to Finnhub and never touches CoinGecko", async () => {
+    fhQuote.mockResolvedValue(q("finnhub"));
+    const out = await getQuote("AAPL");
+    expect(out.provider).toBe("finnhub");
+    expect(cgQuote).not.toHaveBeenCalled();
+  });
+
+  it("falls through to the next provider when CoinGecko fails for a crypto symbol", async () => {
+    cgQuote.mockRejectedValue(new Error("coingecko down"));
+    fhQuote.mockResolvedValue(q("finnhub"));
+    const out = await getQuote("ETH-USD");
+    expect(cgQuote).toHaveBeenCalled();
+    expect(fhQuote).toHaveBeenCalled();
+    expect(out.provider).toBe("finnhub");
+  });
+});

--- a/apps/web/src/lib/markets/rates.test.ts
+++ b/apps/web/src/lib/markets/rates.test.ts
@@ -38,6 +38,19 @@ describe("ratesAvailable", () => {
   });
 });
 
+// Build a FRED response with N descending-date observations from raw values.
+function obsRows(values: string[]): Response {
+  const observations = values.map((v, i) => ({
+    date: `2026-06-${String(23 - i).padStart(2, "0")}`,
+    value: v,
+  }));
+  return {
+    ok: true,
+    status: 200,
+    text: async () => JSON.stringify({ observations }),
+  } as Response;
+}
+
 describe("getRatesBoard", () => {
   it("throws when no key is configured", async () => {
     delete process.env.FRED_API_KEY;
@@ -81,5 +94,31 @@ describe("getRatesBoard", () => {
     const callsAfterFirst = fetchMock.mock.calls.length;
     await getRatesBoard();
     expect(fetchMock.mock.calls.length).toBe(callsAfterFirst); // served from cache
+  });
+
+  it("resolves value + change from deeper rows when the newest observation is '.'", async () => {
+    process.env.FRED_API_KEY = "k";
+    // newest row is a pending placeholder, then two real business days
+    vi.stubGlobal("fetch", vi.fn(async () => obsRows([".", "4.50", "4.48"])));
+    const board = await getRatesBoard();
+    const threeM = board.treasury.find((r) => r.label === "3M")!;
+    expect(threeM.value).toBe(4.5); // latest real value, not null
+    expect(threeM.change).toBeCloseTo(0.02, 3); // 4.50 − 4.48 (true prior day)
+  });
+
+  it("does NOT cache an all-null board — retries FRED on the next call", async () => {
+    process.env.FRED_API_KEY = "k";
+    let recovered = false;
+    const fetchMock = vi.fn(async () =>
+      recovered ? obsRes("4.10", "4.05") : obsRows(["."]),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const first = await getRatesBoard();
+    expect(first.treasury.every((r) => r.value === null)).toBe(true);
+    const callsAfterFirst = fetchMock.mock.calls.length;
+    recovered = true;
+    const second = await getRatesBoard(); // must re-fetch, not serve cached nulls
+    expect(fetchMock.mock.calls.length).toBeGreaterThan(callsAfterFirst);
+    expect(second.treasury.find((r) => r.label === "3M")!.value).toBe(4.1);
   });
 });

--- a/apps/web/src/lib/markets/rates.ts
+++ b/apps/web/src/lib/markets/rates.ts
@@ -80,10 +80,13 @@ function parseVal(v: string | undefined): number | null {
 
 async function fetchSeries(def: SeriesDef, key: string): Promise<RateRow> {
   try {
+    // Pull headroom (not just 2): the latest FRED rows are often "." while a
+    // value is pending, and weekends/holidays are missing — so the freshest
+    // real value + true prior business-day value can sit a few rows deep.
     const url =
       `${BASE}/series/observations?series_id=${encodeURIComponent(def.id)}` +
       `&api_key=${encodeURIComponent(key)}&file_type=json` +
-      `&sort_order=desc&limit=2`;
+      `&sort_order=desc&limit=8`;
     const data = await fetchJson<FredObsResponse>(url, { provider: "fred" });
     const obs = (data.observations ?? []).filter((o) => parseVal(o.value) !== null);
     const latest = obs[0];
@@ -117,7 +120,11 @@ export async function getRatesBoard(): Promise<RatesBoard> {
     Promise.all(REFERENCE.map((d) => fetchSeries(d, key))),
   ]);
   const board: RatesBoard = { treasury, reference };
-  cache = { board, at: Date.now() };
+  // Don't memoize a board where every series failed (transient FRED outage or a
+  // cold-start network race) — caching it would pin the ribbon to all-null for
+  // a full hour even after FRED recovers. Serve it once, retry next request.
+  const hasAny = [...treasury, ...reference].some((r) => r.value !== null);
+  if (hasAny) cache = { board, at: Date.now() };
   return board;
 }
 


### PR DESCRIPTION
## What
Fixes the **7 issues** an adversarial multi-agent review of tonight's Markets PRs (#292–#298) confirmed (4 other flagged items were verified as false positives and dismissed).

| # | Severity | Fix |
|---|----------|-----|
| 5 | high-impact | Bare equity-collision tickers (LINK/DOT/ADA/BCH…) no longer routed to CoinGecko — a watchlist's `LINK` stays the **equity**, not Chainlink. Crypto needs an explicit `-USD`/`USD`/`USDT` suffix unless the base is unambiguous (BTC/ETH/XRP/SOL/DOGE/USDT/USDC). |
| 1 | low | Separator-less `BTCUSDT` pair form now resolves. |
| 0 | medium | Rates: fetch 8 FRED observations not 2 — a `.` placeholder at the head (FRED publishes pending/holiday rows as `.`) no longer drops the value or day-over-day change. |
| 3 | medium | Rates: never cache an all-null board — a transient FRED outage would otherwise pin the ribbon to nulls for a full hour. |
| 2 | low | MarketsCard: reset the skeleton on watchlist switch, so the new list reads as "loading" not a flash of "—". |
| 4, 6 | tests | New facade `getQuote` routing/fallback test + rates missing-head/no-empty-cache + coingecko collision tests. |

## Test
- 22 tests across coingecko / getquote / rates / availability / MarketsCard — all green. tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)