### PR TITLE
feat(contacts): REST API — CRUD, search, dedupe (Phase A.2)

### DIFF
--- a/apps/web/src/app/api/v1/contacts/[id]/route.ts
+++ b/apps/web/src/app/api/v1/contacts/[id]/route.ts
@@ -1,0 +1,75 @@
+import { type NextRequest } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { withObservability } from "@/lib/observability";
+import { ok, noContent, unauthorized, badRequest, notFound } from "@/lib/contacts/api";
+import {
+  getContact,
+  updateContact,
+  archiveContact,
+} from "@/lib/contacts/queries";
+
+export const dynamic = "force-dynamic";
+
+interface Props {
+  params: Promise<{ id: string }>;
+}
+
+/** GET /api/v1/contacts/:id */
+async function handleGet(_request: NextRequest, { params }: Props) {
+  const { id } = await params;
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return unauthorized();
+  try {
+    const contact = await getContact(supabase, user.id, id);
+    if (!contact) return notFound("Contact not found");
+    return ok({ contact });
+  } catch (e) {
+    return badRequest(e instanceof Error ? e.message : "Failed");
+  }
+}
+
+/** PATCH /api/v1/contacts/:id */
+async function handlePatch(request: NextRequest, { params }: Props) {
+  const { id } = await params;
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return unauthorized();
+  let body: Record<string, unknown>;
+  try {
+    body = (await request.json()) as Record<string, unknown>;
+  } catch {
+    return badRequest("Invalid JSON body");
+  }
+  try {
+    const contact = await updateContact(supabase, user.id, id, body);
+    if (!contact) return notFound("Contact not found");
+    return ok({ contact });
+  } catch (e) {
+    return badRequest(e instanceof Error ? e.message : "Could not update contact");
+  }
+}
+
+/** DELETE /api/v1/contacts/:id — soft archive. */
+async function handleDelete(_request: NextRequest, { params }: Props) {
+  const { id } = await params;
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return unauthorized();
+  try {
+    await archiveContact(supabase, user.id, id);
+    return noContent();
+  } catch (e) {
+    return badRequest(e instanceof Error ? e.message : "Could not archive contact");
+  }
+}
+
+export const GET = withObservability<Props>(handleGet, "GET /api/v1/contacts/:id");
+export const PATCH = withObservability<Props>(handlePatch, "PATCH /api/v1/contacts/:id");
+export const DELETE = withObservability<Props>(handleDelete, "DELETE /api/v1/contacts/:id");

--- a/apps/web/src/app/api/v1/contacts/route.ts
+++ b/apps/web/src/app/api/v1/contacts/route.ts
@@ -1,0 +1,74 @@
+import { type NextRequest } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { withObservability } from "@/lib/observability";
+import { ok, unauthorized, badRequest } from "@/lib/contacts/api";
+import {
+  listContacts,
+  createContact,
+  findDuplicate,
+} from "@/lib/contacts/queries";
+import { primaryEmail, primaryPhone } from "@/lib/contacts/normalize";
+
+export const dynamic = "force-dynamic";
+
+/** GET /api/v1/contacts?q=&type=&tag=&status=&limit= — the viewer's contacts. */
+async function handleGet(request: NextRequest) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return unauthorized();
+
+  const sp = request.nextUrl.searchParams;
+  const status = sp.get("status");
+  try {
+    const contacts = await listContacts(supabase, user.id, {
+      q: sp.get("q") ?? undefined,
+      type: sp.get("type") ?? undefined,
+      tag: sp.get("tag") ?? undefined,
+      status: status === "archived" ? "archived" : "active",
+      limit: sp.get("limit") ? Number(sp.get("limit")) : undefined,
+    });
+    return ok({ contacts });
+  } catch (e) {
+    return badRequest(e instanceof Error ? e.message : "Failed to load contacts");
+  }
+}
+
+/**
+ * POST /api/v1/contacts — create a contact. Dedupe: if an active contact with
+ * the same primary email/phone exists and `?force=true` isn't set, returns
+ * `{ contact: null, duplicate }` (200) so the client can offer "open existing"
+ * or retry with force.
+ */
+async function handlePost(request: NextRequest) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return unauthorized();
+
+  let body: Record<string, unknown>;
+  try {
+    body = (await request.json()) as Record<string, unknown>;
+  } catch {
+    return badRequest("Invalid JSON body");
+  }
+
+  const force = request.nextUrl.searchParams.get("force") === "true";
+  try {
+    const email = primaryEmail(body.emails as never);
+    const phone = primaryPhone(body.phones as never);
+    if (!force) {
+      const duplicate = await findDuplicate(supabase, user.id, email, phone);
+      if (duplicate) return ok({ contact: null, duplicate });
+    }
+    const contact = await createContact(supabase, user.id, body);
+    return ok({ contact, duplicate: null }, 201);
+  } catch (e) {
+    return badRequest(e instanceof Error ? e.message : "Could not create contact");
+  }
+}
+
+export const GET = withObservability(handleGet, "GET /api/v1/contacts");
+export const POST = withObservability(handlePost, "POST /api/v1/contacts");

