### PR TITLE
feat(contacts): data foundation — contacts + interactions (Phase A.1)

### DIFF
--- a/apps/web/src/lib/contacts/db.ts
+++ b/apps/web/src/lib/contacts/db.ts
@@ -1,0 +1,113 @@
+/**
+ * Typed Row interfaces for the contacts tables + a loosely-typed client accessor.
+ *
+ * The generated `@rokki/db` types don't yet include `contacts`/`interactions` —
+ * they're picked up when `supabase gen types` is re-run after
+ * `20260628120000_contacts_init.sql`. Until then we follow the repo's established
+ * Supabase-client-boundary convention (see `lib/markets/db.ts`,
+ * `lib/resolve-terminal.ts`): `contactsDb()` returns a loosely-typed client so
+ * `.from("contacts")` resolves, and query RESULTS are cast back to the Row
+ * interfaces below at each call site. Delete `contactsDb` and switch to the
+ * generated types once they include these tables.
+ */
+
+export interface ContactEmail {
+  email: string;
+  label?: string;
+  primary?: boolean;
+}
+export interface ContactPhone {
+  phone: string;
+  label?: string;
+  primary?: boolean;
+}
+export interface ContactAddress {
+  line1?: string;
+  line2?: string;
+  city?: string;
+  state?: string;
+  postal?: string;
+  country?: string;
+  label?: string;
+}
+export interface ContactSocial {
+  kind: string; // linkedin|instagram|x|facebook|website|...
+  value: string;
+}
+
+export interface ContactRow {
+  id: string;
+  owner_id: string;
+  /** Linked Rokki user, for synced team-member contacts. */
+  user_id: string | null;
+  first_name: string;
+  middle_name: string | null;
+  last_name: string;
+  prefix: string | null;
+  suffix: string | null;
+  nickname: string | null;
+  avatar_url: string | null;
+  contact_types: string[];
+  tags: string[];
+  title: string | null;
+  firm: string | null;
+  license_no: string | null;
+  strength: number;
+  source: string | null;
+  status: "active" | "archived";
+  do_not_contact: boolean;
+  notes: string | null;
+  emails: ContactEmail[];
+  phones: ContactPhone[];
+  addresses: ContactAddress[];
+  socials: ContactSocial[];
+  primary_email: string | null;
+  primary_phone: string | null;
+  custom: Record<string, unknown>;
+  created_at: string;
+  updated_at: string;
+}
+
+export type InteractionType =
+  | "note"
+  | "call"
+  | "email"
+  | "meeting"
+  | "text"
+  | "site_visit"
+  | "offer"
+  | "stage_change"
+  | "follow_up";
+
+export interface InteractionRow {
+  id: string;
+  owner_id: string;
+  space_id: string | null;
+  contact_id: string | null;
+  lead_id: string | null;
+  terminal_id: string | null;
+  type: InteractionType;
+  body: string;
+  occurred_at: string;
+  /** Set (with done_at null) ⇒ this is an open follow-up reminder. */
+  due_at: string | null;
+  done_at: string | null;
+  created_by: string;
+  created_at: string;
+}
+
+/** Columns a contact card needs in a list (keeps payloads lean). */
+export const CONTACT_LIST_COLUMNS =
+  "id, first_name, last_name, nickname, avatar_url, contact_types, tags, firm, " +
+  "title, primary_email, primary_phone, status, strength, user_id, updated_at";
+
+/**
+ * Loosely-typed Supabase client for the contacts tables. Same `any`-boundary
+ * convention as `marketsDb()`; remove once the generated types include the
+ * `contacts`/`interactions` tables.
+ */
+export type ContactsClient = any;
+
+export function contactsDb(client: unknown): ContactsClient {
+  return client as ContactsClient;
+}

