### PR TITLE
feat(markets): risk/return stats under the price chart

### DIFF
--- a/apps/web/src/lib/markets/risk.test.ts
+++ b/apps/web/src/lib/markets/risk.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { dailyReturns, stdev, maxDrawdown, totalReturn } from "./risk";
+
+describe("dailyReturns", () => {
+  it("computes period-over-period returns", () => {
+    expect(dailyReturns([1, 2, 3])).toEqual([1, 0.5]);
+  });
+  it("skips a bar whose prior close is 0", () => {
+    expect(dailyReturns([0, 2, 4])).toEqual([1]); // (4-2)/2 only
+  });
+  it("is empty for a single point", () => {
+    expect(dailyReturns([5])).toEqual([]);
+  });
+});
+
+describe("stdev", () => {
+  it("0 for constant or single-element series", () => {
+    expect(stdev([3, 3, 3])).toBe(0);
+    expect(stdev([3])).toBe(0);
+  });
+  it("sample std (n-1)", () => {
+    expect(stdev([0, 2])).toBeCloseTo(Math.SQRT2, 6); // var=2 → √2
+  });
+});
+
+describe("maxDrawdown", () => {
+  it("finds the largest peak-to-trough drop", () => {
+    expect(maxDrawdown([10, 8, 12, 6])).toBeCloseTo(0.5, 6); // 12 → 6
+  });
+  it("0 for a monotonically rising series", () => {
+    expect(maxDrawdown([1, 2, 3, 4])).toBe(0);
+  });
+});
+
+describe("totalReturn", () => {
+  it("first → last", () => {
+    expect(totalReturn([100, 110])).toBeCloseTo(0.1, 6);
+    expect(totalReturn([100, 80])).toBeCloseTo(-0.2, 6);
+  });
+  it("0 when too short", () => {
+    expect(totalReturn([100])).toBe(0);
+  });
+});

--- a/apps/web/src/lib/markets/risk.ts
+++ b/apps/web/src/lib/markets/risk.ts
@@ -1,0 +1,48 @@
+/**
+ * Return + risk statistics from a price (close) series. Pure + framework-free
+ * so it's unit-testable. Deliberately annualization-free — the chart's bar
+ * interval varies by range (intraday vs daily vs weekly), so these are reported
+ * over the series as shown rather than scaled to a year (which would be wrong
+ * for intraday bars).
+ */
+
+/** Period-over-period simple returns. Skips a bar whose prior close is 0. */
+export function dailyReturns(closes: number[]): number[] {
+  const out: number[] = [];
+  for (let i = 1; i < closes.length; i++) {
+    const prev = closes[i - 1]!;
+    if (prev !== 0) out.push((closes[i]! - prev) / prev);
+  }
+  return out;
+}
+
+/** Sample standard deviation (n-1). Returns 0 for fewer than 2 points. */
+export function stdev(values: number[]): number {
+  if (values.length < 2) return 0;
+  const mean = values.reduce((a, b) => a + b, 0) / values.length;
+  const variance =
+    values.reduce((a, b) => a + (b - mean) ** 2, 0) / (values.length - 1);
+  return Math.sqrt(variance);
+}
+
+/** Max peak-to-trough drawdown over the series, as a positive fraction
+ *  (0.2 = a 20% drop from a prior peak). */
+export function maxDrawdown(closes: number[]): number {
+  let peak = -Infinity;
+  let maxDD = 0;
+  for (const c of closes) {
+    if (c > peak) peak = c;
+    if (peak > 0) {
+      const dd = (peak - c) / peak;
+      if (dd > maxDD) maxDD = dd;
+    }
+  }
+  return maxDD;
+}
+
+/** Total return across the series (first → last close), as a fraction. */
+export function totalReturn(closes: number[]): number {
+  if (closes.length < 2) return 0;
+  const first = closes[0]!;
+  return first !== 0 ? (closes[closes.length - 1]! - first) / first : 0;
+}

--- a/apps/web/src/modules/markets/components/PriceChart.tsx
+++ b/apps/web/src/modules/markets/components/PriceChart.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { getCandles } from "../lib/client-api";
 import { sma, ema } from "@/lib/markets/indicators";
+import { dailyReturns, maxDrawdown, stdev, totalReturn } from "@/lib/markets/risk";
 import type { Candle, Range } from "@/lib/markets/providers/types";
 
 const RANGES: Range[] = ["1D", "5D", "1M", "6M", "YTD", "1Y", "5Y", "MAX"];
@@ -227,6 +228,18 @@ export function PriceChart({
 
   const hc = hover !== null ? candles[hover] : null;
 
+  // Risk/return stats over the visible range — annualization-free so they're
+  // correct whatever the bar interval is.
+  const stats = useMemo(() => {
+    if (candles.length < 3) return null;
+    const closes = candles.map((c) => c.close);
+    return {
+      ret: totalReturn(closes),
+      dd: maxDrawdown(closes),
+      vol: stdev(dailyReturns(closes)),
+    };
+  }, [candles]);
+
   return (
     <div ref={wrapRef} className="w-full">
       <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
@@ -305,6 +318,34 @@ export function PriceChart({
           </>
         )}
       </div>
+
+      {stats && (
+        <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-[10px] text-text-3">
+          <span>
+            Range{" "}
+            <span
+              className={`font-mono ${
+                stats.ret >= 0 ? "text-success" : "text-danger"
+              }`}
+            >
+              {stats.ret >= 0 ? "+" : ""}
+              {(stats.ret * 100).toFixed(1)}%
+            </span>
+          </span>
+          <span>
+            Max drawdown{" "}
+            <span className="font-mono text-danger">
+              −{(stats.dd * 100).toFixed(1)}%
+            </span>
+          </span>
+          <span>
+            Volatility/bar{" "}
+            <span className="font-mono text-text-1">
+              {(stats.vol * 100).toFixed(2)}%
+            </span>
+          </span>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## What
A new tested `lib/markets/risk.ts` (period returns, sample stdev, max drawdown, total return) and a compact **stats line under the price chart**: **Range return · Max drawdown · Volatility/bar**, computed from the candles the chart already loaded.

## Why
"Go deep on analytics" (#29) — per-symbol risk at a glance, on both the module chart page and the dashboard Chart view.

## Notes
- **Annualization-free on purpose**: the chart's bar interval varies by range (5-min → weekly), so scaling to a year would be wrong for intraday. Reported over the series as shown.
- Hidden for series shorter than 3 bars.

## Test
- `risk.test.ts` — returns, stdev (n-1), max drawdown, total return against known sequences + edge cases. 9 tests green; tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)