### PR TITLE
feat(markets): FIFO realized-gains (short/long-term) on the portfolio

### DIFF
--- a/apps/web/src/lib/markets/tax-lots.test.ts
+++ b/apps/web/src/lib/markets/tax-lots.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from "vitest";
+import type { MktLotRow } from "./db";
+import { realizedGains, summarizeRealized } from "./tax-lots";
+
+let seq = 0;
+function lot(
+  side: "buy" | "sell",
+  quantity: number,
+  price: number,
+  trade_date: string,
+  fees = 0,
+  symbol = "AAPL",
+): MktLotRow {
+  return {
+    id: `l${seq++}`,
+    portfolio_id: "p1",
+    symbol,
+    side,
+    quantity,
+    price,
+    fees,
+    trade_date,
+    note: null,
+    created_at: trade_date,
+  };
+}
+
+describe("realizedGains (FIFO)", () => {
+  it("matches a simple round trip", () => {
+    const g = realizedGains([
+      lot("buy", 10, 100, "2026-01-01"),
+      lot("sell", 10, 120, "2026-02-01"),
+    ]);
+    expect(g).toHaveLength(1);
+    expect(g[0]!.quantity).toBe(10);
+    expect(g[0]!.gain).toBeCloseTo(200, 6); // (120-100)*10
+    expect(g[0]!.longTerm).toBe(false);
+  });
+
+  it("consumes oldest buys first across a partial sell", () => {
+    const g = realizedGains([
+      lot("buy", 10, 100, "2026-01-01"),
+      lot("buy", 10, 110, "2026-01-10"),
+      lot("sell", 15, 130, "2026-03-01"),
+    ]);
+    expect(g).toHaveLength(2);
+    expect(g[0]!.quantity).toBe(10);
+    expect(g[0]!.gain).toBeCloseTo(300, 6); // (130-100)*10 from lot 1
+    expect(g[1]!.quantity).toBe(5);
+    expect(g[1]!.gain).toBeCloseTo(100, 6); // (130-110)*5 from lot 2
+    expect(realizedGains([]).length).toBe(0);
+  });
+
+  it("folds buy fees into basis and nets sell fees from proceeds", () => {
+    const g = realizedGains([
+      lot("buy", 10, 100, "2026-01-01", 10), // cost/sh = 101
+      lot("sell", 10, 120, "2026-02-01", 5), // proceeds = 1200 - 5
+    ]);
+    expect(g[0]!.costBasis).toBeCloseTo(1010, 6);
+    expect(g[0]!.proceeds).toBeCloseTo(1195, 6);
+    expect(g[0]!.gain).toBeCloseTo(185, 6);
+  });
+
+  it("long-term = held more than one year, by calendar anniversary", () => {
+    const lt = (buyDate: string, sellDate: string) =>
+      realizedGains([
+        lot("buy", 1, 100, buyDate),
+        lot("sell", 1, 100, sellDate),
+      ])[0]!.longTerm;
+
+    expect(lt("2021-01-01", "2021-06-01")).toBe(false); // ~5 months → short
+    expect(lt("2020-01-01", "2021-06-01")).toBe(true); // ~17 months → long
+    // A sale on the one-year anniversary is still short-term…
+    expect(lt("2021-01-01", "2022-01-01")).toBe(false);
+    // …long-term begins the day after.
+    expect(lt("2021-01-01", "2022-01-02")).toBe(true);
+    // A one-calendar-year hold spanning a leap day (366 raw days) is short-term.
+    expect(lt("2019-03-01", "2020-03-01")).toBe(false);
+  });
+
+  it("skips a sell with no matching buys (no basis)", () => {
+    expect(realizedGains([lot("sell", 5, 50, "2026-01-01")])).toHaveLength(0);
+  });
+
+  it("leaves the remaining open lot uncrystallized on a partial close", () => {
+    const g = realizedGains([
+      lot("buy", 10, 100, "2026-01-01"),
+      lot("sell", 4, 120, "2026-02-01"),
+    ]);
+    expect(g).toHaveLength(1);
+    expect(g[0]!.quantity).toBe(4);
+    expect(g[0]!.gain).toBeCloseTo(80, 6); // only 4 shares closed
+  });
+});
+
+describe("summarizeRealized", () => {
+  it("rolls up totals, short/long-term, and a year's slice", () => {
+    const gains = realizedGains([
+      lot("buy", 10, 100, "2020-01-01"),
+      lot("sell", 10, 130, "2026-02-01"), // long-term, +300, closed 2026
+      lot("buy", 10, 100, "2026-01-01"),
+      lot("sell", 10, 90, "2026-03-01"), // short-term, -100, closed 2026
+    ]);
+    const s = summarizeRealized(gains, 2026);
+    expect(s.count).toBe(2);
+    expect(s.totalGain).toBeCloseTo(200, 6);
+    expect(s.longTermGain).toBeCloseTo(300, 6);
+    expect(s.shortTermGain).toBeCloseTo(-100, 6);
+    expect(s.ytdGain).toBeCloseTo(200, 6);
+    expect(summarizeRealized(gains, 2025).ytdGain).toBe(0);
+  });
+});