--- a/apps/web/src/lib/contacts/api.ts
+++ b/apps/web/src/lib/contacts/api.ts
@@ -1,0 +1,32 @@
+/**
+ * Shared response + error helpers for the contacts API routes.
+ *
+ * Matches Rokki's envelope conventions (same as the markets module): success →
+ * `{ data }`, error → `{ errors: [{ code, message }] }` with the right status.
+ */
+import { NextResponse } from "next/server";
+
+export function ok<T>(data: T, status = 200): NextResponse {
+  return NextResponse.json({ data }, { status });
+}
+
+export function noContent(): NextResponse {
+  return new NextResponse(null, { status: 204 });
+}
+
+export function errResponse(
+  code: string,
+  message: string,
+  status: number,
+): NextResponse {
+  return NextResponse.json({ errors: [{ code, message }] }, { status });
+}
+
+export const unauthorized = () =>
+  errResponse("unauthenticated", "Sign in required", 401);
+export const badRequest = (message: string) =>
+  errResponse("invalid_request", message, 400);
+export const notFound = (message = "Not found") =>
+  errResponse("not_found", message, 404);
+export const internal = (message: string) =>
+  errResponse("internal_error", message, 500);

--- a/apps/web/src/lib/contacts/normalize.test.ts
+++ b/apps/web/src/lib/contacts/normalize.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import {
+  normalizeEmail,
+  normalizePhone,
+  primaryEmail,
+  primaryPhone,
+  displayName,
+  hasName,
+} from "./normalize";
+
+describe("normalizeEmail/Phone", () => {
+  it("lower-cases + trims emails", () => {
+    expect(normalizeEmail("  Broker@Realty.COM ")).toBe("broker@realty.com");
+  });
+  it("keeps digits + a leading +", () => {
+    expect(normalizePhone("(305) 555-1212")).toBe("3055551212");
+    expect(normalizePhone("+1 305-555-1212")).toBe("+13055551212");
+  });
+});
+
+describe("primaryEmail/Phone", () => {
+  it("prefers the flagged primary, else the first", () => {
+    expect(
+      primaryEmail([
+        { email: "a@x.com" },
+        { email: "B@X.com", primary: true },
+      ]),
+    ).toBe("b@x.com");
+    expect(primaryEmail([{ email: "a@x.com" }])).toBe("a@x.com");
+    expect(primaryEmail([])).toBeNull();
+    expect(primaryEmail(undefined)).toBeNull();
+  });
+  it("normalizes the chosen phone", () => {
+    expect(primaryPhone([{ phone: "(305) 555-1212", primary: true }])).toBe(
+      "3055551212",
+    );
+    expect(primaryPhone(undefined)).toBeNull();
+  });
+});
+
+describe("displayName / hasName", () => {
+  it("nickname wins, then full name, then email", () => {
+    expect(displayName({ first_name: "Bob", last_name: "Jones" })).toBe("Bob Jones");
+    expect(displayName({ first_name: "Bob", nickname: "BJ" })).toBe("BJ");
+    expect(displayName({ primary_email: "x@y.com" })).toBe("x@y.com");
+    expect(displayName({})).toBe("Unnamed");
+  });
+  it("hasName mirrors the DB check", () => {
+    expect(hasName({ first_name: "Bob" })).toBe(true);
+    expect(hasName({ nickname: "BJ" })).toBe(true);
+    expect(hasName({ first_name: " ", last_name: "" })).toBe(false);
+    expect(hasName({})).toBe(false);
+  });
+});

