### PR TITLE
feat(markets): Movers + News views on the dashboard panel

### DIFF
--- a/apps/web/src/components/dashboard/MarketsCard.test.tsx
+++ b/apps/web/src/components/dashboard/MarketsCard.test.tsx
@@ -10,6 +10,7 @@ vi.mock("@/modules/markets/lib/client-api", () => ({
   getRatesBoard: vi.fn().mockResolvedValue({ configured: false, board: null }),
   getOverview: vi.fn(),
   getMovers: vi.fn(),
+  getNews: vi.fn(),
 }));
 
 import {
@@ -17,6 +18,7 @@ import {
   getQuotes,
   getOverview,
   getMovers,
+  getNews,
 } from "@/modules/markets/lib/client-api";
 import { MarketsCard } from "./MarketsCard";
 
@@ -24,6 +26,7 @@ const mockList = vi.mocked(listWatchlists);
 const mockQuotes = vi.mocked(getQuotes);
 const mockOverview = vi.mocked(getOverview);
 const mockMovers = vi.mocked(getMovers);
+const mockNews = vi.mocked(getNews);
 
 function q(symbol: string, price: number, changePct: number): Quote {
   return { symbol, name: `${symbol} Inc`, price, changePct } as unknown as Quote;
@@ -98,5 +101,30 @@ describe("MarketsCard", () => {
     fireEvent.click(screen.getByRole("button", { name: "Movers" }));
     expect(await screen.findByText("AMD")).toBeTruthy(); // mover row (not in Watching)
     expect(mockMovers).toHaveBeenCalledWith("gainers");
+  });
+
+  it("switches to the News view and renders merged headlines", async () => {
+    mockList.mockResolvedValue([]);
+    mockQuotes.mockResolvedValue({});
+    mockNews.mockResolvedValue([
+      {
+        id: "n1",
+        headline: "Apple ships a new thing",
+        summary: null,
+        source: "Reuters",
+        url: "https://example.com/news/1",
+        imageUrl: null,
+        datetime: "2026-06-23T12:00:00Z",
+        symbols: ["AAPL"],
+      },
+    ]);
+
+    render(<MarketsCard />);
+    expect(await screen.findByText("AAPL")).toBeTruthy(); // default Watchlist view
+
+    fireEvent.click(screen.getByRole("button", { name: "News" }));
+    // Same article returned per symbol → deduped to one headline.
+    expect(await screen.findByText("Apple ships a new thing")).toBeTruthy();
+    expect(mockNews).toHaveBeenCalled();
   });
 });

--- a/apps/web/src/components/dashboard/MarketsCard.test.tsx
+++ b/apps/web/src/components/dashboard/MarketsCard.test.tsx
@@ -9,18 +9,21 @@ vi.mock("@/modules/markets/lib/client-api", () => ({
   getQuotes: vi.fn(),
   getRatesBoard: vi.fn().mockResolvedValue({ configured: false, board: null }),
   getOverview: vi.fn(),
+  getMovers: vi.fn(),
 }));
 
 import {
   listWatchlists,
   getQuotes,
   getOverview,
+  getMovers,
 } from "@/modules/markets/lib/client-api";
 import { MarketsCard } from "./MarketsCard";
 
 const mockList = vi.mocked(listWatchlists);
 const mockQuotes = vi.mocked(getQuotes);
 const mockOverview = vi.mocked(getOverview);
+const mockMovers = vi.mocked(getMovers);
 
 function q(symbol: string, price: number, changePct: number): Quote {
   return { symbol, name: `${symbol} Inc`, price, changePct } as unknown as Quote;
@@ -80,5 +83,20 @@ describe("MarketsCard", () => {
     expect(await screen.findByText("Indices")).toBeTruthy(); // group header
     expect(screen.getByText("S&P 500")).toBeTruthy(); // board row
     expect(mockOverview).toHaveBeenCalled();
+  });
+
+  it("switches to the Movers view and renders gainers", async () => {
+    mockList.mockResolvedValue([]);
+    mockQuotes.mockResolvedValue({});
+    mockMovers.mockResolvedValue([
+      { symbol: "AMD", name: "Advanced Micro", price: 120, change: 5, changePct: 4.3, volume: null },
+    ]);
+
+    render(<MarketsCard />);
+    expect(await screen.findByText("AAPL")).toBeTruthy(); // default Watchlist view
+
+    fireEvent.click(screen.getByRole("button", { name: "Movers" }));
+    expect(await screen.findByText("AMD")).toBeTruthy(); // mover row (not in Watching)
+    expect(mockMovers).toHaveBeenCalledWith("gainers");
   });
 });

--- a/apps/web/src/components/dashboard/MarketsCard.tsx
+++ b/apps/web/src/components/dashboard/MarketsCard.tsx
@@ -10,9 +10,15 @@ import {
   fmtPct,
   fmtChange,
   fmtVolume,
+  fmtRelative,
   changeClass,
 } from "@/lib/markets/format";