--- a/apps/web/src/lib/markets/tax-lots.ts
+++ b/apps/web/src/lib/markets/tax-lots.ts
@@ -1,0 +1,147 @@
+/**
+ * FIFO realized-gains accounting from a lot ledger — pure, no I/O.
+ *
+ * Complements the average-cost view in `portfolio.ts`: matches each sell
+ * against the earliest open buy lots (first-in-first-out), so each realized
+ * gain carries a true holding period (short- vs long-term, the >1-year US
+ * tax boundary). Buy fees raise the lot's cost basis; sell fees reduce
+ * proceeds, allocated pro-rata across the shares sold. Unmatched sell shares
+ * (a sell with no remaining buys — e.g. a short or incomplete ledger) are
+ * skipped, since there's no basis to compute against.
+ *
+ * NOT a tax filing: wash-sale adjustments are intentionally out of scope.
+ */
+import type { MktLotRow } from "./db";
+
+export interface RealizedGain {
+  symbol: string;
+  /** Shares closed in this match. */
+  quantity: number;
+  /** Sale proceeds for these shares (net of pro-rata sell fees). */
+  proceeds: number;
+  /** FIFO-matched buy cost (incl. buy fees) for these shares. */
+  costBasis: number;
+  /** proceeds − costBasis. */
+  gain: number;
+  /** trade_date of the matched buy lot. */
+  openedAt: string;
+  /** trade_date of the sell. */
+  closedAt: string;
+  /** Long-term: held more than one year (sold on/after the day after the
+   *  one-year anniversary of the buy). */
+  longTerm: boolean;
+}
+
+export interface RealizedSummary {
+  totalGain: number;
+  shortTermGain: number;
+  longTermGain: number;
+  /** Gains whose sale closed in `year`. */
+  ytdGain: number;
+  /** Number of matched lots. */
+  count: number;
+}
+
+/**
+ * US long-term test: held MORE than one year. The holding period starts the
+ * day AFTER acquisition, so a sale on the one-year anniversary is still
+ * short-term and long-term begins the day after. Classify by calendar
+ * anniversary (not a raw 365-day count, which a leap day shifts by one).
+ */
+function isLongTerm(buyIso: string, sellIso: string): boolean {
+  const buy = new Date(buyIso);
+  const sell = new Date(sellIso);
+  if (Number.isNaN(buy.getTime()) || Number.isNaN(sell.getTime())) return false;
+  const cutoff = Date.UTC(
+    buy.getUTCFullYear() + 1,
+    buy.getUTCMonth(),
+    buy.getUTCDate() + 1,
+  );
+  return sell.getTime() >= cutoff;
+}
+
+interface OpenLot {
+  qty: number;
+  costPerShare: number;
+  date: string;
+}
+
+/**
+ * FIFO-match the ledger and return one realized-gain record per (sell, matched
+ * buy lot) pair, oldest match first. Buys before sells when dated the same day.
+ */
+export function realizedGains(lots: MktLotRow[]): RealizedGain[] {
+  const sorted = [...lots].sort((a, b) => {
+    if (a.trade_date !== b.trade_date)
+      return a.trade_date < b.trade_date ? -1 : 1;
+    // Same day: process buys before sells so a same-day round trip matches.
+    if (a.side !== b.side) return a.side === "buy" ? -1 : 1;
+    return 0;
+  });
+
+  const open = new Map<string, OpenLot[]>();
+  const out: RealizedGain[] = [];
+
+  for (const lot of sorted) {
+    const qty = Number(lot.quantity);
+    const price = Number(lot.price);
+    const fees = Number(lot.fees) || 0;
+    if (!(qty > 0) || !Number.isFinite(price)) continue;
+
+    if (lot.side === "buy") {
+      const queue = open.get(lot.symbol) ?? [];
+      queue.push({
+        qty,
+        costPerShare: price + fees / qty,
+        date: lot.trade_date,
+      });
+      open.set(lot.symbol, queue);
+      continue;
+    }
+
+    // sell → consume open buy lots FIFO
+    const queue = open.get(lot.symbol) ?? [];
+    const sellFeePerShare = fees / qty;
+    let remaining = qty;
+    while (remaining > 1e-9 && queue.length > 0) {
+      const front = queue[0]!;
+      const take = Math.min(remaining, front.qty);
+      const proceeds = take * price - take * sellFeePerShare;
+      const costBasis = take * front.costPerShare;
+      out.push({
+        symbol: lot.symbol,
+        quantity: take,
+        proceeds,
+        costBasis,
+        gain: proceeds - costBasis,
+        openedAt: front.date,
+        closedAt: lot.trade_date,
+        longTerm: isLongTerm(front.date, lot.trade_date),
+      });
+      front.qty -= take;
+      remaining -= take;
+      if (front.qty <= 1e-9) queue.shift();
+    }
+    // any `remaining` is an unmatched sell → skipped (no basis)
+  }
+
+  return out;
+}
+
+/** Roll up realized gains into totals + short/long-term + a year's YTD slice. */
+export function summarizeRealized(
+  gains: RealizedGain[],
+  year: number,
+): RealizedSummary {
+  let totalGain = 0;
+  let shortTermGain = 0;
+  let longTermGain = 0;
+  let ytdGain = 0;
+  for (const g of gains) {
+    totalGain += g.gain;
+    if (g.longTerm) longTermGain += g.gain;
+    else shortTermGain += g.gain;
+    if (new Date(g.closedAt).getUTCFullYear() === year) ytdGain += g.gain;
+  }
+  return { totalGain, shortTermGain, longTermGain, ytdGain, count: gains.length };
+}

