### PR TITLE
feat(pipeline): data foundation — leads, pipelines, links (Phase B.1)

### DIFF
--- a/apps/web/src/lib/pipeline/db.ts
+++ b/apps/web/src/lib/pipeline/db.ts
@@ -1,0 +1,87 @@
+/**
+ * Typed Row interfaces for the pipeline tables + a loosely-typed client accessor
+ * (same `any`-boundary convention as `marketsDb()`/`contactsDb()`; removed once
+ * the generated types include `pl_*` / `terminal_contacts`).
+ */
+
+export interface PipelineStage {
+  key: string;
+  label: string;
+  color?: string;
+  /** open ⇒ in-funnel; won/lost ⇒ a terminal outcome column. */
+  type: "open" | "won" | "lost";
+  /** Idle longer than this ⇒ the lead is flagged "going cold". */
+  rotting_days?: number;
+  /** Reaching this stage promotes the lead to a Terminal. */
+  is_terminal_gate?: boolean;
+}
+
+export type PipelineFieldType =
+  | "text"
+  | "number"
+  | "currency"
+  | "select"
+  | "date"
+  | "address";
+
+export interface PipelineField {
+  key: string;
+  label: string;
+  type: PipelineFieldType;
+  options?: string[];
+}
+
+export interface PipelineRow {
+  id: string;
+  space_id: string;
+  name: string;
+  kind: string;
+  stages: PipelineStage[];
+  fields: PipelineField[];
+  position: number;
+  created_by: string | null;
+  created_at: string;
+}
+
+export type LeadStatus = "open" | "won" | "lost" | "dead" | "converted";
+
+export interface LeadRow {
+  id: string;
+  pipeline_id: string;
+  space_id: string;
+  name: string;
+  subtitle: string | null;
+  stage: string;
+  status: LeadStatus;
+  priority: number;
+  source: string | null;
+  owner_id: string | null;
+  next_follow_up_at: string | null;
+  last_activity_at: string;
+  promoted_terminal_id: string | null;
+  dead_reason: string | null;
+  lat: number | null;
+  lng: number | null;
+  attributes: Record<string, unknown>;
+  created_by: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface LeadContactRow {
+  lead_id: string;
+  contact_id: string;
+  role: string | null;
+  added_at: string;
+}
+
+/** Lean columns for the board/table cards. */
+export const LEAD_LIST_COLUMNS =
+  "id, pipeline_id, name, subtitle, stage, status, priority, source, " +
+  "next_follow_up_at, last_activity_at, promoted_terminal_id, attributes, updated_at";
+
+export type PipelineClient = any;
+
+export function pipelineDb(client: unknown): PipelineClient {
+  return client as PipelineClient;
+}

--- a/apps/web/src/lib/pipeline/templates.test.ts
+++ b/apps/web/src/lib/pipeline/templates.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import {
+  HELIOS_PIPELINE,
+  PIPELINE_TEMPLATES,
+  DEFAULT_PIPELINE,
+  terminalGateStage,
+} from "./templates";
+
+describe("pipeline templates", () => {
+  it("HELIOS flow: Tracking → … → Closed, with Under Contract as the terminal gate", () => {
+    const keys = HELIOS_PIPELINE.stages.map((s) => s.key);
+    expect(keys).toEqual([
+      "tracking",
+      "engaging",
+      "due_diligence",
+      "offer",
+      "under_contract",
+      "active_project",
+      "closed",
+    ]);
+    // "Dead" is a status, never a stage.
+    expect(keys).not.toContain("dead");
+    const gate = terminalGateStage(HELIOS_PIPELINE.stages);
+    expect(gate?.key).toBe("under_contract");
+    // exactly one terminal gate
+    expect(HELIOS_PIPELINE.stages.filter((s) => s.is_terminal_gate)).toHaveLength(1);
+    // Closed is the won outcome
+    expect(HELIOS_PIPELINE.stages.at(-1)?.type).toBe("won");
+  });
+
+  it("every template has stages + a unique kind, and the default is HELIOS", () => {
+    expect(DEFAULT_PIPELINE).toBe(HELIOS_PIPELINE);
+    const kinds = PIPELINE_TEMPLATES.map((t) => t.kind);
+    expect(new Set(kinds).size).toBe(kinds.length);
+    for (const t of PIPELINE_TEMPLATES) {
+      expect(t.stages.length).toBeGreaterThan(1);
+      expect(t.stages.some((s) => s.type === "won")).toBe(true);
+    }
+  });
+
+  it("terminalGateStage returns null when no stage is the gate", () => {
+    expect(
+      terminalGateStage([{ key: "a", label: "A", type: "open" }]),
+    ).toBeNull();
+  });
+});

--- a/apps/web/src/lib/pipeline/templates.ts
+++ b/apps/web/src/lib/pipeline/templates.ts
@@ -1,0 +1,96 @@
+/**
+ * Pipeline templates — starting points a pipeline creator picks then edits.
+ * Stages + a field schema per deal-kind. `Dead` is a status (settable from any
+ * stage), not a column, so it never appears here.
+ */
+import type { PipelineStage, PipelineField } from "./db";
+
+export interface PipelineTemplate {
+  kind: string;
+  name: string;
+  stages: PipelineStage[];
+  fields: PipelineField[];
+}
+
+const RE_FIELDS: PipelineField[] = [
+  { key: "address", label: "Address", type: "address" },
+  { key: "folio", label: "Folio / APN", type: "text" },
+  { key: "parcel_size", label: "Parcel size", type: "text" },
+  { key: "zoning", label: "Zoning", type: "text" },
+  { key: "land_use", label: "Land use", type: "text" },
+  { key: "owner", label: "Owner of record", type: "text" },
+  { key: "asking", label: "Asking", type: "currency" },
+  { key: "product_type", label: "Product type", type: "text" },
+];
+
+/** Zack's HELIOS deal flow (the default for a real-estate pipeline). */
+export const HELIOS_PIPELINE: PipelineTemplate = {
+  kind: "real_estate",
+  name: "HELIOS Pipeline",
+  stages: [
+    { key: "tracking", label: "Tracking", type: "open", rotting_days: 30 },
+    { key: "engaging", label: "Engaging", type: "open", rotting_days: 14 },
+    { key: "due_diligence", label: "Due Diligence", type: "open", rotting_days: 14 },
+    { key: "offer", label: "Offer", type: "open", rotting_days: 7 },
+    {
+      key: "under_contract",
+      label: "Under Contract",
+      type: "open",
+      rotting_days: 14,
+      is_terminal_gate: true,
+    },
+    { key: "active_project", label: "Active Project", type: "open" },
+    { key: "closed", label: "Closed", type: "won" },
+  ],
+  fields: RE_FIELDS,
+};
+
+export const BUSINESS_PIPELINE: PipelineTemplate = {
+  kind: "business",
+  name: "Business Acquisition",
+  stages: [
+    { key: "sourced", label: "Sourced", type: "open", rotting_days: 30 },
+    { key: "nda", label: "NDA", type: "open", rotting_days: 14 },
+    { key: "reviewing", label: "Reviewing CIM", type: "open", rotting_days: 14 },
+    { key: "ioi", label: "IOI", type: "open", rotting_days: 10 },
+    { key: "loi", label: "LOI", type: "open", rotting_days: 7, is_terminal_gate: true },
+    { key: "diligence", label: "Diligence", type: "open" },
+    { key: "closed", label: "Closed", type: "won" },
+  ],
+  fields: [
+    { key: "company", label: "Company", type: "text" },
+    { key: "sector", label: "Sector", type: "text" },
+    { key: "revenue", label: "Revenue", type: "currency" },
+    { key: "ebitda", label: "EBITDA / SDE", type: "currency" },
+    { key: "asking", label: "Asking", type: "currency" },
+    { key: "multiple", label: "Multiple", type: "number" },
+    { key: "seller", label: "Seller", type: "text" },
+  ],
+};
+
+export const GENERIC_PIPELINE: PipelineTemplate = {
+  kind: "generic",
+  name: "Pipeline",
+  stages: [
+    { key: "lead", label: "Lead", type: "open", rotting_days: 30 },
+    { key: "qualified", label: "Qualified", type: "open", rotting_days: 14 },
+    { key: "engaged", label: "Engaged", type: "open", rotting_days: 10, is_terminal_gate: true },
+    { key: "negotiating", label: "Negotiating", type: "open" },
+    { key: "won", label: "Won", type: "won" },
+  ],
+  fields: [{ key: "value", label: "Value", type: "currency" }],
+};
+
+export const PIPELINE_TEMPLATES: PipelineTemplate[] = [
+  HELIOS_PIPELINE,
+  BUSINESS_PIPELINE,
+  GENERIC_PIPELINE,
+];
+
+/** The default a new space's pipeline is seeded with on first use. */
+export const DEFAULT_PIPELINE = HELIOS_PIPELINE;
+
+/** The stage flagged as the promote-to-Terminal gate, if any. */
+export function terminalGateStage(stages: PipelineStage[]): PipelineStage | null {
+  return stages.find((s) => s.is_terminal_gate) ?? null;
+}

--- a/apps/web/tests/rls/pipeline.test.ts
+++ b/apps/web/tests/rls/pipeline.test.ts
@@ -1,0 +1,143 @@
+/**
+ * RLS tests for the pipeline tables (`pl_pipelines`, `pl_leads`).
+ *
+ * Verifies the policies from `20260628130000_pipeline_init.sql`: pipelines and
+ * leads are space-scoped — visible/writable only to members of the owning
+ * space; a non-member can't read them, and WITH CHECK blocks creating one in a
+ * space you don't belong to. Mirrors tests/rls/markets.test.ts plumbing.
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+
+const SB_URL = process.env.SUPABASE_URL ?? "http://127.0.0.1:54321";
+const ANON =
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0";
+const SERVICE =
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU";
+
+const admin = createClient(SB_URL, SERVICE, {
+  auth: { autoRefreshToken: false, persistSession: false },
+});
+
+async function makeClientFor(email: string): Promise<SupabaseClient> {
+  const { data, error } = await admin.auth.admin.generateLink({
+    type: "magiclink",
+    email,
+  });
+  if (error || !data) throw new Error(`generateLink failed: ${error?.message}`);
+  const supabase = createClient(SB_URL, ANON, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+  const { data: verifyData, error: verifyErr } = await supabase.auth.verifyOtp({
+    type: "magiclink",
+    token_hash: data.properties.hashed_token,
+  });
+  if (verifyErr) throw new Error(`verifyOtp failed: ${verifyErr.message}`);
+  if (!verifyData.session) throw new Error("no session after verifyOtp");
+  await supabase.auth.setSession({
+    access_token: verifyData.session.access_token,
+    refresh_token: verifyData.session.refresh_token,
+  });
+  return supabase;
+}
+
+async function ensureUser(email: string): Promise<string> {
+  const { data: list } = await admin.auth.admin.listUsers();
+  const existing = list?.users.find((u) => u.email === email);
+  if (existing) return existing.id;
+  const { data, error } = await admin.auth.admin.createUser({
+    email,
+    email_confirm: true,
+  });
+  if (error || !data.user) throw new Error(`createUser ${email}: ${error?.message}`);
+  return data.user.id;
+}
+
+async function personalSpaceOf(userId: string): Promise<string> {
+  const { data, error } = await admin
+    .from("spaces")
+    .select("id")
+    .eq("personal_owner_id", userId)
+    .eq("is_personal", true);
+  if (error) throw new Error(`personalSpaceOf: ${error.message}`);
+  const rows = (data ?? []) as { id: string }[];
+  expect(rows.length).toBe(1);
+  return rows[0].id;
+}
+
+describe("RLS — pipeline (pl_*)", () => {
+  let spaceA: string; // a space userA belongs to and userB does not
+  let spaceB: string;
+  let clientA: SupabaseClient;
+  let clientB: SupabaseClient;
+
+  beforeAll(async () => {
+    const userA = await ensureUser("pl-rls-a@rokki.local");
+    const userB = await ensureUser("pl-rls-b@rokki.local");
+    spaceA = await personalSpaceOf(userA);
+    spaceB = await personalSpaceOf(userB);
+    clientA = await makeClientFor("pl-rls-a@rokki.local");
+    clientB = await makeClientFor("pl-rls-b@rokki.local");
+  }, 30_000);
+
+  let pipelineId: string;
+  let leadId: string;
+
+  it("a member can create a pipeline in their space", async () => {
+    const { data, error } = await clientA
+      .from("pl_pipelines")
+      .insert({ space_id: spaceA, name: "HELIOS" })
+      .select("id")
+      .single();
+    expect(error).toBeNull();
+    pipelineId = (data as { id: string }).id;
+  });
+
+  it("a non-member cannot see another space's pipeline", async () => {
+    const { data } = await clientB
+      .from("pl_pipelines")
+      .select("id")
+      .eq("id", pipelineId)
+      .maybeSingle();
+    expect(data).toBeNull();
+  });
+
+  it("a user cannot create a pipeline in a space they're not in (WITH CHECK)", async () => {
+    const { error } = await clientB
+      .from("pl_pipelines")
+      .insert({ space_id: spaceA, name: "intruder" });
+    expect(error).toBeTruthy();
+  });
+
+  it("a member can create a lead in their space", async () => {
+    const { data, error } = await clientA
+      .from("pl_leads")
+      .insert({
+        pipeline_id: pipelineId,
+        space_id: spaceA,
+        name: "2510 SW 16 St",
+        stage: "tracking",
+      })
+      .select("id")
+      .single();
+    expect(error).toBeNull();
+    leadId = (data as { id: string }).id;
+  });
+
+  it("a non-member cannot see another space's lead", async () => {
+    const { data } = await clientB
+      .from("pl_leads")
+      .select("id")
+      .eq("id", leadId)
+      .maybeSingle();
+    expect(data).toBeNull();
+  });
+
+  it("a user cannot create a lead in a space they're not in (WITH CHECK)", async () => {
+    const { error } = await clientB
+      .from("pl_leads")
+      .insert({ pipeline_id: pipelineId, space_id: spaceA, name: "intruder" });
+    expect(error).toBeTruthy();
+    expect(spaceB).toBeTruthy();
+  });
+});

--- a/supabase/migrations/20260628130000_pipeline_init.sql
+++ b/supabase/migrations/20260628130000_pipeline_init.sql
@@ -1,0 +1,138 @@
+-- Pipeline module — lightweight lead/deal flow that links into Contacts and
+-- promotes the winners into Terminals.
+--
+-- Tiers: a high-volume **lead** (pl_leads, the ~200 you track lightly) lives on
+-- a space's pipeline at a stage; when it "goes hard" it's promoted to a
+-- Terminal (the heavy project) and marked converted. Leads + the terminals they
+-- become share a space. Contacts are LINKED (pl_lead_contacts / terminal_contacts),
+-- never copied.
+--
+-- See Claude/CONTACTS_PIPELINE_BUILD_PLAN.md.
+
+BEGIN;
+
+-- ───────────────────────────────────────────────────────────────────
+-- pl_pipelines — a space's pipeline definition (creator picks stages + fields).
+-- ───────────────────────────────────────────────────────────────────
+CREATE TABLE pl_pipelines (
+  id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  space_id   UUID NOT NULL REFERENCES spaces(id) ON DELETE CASCADE,
+  name       TEXT NOT NULL CHECK (char_length(name) BETWEEN 1 AND 80),
+  kind       TEXT NOT NULL DEFAULT 'generic',
+  -- ordered [{key,label,color,type:open|won|lost,rotting_days?,is_terminal_gate?}]
+  stages     JSONB NOT NULL DEFAULT '[]'::jsonb,
+  -- custom field schema [{key,label,type,options?}]
+  fields     JSONB NOT NULL DEFAULT '[]'::jsonb,
+  position   INT  NOT NULL DEFAULT 0,
+  created_by UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE pl_pipelines ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "pl_pipelines_read" ON pl_pipelines
+  FOR SELECT TO authenticated
+  USING (space_id IN (SELECT space_id FROM space_members WHERE user_id = auth.uid()));
+CREATE POLICY "pl_pipelines_write" ON pl_pipelines
+  FOR ALL TO authenticated
+  USING (space_id IN (SELECT space_id FROM space_members WHERE user_id = auth.uid()))
+  WITH CHECK (space_id IN (SELECT space_id FROM space_members WHERE user_id = auth.uid()));
+
+CREATE INDEX pl_pipelines_space_idx ON pl_pipelines(space_id, position);
+
+-- ───────────────────────────────────────────────────────────────────
+-- pl_leads — the lightweight top-of-funnel record.
+-- ───────────────────────────────────────────────────────────────────
+CREATE TABLE pl_leads (
+  id                   UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  pipeline_id          UUID NOT NULL REFERENCES pl_pipelines(id) ON DELETE CASCADE,
+  space_id             UUID NOT NULL REFERENCES spaces(id) ON DELETE CASCADE,
+  name                 TEXT NOT NULL CHECK (char_length(name) BETWEEN 1 AND 200),
+  subtitle             TEXT,
+  stage                TEXT NOT NULL DEFAULT '',
+  status               TEXT NOT NULL DEFAULT 'open'
+                         CHECK (status IN ('open','won','lost','dead','converted')),
+  priority             INT  NOT NULL DEFAULT 0 CHECK (priority BETWEEN 0 AND 3),
+  source               TEXT,
+  owner_id             UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  next_follow_up_at    TIMESTAMPTZ,
+  last_activity_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+  promoted_terminal_id UUID REFERENCES terminals(id) ON DELETE SET NULL,
+  dead_reason          TEXT,
+  lat                  DOUBLE PRECISION,
+  lng                  DOUBLE PRECISION,
+  attributes           JSONB NOT NULL DEFAULT '{}'::jsonb,  -- custom field values
+  created_by           UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  created_at           TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at           TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE pl_leads ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "pl_leads_read" ON pl_leads
+  FOR SELECT TO authenticated
+  USING (space_id IN (SELECT space_id FROM space_members WHERE user_id = auth.uid()));
+CREATE POLICY "pl_leads_write" ON pl_leads
+  FOR ALL TO authenticated
+  USING (space_id IN (SELECT space_id FROM space_members WHERE user_id = auth.uid()))
+  WITH CHECK (space_id IN (SELECT space_id FROM space_members WHERE user_id = auth.uid()));
+
+CREATE INDEX pl_leads_pipeline_idx ON pl_leads(pipeline_id, stage);
+CREATE INDEX pl_leads_space_idx ON pl_leads(space_id);
+CREATE INDEX pl_leads_followup_idx ON pl_leads(space_id, next_follow_up_at)
+  WHERE next_follow_up_at IS NOT NULL AND status = 'open';
+CREATE INDEX pl_leads_terminal_idx ON pl_leads(promoted_terminal_id)
+  WHERE promoted_terminal_id IS NOT NULL;
+
+CREATE TRIGGER pl_leads_set_updated_at
+  BEFORE UPDATE ON pl_leads
+  FOR EACH ROW EXECUTE FUNCTION contacts_touch_updated_at();
+
+-- ───────────────────────────────────────────────────────────────────
+-- pl_lead_contacts — link a lead to shared Contacts (with a per-deal role).
+-- ───────────────────────────────────────────────────────────────────
+CREATE TABLE pl_lead_contacts (
+  lead_id    UUID NOT NULL REFERENCES pl_leads(id) ON DELETE CASCADE,
+  contact_id UUID NOT NULL REFERENCES contacts(id) ON DELETE CASCADE,
+  role       TEXT,
+  added_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (lead_id, contact_id)
+);
+ALTER TABLE pl_lead_contacts ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "pl_lead_contacts_rw" ON pl_lead_contacts
+  FOR ALL TO authenticated
+  USING (
+    lead_id IN (SELECT id FROM pl_leads) AND contact_id IN (SELECT id FROM contacts)
+  )
+  WITH CHECK (
+    lead_id IN (SELECT id FROM pl_leads) AND contact_id IN (SELECT id FROM contacts)
+  );
+
+-- ───────────────────────────────────────────────────────────────────
+-- terminal_contacts — the same Contacts follow a deal into its Terminal.
+-- ───────────────────────────────────────────────────────────────────
+CREATE TABLE terminal_contacts (
+  terminal_id UUID NOT NULL REFERENCES terminals(id) ON DELETE CASCADE,
+  contact_id  UUID NOT NULL REFERENCES contacts(id) ON DELETE CASCADE,
+  role        TEXT,
+  added_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (terminal_id, contact_id)
+);
+ALTER TABLE terminal_contacts ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "terminal_contacts_rw" ON terminal_contacts
+  FOR ALL TO authenticated
+  USING (
+    terminal_id IN (SELECT terminal_id FROM terminal_members WHERE user_id = auth.uid())
+    AND contact_id IN (SELECT id FROM contacts)
+  )
+  WITH CHECK (
+    terminal_id IN (SELECT terminal_id FROM terminal_members WHERE user_id = auth.uid())
+    AND contact_id IN (SELECT id FROM contacts)
+  );
+
+-- ───────────────────────────────────────────────────────────────────
+-- Now that pl_leads exists, wire up the deferred interactions.lead_id FK.
+-- ───────────────────────────────────────────────────────────────────
+ALTER TABLE interactions
+  ADD CONSTRAINT interactions_lead_fk
+  FOREIGN KEY (lead_id) REFERENCES pl_leads(id) ON DELETE CASCADE;
+
+COMMIT;


### PR DESCRIPTION
## What
The Pipeline data layer — the lead/deal-flow that links into Contacts and promotes winners to Terminals.

- **Migration** `20260628130000_pipeline_init.sql`:
  - `pl_pipelines` — space-scoped; configurable `stages` + `fields` schema.
  - `pl_leads` — lightweight top-of-funnel (stage/status/priority/`next_follow_up_at`/`attributes`/`promoted_terminal_id`/`dead_reason`).
  - `pl_lead_contacts` + `terminal_contacts` — **link to shared Contacts** (one record per person, leads *and* the terminals they become).
  - Wires the deferred `interactions.lead_id` FK. RLS space-scoped; join tables defer to lead/terminal + contact visibility. Follow-up + stage indexes.
- `lib/pipeline/db.ts` — typed Rows + `pipelineDb()`.
- `lib/pipeline/templates.ts` — the **HELIOS flow** (Tracking → Engaging → Due Diligence → Offer → **Under Contract** [terminal gate] → Active Project → Closed; **Dead** is a status) + Business + Generic starters.

## Test
- `templates.test.ts` — HELIOS stage order, single terminal gate, Dead-not-a-stage, won outcome. 3 tests green.
- `tests/rls/pipeline.test.ts` — pipelines + leads space-isolation, WITH-CHECK forge-blocks. tsc + eslint clean.

> Visual-regression / Bundle-size CI checks are pre-existing non-required failures (unrelated); required checks gate the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)