### PR TITLE
feat(markets): RSI(14) readout on the price chart

### DIFF
--- a/apps/web/src/lib/markets/indicators.test.ts
+++ b/apps/web/src/lib/markets/indicators.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { sma, ema } from "./indicators";
+import { sma, ema, rsi } from "./indicators";
 
 describe("sma", () => {
   it("nulls until the window fills, then averages", () => {
@@ -22,5 +22,35 @@ describe("ema", () => {
   });
   it("returns all-null when shorter than the period", () => {
     expect(ema([1, 2], 5)).toEqual([null, null, null, null, null].slice(0, 2));
+  });
+});
+
+describe("rsi", () => {
+  it("is null until `period` deltas exist, then bounded 0–100", () => {
+    // Wilder's textbook series (period 14).
+    const closes = [
+      44, 44.34, 44.09, 44.15, 43.61, 44.33, 44.83, 45.1, 45.42, 45.84, 46.08,
+      45.89, 46.03, 45.61, 46.28, 46.28,
+    ];
+    const out = rsi(closes, 14);
+    expect(out.slice(0, 14).every((v) => v === null)).toBe(true);
+    expect(out[14]).not.toBeNull();
+    for (const v of out) {
+      if (v !== null) {
+        expect(v).toBeGreaterThanOrEqual(0);
+        expect(v).toBeLessThanOrEqual(100);
+      }
+    }
+  });
+
+  it("is 100 for a rising series and 0 for a falling one", () => {
+    const rising = Array.from({ length: 20 }, (_, i) => i + 1);
+    const falling = Array.from({ length: 20 }, (_, i) => 20 - i);
+    expect(rsi(rising, 14)[19]).toBe(100);
+    expect(rsi(falling, 14)[19]).toBe(0);
+  });
+
+  it("is all-null when shorter than the period", () => {
+    expect(rsi([1, 2, 3], 14).every((v) => v === null)).toBe(true);
   });
 });

--- a/apps/web/src/lib/markets/indicators.ts
+++ b/apps/web/src/lib/markets/indicators.ts
@@ -35,3 +35,33 @@ export function ema(values: number[], period: number): (number | null)[] {
   }
   return out;
 }
+
+/**
+ * Relative Strength Index (Wilder's smoothing), bounded 0–100. Null until the
+ * first `period` deltas are available. >70 ≈ overbought, <30 ≈ oversold.
+ */
+export function rsi(values: number[], period = 14): (number | null)[] {
+  const out: (number | null)[] = new Array(values.length).fill(null);
+  if (period <= 0 || values.length <= period) return out;
+
+  let gain = 0;
+  let loss = 0;
+  for (let i = 1; i <= period; i++) {
+    const d = values[i]! - values[i - 1]!;
+    if (d >= 0) gain += d;
+    else loss -= d;
+  }
+  let avgGain = gain / period;
+  let avgLoss = loss / period;
+  out[period] = avgLoss === 0 ? 100 : 100 - 100 / (1 + avgGain / avgLoss);
+
+  for (let i = period + 1; i < values.length; i++) {
+    const d = values[i]! - values[i - 1]!;
+    const g = d > 0 ? d : 0;
+    const l = d < 0 ? -d : 0;
+    avgGain = (avgGain * (period - 1) + g) / period;
+    avgLoss = (avgLoss * (period - 1) + l) / period;
+    out[i] = avgLoss === 0 ? 100 : 100 - 100 / (1 + avgGain / avgLoss);
+  }
+  return out;
+}

--- a/apps/web/src/modules/markets/components/PriceChart.tsx
+++ b/apps/web/src/modules/markets/components/PriceChart.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { getCandles } from "../lib/client-api";
-import { sma, ema } from "@/lib/markets/indicators";
+import { sma, ema, rsi } from "@/lib/markets/indicators";
 import { dailyReturns, maxDrawdown, stdev, totalReturn } from "@/lib/markets/risk";
 import type { Candle, Range } from "@/lib/markets/providers/types";
 
@@ -233,10 +233,19 @@ export function PriceChart({
   const stats = useMemo(() => {
     if (candles.length < 3) return null;
     const closes = candles.map((c) => c.close);
+    const rsiSeries = rsi(closes, 14);
+    let lastRsi: number | null = null;
+    for (let i = rsiSeries.length - 1; i >= 0; i--) {
+      if (rsiSeries[i] != null) {
+        lastRsi = rsiSeries[i]!;
+        break;
+      }
+    }
     return {
       ret: totalReturn(closes),
       dd: maxDrawdown(closes),
       vol: stdev(dailyReturns(closes)),
+      rsi: lastRsi,
     };
   }, [candles]);
 
@@ -344,6 +353,22 @@ export function PriceChart({
               {(stats.vol * 100).toFixed(2)}%
             </span>
           </span>
+          {stats.rsi != null && (
+            <span>
+              RSI(14){" "}
+              <span
+                className={`font-mono ${
+                  stats.rsi >= 70
+                    ? "text-danger"
+                    : stats.rsi <= 30
+                      ? "text-success"
+                      : "text-text-1"
+                }`}
+              >
+                {stats.rsi.toFixed(1)}
+              </span>
+            </span>
+          )}
         </div>
       )}
     </div>


### PR DESCRIPTION
## What
Adds **Wilder's RSI** to the indicators lib and surfaces the latest **RSI(14)** value in the chart's stats line — color-coded red ≥70 (overbought) / green ≤30 (oversold).

## Why
"Go deep on charts" (#23) — RSI is the most-used momentum oscillator. Surfaced as a **numeric readout, not a canvas sub-panel**, so it's safe to ship without visual verification (the sub-panel render stays for when you can review live).

## Test
- `indicators.test.ts` — RSI bounded 0–100, 100 for a rising series / 0 for falling, null until `period` deltas, all-null when too short. 7 indicator tests green; tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)