### PR TITLE
feat(markets): live market-context band on the module dashboard

### DIFF
--- a/apps/web/src/modules/markets/components/MarketContextBand.test.tsx
+++ b/apps/web/src/modules/markets/components/MarketContextBand.test.tsx
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, screen, cleanup, waitFor } from "@testing-library/react";
+
+vi.mock("../lib/client-api", () => ({
+  getOverview: vi.fn(),
+  getRatesBoard: vi.fn(),
+}));
+
+import { getOverview, getRatesBoard } from "../lib/client-api";
+import { MarketContextBand } from "./MarketContextBand";
+
+const mockOverview = vi.mocked(getOverview);
+const mockRates = vi.mocked(getRatesBoard);
+
+afterEach(cleanup);
+
+describe("MarketContextBand", () => {
+  it("renders indices + benchmark rates", async () => {
+    mockOverview.mockResolvedValue({
+      indices: [
+        { symbol: "SPX", label: "S&P 500", price: 5000, change: 5, changePct: 0.2 },
+      ],
+      sectors: [],
+      commodities: [],
+      fx: [],
+    });
+    mockRates.mockResolvedValue({
+      configured: true,
+      board: {
+        treasury: [
+          { id: "DGS3MO", label: "3M", value: 4.3, change: 0.01, asOf: "2026-06-23" },
+        ],
+        reference: [],
+      },
+    });
+
+    render(<MarketContextBand />);
+    expect(await screen.findByText("S&P 500")).toBeTruthy();
+    expect(await screen.findByText("3M")).toBeTruthy();
+  });
+
+  it("renders nothing when both feeds are empty / unconfigured", async () => {
+    mockOverview.mockResolvedValue({ indices: [], sectors: [], commodities: [], fx: [] });
+    mockRates.mockResolvedValue({ configured: false, board: null });
+
+    const { container } = render(<MarketContextBand />);
+    await waitFor(() => expect(container.firstChild).toBeNull());
+  });
+});

--- a/apps/web/src/modules/markets/components/MarketContextBand.tsx
+++ b/apps/web/src/modules/markets/components/MarketContextBand.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { changeClass, fmtPct } from "@/lib/markets/format";
+import type { RatesBoard } from "@/lib/markets/rates";
+import { getOverview, getRatesBoard, type BoardRow } from "../lib/client-api";
+
+/**
+ * Live market-context band for the top of the Markets module dashboard — the
+ * major indices plus a few benchmark rates, so the landing page opens with
+ * actual market context instead of just the viewer's (possibly empty)
+ * watchlists. Reuses the same overview + FRED rates endpoints as the
+ * dashboard panel. Hides itself entirely when neither feed returns anything.
+ */
+export function MarketContextBand() {
+  const [indices, setIndices] = useState<BoardRow[]>([]);
+  const [rates, setRates] = useState<RatesBoard | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    getOverview()
+      .then((b) => {
+        if (alive) setIndices(b.indices);
+      })
+      .catch(() => {
+        /* feed down → band shrinks or hides */
+      });
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    let alive = true;
+    getRatesBoard()
+      .then((r) => {
+        if (alive && r.configured) setRates(r.board);
+      })
+      .catch(() => {
+        /* no FRED key → rates omitted */
+      });
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  const rateRows = rates
+    ? [...rates.treasury, ...rates.reference].filter((r) => r.value !== null).slice(0, 6)
+    : [];
+
+  if (indices.length === 0 && rateRows.length === 0) return null;
+
+  return (
+    <div className="flex flex-wrap items-center gap-x-4 gap-y-1 rounded border border-border bg-bg-1 px-3 py-2 text-xs">
+      {indices.map((i) => (
+        <span key={i.symbol} className="flex items-baseline gap-1.5 whitespace-nowrap">
+          <span className="text-text-2">{i.label}</span>
+          <span className={`font-mono tabular-nums ${changeClass(i.changePct)}`}>
+            {i.changePct != null ? fmtPct(i.changePct) : "—"}
+          </span>
+        </span>
+      ))}
+      {rateRows.length > 0 ? (
+        <span className="mx-1 hidden h-3 w-px bg-border sm:inline-block" aria-hidden="true" />
+      ) : null}
+      {rateRows.map((r) => (
+        <span key={r.id} className="flex items-baseline gap-1.5 whitespace-nowrap text-text-2">
+          <span className="uppercase tracking-wide text-text-3">{r.label}</span>
+          <span className="font-mono tabular-nums text-text-1">{r.value!.toFixed(2)}</span>
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/modules/markets/components/MarketsDashboard.tsx
+++ b/apps/web/src/modules/markets/components/MarketsDashboard.tsx
@@ -22,6 +22,7 @@ import {
 import { SymbolSearch } from "./SymbolSearch";
 import { WatchlistPanel } from "./WatchlistPanel";
 import { AttributionFooter } from "./AttributionFooter";
+import { MarketContextBand } from "./MarketContextBand";
 
 interface QuoteCacheRow {
   symbol: string;
@@ -147,6 +148,9 @@ export function MarketsDashboard({
 
   return (
     <div className="space-y-4 p-2 sm:p-3">
+      {/* Live market context — indices + benchmark rates */}
+      <MarketContextBand />
+
       {/* Toolbar */}
       <div className="flex flex-wrap items-center gap-2">
         <SymbolSearch


### PR DESCRIPTION
## What
The Markets module landing (`/modules/markets`) now opens with a live **market-context band** — the major indices + a few benchmark rates — instead of just the viewer's (possibly empty) watchlists/portfolios.

## Why
You asked for "more in the module dashboard itself." This gives the landing page real market context on open, reusing the same `getOverview` + `getRatesBoard` endpoints as the dashboard panel.

## Notes
- Hides itself entirely when neither feed returns anything (no broken empty band).
- Rates omitted without a FRED key; indices need the existing market keys.

## Test
- `MarketContextBand.test.tsx` — renders indices + rates; renders nothing when both feeds are empty. tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)