--- a/apps/web/tests/rls/contacts.test.ts
+++ b/apps/web/tests/rls/contacts.test.ts
@@ -1,0 +1,156 @@
+/**
+ * RLS tests for the contacts tables (`contacts`, `interactions`).
+ *
+ * Runs against the local Supabase stack (CI spins it up via `supabase db
+ * reset`). Verifies the policies from `20260628120000_contacts_init.sql`:
+ *
+ *   - contacts — strictly owner-scoped (owner_id = auth.uid()); a non-owner
+ *     can't read another user's contact, and WITH CHECK blocks creating one
+ *     owned by someone else.
+ *   - interactions — readable by the owner/creator (and space members /
+ *     own-contact links); WITH CHECK blocks forging owner_id/created_by.
+ *
+ * Mirrors tests/rls/markets.test.ts for the auth/session plumbing.
+ */
+
+import { describe, it, expect, beforeAll } from "vitest";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+
+const SB_URL = process.env.SUPABASE_URL ?? "http://127.0.0.1:54321";
+const ANON =
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0";
+const SERVICE =
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU";
+
+const admin = createClient(SB_URL, SERVICE, {
+  auth: { autoRefreshToken: false, persistSession: false },
+});
+
+async function makeClientFor(email: string): Promise<SupabaseClient> {
+  const { data, error } = await admin.auth.admin.generateLink({
+    type: "magiclink",
+    email,
+  });
+  if (error || !data) throw new Error(`generateLink failed: ${error?.message}`);
+  const supabase = createClient(SB_URL, ANON, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+  const { data: verifyData, error: verifyErr } = await supabase.auth.verifyOtp({
+    type: "magiclink",
+    token_hash: data.properties.hashed_token,
+  });
+  if (verifyErr) throw new Error(`verifyOtp failed: ${verifyErr.message}`);
+  if (!verifyData.session) throw new Error("no session after verifyOtp");
+  await supabase.auth.setSession({
+    access_token: verifyData.session.access_token,
+    refresh_token: verifyData.session.refresh_token,
+  });
+  return supabase;
+}
+
+async function ensureUser(email: string): Promise<string> {
+  const { data: list } = await admin.auth.admin.listUsers();
+  const existing = list?.users.find((u) => u.email === email);
+  if (existing) return existing.id;
+  const { data, error } = await admin.auth.admin.createUser({
+    email,
+    email_confirm: true,
+  });
+  if (error || !data.user) throw new Error(`createUser ${email}: ${error?.message}`);
+  return data.user.id;
+}
+
+describe("RLS — contacts", () => {
+  let userA: string;
+  let userB: string;
+  let clientA: SupabaseClient;
+  let clientB: SupabaseClient;
+
+  beforeAll(async () => {
+    userA = await ensureUser("contacts-rls-a@rokki.local");
+    userB = await ensureUser("contacts-rls-b@rokki.local");
+    clientA = await makeClientFor("contacts-rls-a@rokki.local");
+    clientB = await makeClientFor("contacts-rls-b@rokki.local");
+  }, 30_000);
+
+  // ----- contacts: strictly owner-scoped -----
+  let contactId: string;
+
+  it("owner can create a contact", async () => {
+    const { data, error } = await clientA
+      .from("contacts")
+      .insert({ owner_id: userA, first_name: "Broker", last_name: "Jones" })
+      .select("id")
+      .single();
+    expect(error).toBeNull();
+    contactId = (data as { id: string }).id;
+  });
+
+  it("owner sees their own contact", async () => {
+    const { data, error } = await clientA
+      .from("contacts")
+      .select("id")
+      .eq("id", contactId)
+      .maybeSingle();
+    expect(error).toBeNull();
+    expect(data).toBeTruthy();
+  });
+
+  it("another user cannot see someone else's contact", async () => {
+    const { data } = await clientB
+      .from("contacts")
+      .select("id")
+      .eq("id", contactId)
+      .maybeSingle();
+    expect(data).toBeNull();
+  });
+
+  it("a user cannot create a contact owned by someone else (WITH CHECK)", async () => {
+    const { error } = await clientB
+      .from("contacts")
+      .insert({ owner_id: userA, first_name: "Forged" });
+    expect(error).toBeTruthy();
+  });
+
+  it("a name is required (CHECK constraint)", async () => {
+    const { error } = await clientA
+      .from("contacts")
+      .insert({ owner_id: userA, first_name: "", last_name: "" });
+    expect(error).toBeTruthy();
+  });
+
+  // ----- interactions: owner/creator scoped -----
+  let interactionId: string;
+
+  it("owner can log an interaction", async () => {
+    const { data, error } = await clientA
+      .from("interactions")
+      .insert({
+        owner_id: userA,
+        created_by: userA,
+        contact_id: contactId,
+        type: "note",
+        body: "Called about the parcel.",
+      })
+      .select("id")
+      .single();
+    expect(error).toBeNull();
+    interactionId = (data as { id: string }).id;
+  });
+
+  it("another user cannot read someone else's interaction", async () => {
+    const { data } = await clientB
+      .from("interactions")
+      .select("id")
+      .eq("id", interactionId)
+      .maybeSingle();
+    expect(data).toBeNull();
+  });
+
+  it("a user cannot forge an interaction owned by someone else (WITH CHECK)", async () => {
+    const { error } = await clientB
+      .from("interactions")
+      .insert({ owner_id: userA, created_by: userA, type: "note", body: "forged" });
+    expect(error).toBeTruthy();
+  });
+});

--- a/supabase/migrations/20260628120000_contacts_init.sql
+++ b/supabase/migrations/20260628120000_contacts_init.sql
@@ -1,0 +1,134 @@
+-- Contacts module — the relationship layer.
+--
+-- A user-owned, cross-space contact book (people you deal with: owners, brokers,
+-- partners, lenders, attorneys, GCs, and your own teammates). Foundational: the
+-- Pipeline module's leads and Terminals LINK to these records rather than
+-- embedding their own copies, so one person is one record everywhere and a note
+-- logged on a deal also lands on that person's timeline.
+--
+-- Scope: each contact is owned by a user (your global network). Team members are
+-- contacts whose `user_id` points at a Rokki profile (synced from it). Wider
+-- space-visibility (a contact becoming visible to a space's members because it's
+-- linked to a lead there) is layered on in a later phase via the link tables.
+--
+-- See Claude/CONTACTS_PIPELINE_BUILD_PLAN.md.
+
+BEGIN;
+
+-- ───────────────────────────────────────────────────────────────────
+-- contacts — one person. Multi-value reach (emails/phones/addresses/socials)
+-- lives in JSONB for MVP flexibility; the primary email/phone are denormalized
+-- into columns for dedupe + fast search.
+-- ───────────────────────────────────────────────────────────────────
+CREATE TABLE contacts (
+  id             UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  owner_id       UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  user_id        UUID REFERENCES auth.users(id) ON DELETE SET NULL, -- linked Rokki user (team contact)
+  first_name     TEXT NOT NULL DEFAULT '',
+  middle_name    TEXT,
+  last_name      TEXT NOT NULL DEFAULT '',
+  prefix         TEXT,
+  suffix         TEXT,
+  nickname       TEXT,
+  avatar_url     TEXT,
+  contact_types  TEXT[] NOT NULL DEFAULT '{}',     -- owner|broker|partner|lender|attorney|...
+  tags           TEXT[] NOT NULL DEFAULT '{}',
+  title          TEXT,
+  firm           TEXT,
+  license_no     TEXT,
+  strength       INT  NOT NULL DEFAULT 0 CHECK (strength BETWEEN 0 AND 3),
+  source         TEXT,
+  status         TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active','archived')),
+  do_not_contact BOOLEAN NOT NULL DEFAULT FALSE,
+  notes          TEXT,
+  emails         JSONB NOT NULL DEFAULT '[]'::jsonb,  -- [{email,label,primary}]
+  phones         JSONB NOT NULL DEFAULT '[]'::jsonb,  -- [{phone,label,primary}]
+  addresses      JSONB NOT NULL DEFAULT '[]'::jsonb,
+  socials        JSONB NOT NULL DEFAULT '[]'::jsonb,
+  primary_email  TEXT,
+  primary_phone  TEXT,
+  custom         JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+  -- a contact must carry at least one name character
+  CONSTRAINT contacts_has_name
+    CHECK (char_length(coalesce(first_name,'') || coalesce(last_name,'') || coalesce(nickname,'')) BETWEEN 1 AND 300)
+);
+
+ALTER TABLE contacts ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "contacts_own" ON contacts
+  FOR ALL TO authenticated
+  USING (owner_id = auth.uid())
+  WITH CHECK (owner_id = auth.uid());
+
+CREATE INDEX contacts_owner_idx        ON contacts(owner_id);
+CREATE INDEX contacts_owner_email_idx  ON contacts(owner_id, primary_email);
+CREATE INDEX contacts_owner_phone_idx  ON contacts(owner_id, primary_phone);
+CREATE INDEX contacts_user_idx         ON contacts(user_id) WHERE user_id IS NOT NULL;
+CREATE INDEX contacts_tags_idx         ON contacts USING GIN (tags);
+CREATE INDEX contacts_types_idx        ON contacts USING GIN (contact_types);
+
+-- ───────────────────────────────────────────────────────────────────
+-- interactions — the shared activity timeline. A row can reference a contact
+-- AND a lead AND/OR a terminal, so the same note aggregates onto every relevant
+-- timeline. `due_at` (with done_at NULL) makes it a follow-up reminder.
+-- `lead_id` is intentionally FK-less here — pl_leads is created by the Pipeline
+-- migration, which will add the constraint.
+-- ───────────────────────────────────────────────────────────────────
+CREATE TABLE interactions (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  owner_id    UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  space_id    UUID REFERENCES spaces(id) ON DELETE CASCADE,
+  contact_id  UUID REFERENCES contacts(id) ON DELETE CASCADE,
+  lead_id     UUID,
+  terminal_id UUID REFERENCES terminals(id) ON DELETE CASCADE,
+  type        TEXT NOT NULL DEFAULT 'note'
+                CHECK (type IN ('note','call','email','meeting','text','site_visit','offer','stage_change','follow_up')),
+  body        TEXT NOT NULL DEFAULT '',
+  occurred_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  due_at      TIMESTAMPTZ,
+  done_at     TIMESTAMPTZ,
+  created_by  UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE interactions ENABLE ROW LEVEL SECURITY;
+
+-- Readable if you own it, you created it, it's in one of your spaces, or it's
+-- about one of your contacts (which RLS already scopes to you).
+CREATE POLICY "interactions_read" ON interactions
+  FOR SELECT TO authenticated
+  USING (
+    owner_id = auth.uid()
+    OR created_by = auth.uid()
+    OR (space_id IN (SELECT space_id FROM space_members WHERE user_id = auth.uid()))
+    OR (contact_id IN (SELECT id FROM contacts))
+  );
+
+CREATE POLICY "interactions_write" ON interactions
+  FOR ALL TO authenticated
+  USING (owner_id = auth.uid() OR created_by = auth.uid())
+  WITH CHECK (owner_id = auth.uid() OR created_by = auth.uid());
+
+CREATE INDEX interactions_contact_idx  ON interactions(contact_id, occurred_at DESC);
+CREATE INDEX interactions_lead_idx     ON interactions(lead_id, occurred_at DESC);
+CREATE INDEX interactions_terminal_idx ON interactions(terminal_id, occurred_at DESC);
+CREATE INDEX interactions_followup_idx ON interactions(owner_id, due_at)
+  WHERE due_at IS NOT NULL AND done_at IS NULL;
+
+-- ───────────────────────────────────────────────────────────────────
+-- updated_at touch trigger for contacts
+-- ───────────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION contacts_touch_updated_at() RETURNS trigger AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER contacts_set_updated_at
+  BEFORE UPDATE ON contacts
+  FOR EACH ROW EXECUTE FUNCTION contacts_touch_updated_at();
+
+COMMIT;


### PR DESCRIPTION
## What
The first slice of the **Contacts** module — the relationship layer the Pipeline module links into.

- **Migration** `20260628120000_contacts_init.sql`:
  - `contacts` — user-owned; rich identity, jsonb emails/phones/addresses/socials, denormalized `primary_email`/`primary_phone` (dedupe + search), `user_id` link for synced team members. RLS: strictly owner-scoped.
  - `interactions` — the shared timeline; a row can reference a **contact + lead + terminal** at once (so a note aggregates onto every relevant timeline); `due_at` (with `done_at` null) makes it a follow-up. RLS: owner/creator-scoped (+ space + own-contact read).
  - Indexes (owner, primary email/phone, GIN tags/types, follow-up partial) + `updated_at` trigger.
- `lib/contacts/db.ts` — typed Row interfaces + the `contactsDb()` any-boundary accessor (mirrors `marketsDb()`).

## Why
Phase A.1 of the Contacts + Pipeline build. Contacts is foundational — built first so the Pipeline's leads and Terminals can *link* to one shared record per person.

## Test
- `tests/rls/contacts.test.ts` — owner isolation, cross-user read denial, WITH-CHECK forge-blocks, name-required constraint, interaction scoping (runs in CI against the local stack).
- tsc + eslint clean. Migration + RLS validated by the CI migrations + RLS suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)