### PR TITLE
feat(contacts): register module so it appears in the launcher

### DIFF
--- a/apps/web/src/modules/contacts/manifest.ts
+++ b/apps/web/src/modules/contacts/manifest.ts
@@ -1,0 +1,28 @@
+/**
+ * Contacts module manifest.
+ *
+ * Your personal relationship layer — people, firms, and the contact
+ * details / interaction history behind every deal. Contacts are
+ * owner-scoped (RLS `owner_id = auth.uid()`), so the module lives at the
+ * **user** scope only; the Pipeline and Terminal modules *link* to these
+ * records (pl_lead_contacts / terminal_contacts) rather than copying them.
+ *
+ * Registered in `modules/index.ts`; catalog row seeded in
+ * `20260628140000_contacts_catalog.sql`. See
+ * Claude/CONTACTS_PIPELINE_BUILD_PLAN.md.
+ */
+import type { ModuleManifest } from "@rokki/sdk";
+
+export const contactsManifest: ModuleManifest = {
+  slug: "contacts",
+  name: "Contacts",
+  description:
+    "Your relationship layer — people, firms, contact details, and interaction history.",
+  icon: "contact",
+  scopes: ["user"],
+  vertical: null,
+  routes: {
+    user: "/modules/contacts",
+  },
+  fnKey: { label: "Contacts", default: 7 },
+};

--- a/apps/web/src/modules/index.ts
+++ b/apps/web/src/modules/index.ts
@@ -18,6 +18,7 @@ import { messengerManifest } from "./messenger/manifest";
 import { scheduleManifest } from "./schedule/manifest";
 import { goalsManifest } from "./goals/manifest";
 import { marketsManifest } from "./markets/manifest";
+import { contactsManifest } from "./contacts/manifest";
 
 let registered = false;
 
@@ -34,6 +35,7 @@ export function registerAllModules(): void {
   registerModule(scheduleManifest);
   registerModule(goalsManifest);
   registerModule(marketsManifest);
+  registerModule(contactsManifest);
   registered = true;
 }
 

--- a/supabase/migrations/20260628140000_contacts_catalog.sql
+++ b/supabase/migrations/20260628140000_contacts_catalog.sql
@@ -1,0 +1,25 @@
+-- Register the Contacts module in the global catalog.
+--
+-- The user-scope tab strip is driven by the in-process manifest registry
+-- (apps/web/src/modules/index.ts), so Contacts shows up for users without
+-- this row. But user_module_pins.slug and the marketplace both FK against
+-- modules_catalog, so we seed the row to keep those paths consistent —
+-- exactly as the Markets module did (20260616010000_markets_init.sql).
+--
+-- Contacts is owner-scoped (RLS owner_id = auth.uid()), so it's a user-only
+-- module: no space/terminal install rows. enabled_by_default is moot for a
+-- user-scope module (every "user"-scoped manifest renders regardless) and
+-- left FALSE to match the opt-in convention.
+
+BEGIN;
+
+INSERT INTO modules_catalog (slug, name, description, icon, scopes, enabled_by_default) VALUES
+  ('contacts', 'Contacts',
+   'Your relationship layer — people, firms, contact details, and interaction history.',
+   'contact', ARRAY['user'], FALSE)
+ON CONFLICT (slug) DO NOTHING;
+
+COMMIT;
+
+-- ROLLBACK:
+-- DELETE FROM modules_catalog WHERE slug = 'contacts';


### PR DESCRIPTION
## Why
Contacts shipped (#311 data · #312 API · #313 UI) and is live at `/modules/contacts`, but it **never appeared in the module tab strip** — it was never registered. The user-scope strip is built from `listManifestsForScope("user")` (the in-process manifest registry populated at boot by `instrumentation.ts` → `modules/index.ts`), and Contacts had no manifest.

## What
- **`modules/contacts/manifest.ts`** — user-scope manifest. Contacts are owner-scoped (RLS `owner_id = auth.uid()`), so it's a **user-only** module; route `/modules/contacts`; default F7.
- **`modules/index.ts`** — `registerModule(contactsManifest)` at boot.
- **`20260628140000_contacts_catalog.sql`** — seed the `modules_catalog` row so `user_module_pins.slug` + the marketplace FK-resolve, mirroring the Markets seed. `ON CONFLICT DO NOTHING`.

## Effect
Contacts shows up in the Home (user-scope) module strip / launcher with the rest (Tasks, Files, Messenger, Schedule, Goals, Markets), reachable by click + F7.

> Pipeline gets the same treatment once its UI lands (Phase B.3) — registering it now would be a dead tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)