--- a/apps/web/src/lib/contacts/normalize.ts
+++ b/apps/web/src/lib/contacts/normalize.ts
@@ -1,0 +1,57 @@
+/**
+ * Pure contact-field normalization — deriving the denormalized primary
+ * email/phone from the multi-value arrays, plus display name + dedupe keys.
+ * No I/O, so it's unit-tested and reused by both the API and the client.
+ */
+import type { ContactEmail, ContactPhone } from "./db";
+
+/** Lower-case + trim an email for comparison/storage. */
+export function normalizeEmail(email: string): string {
+  return email.trim().toLowerCase();
+}
+
+/** Reduce a phone to a comparable form (keep digits + a leading +). */
+export function normalizePhone(phone: string): string {
+  const p = phone.trim();
+  const plus = p.startsWith("+") ? "+" : "";
+  return plus + p.replace(/\D/g, "");
+}
+
+/** The primary email: the one flagged `primary`, else the first, else null. */
+export function primaryEmail(emails: ContactEmail[] | undefined): string | null {
+  if (!Array.isArray(emails) || emails.length === 0) return null;
+  const chosen =
+    emails.find((e) => e?.primary && e?.email) ?? emails.find((e) => e?.email);
+  return chosen?.email ? normalizeEmail(chosen.email) : null;
+}
+
+/** The primary phone: the one flagged `primary`, else the first, else null. */
+export function primaryPhone(phones: ContactPhone[] | undefined): string | null {
+  if (!Array.isArray(phones) || phones.length === 0) return null;
+  const chosen =
+    phones.find((p) => p?.primary && p?.phone) ?? phones.find((p) => p?.phone);
+  return chosen?.phone ? normalizePhone(chosen.phone) : null;
+}
+
+/** Human display name (nickname wins; falls back to first+last, then email). */
+export function displayName(c: {
+  first_name?: string | null;
+  last_name?: string | null;
+  nickname?: string | null;
+  primary_email?: string | null;
+}): string {
+  const full = [c.first_name, c.last_name].filter(Boolean).join(" ").trim();
+  return (c.nickname?.trim() || full || c.primary_email || "Unnamed").trim();
+}
+
+/** Whether a contact has at least one name character (mirrors the DB CHECK). */
+export function hasName(c: {
+  first_name?: string | null;
+  last_name?: string | null;
+  nickname?: string | null;
+}): boolean {
+  return (
+    ((c.first_name ?? "") + (c.last_name ?? "") + (c.nickname ?? "")).trim()
+      .length > 0
+  );
+}

