### PR TITLE
feat(markets): chart indicators lib + EMA overlay

### DIFF
--- a/apps/web/src/lib/markets/indicators.test.ts
+++ b/apps/web/src/lib/markets/indicators.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { sma, ema } from "./indicators";
+
+describe("sma", () => {
+  it("nulls until the window fills, then averages", () => {
+    expect(sma([1, 2, 3, 4], 2)).toEqual([null, 1.5, 2.5, 3.5]);
+  });
+  it("returns all-null when shorter than the period", () => {
+    expect(sma([1, 2], 3)).toEqual([null, null]);
+  });
+});
+
+describe("ema", () => {
+  it("seeds with the SMA of the first window, then smooths", () => {
+    // period 3 → k = 0.5; seed = mean(1,2,3) = 2
+    const out = ema([1, 2, 3, 4, 5], 3);
+    expect(out[0]).toBeNull();
+    expect(out[1]).toBeNull();
+    expect(out[2]).toBeCloseTo(2, 6);
+    expect(out[3]).toBeCloseTo(3, 6); // 4*0.5 + 2*0.5
+    expect(out[4]).toBeCloseTo(4, 6); // 5*0.5 + 3*0.5
+  });
+  it("returns all-null when shorter than the period", () => {
+    expect(ema([1, 2], 5)).toEqual([null, null, null, null, null].slice(0, 2));
+  });
+});

--- a/apps/web/src/lib/markets/indicators.ts
+++ b/apps/web/src/lib/markets/indicators.ts
@@ -1,0 +1,37 @@
+/**
+ * Technical-indicator math for the price chart. Pure + framework-free so it is
+ * unit-testable and reusable across the chart's overlays. Each function returns
+ * an array aligned 1:1 with the input, with `null` for points that don't yet
+ * have enough history.
+ */
+
+/** Simple moving average. Null for the first (period-1) points. */
+export function sma(values: number[], period: number): (number | null)[] {
+  const out: (number | null)[] = [];
+  let sum = 0;
+  for (let i = 0; i < values.length; i++) {
+    sum += values[i]!;
+    if (i >= period) sum -= values[i - period]!;
+    out.push(i >= period - 1 ? sum / period : null);
+  }
+  return out;
+}
+
+/**
+ * Exponential moving average. Seeded with the SMA of the first `period` points
+ * (null before that); smoothing factor k = 2/(period+1).
+ */
+export function ema(values: number[], period: number): (number | null)[] {
+  const out: (number | null)[] = new Array(values.length).fill(null);
+  if (period <= 0 || values.length < period) return out;
+  const k = 2 / (period + 1);
+  let prev = 0;
+  for (let i = 0; i < period; i++) prev += values[i]!;
+  prev /= period; // seed = SMA of the first `period` values
+  out[period - 1] = prev;
+  for (let i = period; i < values.length; i++) {
+    prev = values[i]! * k + prev * (1 - k);
+    out[i] = prev;
+  }
+  return out;
+}

--- a/apps/web/src/modules/markets/components/PriceChart.tsx
+++ b/apps/web/src/modules/markets/components/PriceChart.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { getCandles } from "../lib/client-api";
+import { sma, ema } from "@/lib/markets/indicators";
 import type { Candle, Range } from "@/lib/markets/providers/types";
 
 const RANGES: Range[] = ["1D", "5D", "1M", "6M", "YTD", "1Y", "5Y", "MAX"];
@@ -11,21 +12,11 @@ const COLORS = {
   down: "#f85149",
   line: "#58a6ff",
   ma: "#ff9d00",
+  ema: "#bc8cff",
   grid: "#3b3b45",
   text: "#9099a4",
   vol: "#2d2d32",
 };
-
-function sma(values: number[], period: number): (number | null)[] {
-  const out: (number | null)[] = [];
-  let sum = 0;
-  for (let i = 0; i < values.length; i++) {
-    sum += values[i]!;
-    if (i >= period) sum -= values[i - period]!;
-    out.push(i >= period - 1 ? sum / period : null);
-  }
-  return out;
-}
 
 /**
  * Dependency-free canvas price chart. Line/candle modes, range presets, an
@@ -42,6 +33,7 @@ export function PriceChart({
   const [range, setRange] = useState<Range>(initialRange);
   const [type, setType] = useState<"line" | "candle">("line");
   const [showMA, setShowMA] = useState(true);
+  const [showEMA, setShowEMA] = useState(false);
   const [candles, setCandles] = useState<Candle[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -187,6 +179,25 @@ export function PriceChart({
       ctx.stroke();
     }
 
+    // EMA overlay
+    if (showEMA && candles.length > 21) {
+      const e = ema(closes, 21);
+      ctx.beginPath();
+      let startedE = false;
+      e.forEach((m, i) => {
+        if (m === null) return;
+        const xx = x(i);
+        const yy = y(m);
+        if (!startedE) {
+          ctx.moveTo(xx, yy);
+          startedE = true;
+        } else ctx.lineTo(xx, yy);
+      });
+      ctx.strokeStyle = COLORS.ema;
+      ctx.lineWidth = 1;
+      ctx.stroke();
+    }
+
     // Crosshair
     if (hover !== null && hover >= 0 && hover < candles.length) {
       const xx = x(hover);
@@ -197,7 +208,7 @@ export function PriceChart({
       ctx.lineTo(xx, priceBottom);
       ctx.stroke();
     }
-  }, [candles, type, showMA, hover, width]);
+  }, [candles, type, showMA, showEMA, hover, width]);
 
   useEffect(() => {
     draw();
@@ -248,6 +259,14 @@ export function PriceChart({
             }`}
           >
             MA50
+          </button>
+          <button
+            onClick={() => setShowEMA((v) => !v)}
+            className={`rounded-sm px-1.5 py-0.5 text-[10px] font-semibold ${
+              showEMA ? "text-accent" : "text-text-2 hover:text-text-0"
+            }`}
+          >
+            EMA21
           </button>
         </div>
       </div>


### PR DESCRIPTION
## What
- New `lib/markets/indicators.ts` — pure, unit-tested **SMA + EMA** (extracts the chart's inline SMA into a reusable, tested module).
- `PriceChart` — an **EMA(21) overlay** toggle alongside the existing MA50, in a distinct color. Lands on both the module chart page and the dashboard Chart view.

## Why
"Go deep on charts" (#23). Starts the indicator suite with the two moving averages; the lib is structured to host RSI/MACD next.

## Notes
- RSI/MACD **sub-panels** need visual layout verification (separate panes), so they're a planned follow-up rather than shipped blind.

## Test
- `indicators.test.ts` — SMA + EMA against known sequences (windowing, seeding, smoothing, too-short input). 4 tests green; tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)