### PR TITLE
feat(markets): Chart + TV views complete the in-panel switcher

### DIFF
--- a/apps/web/src/components/dashboard/MarketsCard.test.tsx
+++ b/apps/web/src/components/dashboard/MarketsCard.test.tsx
@@ -12,6 +12,13 @@ vi.mock("@/modules/markets/lib/client-api", () => ({
   getMovers: vi.fn(),
   getNews: vi.fn(),
 }));
+// PriceChart is canvas-based and MarketsTV fetches — stub both for jsdom.
+vi.mock("@/modules/markets/components/PriceChart", () => ({
+  PriceChart: ({ symbol }: { symbol: string }) => <div>{`chart-${symbol}`}</div>,
+}));
+vi.mock("@/modules/markets/components/MarketsTV", () => ({
+  MarketsTV: () => <div>TV stream</div>,
+}));
 
 import {
   listWatchlists,
@@ -126,5 +133,25 @@ describe("MarketsCard", () => {
     // Same article returned per symbol → deduped to one headline.
     expect(await screen.findByText("Apple ships a new thing")).toBeTruthy();
     expect(mockNews).toHaveBeenCalled();
+  });
+
+  it("switches to the Chart view and charts the first symbol", async () => {
+    mockList.mockResolvedValue([]);
+    mockQuotes.mockResolvedValue({});
+    render(<MarketsCard />);
+    expect(await screen.findByText("AAPL")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Chart" }));
+    expect(await screen.findByText("chart-AAPL")).toBeTruthy(); // first Watching symbol
+  });
+
+  it("switches to the TV view and embeds the stream", async () => {
+    mockList.mockResolvedValue([]);
+    mockQuotes.mockResolvedValue({});
+    render(<MarketsCard />);
+    expect(await screen.findByText("AAPL")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "TV" }));
+    expect(await screen.findByText("TV stream")).toBeTruthy();
   });
 });

--- a/apps/web/src/components/dashboard/MarketsCard.tsx
+++ b/apps/web/src/components/dashboard/MarketsCard.tsx
@@ -34,14 +34,18 @@ import {
   listWatchlists,
   type BoardRow,
 } from "@/modules/markets/lib/client-api";
+import { PriceChart } from "@/modules/markets/components/PriceChart";
+import { MarketsTV } from "@/modules/markets/components/MarketsTV";
 
 /** The in-panel views — the dashboard card switches mode without routing. */
-type MarketsView = "list" | "overview" | "movers" | "news";
+type MarketsView = "list" | "overview" | "movers" | "news" | "chart" | "tv";
 const VIEWS: { key: MarketsView; label: string }[] = [
   { key: "list", label: "Watchlist" },
   { key: "overview", label: "Overview" },
   { key: "movers", label: "Movers" },
   { key: "news", label: "News" },
+  { key: "chart", label: "Chart" },
+  { key: "tv", label: "TV" },
 ];
 
 /** Index/ETF pulse shown at the top of the card (free-feed-friendly proxies). */
@@ -203,6 +207,12 @@ export function MarketsCard() {
           <MoversView />
         ) : view === "news" ? (
           <NewsView symbols={active?.symbols.map((s) => s.symbol) ?? []} />
+        ) : view === "chart" ? (
+          <ChartView symbols={active?.symbols.map((s) => s.symbol) ?? []} />
+        ) : view === "tv" ? (
+          <div className="min-h-0 flex-1 overflow-y-auto">
+            <MarketsTV />
+          </div>
         ) : (
           <>
             <IndicesStrip quotes={quotes} />
@@ -405,6 +415,45 @@ function MoversView() {
           ))}
         </ul>
       )}
+    </div>
+  );
+}
+
+/** Chart view — a price chart for one symbol from the active list, chosen via
+ *  a compact picker. Reuses the module's dependency-free PriceChart. */
+function ChartView({ symbols }: { symbols: string[] }) {
+  const [sym, setSym] = useState(symbols[0] ?? "");
+  // Keep the selection valid if the active list changes underneath us.
+  useEffect(() => {
+    if (symbols.length > 0 && !symbols.includes(sym)) setSym(symbols[0]);
+  }, [symbols, sym]);
+
+  if (!sym) {
+    return (
+      <div className="flex flex-1 items-center justify-center p-4 text-xs text-text-3">
+        No symbols to chart.
+      </div>
+    );
+  }
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="flex flex-shrink-0 items-center gap-2 border-b border-border/40 px-2 py-1">
+        <select
+          value={sym}
+          onChange={(e) => setSym(e.target.value)}
+          aria-label="Chart symbol"
+          className="rounded-sm border border-border bg-bg-0 px-1.5 py-0.5 text-2xs text-text-1 outline-none focus:border-border-focus"
+        >
+          {symbols.map((s) => (
+            <option key={s} value={s}>
+              {s}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div className="min-h-0 flex-1 overflow-auto p-2">
+        <PriceChart symbol={sym} initialRange="1M" />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## What
The final two tabs of the dashboard Markets view switcher (item #5 **done** — the panel is now a full multi-view terminal: **Watchlist · Overview · Movers · News · Chart · TV**):
- **Chart** — the module's dependency-free `PriceChart` for a symbol picked from the active list (defaults to the first).
- **TV** — embeds the existing `MarketsTV` (Bloomberg Television live stream) **inline on the dashboard** — what you asked for, no module click.

## Why
Completes the in-panel view switcher (your #1 ask: "don't make me click into a module"), reusing the module's `PriceChart` + `MarketsTV` verbatim.

## Notes
- Chart degrades to its own error state without a candles (Twelve Data) key; TV falls back to a "watch on YouTube" link without a YouTube key.
- Reuses existing, already-shipped components — no duplicated logic.

## Test
- `MarketsCard.test.tsx` — switching to Chart charts the first symbol; switching to TV embeds the stream (both stubbed, since canvas/fetch don't run in jsdom). 7 tests green; tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)