### PR TITLE
feat(markets): auto-refresh the Overview + Movers dashboard views

### DIFF
--- a/apps/web/src/components/dashboard/MarketsCard.test.tsx
+++ b/apps/web/src/components/dashboard/MarketsCard.test.tsx
@@ -171,4 +171,29 @@ describe("MarketsCard", () => {
     expect(await screen.findByText("AMD")).toBeTruthy();
     expect(mockMovers).toHaveBeenCalledWith("gainers");
   });
+
+  it("auto-refreshes the Overview board on an interval", async () => {
+    vi.useFakeTimers();
+    try {
+      mockList.mockResolvedValue([]);
+      mockQuotes.mockResolvedValue({});
+      mockOverview.mockResolvedValue({
+        indices: [],
+        sectors: [],
+        commodities: [],
+        fx: [],
+      });
+      localStorage.setItem("rokki:markets-view", "overview"); // open straight into Overview
+
+      render(<MarketsCard />);
+      await vi.advanceTimersByTimeAsync(0); // flush mount effects + initial fetch
+      const initial = mockOverview.mock.calls.length;
+      expect(initial).toBeGreaterThan(0);
+
+      await vi.advanceTimersByTimeAsync(60_000); // one refresh tick
+      expect(mockOverview.mock.calls.length).toBeGreaterThan(initial);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/apps/web/src/components/dashboard/MarketsCard.tsx
+++ b/apps/web/src/components/dashboard/MarketsCard.tsx
@@ -52,6 +52,10 @@ const VIEWS: { key: MarketsView; label: string }[] = [
 const VIEW_KEY = "rokki:markets-view";
 const LIST_KEY = "rokki:markets-list";
 
+// The non-realtime views (Overview/Movers) poll on this cadence so they stay
+// live like the watchlist; quotes ride the realtime cache instead.
+const REFRESH_MS = 60_000;
+
 /** Index/ETF pulse shown at the top of the card (free-feed-friendly proxies). */
 const INDICES = [
   { symbol: "SPY", label: "S&P 500" },
@@ -325,6 +329,8 @@ function OverviewView() {
 
   useEffect(() => {
     let alive = true;
+    // Initial load may surface an error; periodic refreshes update on success
+    // but keep the last good board on failure (never flip live data to an error).
     getOverview()
       .then((b) => {
         if (alive) setBoard(b);
@@ -332,8 +338,21 @@ function OverviewView() {
       .catch((e) => {
         if (alive) setErr(e instanceof Error ? e.message : "Unavailable");
       });
+    const id = setInterval(() => {
+      getOverview()
+        .then((b) => {
+          if (alive) {
+            setBoard(b);
+            setErr(null);
+          }
+        })
+        .catch(() => {
+          /* keep stale board */
+        });
+    }, REFRESH_MS);
     return () => {
       alive = false;
+      clearInterval(id);
     };
   }, []);
 
@@ -379,21 +398,27 @@ function MoversView() {
     let alive = true;
     setErr(null);
     setLoading(true);
-    getMovers(kind)
-      .then((m) => {
-        if (alive) setMovers(m);
-      })
-      .catch((e) => {
-        if (alive) {
-          setMovers([]);
-          setErr(e instanceof Error ? e.message : "Movers unavailable");
-        }
-      })
-      .finally(() => {
-        if (alive) setLoading(false);
-      });
+    // initial=true surfaces errors + clears the skeleton; periodic refreshes
+    // update silently and keep the last good list on failure.
+    const fetchKind = (initial: boolean) =>
+      getMovers(kind)
+        .then((m) => {
+          if (alive) setMovers(m);
+        })
+        .catch((e) => {
+          if (alive && initial) {
+            setMovers([]);
+            setErr(e instanceof Error ? e.message : "Movers unavailable");
+          }
+        })
+        .finally(() => {
+          if (alive && initial) setLoading(false);
+        });
+    fetchKind(true);
+    const id = setInterval(() => fetchKind(false), REFRESH_MS);
     return () => {
       alive = false;
+      clearInterval(id);
     };
   }, [kind]);
 


### PR DESCRIPTION
## What
The non-realtime views (Overview, Movers) fetched once when opened and then went stale. They now **poll every 60s** so they stay live like the Watchlist view (which rides the realtime quote cache).

## Why
A real terminal's macro board and movers tick. Continuing the deferred list — makes the new views feel live.

## Notes
- Refreshes **update on success but keep the last good data on failure** — a transient blip never flips a working board to an error screen.
- Intervals are cleared on unmount / view-switch (no leaks).
- News is intentionally left fetch-on-open (it changes slower and its per-symbol fan-out is the rate-heaviest).

## Test
- `MarketsCard.test.tsx` — a fake-timer test asserts `getOverview` is called again after a 60s tick (stable across repeated runs). 9 tests green; tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)