-import type { Quote, Mover, MoverKind } from "@/lib/markets/providers/types";
+import type {
+  Quote,
+  Mover,
+  MoverKind,
+  NewsItem,
+} from "@/lib/markets/providers/types";
 import {
   WATCHING_ID,
   watchingList,
@@ -21,6 +27,7 @@ import {
 import type { RatesBoard, RateRow } from "@/lib/markets/rates";
 import {
   getMovers,
+  getNews,
   getOverview,
   getQuotes,
   getRatesBoard,
@@ -29,11 +36,12 @@ import {
 } from "@/modules/markets/lib/client-api";
 
 /** The in-panel views — the dashboard card switches mode without routing. */
-type MarketsView = "list" | "overview" | "movers";
+type MarketsView = "list" | "overview" | "movers" | "news";
 const VIEWS: { key: MarketsView; label: string }[] = [
   { key: "list", label: "Watchlist" },
   { key: "overview", label: "Overview" },
   { key: "movers", label: "Movers" },
+  { key: "news", label: "News" },
 ];
 
 /** Index/ETF pulse shown at the top of the card (free-feed-friendly proxies). */
@@ -193,6 +201,8 @@ export function MarketsCard() {
           <OverviewView />
         ) : view === "movers" ? (
           <MoversView />
+        ) : view === "news" ? (
+          <NewsView symbols={active?.symbols.map((s) => s.symbol) ?? []} />
         ) : (
           <>
             <IndicesStrip quotes={quotes} />
@@ -396,6 +406,85 @@ function MoversView() {
         </ul>
       )}
     </div>
+  );
+}
+
+/** Merge per-symbol news into one stream: dedupe by id|url, newest first. */
+function mergeNews(lists: NewsItem[][]): NewsItem[] {
+  const seen = new Set<string>();
+  const out: NewsItem[] = [];
+  for (const item of lists.flat()) {
+    const key = item.url || item.id;
+    if (key && !seen.has(key)) {
+      seen.add(key);
+      out.push(item);
+    }
+  }
+  out.sort((a, b) => (a.datetime < b.datetime ? 1 : -1));
+  return out;
+}
+
+/** News view — a watchlist-wide headline feed (the active list's first few
+ *  symbols, merged). Capped to stay within the free news feed's rate limits;
+ *  symbols with no company news (crypto/commodities) simply contribute none. */
+function NewsView({ symbols }: { symbols: string[] }) {
+  const [items, setItems] = useState<NewsItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  // Cap the fan-out — one news call per symbol, so keep it small on a panel.
+  const key = symbols.slice(0, 6).join(",");
+
+  useEffect(() => {
+    let alive = true;
+    setLoading(true);
+    const subset = key ? key.split(",") : [];
+    Promise.all(
+      subset.map((s) => getNews(s, 7).catch(() => [] as NewsItem[])),
+    )
+      .then((lists) => {
+        if (alive) setItems(mergeNews(lists).slice(0, 30));
+      })
+      .finally(() => {
+        if (alive) setLoading(false);
+      });
+    return () => {
+      alive = false;
+    };
+  }, [key]);
+
+  if (loading && items.length === 0) {
+    return (
+      <div className="flex flex-1 items-center justify-center p-4 text-xs text-text-3">
+        Loading…
+      </div>
+    );
+  }
+  if (items.length === 0) {
+    return (
+      <div className="flex flex-1 items-center justify-center p-4 text-center text-xs text-text-3">
+        No recent news for this list.
+      </div>
+    );
+  }
+  return (
+    <ul className="min-h-0 flex-1 divide-y divide-border/30 overflow-y-auto">
+      {items.map((n) => (
+        <li key={n.url || n.id}>
+          <a
+            href={n.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="block px-3 py-1.5 hover:bg-bg-2"
+          >
+            <p className="line-clamp-2 text-xs text-text-1">{n.headline}</p>
+            <p className="mt-0.5 flex items-center gap-1.5 text-[10px] text-text-3">
+              <span className="truncate">{n.source}</span>
+              <span aria-hidden="true">·</span>
+              <span className="flex-shrink-0">{fmtRelative(n.datetime)}</span>
+            </p>
+          </a>
+        </li>
+      ))}
+    </ul>
   );
 }
 

--- a/apps/web/src/components/dashboard/MarketsCard.tsx
+++ b/apps/web/src/components/dashboard/MarketsCard.tsx
@@ -12,7 +12,7 @@ import {
   fmtVolume,
   changeClass,
 } from "@/lib/markets/format";
-import type { Quote } from "@/lib/markets/providers/types";
+import type { Quote, Mover, MoverKind } from "@/lib/markets/providers/types";
 import {
   WATCHING_ID,
   watchingList,
@@ -20,6 +20,7 @@ import {
 } from "@/lib/markets/watching";
 import type { RatesBoard, RateRow } from "@/lib/markets/rates";
 import {
+  getMovers,
   getOverview,
   getQuotes,
   getRatesBoard,
@@ -28,10 +29,11 @@ import {
 } from "@/modules/markets/lib/client-api";
 
 /** The in-panel views — the dashboard card switches mode without routing. */
-type MarketsView = "list" | "overview";
+type MarketsView = "list" | "overview" | "movers";
 const VIEWS: { key: MarketsView; label: string }[] = [
   { key: "list", label: "Watchlist" },
   { key: "overview", label: "Overview" },
+  { key: "movers", label: "Movers" },
 ];
 
 /** Index/ETF pulse shown at the top of the card (free-feed-friendly proxies). */
@@ -189,6 +191,8 @@ export function MarketsCard() {
         <ViewTabs view={view} onChange={setView} />
         {view === "overview" ? (
           <OverviewView />
+        ) : view === "movers" ? (
+          <MoversView />
         ) : (
           <>
             <IndicesStrip quotes={quotes} />
@@ -295,6 +299,102 @@ function OverviewView() {
       <OverviewGroup title="Sectors" rows={board.sectors} />
       <OverviewGroup title="Commodities" rows={board.commodities} />
       <OverviewGroup title="FX" rows={board.fx} />
+    </div>
+  );
+}
+
+const MOVER_TABS: { key: MoverKind; label: string }[] = [
+  { key: "gainers", label: "Gainers" },
+  { key: "losers", label: "Losers" },
+  { key: "active", label: "Active" },
+];
+
+/** Movers view — market gainers / losers / most-active, inline on the
+ *  dashboard. Read-only; degrades to a message when the feed is down. */
+function MoversView() {
+  const [kind, setKind] = useState<MoverKind>("gainers");
+  const [movers, setMovers] = useState<Mover[]>([]);
+  const [err, setErr] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let alive = true;
+    setErr(null);
+    setLoading(true);
+    getMovers(kind)
+      .then((m) => {
+        if (alive) setMovers(m);
+      })
+      .catch((e) => {
+        if (alive) {
+          setMovers([]);
+          setErr(e instanceof Error ? e.message : "Movers unavailable");
+        }
+      })
+      .finally(() => {
+        if (alive) setLoading(false);
+      });
+    return () => {
+      alive = false;
+    };
+  }, [kind]);
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="flex flex-shrink-0 items-center gap-1 border-b border-border/40 px-2 py-1">
+        {MOVER_TABS.map((t) => (
+          <button
+            key={t.key}
+            type="button"
+            onClick={() => setKind(t.key)}
+            aria-pressed={kind === t.key}
+            className={`rounded-sm px-2 py-0.5 text-2xs font-medium ${
+              kind === t.key
+                ? "bg-bg-3 text-text-0"
+                : "text-text-2 hover:bg-bg-2 hover:text-text-0"
+            }`}
+          >
+            {t.label}
+          </button>
+        ))}
+      </div>
+      {err ? (
+        <div className="flex flex-1 items-center justify-center p-4 text-center text-xs text-text-3">
+          {err}
+        </div>
+      ) : loading && movers.length === 0 ? (
+        <div className="flex flex-1 items-center justify-center p-4 text-xs text-text-3">
+          Loading…
+        </div>
+      ) : (
+        <ul className="min-h-0 flex-1 divide-y divide-border/30 overflow-y-auto">
+          {movers.map((m) => (
+            <li key={m.symbol}>
+              <Link
+                href={`/modules/markets/quote/${encodeURIComponent(m.symbol)}`}
+                className="flex items-center gap-2 px-3 py-[var(--rk-row-py)] hover:bg-bg-2"
+              >
+                <span className="w-16 flex-shrink-0 truncate font-mono text-xs font-semibold text-text-0">
+                  {m.symbol}
+                </span>
+                <span className="flex-1 truncate text-2xs text-text-3">
+                  {m.name ?? ""}
+                </span>
+                <span className="font-mono text-xs tabular-nums text-text-0">
+                  {fmtPrice(m.price)}
+                </span>
+                <span
+                  className={`w-16 text-right font-mono text-2xs tabular-nums ${changeClass(
+                    m.changePct,
+                  )}`}
+                >
+                  {fmtPct(m.changePct)}
+                </span>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## What
Two more tabs for the in-panel view switcher (item #5), both inline on the dashboard — no routing into the module:
- **Movers** — gainers / losers / most-active (sub-tabs), each row linking to the quote. Reuses `getMovers` (FMP).
- **News** — a watchlist-wide headline feed that merges per-symbol news (the active list's first ~6 symbols), deduped by URL, newest-first, each linking out to the source.

## Why
Continuing the deferred 70-item list, building on the view-switcher frame (#300).

## Notes
- Both read-only; degrade to a message when the feed is down.
- News fan-out is capped at ~6 symbols to stay within the free news feed's rate limits; symbols with no company news (crypto/commodities) contribute none.

## Test
- `MarketsCard.test.tsx` — switching to Movers calls `getMovers("gainers")` and renders a mover; switching to News renders a (deduped) merged headline. 6 tests green; tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)