### PR TITLE
feat(markets): P/E + day & 52-week range bars on the quote summary

### DIFF
--- a/apps/web/src/modules/markets/components/QuoteView.test.tsx
+++ b/apps/web/src/modules/markets/components/QuoteView.test.tsx
@@ -1,0 +1,52 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import type { Quote } from "@/lib/markets/providers/types";
+
+// getQuote rejects so the re-fetch never overwrites initialQuote; stub the
+// heavy tab children (canvas chart / network lists) for jsdom.
+vi.mock("../lib/client-api", () => ({
+  getQuote: vi.fn().mockRejectedValue(new Error("offline")),
+}));
+vi.mock("./PriceChart", () => ({ PriceChart: () => <div /> }));
+vi.mock("./NewsList", () => ({ NewsList: () => <div /> }));
+vi.mock("./FinancialsTable", () => ({ FinancialsTable: () => <div /> }));
+vi.mock("./AttributionFooter", () => ({ AttributionFooter: () => <div /> }));
+
+import { QuoteView } from "./QuoteView";
+
+afterEach(cleanup);
+
+function q(): Quote {
+  return {
+    symbol: "AAPL",
+    name: "Apple",
+    price: 150,
+    change: 1,
+    changePct: 0.7,
+    open: 149,
+    high: 151,
+    low: 148,
+    prevClose: 149,
+    volume: 1_000_000,
+    marketCap: 2_000_000_000_000,
+    peRatio: 28.5,
+    week52High: 200,
+    week52Low: 120,
+    currency: "USD",
+    exchange: "NASDAQ",
+    marketState: "open",
+    asOf: "2026-06-23T12:00:00Z",
+    provider: "finnhub",
+  };
+}
+
+describe("QuoteView summary", () => {
+  it("shows P/E and the 52-week range bar", () => {
+    render(<QuoteView symbol="AAPL" initialQuote={q()} profile={null} />);
+    expect(screen.getByText("P/E")).toBeTruthy();
+    expect(screen.getByText("28.50")).toBeTruthy();
+    expect(screen.getByText("52-week range")).toBeTruthy();
+    expect(screen.getByText("Day range")).toBeTruthy();
+  });
+});

--- a/apps/web/src/modules/markets/components/QuoteView.tsx
+++ b/apps/web/src/modules/markets/components/QuoteView.tsx
@@ -33,6 +33,41 @@ function Stat({ label, value }: { label: string; value: string }) {
   );
 }
 
+/** Horizontal range bar showing where `value` sits between low and high.
+ *  CSS-only (deterministic marker position); hidden when data is missing. */
+function RangeBar({
+  label,
+  low,
+  high,
+  value,
+  currency,
+}: {
+  label: string;
+  low: number | null;
+  high: number | null;
+  value: number | null;
+  currency?: string;
+}) {
+  if (low == null || high == null || value == null || high <= low) return null;
+  const pct = Math.min(100, Math.max(0, ((value - low) / (high - low)) * 100));
+  return (
+    <div className="col-span-2 py-1">
+      <span className="text-[10px] uppercase tracking-wide text-text-3">{label}</span>
+      <div className="relative mt-1.5 h-1.5 rounded-full bg-bg-3">
+        <div
+          className="absolute top-1/2 h-3 w-1 -translate-x-1/2 -translate-y-1/2 rounded-sm bg-accent"
+          style={{ left: `${pct}%` }}
+          aria-hidden="true"
+        />
+      </div>
+      <div className="mt-1 flex justify-between font-mono text-[10px] text-text-2">
+        <span>{fmtPrice(low, currency)}</span>
+        <span>{fmtPrice(high, currency)}</span>
+      </div>
+    </div>
+  );
+}
+
 export function QuoteView({
   symbol,
   initialQuote,
@@ -104,8 +139,28 @@ export function QuoteView({
             <Stat label="52W Low" value={fmtPrice(quote?.week52Low, quote?.currency)} />
             <Stat label="Volume" value={fmtCompact(quote?.volume)} />
             <Stat label="Market Cap" value={fmtMarketCap(quote?.marketCap ?? profile?.marketCap)} />
+            <Stat
+              label="P/E"
+              value={
+                quote?.peRatio != null ? quote.peRatio.toFixed(2) : "—"
+              }
+            />
             <Stat label="Sector" value={profile?.sector ?? "—"} />
             <Stat label="Country" value={profile?.country ?? "—"} />
+            <RangeBar
+              label="Day range"
+              low={quote?.low ?? null}
+              high={quote?.high ?? null}
+              value={quote?.price ?? null}
+              currency={quote?.currency}
+            />
+            <RangeBar
+              label="52-week range"
+              low={quote?.week52Low ?? null}
+              high={quote?.week52High ?? null}
+              value={quote?.price ?? null}
+              currency={quote?.currency}
+            />
           </div>
           <div className="space-y-2 text-xs text-text-2">
             {profile?.description ? (


### PR DESCRIPTION
## What
The quote **Summary** tab now shows a **P/E** stat and two **range bars** — *Day range* and *52-week range* — marking where the current price sits in each band.

## Why
"Go deep on analytics" (#31, valuation snapshot) — a quick read on where a name is trading relative to its day/year.

## Notes
- Range bars are **CSS-only** (deterministic marker position, no canvas) so they're safe to ship without visual verification.
- Each bar hides when its low/high/price data is missing.

## Test
- `QuoteView.test.tsx` — renders P/E + both range bars from a quote (heavy tab children stubbed for jsdom). tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)