--- a/apps/web/src/lib/contacts/queries.ts
+++ b/apps/web/src/lib/contacts/queries.ts
@@ -1,0 +1,206 @@
+/**
+ * Server-side data access for contacts. Thin functions over the Supabase
+ * client (RLS does the authorization); the HTTP routes stay declarative.
+ * Owner scoping is also applied here defensively (belt + braces with RLS).
+ */
+import {
+  contactsDb,
+  CONTACT_LIST_COLUMNS,
+  type ContactRow,
+  type ContactEmail,
+  type ContactPhone,
+  type ContactAddress,
+  type ContactSocial,
+} from "./db";
+import { primaryEmail, primaryPhone, hasName } from "./normalize";
+
+export interface ContactInput {
+  first_name?: string;
+  middle_name?: string | null;
+  last_name?: string;
+  prefix?: string | null;
+  suffix?: string | null;
+  nickname?: string | null;
+  avatar_url?: string | null;
+  contact_types?: string[];
+  tags?: string[];
+  title?: string | null;
+  firm?: string | null;
+  license_no?: string | null;
+  strength?: number;
+  source?: string | null;
+  status?: "active" | "archived";
+  do_not_contact?: boolean;
+  notes?: string | null;
+  emails?: ContactEmail[];
+  phones?: ContactPhone[];
+  addresses?: ContactAddress[];
+  socials?: ContactSocial[];
+  custom?: Record<string, unknown>;
+  user_id?: string | null;
+}
+
+const WRITABLE: (keyof ContactInput)[] = [
+  "first_name", "middle_name", "last_name", "prefix", "suffix", "nickname",
+  "avatar_url", "contact_types", "tags", "title", "firm", "license_no",
+  "strength", "source", "status", "do_not_contact", "notes", "emails",
+  "phones", "addresses", "socials", "custom", "user_id",
+];
+
+/** Strip everything except the writable fields (never trust client owner_id/id). */
+function pickWritable(input: ContactInput): Partial<ContactRow> {
+  const out: Record<string, unknown> = {};
+  for (const k of WRITABLE) {
+    if (input[k] !== undefined) out[k] = input[k];
+  }
+  return out as Partial<ContactRow>;
+}
+
+/** Recompute denormalized primary email/phone from whatever arrays are present. */
+function withDerivedKeys(
+  patch: Partial<ContactRow>,
+  input: ContactInput,
+): Partial<ContactRow> {
+  const next = { ...patch };
+  if (input.emails !== undefined) next.primary_email = primaryEmail(input.emails);
+  if (input.phones !== undefined) next.primary_phone = primaryPhone(input.phones);
+  return next;
+}
+
+export interface ListOpts {
+  q?: string;
+  type?: string;
+  tag?: string;
+  status?: "active" | "archived";
+  limit?: number;
+}
+
+export async function listContacts(
+  client: unknown,
+  ownerId: string,
+  opts: ListOpts = {},
+): Promise<Partial<ContactRow>[]> {
+  const db = contactsDb(client);
+  let query = db
+    .from("contacts")
+    .select(CONTACT_LIST_COLUMNS)
+    .eq("owner_id", ownerId)
+    .eq("status", opts.status ?? "active");
+  if (opts.type) query = query.contains("contact_types", [opts.type]);
+  if (opts.tag) query = query.contains("tags", [opts.tag]);
+  if (opts.q) {
+    // Strip chars that would break PostgREST's or()/ilike filter syntax.
+    const q = opts.q.replace(/[%,()*]/g, "").trim();
+    if (q) {
+      query = query.or(
+        [
+          `first_name.ilike.%${q}%`,
+          `last_name.ilike.%${q}%`,
+          `nickname.ilike.%${q}%`,
+          `firm.ilike.%${q}%`,
+          `primary_email.ilike.%${q}%`,
+          `primary_phone.ilike.%${q}%`,
+        ].join(","),
+      );
+    }
+  }
+  const { data, error } = await query
+    .order("updated_at", { ascending: false })
+    .limit(Math.min(opts.limit ?? 100, 500));
+  if (error) throw new Error(error.message);
+  return (data ?? []) as Partial<ContactRow>[];
+}
+
+export async function getContact(
+  client: unknown,
+  ownerId: string,
+  id: string,
+): Promise<ContactRow | null> {
+  const { data, error } = await contactsDb(client)
+    .from("contacts")
+    .select("*")
+    .eq("owner_id", ownerId)
+    .eq("id", id)
+    .maybeSingle();
+  if (error) throw new Error(error.message);
+  return (data ?? null) as ContactRow | null;
+}
+
+export interface DuplicateHit {
+  id: string;
+  first_name: string;
+  last_name: string;
+}
+
+/** Find an existing contact for this owner matching the email or phone. */
+export async function findDuplicate(
+  client: unknown,
+  ownerId: string,
+  email: string | null,
+  phone: string | null,
+): Promise<DuplicateHit | null> {
+  if (!email && !phone) return null;
+  const ors: string[] = [];
+  if (email) ors.push(`primary_email.eq.${email}`);
+  if (phone) ors.push(`primary_phone.eq.${phone}`);
+  const { data } = await contactsDb(client)
+    .from("contacts")
+    .select("id, first_name, last_name")
+    .eq("owner_id", ownerId)
+    .eq("status", "active")
+    .or(ors.join(","))
+    .limit(1);
+  return ((data ?? [])[0] ?? null) as DuplicateHit | null;
+}
+
+export async function createContact(
+  client: unknown,
+  ownerId: string,
+  input: ContactInput,
+): Promise<ContactRow> {
+  if (!hasName(input)) throw new Error("A contact needs a name");
+  const row = {
+    owner_id: ownerId,
+    ...withDerivedKeys(pickWritable(input), input),
+  };
+  const { data, error } = await contactsDb(client)
+    .from("contacts")
+    .insert(row)
+    .select("*")
+    .single();
+  if (error) throw new Error(error.message);
+  return data as ContactRow;
+}
+
+export async function updateContact(
+  client: unknown,
+  ownerId: string,
+  id: string,
+  input: ContactInput,
+): Promise<ContactRow | null> {
+  const patch = withDerivedKeys(pickWritable(input), input);
+  if (Object.keys(patch).length === 0) return getContact(client, ownerId, id);
+  const { data, error } = await contactsDb(client)
+    .from("contacts")
+    .update(patch)
+    .eq("owner_id", ownerId)
+    .eq("id", id)
+    .select("*")
+    .maybeSingle();
+  if (error) throw new Error(error.message);
+  return (data ?? null) as ContactRow | null;
+}
+
+/** Soft-archive (status='archived'); keeps history + links intact. */
+export async function archiveContact(
+  client: unknown,
+  ownerId: string,
+  id: string,
+): Promise<void> {
+  const { error } = await contactsDb(client)
+    .from("contacts")
+    .update({ status: "archived" })
+    .eq("owner_id", ownerId)
+    .eq("id", id);
+  if (error) throw new Error(error.message);
+}

