### PR TITLE
feat(markets): persist last view + watchlist; memoize active symbols

### DIFF
--- a/apps/web/src/components/dashboard/MarketsCard.test.tsx
+++ b/apps/web/src/components/dashboard/MarketsCard.test.tsx
@@ -39,7 +39,10 @@ function q(symbol: string, price: number, changePct: number): Quote {
   return { symbol, name: `${symbol} Inc`, price, changePct } as unknown as Quote;
 }
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  localStorage.clear(); // the card persists view/list — isolate tests
+});
 
 describe("MarketsCard", () => {
   it("renders the built-in Watching list + indices strip even with no DB watchlists", async () => {
@@ -153,5 +156,19 @@ describe("MarketsCard", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "TV" }));
     expect(await screen.findByText("TV stream")).toBeTruthy();
+  });
+
+  it("restores the last-used view from localStorage on mount", async () => {
+    mockList.mockResolvedValue([]);
+    mockQuotes.mockResolvedValue({});
+    mockMovers.mockResolvedValue([
+      { symbol: "AMD", name: "Advanced Micro", price: 120, change: 5, changePct: 4.3, volume: null },
+    ]);
+    localStorage.setItem("rokki:markets-view", "movers");
+
+    render(<MarketsCard />);
+    // Opens directly in the restored Movers view, not the default Watchlist.
+    expect(await screen.findByText("AMD")).toBeTruthy();
+    expect(mockMovers).toHaveBeenCalledWith("gainers");
   });
 });

--- a/apps/web/src/components/dashboard/MarketsCard.tsx
+++ b/apps/web/src/components/dashboard/MarketsCard.tsx
@@ -48,6 +48,10 @@ const VIEWS: { key: MarketsView; label: string }[] = [
   { key: "tv", label: "TV" },
 ];
 
+// Per-device persistence: remember the last view + watchlist across reloads.
+const VIEW_KEY = "rokki:markets-view";
+const LIST_KEY = "rokki:markets-list";
+
 /** Index/ETF pulse shown at the top of the card (free-feed-friendly proxies). */
 const INDICES = [
   { symbol: "SPY", label: "S&P 500" },
@@ -82,6 +86,13 @@ export function MarketsCard() {
   // The built-in Watching list always leads; the viewer's own watchlists follow.
   const lists = useMemo(() => [watchingList(), ...userLists], [userLists]);
   const active = lists.find((l) => l.id === activeId) ?? lists[0];
+  // Stable symbol array for the Chart/News views — memoized so their effects
+  // don't re-fire on every realtime quote tick (the inline .map would allocate
+  // a fresh array each render).
+  const activeSymbols = useMemo(
+    () => active?.symbols.map((s) => s.symbol) ?? [],
+    [active],
+  );
   // Density tiers: tight → +name → +change/volume table as the panel widens.
   const wide = width >= 460;
   const xwide = width >= 640;
@@ -96,6 +107,33 @@ export function MarketsCard() {
     }
     return max > 0 ? new Date(max) : null;
   }, [quotes]);
+
+  // Restore the last-used view + watchlist on mount (client-only; an effect, not
+  // a useState initializer, to avoid an SSR/hydration mismatch).
+  useEffect(() => {
+    try {
+      const v = localStorage.getItem(VIEW_KEY);
+      if (v && VIEWS.some((x) => x.key === v)) setView(v as MarketsView);
+      const l = localStorage.getItem(LIST_KEY);
+      if (l) setActiveId(l);
+    } catch {
+      /* storage blocked (private mode) → defaults */
+    }
+  }, []);
+  useEffect(() => {
+    try {
+      localStorage.setItem(VIEW_KEY, view);
+    } catch {
+      /* ignore */
+    }
+  }, [view]);
+  useEffect(() => {
+    try {
+      localStorage.setItem(LIST_KEY, activeId);
+    } catch {
+      /* ignore */
+    }
+  }, [activeId]);
 
   useEffect(() => {
     let alive = true;
@@ -206,9 +244,9 @@ export function MarketsCard() {
         ) : view === "movers" ? (
           <MoversView />
         ) : view === "news" ? (
-          <NewsView symbols={active?.symbols.map((s) => s.symbol) ?? []} />
+          <NewsView symbols={activeSymbols} />
         ) : view === "chart" ? (
-          <ChartView symbols={active?.symbols.map((s) => s.symbol) ?? []} />
+          <ChartView symbols={activeSymbols} />
         ) : view === "tv" ? (
           <div className="min-h-0 flex-1 overflow-y-auto">
             <MarketsTV />


### PR DESCRIPTION
## What
- **Persistence** — the dashboard Markets panel now remembers your last **view** (Watchlist/Overview/Movers/News/Chart/TV) and selected **watchlist** across reloads, per-device via `localStorage`.
- **Perf fix** — memoize the active-symbol array passed to Chart/News so their effects don't re-fire on every realtime quote tick (the unstable-array dep the view-switcher self-review flagged, low severity).

## Why
Continuing the deferred list — "remember where I was" is part of #12/#47 (saved layout/state), and the memo closes the one real finding from the #300–#302 review.

## Notes
- Restore runs in an effect (not a `useState` initializer) to avoid an SSR/hydration mismatch; storage failures (private mode) fall back to defaults.
- A stale persisted watchlist id just falls back to the built-in Watching list.

## Test
- `MarketsCard.test.tsx` — restores the saved view on mount; `afterEach` clears localStorage to isolate tests. 8 tests green; tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)