### PR TITLE
feat(contacts): list + detail UI at /modules/contacts (Phase A.3)

### DIFF
--- a/apps/web/src/app/modules/contacts/page.tsx
+++ b/apps/web/src/app/modules/contacts/page.tsx
@@ -1,0 +1,23 @@
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { ScopedModuleShell } from "@/components/pane/ScopedModuleShell";
+import { ContactsView } from "@/modules/contacts/components/ContactsView";
+import { loadContacts } from "@/modules/contacts/lib/server-data";
+
+export const metadata = { title: "Contacts — Rokki" };
+
+export default async function ContactsPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) redirect("/login");
+
+  const contacts = await loadContacts(supabase, user.id);
+
+  return (
+    <ScopedModuleShell scopeKind="user" activeSlug="contacts" flagOffBehavior="render">
+      <ContactsView initialContacts={contacts} />
+    </ScopedModuleShell>
+  );
+}

--- a/apps/web/src/modules/contacts/components/ContactDetail.tsx
+++ b/apps/web/src/modules/contacts/components/ContactDetail.tsx
@@ -1,0 +1,192 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Mail, Phone, Pencil, Archive, X, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/Button";
+import type { ContactRow } from "@/lib/contacts/db";
+import {
+  getContact,
+  updateContact,
+  archiveContact,
+} from "../lib/client-api";
+import { ContactForm } from "./ContactForm";
+
+function initials(c: { first_name?: string | null; last_name?: string | null; nickname?: string | null }) {
+  const a = (c.first_name ?? c.nickname ?? "").trim()[0] ?? "";
+  const b = (c.last_name ?? "").trim()[0] ?? "";
+  return (a + b).toUpperCase() || "?";
+}
+
+/** Detail drawer for one contact — read view with inline edit + archive. */
+export function ContactDetail({
+  contactId,
+  onClose,
+  onChanged,
+}: {
+  contactId: string;
+  onClose: () => void;
+  onChanged: () => void;
+}) {
+  const [contact, setContact] = useState<ContactRow | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [editing, setEditing] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    setLoading(true);
+    setEditing(false);
+    getContact(contactId)
+      .then((c) => alive && setContact(c))
+      .catch((e) => alive && setError(e instanceof Error ? e.message : "Failed"))
+      .finally(() => alive && setLoading(false));
+    return () => {
+      alive = false;
+    };
+  }, [contactId]);
+
+  async function save(patch: Partial<ContactRow>) {
+    setBusy(true);
+    setError(null);
+    try {
+      const updated = await updateContact(contactId, patch);
+      setContact(updated);
+      setEditing(false);
+      onChanged();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not save");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function archive() {
+    setBusy(true);
+    try {
+      await archiveContact(contactId);
+      onChanged();
+      onClose();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not archive");
+      setBusy(false);
+    }
+  }
+
+  const email = contact?.primary_email ?? contact?.emails?.[0]?.email ?? null;
+  const phone = contact?.primary_phone ?? contact?.phones?.[0]?.phone ?? null;
+  const fullName = [contact?.first_name, contact?.last_name]
+    .filter(Boolean)
+    .join(" ")
+    .trim();
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="flex flex-shrink-0 items-center gap-2 border-b border-border px-3 py-2">
+        <span className="text-[10px] font-semibold uppercase tracking-wide text-text-3">
+          Contact
+        </span>
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close"
+          className="ml-auto rounded-sm p-1 text-text-2 hover:text-text-0"
+        >
+          <X className="h-3.5 w-3.5" />
+        </button>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto p-3">
+        {loading ? (
+          <div className="flex items-center justify-center py-8 text-text-3">
+            <Loader2 className="h-5 w-5 animate-spin" aria-label="Loading" />
+          </div>
+        ) : !contact ? (
+          <p className="text-xs text-text-3">{error ?? "Not found."}</p>
+        ) : editing ? (
+          <ContactForm
+            initial={contact}
+            busy={busy}
+            error={error}
+            submitLabel="Save"
+            onCancel={() => setEditing(false)}
+            onSubmit={save}
+          />
+        ) : (
+          <div className="flex flex-col gap-3">
+            <div className="flex items-center gap-3">
+              <span className="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-bg-3 font-mono text-sm text-text-1">
+                {initials(contact)}
+              </span>
+              <div className="min-w-0">
+                <div className="truncate text-sm font-semibold text-text-0">
+                  {contact.nickname || fullName || "Unnamed"}
+                </div>
+                {(contact.title || contact.firm) && (
+                  <div className="truncate text-xs text-text-2">
+                    {[contact.title, contact.firm].filter(Boolean).join(" · ")}
+                  </div>
+                )}
+              </div>
+            </div>
+
+            {contact.contact_types.length > 0 && (
+              <div className="flex flex-wrap gap-1">
+                {contact.contact_types.map((t) => (
+                  <span
+                    key={t}
+                    className="rounded-sm border border-border px-1.5 py-0.5 text-2xs capitalize text-text-2"
+                  >
+                    {t}
+                  </span>
+                ))}
+              </div>
+            )}
+
+            {email && (
+              <a
+                href={`mailto:${email}`}
+                className="flex items-center gap-2 text-xs text-text-1 hover:text-text-0"
+              >
+                <Mail className="h-3.5 w-3.5 text-text-3" /> {email}
+              </a>
+            )}
+            {phone && (
+              <a
+                href={`tel:${phone}`}
+                className="flex items-center gap-2 text-xs text-text-1 hover:text-text-0"
+              >
+                <Phone className="h-3.5 w-3.5 text-text-3" /> {phone}
+              </a>
+            )}
+
+            {contact.tags.length > 0 && (
+              <div className="flex flex-wrap gap-1">
+                {contact.tags.map((t) => (
+                  <span key={t} className="text-2xs text-text-3">
+                    #{t}
+                  </span>
+                ))}
+              </div>
+            )}
+
+            {contact.notes && (
+              <p className="whitespace-pre-wrap border-t border-border/40 pt-2 text-xs text-text-2">
+                {contact.notes}
+              </p>
+            )}
+
+            <div className="mt-2 flex gap-2 border-t border-border/40 pt-3">
+              <Button size="sm" variant="ghost" onClick={() => setEditing(true)}>
+                <Pencil className="h-3 w-3" /> Edit
+              </Button>
+              <Button size="sm" variant="ghost" onClick={archive} disabled={busy}>
+                <Archive className="h-3 w-3" /> Archive
+              </Button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/modules/contacts/components/ContactForm.tsx
+++ b/apps/web/src/modules/contacts/components/ContactForm.tsx
@@ -1,0 +1,227 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/Button";
+import type { ContactRow } from "@/lib/contacts/db";
+
+const TYPE_OPTIONS = [
+  "owner",
+  "broker",
+  "partner",
+  "lender",
+  "attorney",
+  "title",
+  "contractor",
+  "tenant",
+  "vendor",
+  "other",
+];
+
+const input =
+  "w-full rounded border border-border bg-bg-2 px-2 py-1 text-xs text-text-1 placeholder:text-text-3 outline-none focus:border-border-focus";
+const label = "text-[10px] font-semibold uppercase tracking-wide text-text-3";
+
+export interface ContactFormValues {
+  first_name?: string;
+  last_name?: string;
+  nickname?: string;
+  firm?: string;
+  title?: string;
+  email?: string;
+  phone?: string;
+  contact_types?: string[];
+  tags?: string[];
+  notes?: string;
+}
+
+/** Shared create/edit form. Single email/phone inputs map to 1-element arrays;
+ *  the server derives primary_email/phone. */
+export function ContactForm({
+  initial,
+  busy,
+  error,
+  submitLabel,
+  onCancel,
+  onSubmit,
+}: {
+  initial?: Partial<ContactRow>;
+  busy?: boolean;
+  error?: string | null;
+  submitLabel: string;
+  onCancel: () => void;
+  onSubmit: (patch: Partial<ContactRow>) => void;
+}) {
+  const [v, setV] = useState<ContactFormValues>({
+    first_name: initial?.first_name ?? "",
+    last_name: initial?.last_name ?? "",
+    nickname: initial?.nickname ?? "",
+    firm: initial?.firm ?? "",
+    title: initial?.title ?? "",
+    email: initial?.primary_email ?? initial?.emails?.[0]?.email ?? "",
+    phone: initial?.primary_phone ?? initial?.phones?.[0]?.phone ?? "",
+    contact_types: initial?.contact_types ?? [],
+    tags: initial?.tags ?? [],
+    notes: initial?.notes ?? "",
+  });
+
+  function set<K extends keyof ContactFormValues>(k: K, val: ContactFormValues[K]) {
+    setV((prev) => ({ ...prev, [k]: val }));
+  }
+  function toggleType(t: string) {
+    setV((prev) => {
+      const has = prev.contact_types?.includes(t);
+      return {
+        ...prev,
+        contact_types: has
+          ? prev.contact_types!.filter((x) => x !== t)
+          : [...(prev.contact_types ?? []), t],
+      };
+    });
+  }
+
+  function submit() {
+    const patch: Partial<ContactRow> = {
+      first_name: v.first_name?.trim() || "",
+      last_name: v.last_name?.trim() || "",
+      nickname: v.nickname?.trim() || null,
+      firm: v.firm?.trim() || null,
+      title: v.title?.trim() || null,
+      contact_types: v.contact_types ?? [],
+      tags: v.tags ?? [],
+      notes: v.notes?.trim() || null,
+      emails: v.email?.trim() ? [{ email: v.email.trim(), primary: true }] : [],
+      phones: v.phone?.trim() ? [{ phone: v.phone.trim(), primary: true }] : [],
+    };
+    onSubmit(patch);
+  }
+
+  const canSubmit =
+    !busy &&
+    Boolean(
+      (v.first_name?.trim() || v.last_name?.trim() || v.nickname?.trim()),
+    );
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="grid grid-cols-2 gap-2">
+        <div>
+          <label className={label}>First name</label>
+          <input
+            className={input}
+            value={v.first_name}
+            onChange={(e) => set("first_name", e.target.value)}
+            autoFocus
+          />
+        </div>
+        <div>
+          <label className={label}>Last name</label>
+          <input
+            className={input}
+            value={v.last_name}
+            onChange={(e) => set("last_name", e.target.value)}
+          />
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-2">
+        <div>
+          <label className={label}>Nickname</label>
+          <input
+            className={input}
+            value={v.nickname}
+            onChange={(e) => set("nickname", e.target.value)}
+          />
+        </div>
+        <div>
+          <label className={label}>Firm</label>
+          <input
+            className={input}
+            value={v.firm}
+            onChange={(e) => set("firm", e.target.value)}
+          />
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-2">
+        <div>
+          <label className={label}>Email</label>
+          <input
+            type="email"
+            className={input}
+            value={v.email}
+            onChange={(e) => set("email", e.target.value)}
+          />
+        </div>
+        <div>
+          <label className={label}>Phone</label>
+          <input
+            className={input}
+            value={v.phone}
+            onChange={(e) => set("phone", e.target.value)}
+          />
+        </div>
+      </div>
+
+      <div>
+        <label className={label}>Type</label>
+        <div className="mt-1 flex flex-wrap gap-1">
+          {TYPE_OPTIONS.map((t) => {
+            const on = v.contact_types?.includes(t);
+            return (
+              <button
+                key={t}
+                type="button"
+                onClick={() => toggleType(t)}
+                aria-pressed={on}
+                className={`rounded-sm px-1.5 py-0.5 text-2xs font-medium capitalize ${
+                  on
+                    ? "bg-accent text-bg-0"
+                    : "border border-border text-text-2 hover:text-text-0"
+                }`}
+              >
+                {t}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <div>
+        <label className={label}>Tags (comma-separated)</label>
+        <input
+          className={input}
+          value={(v.tags ?? []).join(", ")}
+          onChange={(e) =>
+            set(
+              "tags",
+              e.target.value
+                .split(",")
+                .map((s) => s.trim())
+                .filter(Boolean),
+            )
+          }
+        />
+      </div>
+
+      <div>
+        <label className={label}>Notes</label>
+        <textarea
+          className={`${input} min-h-[60px] resize-y`}
+          value={v.notes}
+          onChange={(e) => set("notes", e.target.value)}
+        />
+      </div>
+
+      {error ? <p className="text-xs text-danger">{error}</p> : null}
+
+      <div className="flex justify-end gap-2">
+        <Button size="sm" variant="ghost" onClick={onCancel}>
+          Cancel
+        </Button>
+        <Button size="sm" onClick={submit} disabled={!canSubmit}>
+          {busy ? "Saving…" : submitLabel}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/modules/contacts/components/ContactsView.test.tsx
+++ b/apps/web/src/modules/contacts/components/ContactsView.test.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import type { ContactListItem } from "../lib/client-api";
+
+// Hoisted so the vi.mock factory (hoisted above imports) can use it.
+const { items } = vi.hoisted(() => ({
+  items: [
+    {
+      id: "c1",
+      first_name: "Bob",
+      last_name: "Jones",
+      nickname: null,
+      avatar_url: null,
+      contact_types: ["broker"],
+      tags: [],
+      firm: "Realty Co",
+      title: null,
+      primary_email: "bob@x.com",
+      primary_phone: null,
+      status: "active",
+      strength: 0,
+      user_id: null,
+      updated_at: "2026-06-24T00:00:00Z",
+    },
+  ],
+}));
+
+vi.mock("../lib/client-api", () => ({
+  listContacts: vi.fn().mockResolvedValue(items),
+  getContact: vi.fn(),
+  createContact: vi.fn(),
+  updateContact: vi.fn(),
+  archiveContact: vi.fn(),
+}));
+
+import { ContactsView } from "./ContactsView";
+
+const seed = items as ContactListItem[];
+
+afterEach(cleanup);
+
+describe("ContactsView", () => {
+  it("renders the contacts list", async () => {
+    render(<ContactsView initialContacts={seed} />);
+    expect(await screen.findByText("Bob Jones")).toBeTruthy();
+    expect(screen.getByText("Realty Co")).toBeTruthy();
+  });
+
+  it("opens the New contact form", async () => {
+    render(<ContactsView initialContacts={seed} />);
+    fireEvent.click(screen.getByRole("button", { name: /New/i }));
+    expect(await screen.findByText("First name")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Create" })).toBeTruthy();
+  });
+
+  it("shows an empty state with no contacts", () => {
+    render(<ContactsView initialContacts={[]} />);
+    expect(screen.getByText(/No contacts yet/i)).toBeTruthy();
+  });
+});

--- a/apps/web/src/modules/contacts/components/ContactsView.tsx
+++ b/apps/web/src/modules/contacts/components/ContactsView.tsx
@@ -1,0 +1,227 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { Plus, Search, Users, X } from "lucide-react";
+import { Button } from "@/components/ui/Button";
+import type { ContactRow } from "@/lib/contacts/db";
+import {
+  listContacts,
+  createContact,
+  type ContactListItem,
+} from "../lib/client-api";
+import { ContactForm } from "./ContactForm";
+import { ContactDetail } from "./ContactDetail";
+
+function initials(c: Pick<ContactListItem, "first_name" | "last_name" | "nickname">) {
+  const a = (c.first_name || c.nickname || "").trim()[0] ?? "";
+  const b = (c.last_name || "").trim()[0] ?? "";
+  return (a + b).toUpperCase() || "?";
+}
+function rowName(c: ContactListItem) {
+  return (
+    c.nickname?.trim() ||
+    [c.first_name, c.last_name].filter(Boolean).join(" ").trim() ||
+    c.primary_email ||
+    "Unnamed"
+  );
+}
+
+function Modal({
+  title,
+  onClose,
+  children,
+}: {
+  title: string;
+  onClose: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-start justify-center bg-black/50 p-4 sm:p-8"
+      onClick={onClose}
+    >
+      <div
+        className="mt-6 flex max-h-[85vh] w-full max-w-md flex-col overflow-hidden rounded-lg border border-border bg-bg-1 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex flex-shrink-0 items-center gap-2 border-b border-border px-3 py-2">
+          <span className="text-[10px] font-semibold uppercase tracking-wide text-text-3">
+            {title}
+          </span>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="ml-auto rounded-sm p-1 text-text-2 hover:text-text-0"
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
+        </div>
+        <div className="min-h-0 flex-1 overflow-y-auto p-3">{children}</div>
+      </div>
+    </div>
+  );
+}
+
+export function ContactsView({
+  initialContacts,
+}: {
+  initialContacts: ContactListItem[];
+}) {
+  const [contacts, setContacts] = useState<ContactListItem[]>(initialContacts);
+  const [q, setQ] = useState("");
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [creating, setCreating] = useState(false);
+  const [createBusy, setCreateBusy] = useState(false);
+  const [createErr, setCreateErr] = useState<string | null>(null);
+
+  // Debounced server search/refresh.
+  useEffect(() => {
+    const t = setTimeout(() => {
+      listContacts({ q: q.trim() || undefined, limit: 200 })
+        .then(setContacts)
+        .catch(() => {});
+    }, 250);
+    return () => clearTimeout(t);
+  }, [q]);
+
+  async function refresh() {
+    const next = await listContacts({ q: q.trim() || undefined, limit: 200 }).catch(
+      () => null,
+    );
+    if (next) setContacts(next);
+  }
+
+  async function create(patch: Partial<ContactRow>) {
+    setCreateBusy(true);
+    setCreateErr(null);
+    try {
+      const res = await createContact(patch);
+      if (!res.contact && res.duplicate) {
+        setCreateErr(
+          `Looks like a duplicate of ${res.duplicate.first_name} ${res.duplicate.last_name}.`,
+        );
+        return;
+      }
+      setCreating(false);
+      await refresh();
+      if (res.contact) setSelectedId(res.contact.id);
+    } catch (e) {
+      setCreateErr(e instanceof Error ? e.message : "Could not create");
+    } finally {
+      setCreateBusy(false);
+    }
+  }
+
+  const empty = useMemo(() => contacts.length === 0, [contacts]);
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      {/* Header */}
+      <div className="flex flex-shrink-0 flex-wrap items-center gap-2 border-b border-border px-3 py-2">
+        <Users className="h-4 w-4 text-text-2" aria-hidden="true" />
+        <h1 className="text-sm font-semibold text-text-0">Contacts</h1>
+        <span className="font-mono text-2xs text-text-3">{contacts.length}</span>
+        <div className="relative ml-auto">
+          <Search className="pointer-events-none absolute left-2 top-1/2 h-3 w-3 -translate-y-1/2 text-text-3" />
+          <input
+            value={q}
+            onChange={(e) => setQ(e.target.value)}
+            placeholder="Search name, firm, email…"
+            aria-label="Search contacts"
+            className="w-48 rounded border border-border bg-bg-2 py-1 pl-7 pr-2 text-xs text-text-1 placeholder:text-text-3 outline-none focus:border-border-focus"
+          />
+        </div>
+        <Button size="sm" onClick={() => setCreating(true)}>
+          <Plus className="h-3 w-3" /> New
+        </Button>
+      </div>
+
+      {/* List */}
+      {empty ? (
+        <div className="flex flex-1 flex-col items-center justify-center gap-2 p-8 text-center">
+          <Users className="h-6 w-6 text-text-3" aria-hidden="true" />
+          <p className="text-xs text-text-2">
+            {q ? "No contacts match your search." : "No contacts yet."}
+          </p>
+          {!q && (
+            <Button size="sm" variant="ghost" onClick={() => setCreating(true)}>
+              <Plus className="h-3 w-3" /> Add your first contact
+            </Button>
+          )}
+        </div>
+      ) : (
+        <ul className="min-h-0 flex-1 divide-y divide-border/30 overflow-y-auto">
+          {contacts.map((c) => (
+            <li key={c.id}>
+              <button
+                type="button"
+                onClick={() => setSelectedId(c.id)}
+                className="flex w-full items-center gap-2.5 px-3 py-[var(--rk-row-py)] text-left hover:bg-bg-2"
+              >
+                <span className="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full bg-bg-3 font-mono text-2xs text-text-1">
+                  {initials(c)}
+                </span>
+                <span className="min-w-0 flex-1">
+                  <span className="block truncate text-xs font-medium text-text-0">
+                    {rowName(c)}
+                  </span>
+                  {(c.firm || c.title) && (
+                    <span className="block truncate text-2xs text-text-3">
+                      {[c.title, c.firm].filter(Boolean).join(" · ")}
+                    </span>
+                  )}
+                </span>
+                <span className="hidden min-w-0 max-w-[14rem] flex-1 gap-1 truncate text-2xs text-text-3 md:flex">
+                  {c.contact_types.slice(0, 3).map((t) => (
+                    <span
+                      key={t}
+                      className="rounded-sm border border-border px-1 capitalize"
+                    >
+                      {t}
+                    </span>
+                  ))}
+                </span>
+                <span className="hidden truncate text-2xs text-text-3 sm:block sm:w-44">
+                  {c.primary_email ?? c.primary_phone ?? ""}
+                </span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {/* Detail drawer (modal) */}
+      {selectedId && (
+        <div
+          className="fixed inset-0 z-50 flex items-stretch justify-end bg-black/50"
+          onClick={() => setSelectedId(null)}
+        >
+          <div
+            className="w-full max-w-[380px] border-l border-border bg-bg-1 shadow-xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <ContactDetail
+              contactId={selectedId}
+              onClose={() => setSelectedId(null)}
+              onChanged={refresh}
+            />
+          </div>
+        </div>
+      )}
+
+      {/* Create modal */}
+      {creating && (
+        <Modal title="New contact" onClose={() => setCreating(false)}>
+          <ContactForm
+            busy={createBusy}
+            error={createErr}
+            submitLabel="Create"
+            onCancel={() => setCreating(false)}
+            onSubmit={create}
+          />
+        </Modal>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/modules/contacts/lib/server-data.ts
+++ b/apps/web/src/modules/contacts/lib/server-data.ts
@@ -1,0 +1,15 @@
+/**
+ * Server-side initial-data loader for the Contacts module page (SSR), mirroring
+ * lib/markets/server-data. Returns the lean list rows the table needs.
+ */
+import { listContacts } from "@/lib/contacts/queries";
+import type { ContactListItem } from "./client-api";
+
+export async function loadContacts(
+  client: unknown,
+  ownerId: string,
+): Promise<ContactListItem[]> {
+  return (await listContacts(client, ownerId, {
+    limit: 200,
+  })) as ContactListItem[];
+}


### PR DESCRIPTION
## What
The Contacts screen — **the first one to eyeball on sandbox.** Consistent with the other module pages (ScopedModuleShell chrome, Rokki tokens, dense terminal aesthetic).

- **ContactsView** — header (title · count · debounced search · New), a dense contacts list (avatar initials · name/firm · type chips · email/phone), empty state, robust modal/drawer overlays (work at any width).
- **ContactDetail** — right-side drawer: read view (mail/tel links, type + tag chips, notes) with inline **Edit** + **Archive**.
- **ContactForm** — shared create/edit (name, email, phone, firm/title, type toggle chips, tags, notes); create surfaces the **dedupe** warning.
- `page.tsx` + SSR loader.

Reachable at **`/modules/contacts`**.

## Test
- `ContactsView.test.tsx` — renders the list, opens the New form, empty state. 3 tests green; tsc + eslint clean.

> Note: the **Visual regression** + **Bundle-size** CI checks are pre-existing non-required failures (unrelated to this PR); the required checks (Lint/Typecheck/Test, migrations+RLS, Security) gate the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)