--- a/apps/web/src/modules/contacts/lib/client-api.ts
+++ b/apps/web/src/modules/contacts/lib/client-api.ts
@@ -1,0 +1,92 @@
+/**
+ * Client-side typed wrappers around the contacts REST API. Browser-safe (plain
+ * fetch); unwraps `{ data }` or throws the server's first error message.
+ */
+"use client";
+
+import type { ContactRow } from "@/lib/contacts/db";
+
+async function req<T>(url: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(url, {
+    ...init,
+    headers: { "content-type": "application/json", ...(init?.headers ?? {}) },
+  });
+  if (res.status === 204) return undefined as T;
+  const json = (await res.json().catch(() => ({}))) as {
+    data?: T;
+    errors?: { code: string; message: string }[];
+  };
+  if (!res.ok) {
+    throw new Error(json.errors?.[0]?.message ?? `Request failed (${res.status})`);
+  }
+  return json.data as T;
+}
+
+const B = "/api/v1/contacts";
+
+/** The lean row a contacts list/card needs. */
+export type ContactListItem = Pick<
+  ContactRow,
+  | "id"
+  | "first_name"
+  | "last_name"
+  | "nickname"
+  | "avatar_url"
+  | "contact_types"
+  | "tags"
+  | "firm"
+  | "title"
+  | "primary_email"
+  | "primary_phone"
+  | "status"
+  | "strength"
+  | "user_id"
+  | "updated_at"
+>;
+
+export interface ContactListParams {
+  q?: string;
+  type?: string;
+  tag?: string;
+  status?: "active" | "archived";
+  limit?: number;
+}
+
+export const listContacts = (params: ContactListParams = {}) => {
+  const sp = new URLSearchParams();
+  if (params.q) sp.set("q", params.q);
+  if (params.type) sp.set("type", params.type);
+  if (params.tag) sp.set("tag", params.tag);
+  if (params.status) sp.set("status", params.status);
+  if (params.limit) sp.set("limit", String(params.limit));
+  const qs = sp.toString();
+  return req<{ contacts: ContactListItem[] }>(`${B}${qs ? `?${qs}` : ""}`).then(
+    (d) => d.contacts,
+  );
+};
+
+export const getContact = (id: string) =>
+  req<{ contact: ContactRow }>(`${B}/${encodeURIComponent(id)}`).then(
+    (d) => d.contact,
+  );
+
+export interface DuplicateHit {
+  id: string;
+  first_name: string;
+  last_name: string;
+}
+
+export const createContact = (input: Partial<ContactRow>, force = false) =>
+  req<{ contact: ContactRow | null; duplicate: DuplicateHit | null }>(
+    `${B}${force ? "?force=true" : ""}`,
+    { method: "POST", body: JSON.stringify(input) },
+  );
+
+export const updateContact = (id: string, patch: Partial<ContactRow>) =>
+  req<{ contact: ContactRow }>(`${B}/${encodeURIComponent(id)}`, {
+    method: "PATCH",
+    body: JSON.stringify(patch),
+  }).then((d) => d.contact);
+
+export const archiveContact = (id: string) =>
+  req<void>(`${B}/${encodeURIComponent(id)}`, { method: "DELETE" });


### PR DESCRIPTION
## What
The Contacts REST layer.
- `lib/contacts/normalize.ts` (pure, unit-tested) — derive denormalized primary email/phone from the arrays, display name, dedupe keys; array-guarded.
- `lib/contacts/queries.ts` — list (owner-scoped + **sanitized** search/filters), get, create (name-required, derived keys), update (**writable-field whitelist** — never trusts client `owner_id`/`id`), soft-archive, `findDuplicate`.
- Routes: `/api/v1/contacts` (GET list, POST create with **dedupe** → `{ contact, duplicate }`, `?force=true` to add anyway), `/api/v1/contacts/[id]` (GET, PATCH, DELETE=archive).
- `modules/contacts/lib/client-api.ts` — typed fetch wrappers.

## Why
Phase A.2 — the API the Contacts UI (next) and Pipeline will call.

## Test
- `normalize.test.ts` — primary email/phone selection, normalization, display name, name-required. 6 tests green; tsc + eslint clean. (Auth/RLS enforced at the DB + route auth gate.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)