--- a/apps/web/src/modules/markets/components/PortfolioView.tsx
+++ b/apps/web/src/modules/markets/components/PortfolioView.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { Button } from "@/components/ui/Button";
 import {
   changeClass,
@@ -11,6 +11,7 @@ import {
 } from "@/lib/markets/format";
 import type { MktLotRow, MktPortfolioRow } from "@/lib/markets/db";
 import type { PortfolioPerformance } from "@/lib/markets/portfolio";
+import { realizedGains, summarizeRealized } from "@/lib/markets/tax-lots";
 import { addLot, deleteLot, getPortfolio } from "../lib/client-api";
 import { AttributionFooter } from "./AttributionFooter";
 
@@ -37,6 +38,13 @@ export function PortfolioView({ initial }: { initial: Data }) {
 
   const { portfolio, performance, lots } = data;
   const cur = portfolio.base_currency;
+
+  // FIFO realized gains (short/long-term, YTD) — complements the average-cost
+  // realized P/L below.
+  const realized = useMemo(
+    () => summarizeRealized(realizedGains(lots), new Date().getUTCFullYear()),
+    [lots],
+  );
 
   async function refresh() {
     setData(await getPortfolio(portfolio.id));
@@ -238,9 +246,48 @@ export function PortfolioView({ initial }: { initial: Data }) {
         </details>
       )}
 
+      {realized.count > 0 && (
+        <div className="rounded border border-border bg-bg-1 px-3 py-2">
+          <div className="mb-1.5 text-[10px] font-semibold uppercase tracking-wide text-text-3">
+            Realized gains (FIFO) · {realized.count} lot
+            {realized.count === 1 ? "" : "s"} closed
+          </div>
+          <div className="flex flex-wrap gap-x-6 gap-y-1 text-xs">
+            <span className="text-text-2">
+              Total{" "}
+              <span className={`font-mono ${changeClass(realized.totalGain)}`}>
+                {fmtChange(realized.totalGain)} {cur}
+              </span>
+            </span>
+            <span className="text-text-2">
+              Short-term{" "}
+              <span
+                className={`font-mono ${changeClass(realized.shortTermGain)}`}
+              >
+                {fmtChange(realized.shortTermGain)}
+              </span>
+            </span>
+            <span className="text-text-2">
+              Long-term{" "}
+              <span
+                className={`font-mono ${changeClass(realized.longTermGain)}`}
+              >
+                {fmtChange(realized.longTermGain)}
+              </span>
+            </span>
+            <span className="text-text-2">
+              YTD{" "}
+              <span className={`font-mono ${changeClass(realized.ytdGain)}`}>
+                {fmtChange(realized.ytdGain)}
+              </span>
+            </span>
+          </div>
+        </div>
+      )}
+
       <p className="text-[10px] text-text-3">
-        Realized P/L to date: {fmtChange(performance.totalRealizedPL)} {cur} ·{" "}
-        cost basis {fmtCompact(performance.totalCostBasis)}
+        Realized P/L to date (avg cost): {fmtChange(performance.totalRealizedPL)}{" "}
+        {cur} · cost basis {fmtCompact(performance.totalCostBasis)}
       </p>
 
       <AttributionFooter />


### PR DESCRIPTION
## What
A new tested `lib/markets/tax-lots.ts` that **FIFO-matches sells to the oldest open buy lots**, and a **Realized gains (FIFO)** summary on the portfolio view — **Total · Short-term · Long-term · YTD** — alongside the existing average-cost realized P/L.

## Why
"Go deep on analytics" (#61, tax-lot / realized-gains). FIFO with true holding periods is what tax reporting needs; the existing average-cost realized P/L can't express short- vs long-term.

## Correctness
- Buy fees raise basis; sell fees are pro-rated from proceeds across partial fills.
- **Long-term = held more than one calendar year by anniversary** (a sale on the anniversary is still short-term), not a raw `>365`-day count.
- A self-review (multi-agent) caught the original `>365` logic misclassifying one-year holds that span a leap day; fixed + pinned by boundary tests.
- Unmatched sells (no basis) are skipped; wash sales are explicitly out of scope (not a tax filing).

## Test
- `tax-lots.test.ts` — round trips, multi-lot FIFO, fees in/out, partial closes, unmatched sells, the anniversary + leap-day boundary, and the summary buckets. 7 tests green; tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)