### PR TITLE
feat(contacts): full profile build-out — avatar, multi-fields, family, birthday

### DIFF
--- a/apps/web/src/app/api/v1/contacts/avatar/route.ts
+++ b/apps/web/src/app/api/v1/contacts/avatar/route.ts
@@ -1,0 +1,54 @@
+import { type NextRequest } from "next/server";
+import { randomUUID } from "node:crypto";
+import { createClient } from "@/lib/supabase/server";
+import { withObservability } from "@/lib/observability";
+import { ok, unauthorized, badRequest, internal } from "@/lib/contacts/api";
+import {
+  AVATAR_BUCKET,
+  AVATAR_MAX_BYTES,
+  imageExtFromType,
+  avatarStorageKey,
+} from "@/lib/contacts/avatar";
+
+export const dynamic = "force-dynamic";
+// Profile pictures are small, but give image processing a little headroom.
+export const maxDuration = 30;
+
+/**
+ * POST /api/v1/contacts/avatar  (multipart/form-data, field `file`)
+ *
+ * Uploads a profile picture to the public `contact-avatars` bucket under
+ * `<userId>/<uuid>.<ext>` and returns its public URL. The client stores that
+ * URL on the contact's `avatar_url` via the normal create/update call — this
+ * route only handles the binary. The bucket's owner-only write RLS authorizes
+ * the upload because the key is prefixed with the caller's id.
+ */
+async function handlePost(request: NextRequest) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return unauthorized();
+
+  const form = await request.formData().catch(() => null);
+  const file = form?.get("file");
+  if (!(file instanceof File)) return badRequest("file is required");
+  if (file.size === 0) return badRequest("file is empty");
+  if (file.size > AVATAR_MAX_BYTES) return badRequest("image too large (max 8 MB)");
+
+  const ext = imageExtFromType(file.type);
+  if (!ext) return badRequest("unsupported image type");
+
+  const key = avatarStorageKey(user.id, randomUUID(), ext);
+  const bytes = new Uint8Array(await file.arrayBuffer());
+
+  const { error } = await supabase.storage
+    .from(AVATAR_BUCKET)
+    .upload(key, bytes, { contentType: file.type, upsert: false });
+  if (error) return internal(error.message);
+
+  const { data } = supabase.storage.from(AVATAR_BUCKET).getPublicUrl(key);
+  return ok({ url: data.publicUrl, key }, 201);
+}
+
+export const POST = withObservability(handlePost, "POST /api/v1/contacts/avatar");

--- a/apps/web/src/lib/contacts/avatar.test.ts
+++ b/apps/web/src/lib/contacts/avatar.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { imageExtFromType, avatarStorageKey, AVATAR_BUCKET } from "./avatar";
+
+describe("imageExtFromType", () => {
+  it("maps accepted image types to extensions", () => {
+    expect(imageExtFromType("image/jpeg")).toBe("jpg");
+    expect(imageExtFromType("image/jpg")).toBe("jpg");
+    expect(imageExtFromType("image/png")).toBe("png");
+    expect(imageExtFromType("image/webp")).toBe("webp");
+    expect(imageExtFromType("image/gif")).toBe("gif");
+    expect(imageExtFromType("image/heic")).toBe("heic");
+  });
+
+  it("tolerates charset params and casing", () => {
+    expect(imageExtFromType("IMAGE/PNG")).toBe("png");
+    expect(imageExtFromType("image/jpeg; charset=binary")).toBe("jpg");
+  });
+
+  it("rejects non-image and empty types", () => {
+    expect(imageExtFromType("application/pdf")).toBeNull();
+    expect(imageExtFromType("text/html")).toBeNull();
+    expect(imageExtFromType("")).toBeNull();
+    expect(imageExtFromType(null)).toBeNull();
+    expect(imageExtFromType(undefined)).toBeNull();
+  });
+});
+
+describe("avatarStorageKey", () => {
+  it("pins the key under the owner's user-id segment (RLS depends on it)", () => {
+    const key = avatarStorageKey("user-123", "abc-def", "png");
+    expect(key).toBe("user-123/abc-def.png");
+    // The first path segment must be exactly the user id — that's what the
+    // contact-avatars write policy checks via storage.foldername(name)[1].
+    expect(key.split("/")[0]).toBe("user-123");
+  });
+
+  it("uses a stable bucket name", () => {
+    expect(AVATAR_BUCKET).toBe("contact-avatars");
+  });
+});

--- a/apps/web/src/lib/contacts/avatar.ts
+++ b/apps/web/src/lib/contacts/avatar.ts
@@ -1,0 +1,41 @@
+/**
+ * Pure helpers for contact avatar uploads — kept DOM/IO-free so the storage
+ * route stays thin and these rules are unit-tested. See
+ * `app/api/v1/contacts/avatar/route.ts` and the `contact-avatars` bucket
+ * (20260628150000_contacts_profile_expand.sql).
+ */
+
+export const AVATAR_BUCKET = "contact-avatars";
+
+/** Hard ceiling for an avatar upload. Profile pictures are small; this is a
+ *  guardrail against someone POSTing a huge file, not a real constraint. */
+export const AVATAR_MAX_BYTES = 8 * 1024 * 1024; // 8 MB
+
+/** Image MIME → file extension. Returns null for anything we won't accept, so
+ *  the route can reject non-images up front. */
+export function imageExtFromType(contentType: string | null | undefined): string | null {
+  switch ((contentType ?? "").split(";")[0].trim().toLowerCase()) {
+    case "image/jpeg":
+    case "image/jpg":
+      return "jpg";
+    case "image/png":
+      return "png";
+    case "image/webp":
+      return "webp";
+    case "image/gif":
+      return "gif";
+    case "image/heic":
+      return "heic";
+    case "image/heif":
+      return "heif";
+    default:
+      return null;
+  }
+}
+
+/** Storage key for a user's avatar upload: `<userId>/<uuid>.<ext>`. The leading
+ *  user-id segment is what the bucket's owner-only write RLS pins against, so it
+ *  must be exactly `auth.uid()`. */
+export function avatarStorageKey(userId: string, uuid: string, ext: string): string {
+  return `${userId}/${uuid}.${ext}`;
+}

--- a/apps/web/src/lib/contacts/db.ts
+++ b/apps/web/src/lib/contacts/db.ts
@@ -34,6 +34,10 @@ export interface ContactSocial {
   kind: string; // linkedin|instagram|x|facebook|website|...
   value: string;
 }
+export interface ContactFamilyMember {
+  name: string;
+  relation?: string; // spouse|child|parent|sibling|partner|assistant|...
+}
 
 export interface ContactRow {
   id: string;
@@ -50,8 +54,9 @@ export interface ContactRow {
   contact_types: string[];
   tags: string[];
   title: string | null;
-  firm: string | null;
+  company: string | null;
   license_no: string | null;
+  birthday: string | null;
   strength: number;
   source: string | null;
   status: "active" | "archived";
@@ -61,6 +66,7 @@ export interface ContactRow {
   phones: ContactPhone[];
   addresses: ContactAddress[];
   socials: ContactSocial[];
+  family: ContactFamilyMember[];
   primary_email: string | null;
   primary_phone: string | null;
   custom: Record<string, unknown>;
@@ -98,7 +104,7 @@ export interface InteractionRow {
 
 /** Columns a contact card needs in a list (keeps payloads lean). */
 export const CONTACT_LIST_COLUMNS =
-  "id, first_name, last_name, nickname, avatar_url, contact_types, tags, firm, " +
+  "id, first_name, last_name, nickname, avatar_url, contact_types, tags, company, " +
   "title, primary_email, primary_phone, status, strength, user_id, updated_at";
 
 /**

--- a/apps/web/src/lib/contacts/format.test.ts
+++ b/apps/web/src/lib/contacts/format.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { timeAgo, formatBirthday } from "./format";
+
+describe("timeAgo", () => {
+  const now = Date.parse("2026-06-28T12:00:00Z");
+  it("renders buckets from seconds to years", () => {
+    expect(timeAgo("2026-06-28T11:59:40Z", now)).toBe("just now");
+    expect(timeAgo("2026-06-28T11:30:00Z", now)).toBe("30m ago");
+    expect(timeAgo("2026-06-28T09:00:00Z", now)).toBe("3h ago");
+    expect(timeAgo("2026-06-24T12:00:00Z", now)).toBe("4d ago");
+    expect(timeAgo("2026-04-29T12:00:00Z", now)).toBe("2mo ago");
+    expect(timeAgo("2024-06-28T12:00:00Z", now)).toBe("2y ago");
+  });
+  it("is empty for null / unparseable", () => {
+    expect(timeAgo(null, now)).toBe("");
+    expect(timeAgo("not-a-date", now)).toBe("");
+  });
+});
+
+describe("formatBirthday", () => {
+  it("formats with and without year", () => {
+    expect(formatBirthday("1985-03-09")).toBe("Mar 9, 1985");
+    expect(formatBirthday("0000-12-25")).toBe("Dec 25");
+  });
+  it("rejects junk", () => {
+    expect(formatBirthday(null)).toBe("");
+    expect(formatBirthday("1985/03/09")).toBe("");
+    expect(formatBirthday("1985-13-40")).toBe("");
+  });
+});

--- a/apps/web/src/lib/contacts/format.ts
+++ b/apps/web/src/lib/contacts/format.ts
@@ -1,0 +1,43 @@
+/**
+ * Pure display helpers for the contacts UI — kept DOM-free + injectable-clock so
+ * they're unit-testable.
+ */
+
+/** Compact "updated 3d ago" style relative time. `nowMs` is injectable for tests. */
+export function timeAgo(iso: string | null | undefined, nowMs: number): string {
+  if (!iso) return "";
+  const then = Date.parse(iso);
+  if (Number.isNaN(then)) return "";
+  const sec = Math.round((nowMs - then) / 1000);
+  if (sec < 45) return "just now";
+  const min = Math.round(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.round(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const day = Math.round(hr / 24);
+  if (day < 30) return `${day}d ago`;
+  const mo = Math.round(day / 30);
+  if (mo < 12) return `${mo}mo ago`;
+  return `${Math.round(mo / 12)}y ago`;
+}
+
+/**
+ * Format a `YYYY-MM-DD` birthday for display, e.g. "Mar 9" or "Mar 9, 1985".
+ * Year-less is supported via the sentinel year `0000`. Parsed as a plain date
+ * (no timezone shift) so it never lands on the wrong day.
+ */
+export function formatBirthday(date: string | null | undefined): string {
+  if (!date) return "";
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(date.trim());
+  if (!m) return "";
+  const [, y, mo, d] = m;
+  const month = Number(mo);
+  const day = Number(d);
+  if (month < 1 || month > 12 || day < 1 || day > 31) return "";
+  const MONTHS = [
+    "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+    "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+  ];
+  const base = `${MONTHS[month - 1]} ${day}`;
+  return y === "0000" ? base : `${base}, ${y}`;
+}

--- a/apps/web/src/lib/contacts/queries.ts
+++ b/apps/web/src/lib/contacts/queries.ts
@@ -11,6 +11,7 @@ import {
   type ContactPhone,
   type ContactAddress,
   type ContactSocial,
+  type ContactFamilyMember,
 } from "./db";
 import { primaryEmail, primaryPhone, hasName } from "./normalize";
 
@@ -25,8 +26,9 @@ export interface ContactInput {
   contact_types?: string[];
   tags?: string[];
   title?: string | null;
-  firm?: string | null;
+  company?: string | null;
   license_no?: string | null;
+  birthday?: string | null;
   strength?: number;
   source?: string | null;
   status?: "active" | "archived";
@@ -36,15 +38,16 @@ export interface ContactInput {
   phones?: ContactPhone[];
   addresses?: ContactAddress[];
   socials?: ContactSocial[];
+  family?: ContactFamilyMember[];
   custom?: Record<string, unknown>;
   user_id?: string | null;
 }
 
 const WRITABLE: (keyof ContactInput)[] = [
   "first_name", "middle_name", "last_name", "prefix", "suffix", "nickname",
-  "avatar_url", "contact_types", "tags", "title", "firm", "license_no",
-  "strength", "source", "status", "do_not_contact", "notes", "emails",
-  "phones", "addresses", "socials", "custom", "user_id",
+  "avatar_url", "contact_types", "tags", "title", "company", "license_no",
+  "birthday", "strength", "source", "status", "do_not_contact", "notes",
+  "emails", "phones", "addresses", "socials", "family", "custom", "user_id",
 ];
 
 /** Strip everything except the writable fields (never trust client owner_id/id). */
@@ -97,7 +100,7 @@ export async function listContacts(
           `first_name.ilike.%${q}%`,
           `last_name.ilike.%${q}%`,
           `nickname.ilike.%${q}%`,
-          `firm.ilike.%${q}%`,
+          `company.ilike.%${q}%`,
           `primary_email.ilike.%${q}%`,
           `primary_phone.ilike.%${q}%`,
         ].join(","),

--- a/apps/web/src/modules/contacts/components/ContactDetail.tsx
+++ b/apps/web/src/modules/contacts/components/ContactDetail.tsx
@@ -1,23 +1,52 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Mail, Phone, Pencil, Archive, X, Loader2 } from "lucide-react";
-import { Button } from "@/components/ui/Button";
-import type { ContactRow } from "@/lib/contacts/db";
 import {
-  getContact,
-  updateContact,
-  archiveContact,
-} from "../lib/client-api";
+  Mail,
+  Phone,
+  MapPin,
+  Cake,
+  Users,
+  Link as LinkIcon,
+  Pencil,
+  Archive,
+  X,
+  Loader2,
+} from "lucide-react";
+import { Button } from "@/components/ui/Button";
+import type { ContactRow, ContactAddress } from "@/lib/contacts/db";
+import { timeAgo, formatBirthday } from "@/lib/contacts/format";
+import { getContact, updateContact, archiveContact } from "../lib/client-api";
 import { ContactForm } from "./ContactForm";
 
-function initials(c: { first_name?: string | null; last_name?: string | null; nickname?: string | null }) {
+function initials(c: {
+  first_name?: string | null;
+  last_name?: string | null;
+  nickname?: string | null;
+}) {
   const a = (c.first_name ?? c.nickname ?? "").trim()[0] ?? "";
   const b = (c.last_name ?? "").trim()[0] ?? "";
   return (a + b).toUpperCase() || "?";
 }
 
-/** Detail drawer for one contact — read view with inline edit + archive. */
+function formatAddress(a: ContactAddress): string {
+  const cityLine = [a.city, a.state].filter(Boolean).join(", ");
+  return [a.line1, a.line2, [cityLine, a.postal].filter(Boolean).join(" "), a.country]
+    .filter(Boolean)
+    .join("\n");
+}
+
+function mapsHref(a: ContactAddress): string {
+  const q = [a.line1, a.line2, a.city, a.state, a.postal, a.country]
+    .filter(Boolean)
+    .join(", ");
+  return `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(q)}`;
+}
+
+const sectionLabel =
+  "text-[10px] font-semibold uppercase tracking-wide text-text-3";
+
+/** Detail drawer for one contact — full read view with inline edit + archive. */
 export function ContactDetail({
   contactId,
   onClose,
@@ -73,12 +102,12 @@ export function ContactDetail({
     }
   }
 
-  const email = contact?.primary_email ?? contact?.emails?.[0]?.email ?? null;
-  const phone = contact?.primary_phone ?? contact?.phones?.[0]?.phone ?? null;
-  const fullName = [contact?.first_name, contact?.last_name]
-    .filter(Boolean)
-    .join(" ")
-    .trim();
+  const fullName = contact
+    ? [contact.prefix, contact.first_name, contact.middle_name, contact.last_name, contact.suffix]
+        .filter(Boolean)
+        .join(" ")
+        .trim()
+    : "";
 
   return (
     <div className="flex h-full min-h-0 flex-col">
@@ -114,17 +143,30 @@ export function ContactDetail({
           />
         ) : (
           <div className="flex flex-col gap-3">
+            {/* Header */}
             <div className="flex items-center gap-3">
-              <span className="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-bg-3 font-mono text-sm text-text-1">
-                {initials(contact)}
-              </span>
+              {contact.avatar_url ? (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  src={contact.avatar_url}
+                  alt=""
+                  className="h-14 w-14 flex-shrink-0 rounded-full object-cover"
+                />
+              ) : (
+                <span className="flex h-14 w-14 flex-shrink-0 items-center justify-center rounded-full bg-bg-3 font-mono text-sm text-text-1">
+                  {initials(contact)}
+                </span>
+              )}
               <div className="min-w-0">
                 <div className="truncate text-sm font-semibold text-text-0">
-                  {contact.nickname || fullName || "Unnamed"}
+                  {fullName || contact.nickname || "Unnamed"}
                 </div>
-                {(contact.title || contact.firm) && (
+                {contact.nickname && fullName && (
+                  <div className="truncate text-xs text-text-3">“{contact.nickname}”</div>
+                )}
+                {(contact.title || contact.company) && (
                   <div className="truncate text-xs text-text-2">
-                    {[contact.title, contact.firm].filter(Boolean).join(" · ")}
+                    {[contact.title, contact.company].filter(Boolean).join(" · ")}
                   </div>
                 )}
               </div>
@@ -143,21 +185,103 @@ export function ContactDetail({
               </div>
             )}
 
-            {email && (
-              <a
-                href={`mailto:${email}`}
-                className="flex items-center gap-2 text-xs text-text-1 hover:text-text-0"
-              >
-                <Mail className="h-3.5 w-3.5 text-text-3" /> {email}
-              </a>
+            {/* Emails */}
+            {contact.emails.length > 0 && (
+              <Section label="Email">
+                {contact.emails.map((e, i) => (
+                  <a
+                    key={i}
+                    href={`mailto:${e.email}`}
+                    className="flex items-center gap-2 text-xs text-text-1 hover:text-text-0"
+                  >
+                    <Mail className="h-3.5 w-3.5 flex-shrink-0 text-text-3" />
+                    <span className="truncate">{e.email}</span>
+                    {e.label && <Tag>{e.label}</Tag>}
+                  </a>
+                ))}
+              </Section>
             )}
-            {phone && (
-              <a
-                href={`tel:${phone}`}
-                className="flex items-center gap-2 text-xs text-text-1 hover:text-text-0"
-              >
-                <Phone className="h-3.5 w-3.5 text-text-3" /> {phone}
-              </a>
+
+            {/* Phones */}
+            {contact.phones.length > 0 && (
+              <Section label="Phone">
+                {contact.phones.map((p, i) => (
+                  <a
+                    key={i}
+                    href={`tel:${p.phone}`}
+                    className="flex items-center gap-2 text-xs text-text-1 hover:text-text-0"
+                  >
+                    <Phone className="h-3.5 w-3.5 flex-shrink-0 text-text-3" />
+                    <span className="truncate">{p.phone}</span>
+                    {p.label && <Tag>{p.label}</Tag>}
+                  </a>
+                ))}
+              </Section>
+            )}
+
+            {/* Birthday */}
+            {contact.birthday && (
+              <Section label="Birthday">
+                <div className="flex items-center gap-2 text-xs text-text-1">
+                  <Cake className="h-3.5 w-3.5 flex-shrink-0 text-text-3" />
+                  {formatBirthday(contact.birthday)}
+                </div>
+              </Section>
+            )}
+
+            {/* Addresses */}
+            {contact.addresses.length > 0 && (
+              <Section label="Addresses">
+                {contact.addresses.map((a, i) => (
+                  <a
+                    key={i}
+                    href={mapsHref(a)}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex items-start gap-2 text-xs text-text-1 hover:text-text-0"
+                  >
+                    <MapPin className="mt-0.5 h-3.5 w-3.5 flex-shrink-0 text-text-3" />
+                    <span className="min-w-0">
+                      {a.label && <Tag>{a.label}</Tag>}
+                      <span className="block whitespace-pre-wrap">{formatAddress(a)}</span>
+                    </span>
+                  </a>
+                ))}
+              </Section>
+            )}
+
+            {/* Family */}
+            {contact.family.length > 0 && (
+              <Section label="Family & relationships">
+                {contact.family.map((f, i) => (
+                  <div key={i} className="flex items-center gap-2 text-xs text-text-1">
+                    <Users className="h-3.5 w-3.5 flex-shrink-0 text-text-3" />
+                    <span className="truncate">{f.name}</span>
+                    {f.relation && <Tag>{f.relation}</Tag>}
+                  </div>
+                ))}
+              </Section>
+            )}
+
+            {/* Socials */}
+            {contact.socials.length > 0 && (
+              <Section label="Social & web">
+                {contact.socials.map((s, i) => (
+                  <a
+                    key={i}
+                    href={
+                      s.value.startsWith("http") ? s.value : `https://${s.value}`
+                    }
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex items-center gap-2 text-xs text-text-1 hover:text-text-0"
+                  >
+                    <LinkIcon className="h-3.5 w-3.5 flex-shrink-0 text-text-3" />
+                    <span className="truncate">{s.value}</span>
+                    <Tag>{s.kind}</Tag>
+                  </a>
+                ))}
+              </Section>
             )}
 
             {contact.tags.length > 0 && (
@@ -176,17 +300,37 @@ export function ContactDetail({
               </p>
             )}
 
-            <div className="mt-2 flex gap-2 border-t border-border/40 pt-3">
+            <div className="mt-1 flex items-center gap-2 border-t border-border/40 pt-3">
               <Button size="sm" variant="ghost" onClick={() => setEditing(true)}>
                 <Pencil className="h-3 w-3" /> Edit
               </Button>
               <Button size="sm" variant="ghost" onClick={archive} disabled={busy}>
                 <Archive className="h-3 w-3" /> Archive
               </Button>
+              <span className="ml-auto text-2xs text-text-3">
+                Updated {timeAgo(contact.updated_at, Date.now())}
+              </span>
             </div>
           </div>
         )}
       </div>
     </div>
+  );
+}
+
+function Section({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-1">
+      <span className={sectionLabel}>{label}</span>
+      {children}
+    </div>
+  );
+}
+
+function Tag({ children }: { children: React.ReactNode }) {
+  return (
+    <span className="ml-1 rounded-sm bg-bg-3 px-1 py-px text-[9px] uppercase tracking-wide text-text-3">
+      {children}
+    </span>
   );
 }

--- a/apps/web/src/modules/contacts/components/ContactForm.test.tsx
+++ b/apps/web/src/modules/contacts/components/ContactForm.test.tsx
@@ -1,0 +1,77 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import type { ContactRow } from "@/lib/contacts/db";
+import { ContactForm } from "./ContactForm";
+
+vi.mock("../lib/client-api", () => ({ uploadAvatar: vi.fn() }));
+
+afterEach(cleanup);
+
+function renderForm(initial: Partial<ContactRow>, submitLabel = "Save") {
+  const onSubmit = vi.fn();
+  render(
+    <ContactForm
+      initial={initial}
+      submitLabel={submitLabel}
+      onCancel={() => {}}
+      onSubmit={onSubmit}
+    />,
+  );
+  return onSubmit;
+}
+
+describe("ContactForm submit mapping", () => {
+  it("preserves a non-first primary email flag (a no-op edit is lossless)", () => {
+    const onSubmit = renderForm({
+      first_name: "Meg",
+      last_name: "W",
+      emails: [
+        { email: "a@x.com", primary: false },
+        { email: "b@x.com", primary: true },
+      ],
+      phones: [],
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit.mock.calls[0][0].emails).toEqual([
+      { email: "a@x.com", label: undefined, primary: false },
+      { email: "b@x.com", label: undefined, primary: true },
+    ]);
+  });
+
+  it("defaults the first non-empty email to primary and drops blank rows", () => {
+    const onSubmit = renderForm(
+      {
+        first_name: "New",
+        last_name: "Person",
+        emails: [{ email: "first@x.com" }, { email: "" }],
+        phones: [],
+      },
+      "Create",
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+    expect(onSubmit.mock.calls[0][0].emails).toEqual([
+      { email: "first@x.com", label: undefined, primary: true },
+    ]);
+  });
+
+  it("keeps multiple values and trims family relations", () => {
+    const onSubmit = renderForm({
+      first_name: "Multi",
+      emails: [{ email: "x@y.com" }],
+      phones: [
+        { phone: "305-1", primary: false },
+        { phone: "305-2", primary: true },
+      ],
+      family: [{ name: " Jane ", relation: " spouse " }],
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    const patch = onSubmit.mock.calls[0][0];
+    expect(patch.phones).toEqual([
+      { phone: "305-1", label: undefined, primary: false },
+      { phone: "305-2", label: undefined, primary: true },
+    ]);
+    expect(patch.family).toEqual([{ name: "Jane", relation: "spouse" }]);
+  });
+});

--- a/apps/web/src/modules/contacts/components/ContactForm.tsx
+++ b/apps/web/src/modules/contacts/components/ContactForm.tsx
@@ -42,10 +42,12 @@ const sectionLabel =
 interface EmailRow {
   label: string;
   email: string;
+  primary?: boolean;
 }
 interface PhoneRow {
   label: string;
   phone: string;
+  primary?: boolean;
 }
 
 interface FormState {
@@ -88,11 +90,11 @@ function fromContact(c?: Partial<ContactRow>): FormState {
     contact_types: c?.contact_types ?? [],
     tags: c?.tags ?? [],
     emails: seed(
-      c?.emails?.map((e) => ({ label: e.label ?? "", email: e.email })),
+      c?.emails?.map((e) => ({ label: e.label ?? "", email: e.email, primary: e.primary })),
       () => ({ label: "", email: "" }),
     ),
     phones: seed(
-      c?.phones?.map((p) => ({ label: p.label ?? "", phone: p.phone })),
+      c?.phones?.map((p) => ({ label: p.label ?? "", phone: p.phone, primary: p.primary })),
       () => ({ label: "", phone: "" }),
     ),
     addresses: c?.addresses ?? [],
@@ -182,22 +184,27 @@ export function ContactForm({
 
   // ── submit ────────────────────────────────────────────────────────
   function submit() {
-    const emails = v.emails
+    // Preserve whichever row is flagged primary (a contact imported via API/MCP
+    // may have its primary in a row other than the first). Only fall back to
+    // "first row wins" when no row carries the flag.
+    const emailRows = v.emails
       .map((e) => ({ ...e, email: e.email.trim() }))
-      .filter((e) => e.email)
-      .map((e, i) => ({
-        email: e.email,
-        label: e.label || undefined,
-        primary: i === 0,
-      }));
-    const phones = v.phones
+      .filter((e) => e.email);
+    const emailPrimary = emailRows.findIndex((e) => e.primary);
+    const emails = emailRows.map((e, i) => ({
+      email: e.email,
+      label: e.label || undefined,
+      primary: emailPrimary === -1 ? i === 0 : i === emailPrimary,
+    }));
+    const phoneRows = v.phones
       .map((p) => ({ ...p, phone: p.phone.trim() }))
-      .filter((p) => p.phone)
-      .map((p, i) => ({
-        phone: p.phone,
-        label: p.label || undefined,
-        primary: i === 0,
-      }));
+      .filter((p) => p.phone);
+    const phonePrimary = phoneRows.findIndex((p) => p.primary);
+    const phones = phoneRows.map((p, i) => ({
+      phone: p.phone,
+      label: p.label || undefined,
+      primary: phonePrimary === -1 ? i === 0 : i === phonePrimary,
+    }));
     const addresses = v.addresses.filter(
       (a) => a.line1 || a.city || a.state || a.postal,
     );
@@ -410,7 +417,7 @@ export function ContactForm({
               value={row.email}
               onChange={(e) => set("emails", patchAt(v.emails, i, { email: e.target.value }))}
             />
-            <RemoveBtn onClick={() => set("emails", seed(removeAt(v.emails, i), () => ({ label: "", email: "" })))} />
+            <RemoveBtn onClick={() => set("emails", removeAt(v.emails, i))} />
           </div>
         ))}
         <AddBtn label="Add email" onClick={() => set("emails", [...v.emails, { label: "", email: "" }])} />
@@ -438,7 +445,7 @@ export function ContactForm({
               value={row.phone}
               onChange={(e) => set("phones", patchAt(v.phones, i, { phone: e.target.value }))}
             />
-            <RemoveBtn onClick={() => set("phones", seed(removeAt(v.phones, i), () => ({ label: "", phone: "" })))} />
+            <RemoveBtn onClick={() => set("phones", removeAt(v.phones, i))} />
           </div>
         ))}
         <AddBtn label="Add phone" onClick={() => set("phones", [...v.phones, { label: "", phone: "" }])} />

--- a/apps/web/src/modules/contacts/components/ContactForm.tsx
+++ b/apps/web/src/modules/contacts/components/ContactForm.tsx
@@ -1,10 +1,17 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
+import { Plus, X, Upload, Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/Button";
-import type { ContactRow } from "@/lib/contacts/db";
+import type {
+  ContactRow,
+  ContactAddress,
+  ContactSocial,
+  ContactFamilyMember,
+} from "@/lib/contacts/db";
+import { uploadAvatar } from "../lib/client-api";
 
-const TYPE_OPTIONS = [
+const PRESET_TYPES = [
   "owner",
   "broker",
   "partner",
@@ -14,28 +21,88 @@ const TYPE_OPTIONS = [
   "contractor",
   "tenant",
   "vendor",
-  "other",
+  "investor",
+  "client",
+  "company",
 ];
+
+const EMAIL_LABELS = ["", "personal", "work", "other"];
+const PHONE_LABELS = ["", "mobile", "work", "home", "other"];
+const ADDRESS_LABELS = ["home", "business", "other"];
+const SOCIAL_KINDS = ["linkedin", "instagram", "x", "facebook", "website", "other"];
 
 const input =
   "w-full rounded border border-border bg-bg-2 px-2 py-1 text-xs text-text-1 placeholder:text-text-3 outline-none focus:border-border-focus";
+const select =
+  "rounded border border-border bg-bg-2 px-1.5 py-1 text-xs text-text-2 outline-none focus:border-border-focus";
 const label = "text-[10px] font-semibold uppercase tracking-wide text-text-3";
+const sectionLabel =
+  "text-[10px] font-semibold uppercase tracking-wide text-text-2";
 
-export interface ContactFormValues {
-  first_name?: string;
-  last_name?: string;
-  nickname?: string;
-  firm?: string;
-  title?: string;
-  email?: string;
-  phone?: string;
-  contact_types?: string[];
-  tags?: string[];
-  notes?: string;
+interface EmailRow {
+  label: string;
+  email: string;
+}
+interface PhoneRow {
+  label: string;
+  phone: string;
 }
 
-/** Shared create/edit form. Single email/phone inputs map to 1-element arrays;
- *  the server derives primary_email/phone. */
+interface FormState {
+  prefix: string;
+  first_name: string;
+  middle_name: string;
+  last_name: string;
+  suffix: string;
+  nickname: string;
+  avatar_url: string | null;
+  company: string;
+  title: string;
+  birthday: string;
+  contact_types: string[];
+  tags: string[];
+  emails: EmailRow[];
+  phones: PhoneRow[];
+  addresses: ContactAddress[];
+  family: ContactFamilyMember[];
+  socials: ContactSocial[];
+  notes: string;
+}
+
+function seed<T>(arr: T[] | undefined, empty: () => T): T[] {
+  return arr && arr.length ? arr : [empty()];
+}
+
+function fromContact(c?: Partial<ContactRow>): FormState {
+  return {
+    prefix: c?.prefix ?? "",
+    first_name: c?.first_name ?? "",
+    middle_name: c?.middle_name ?? "",
+    last_name: c?.last_name ?? "",
+    suffix: c?.suffix ?? "",
+    nickname: c?.nickname ?? "",
+    avatar_url: c?.avatar_url ?? null,
+    company: c?.company ?? "",
+    title: c?.title ?? "",
+    birthday: c?.birthday ?? "",
+    contact_types: c?.contact_types ?? [],
+    tags: c?.tags ?? [],
+    emails: seed(
+      c?.emails?.map((e) => ({ label: e.label ?? "", email: e.email })),
+      () => ({ label: "", email: "" }),
+    ),
+    phones: seed(
+      c?.phones?.map((p) => ({ label: p.label ?? "", phone: p.phone })),
+      () => ({ label: "", phone: "" }),
+    ),
+    addresses: c?.addresses ?? [],
+    family: c?.family ?? [],
+    socials: c?.socials ?? [],
+    notes: c?.notes ?? "",
+  };
+}
+
+/** Shared create/edit form — the full contact profile. */
 export function ContactForm({
   initial,
   busy,
@@ -51,58 +118,187 @@ export function ContactForm({
   onCancel: () => void;
   onSubmit: (patch: Partial<ContactRow>) => void;
 }) {
-  const [v, setV] = useState<ContactFormValues>({
-    first_name: initial?.first_name ?? "",
-    last_name: initial?.last_name ?? "",
-    nickname: initial?.nickname ?? "",
-    firm: initial?.firm ?? "",
-    title: initial?.title ?? "",
-    email: initial?.primary_email ?? initial?.emails?.[0]?.email ?? "",
-    phone: initial?.primary_phone ?? initial?.phones?.[0]?.phone ?? "",
-    contact_types: initial?.contact_types ?? [],
-    tags: initial?.tags ?? [],
-    notes: initial?.notes ?? "",
-  });
+  const [v, setV] = useState<FormState>(() => fromContact(initial));
+  const [customType, setCustomType] = useState("");
+  const [uploading, setUploading] = useState(false);
+  const [dragOver, setDragOver] = useState(false);
+  const [avatarErr, setAvatarErr] = useState<string | null>(null);
+  const fileRef = useRef<HTMLInputElement>(null);
 
-  function set<K extends keyof ContactFormValues>(k: K, val: ContactFormValues[K]) {
+  function set<K extends keyof FormState>(k: K, val: FormState[K]) {
     setV((prev) => ({ ...prev, [k]: val }));
   }
-  function toggleType(t: string) {
-    setV((prev) => {
-      const has = prev.contact_types?.includes(t);
-      return {
-        ...prev,
-        contact_types: has
-          ? prev.contact_types!.filter((x) => x !== t)
-          : [...(prev.contact_types ?? []), t],
-      };
-    });
+
+  // ── avatar ────────────────────────────────────────────────────────
+  async function handleFile(file: File | undefined | null) {
+    if (!file) return;
+    if (!file.type.startsWith("image/")) {
+      setAvatarErr("Choose an image file");
+      return;
+    }
+    setUploading(true);
+    setAvatarErr(null);
+    try {
+      const url = await uploadAvatar(file);
+      set("avatar_url", url);
+    } catch (e) {
+      setAvatarErr(e instanceof Error ? e.message : "Upload failed");
+    } finally {
+      setUploading(false);
+    }
   }
 
+  // ── types ─────────────────────────────────────────────────────────
+  const allTypes = Array.from(
+    new Set([...PRESET_TYPES, ...v.contact_types]),
+  );
+  function toggleType(t: string) {
+    setV((prev) => ({
+      ...prev,
+      contact_types: prev.contact_types.includes(t)
+        ? prev.contact_types.filter((x) => x !== t)
+        : [...prev.contact_types, t],
+    }));
+  }
+  function addCustomType() {
+    const t = customType.trim().toLowerCase();
+    if (!t) return;
+    setV((prev) => ({
+      ...prev,
+      contact_types: prev.contact_types.includes(t)
+        ? prev.contact_types
+        : [...prev.contact_types, t],
+    }));
+    setCustomType("");
+  }
+
+  // ── repeatable rows ───────────────────────────────────────────────
+  function patchAt<T>(arr: T[], i: number, patch: Partial<T>): T[] {
+    return arr.map((row, idx) => (idx === i ? { ...row, ...patch } : row));
+  }
+  function removeAt<T>(arr: T[], i: number): T[] {
+    return arr.filter((_, idx) => idx !== i);
+  }
+
+  // ── submit ────────────────────────────────────────────────────────
   function submit() {
+    const emails = v.emails
+      .map((e) => ({ ...e, email: e.email.trim() }))
+      .filter((e) => e.email)
+      .map((e, i) => ({
+        email: e.email,
+        label: e.label || undefined,
+        primary: i === 0,
+      }));
+    const phones = v.phones
+      .map((p) => ({ ...p, phone: p.phone.trim() }))
+      .filter((p) => p.phone)
+      .map((p, i) => ({
+        phone: p.phone,
+        label: p.label || undefined,
+        primary: i === 0,
+      }));
+    const addresses = v.addresses.filter(
+      (a) => a.line1 || a.city || a.state || a.postal,
+    );
+    const family = v.family
+      .map((f) => ({ name: f.name.trim(), relation: f.relation?.trim() || undefined }))
+      .filter((f) => f.name);
+    const socials = v.socials
+      .map((s) => ({ kind: s.kind, value: s.value.trim() }))
+      .filter((s) => s.value);
+
     const patch: Partial<ContactRow> = {
-      first_name: v.first_name?.trim() || "",
-      last_name: v.last_name?.trim() || "",
-      nickname: v.nickname?.trim() || null,
-      firm: v.firm?.trim() || null,
-      title: v.title?.trim() || null,
-      contact_types: v.contact_types ?? [],
-      tags: v.tags ?? [],
-      notes: v.notes?.trim() || null,
-      emails: v.email?.trim() ? [{ email: v.email.trim(), primary: true }] : [],
-      phones: v.phone?.trim() ? [{ phone: v.phone.trim(), primary: true }] : [],
+      prefix: v.prefix.trim() || null,
+      first_name: v.first_name.trim() || "",
+      middle_name: v.middle_name.trim() || null,
+      last_name: v.last_name.trim() || "",
+      suffix: v.suffix.trim() || null,
+      nickname: v.nickname.trim() || null,
+      avatar_url: v.avatar_url,
+      company: v.company.trim() || null,
+      title: v.title.trim() || null,
+      birthday: v.birthday || null,
+      contact_types: v.contact_types,
+      tags: v.tags,
+      emails,
+      phones,
+      addresses,
+      family,
+      socials,
+      notes: v.notes.trim() || null,
     };
     onSubmit(patch);
   }
 
   const canSubmit =
     !busy &&
-    Boolean(
-      (v.first_name?.trim() || v.last_name?.trim() || v.nickname?.trim()),
-    );
+    !uploading &&
+    Boolean(v.first_name.trim() || v.last_name.trim() || v.nickname.trim());
 
   return (
-    <div className="flex flex-col gap-3">
+    <div className="flex flex-col gap-4">
+      {/* Avatar + identity */}
+      <div className="flex gap-3">
+        <div
+          onClick={() => fileRef.current?.click()}
+          onDragOver={(e) => {
+            e.preventDefault();
+            setDragOver(true);
+          }}
+          onDragLeave={() => setDragOver(false)}
+          onDrop={(e) => {
+            e.preventDefault();
+            setDragOver(false);
+            void handleFile(e.dataTransfer.files?.[0]);
+          }}
+          role="button"
+          tabIndex={0}
+          aria-label="Profile picture — drop an image or click to upload"
+          className={`relative flex h-16 w-16 flex-shrink-0 cursor-pointer items-center justify-center overflow-hidden rounded-full border ${
+            dragOver ? "border-accent bg-accent/10" : "border-border bg-bg-3"
+          }`}
+        >
+          {uploading ? (
+            <Loader2 className="h-5 w-5 animate-spin text-text-3" />
+          ) : v.avatar_url ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={v.avatar_url}
+              alt="Profile"
+              className="h-full w-full object-cover"
+            />
+          ) : (
+            <Upload className="h-4 w-4 text-text-3" />
+          )}
+          <input
+            ref={fileRef}
+            type="file"
+            accept="image/*"
+            className="hidden"
+            onChange={(e) => void handleFile(e.target.files?.[0])}
+          />
+        </div>
+        <div className="flex min-w-0 flex-1 flex-col justify-center gap-1">
+          {v.avatar_url && (
+            <button
+              type="button"
+              onClick={() => set("avatar_url", null)}
+              className="self-start text-2xs text-text-3 hover:text-danger"
+            >
+              Remove photo
+            </button>
+          )}
+          {avatarErr ? (
+            <p className="text-2xs text-danger">{avatarErr}</p>
+          ) : (
+            <p className="text-2xs text-text-3">
+              Drag &amp; drop a photo, or click the circle.
+            </p>
+          )}
+        </div>
+      </div>
+
       <div className="grid grid-cols-2 gap-2">
         <div>
           <label className={label}>First name</label>
@@ -123,7 +319,33 @@ export function ContactForm({
         </div>
       </div>
 
-      <div className="grid grid-cols-2 gap-2">
+      <div className="grid grid-cols-4 gap-2">
+        <div>
+          <label className={label}>Prefix</label>
+          <input
+            className={input}
+            placeholder="Mr."
+            value={v.prefix}
+            onChange={(e) => set("prefix", e.target.value)}
+          />
+        </div>
+        <div>
+          <label className={label}>Middle</label>
+          <input
+            className={input}
+            value={v.middle_name}
+            onChange={(e) => set("middle_name", e.target.value)}
+          />
+        </div>
+        <div>
+          <label className={label}>Suffix</label>
+          <input
+            className={input}
+            placeholder="Jr."
+            value={v.suffix}
+            onChange={(e) => set("suffix", e.target.value)}
+          />
+        </div>
         <div>
           <label className={label}>Nickname</label>
           <input
@@ -132,41 +354,186 @@ export function ContactForm({
             onChange={(e) => set("nickname", e.target.value)}
           />
         </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-2">
         <div>
-          <label className={label}>Firm</label>
+          <label className={label}>Company</label>
           <input
             className={input}
-            value={v.firm}
-            onChange={(e) => set("firm", e.target.value)}
+            value={v.company}
+            onChange={(e) => set("company", e.target.value)}
+          />
+        </div>
+        <div>
+          <label className={label}>Title</label>
+          <input
+            className={input}
+            value={v.title}
+            onChange={(e) => set("title", e.target.value)}
           />
         </div>
       </div>
 
       <div className="grid grid-cols-2 gap-2">
         <div>
-          <label className={label}>Email</label>
+          <label className={label}>Birthday</label>
           <input
-            type="email"
+            type="date"
             className={input}
-            value={v.email}
-            onChange={(e) => set("email", e.target.value)}
-          />
-        </div>
-        <div>
-          <label className={label}>Phone</label>
-          <input
-            className={input}
-            value={v.phone}
-            onChange={(e) => set("phone", e.target.value)}
+            value={v.birthday}
+            onChange={(e) => set("birthday", e.target.value)}
           />
         </div>
       </div>
 
+      {/* Emails */}
+      <div className="flex flex-col gap-1">
+        <span className={sectionLabel}>Email</span>
+        {v.emails.map((row, i) => (
+          <div key={i} className="flex items-center gap-1">
+            <select
+              className={select}
+              value={row.label}
+              onChange={(e) => set("emails", patchAt(v.emails, i, { label: e.target.value }))}
+            >
+              {EMAIL_LABELS.map((l) => (
+                <option key={l} value={l}>
+                  {l || "label"}
+                </option>
+              ))}
+            </select>
+            <input
+              type="email"
+              className={input}
+              placeholder="name@example.com"
+              value={row.email}
+              onChange={(e) => set("emails", patchAt(v.emails, i, { email: e.target.value }))}
+            />
+            <RemoveBtn onClick={() => set("emails", seed(removeAt(v.emails, i), () => ({ label: "", email: "" })))} />
+          </div>
+        ))}
+        <AddBtn label="Add email" onClick={() => set("emails", [...v.emails, { label: "", email: "" }])} />
+      </div>
+
+      {/* Phones */}
+      <div className="flex flex-col gap-1">
+        <span className={sectionLabel}>Phone</span>
+        {v.phones.map((row, i) => (
+          <div key={i} className="flex items-center gap-1">
+            <select
+              className={select}
+              value={row.label}
+              onChange={(e) => set("phones", patchAt(v.phones, i, { label: e.target.value }))}
+            >
+              {PHONE_LABELS.map((l) => (
+                <option key={l} value={l}>
+                  {l || "label"}
+                </option>
+              ))}
+            </select>
+            <input
+              className={input}
+              placeholder="(305) 555-0100"
+              value={row.phone}
+              onChange={(e) => set("phones", patchAt(v.phones, i, { phone: e.target.value }))}
+            />
+            <RemoveBtn onClick={() => set("phones", seed(removeAt(v.phones, i), () => ({ label: "", phone: "" })))} />
+          </div>
+        ))}
+        <AddBtn label="Add phone" onClick={() => set("phones", [...v.phones, { label: "", phone: "" }])} />
+      </div>
+
+      {/* Addresses */}
+      <div className="flex flex-col gap-2">
+        <span className={sectionLabel}>Addresses</span>
+        {v.addresses.map((addr, i) => (
+          <div key={i} className="rounded border border-border/60 p-2">
+            <div className="mb-1 flex items-center justify-between">
+              <select
+                className={select}
+                value={addr.label ?? "home"}
+                onChange={(e) => set("addresses", patchAt(v.addresses, i, { label: e.target.value }))}
+              >
+                {ADDRESS_LABELS.map((l) => (
+                  <option key={l} value={l} className="capitalize">
+                    {l}
+                  </option>
+                ))}
+              </select>
+              <RemoveBtn onClick={() => set("addresses", removeAt(v.addresses, i))} />
+            </div>
+            <div className="flex flex-col gap-1">
+              <input
+                className={input}
+                placeholder="Street address"
+                value={addr.line1 ?? ""}
+                onChange={(e) => set("addresses", patchAt(v.addresses, i, { line1: e.target.value }))}
+              />
+              <input
+                className={input}
+                placeholder="Apt / Suite / Unit"
+                value={addr.line2 ?? ""}
+                onChange={(e) => set("addresses", patchAt(v.addresses, i, { line2: e.target.value }))}
+              />
+              <div className="grid grid-cols-3 gap-1">
+                <input
+                  className={input}
+                  placeholder="City"
+                  value={addr.city ?? ""}
+                  onChange={(e) => set("addresses", patchAt(v.addresses, i, { city: e.target.value }))}
+                />
+                <input
+                  className={input}
+                  placeholder="State"
+                  value={addr.state ?? ""}
+                  onChange={(e) => set("addresses", patchAt(v.addresses, i, { state: e.target.value }))}
+                />
+                <input
+                  className={input}
+                  placeholder="ZIP"
+                  value={addr.postal ?? ""}
+                  onChange={(e) => set("addresses", patchAt(v.addresses, i, { postal: e.target.value }))}
+                />
+              </div>
+            </div>
+          </div>
+        ))}
+        <AddBtn
+          label="Add address"
+          onClick={() => set("addresses", [...v.addresses, { label: "home" }])}
+        />
+      </div>
+
+      {/* Family */}
+      <div className="flex flex-col gap-1">
+        <span className={sectionLabel}>Family &amp; relationships</span>
+        {v.family.map((f, i) => (
+          <div key={i} className="flex items-center gap-1">
+            <input
+              className={input}
+              placeholder="Name"
+              value={f.name}
+              onChange={(e) => set("family", patchAt(v.family, i, { name: e.target.value }))}
+            />
+            <input
+              className={`${input} max-w-[40%]`}
+              placeholder="Relation (spouse, child…)"
+              value={f.relation ?? ""}
+              onChange={(e) => set("family", patchAt(v.family, i, { relation: e.target.value }))}
+            />
+            <RemoveBtn onClick={() => set("family", removeAt(v.family, i))} />
+          </div>
+        ))}
+        <AddBtn label="Add family member" onClick={() => set("family", [...v.family, { name: "", relation: "" }])} />
+      </div>
+
+      {/* Type */}
       <div>
-        <label className={label}>Type</label>
+        <span className={sectionLabel}>Type</span>
         <div className="mt-1 flex flex-wrap gap-1">
-          {TYPE_OPTIONS.map((t) => {
-            const on = v.contact_types?.includes(t);
+          {allTypes.map((t) => {
+            const on = v.contact_types.includes(t);
             return (
               <button
                 key={t}
@@ -184,13 +551,63 @@ export function ContactForm({
             );
           })}
         </div>
+        <div className="mt-1 flex items-center gap-1">
+          <input
+            className={`${input} max-w-[180px]`}
+            placeholder="Add custom type…"
+            value={customType}
+            onChange={(e) => setCustomType(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                addCustomType();
+              }
+            }}
+          />
+          <button
+            type="button"
+            onClick={addCustomType}
+            className="rounded-sm border border-border px-1.5 py-1 text-2xs text-text-2 hover:text-text-0"
+          >
+            Add
+          </button>
+        </div>
       </div>
 
+      {/* Socials */}
+      <div className="flex flex-col gap-1">
+        <span className={sectionLabel}>Social &amp; web</span>
+        {v.socials.map((s, i) => (
+          <div key={i} className="flex items-center gap-1">
+            <select
+              className={select}
+              value={s.kind}
+              onChange={(e) => set("socials", patchAt(v.socials, i, { kind: e.target.value }))}
+            >
+              {SOCIAL_KINDS.map((k) => (
+                <option key={k} value={k} className="capitalize">
+                  {k}
+                </option>
+              ))}
+            </select>
+            <input
+              className={input}
+              placeholder="URL or handle"
+              value={s.value}
+              onChange={(e) => set("socials", patchAt(v.socials, i, { value: e.target.value }))}
+            />
+            <RemoveBtn onClick={() => set("socials", removeAt(v.socials, i))} />
+          </div>
+        ))}
+        <AddBtn label="Add social" onClick={() => set("socials", [...v.socials, { kind: "linkedin", value: "" }])} />
+      </div>
+
+      {/* Tags */}
       <div>
         <label className={label}>Tags (comma-separated)</label>
         <input
           className={input}
-          value={(v.tags ?? []).join(", ")}
+          value={v.tags.join(", ")}
           onChange={(e) =>
             set(
               "tags",
@@ -203,6 +620,7 @@ export function ContactForm({
         />
       </div>
 
+      {/* Notes */}
       <div>
         <label className={label}>Notes</label>
         <textarea
@@ -223,5 +641,30 @@ export function ContactForm({
         </Button>
       </div>
     </div>
+  );
+}
+
+function AddBtn({ label, onClick }: { label: string; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="flex items-center gap-1 self-start text-2xs text-text-3 hover:text-text-1"
+    >
+      <Plus className="h-3 w-3" /> {label}
+    </button>
+  );
+}
+
+function RemoveBtn({ onClick }: { onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label="Remove"
+      className="flex-shrink-0 rounded-sm p-1 text-text-3 hover:text-danger"
+    >
+      <X className="h-3 w-3" />
+    </button>
   );
 }

--- a/apps/web/src/modules/contacts/components/ContactsView.test.tsx
+++ b/apps/web/src/modules/contacts/components/ContactsView.test.tsx
@@ -14,7 +14,7 @@ const { items } = vi.hoisted(() => ({
       avatar_url: null,
       contact_types: ["broker"],
       tags: [],
-      firm: "Realty Co",
+      company: "Realty Co",
       title: null,
       primary_email: "bob@x.com",
       primary_phone: null,
@@ -32,6 +32,7 @@ vi.mock("../lib/client-api", () => ({
   createContact: vi.fn(),
   updateContact: vi.fn(),
   archiveContact: vi.fn(),
+  uploadAvatar: vi.fn(),
 }));
 
 import { ContactsView } from "./ContactsView";

--- a/apps/web/src/modules/contacts/components/ContactsView.tsx
+++ b/apps/web/src/modules/contacts/components/ContactsView.tsx
@@ -8,6 +8,7 @@ import {
   listContacts,
   createContact,
   type ContactListItem,
+  type DuplicateHit,
 } from "../lib/client-api";
 import { ContactForm } from "./ContactForm";
 import { ContactDetail } from "./ContactDetail";
@@ -74,6 +75,20 @@ export function ContactsView({
   const [creating, setCreating] = useState(false);
   const [createBusy, setCreateBusy] = useState(false);
   const [createErr, setCreateErr] = useState<string | null>(null);
+  const [duplicate, setDuplicate] = useState<DuplicateHit | null>(null);
+  const [lastPatch, setLastPatch] = useState<Partial<ContactRow> | null>(null);
+
+  function openCreate() {
+    setDuplicate(null);
+    setLastPatch(null);
+    setCreateErr(null);
+    setCreating(true);
+  }
+  function closeCreate() {
+    setCreating(false);
+    setDuplicate(null);
+    setLastPatch(null);
+  }
 
   // Debounced server search/refresh.
   useEffect(() => {
@@ -92,18 +107,18 @@ export function ContactsView({
     if (next) setContacts(next);
   }
 
-  async function create(patch: Partial<ContactRow>) {
+  async function create(patch: Partial<ContactRow>, force = false) {
     setCreateBusy(true);
     setCreateErr(null);
     try {
-      const res = await createContact(patch);
+      const res = await createContact(patch, force);
       if (!res.contact && res.duplicate) {
-        setCreateErr(
-          `Looks like a duplicate of ${res.duplicate.first_name} ${res.duplicate.last_name}.`,
-        );
+        // Not a dead-end: surface an actionable banner (create anyway / open).
+        setDuplicate(res.duplicate);
+        setLastPatch(patch);
         return;
       }
-      setCreating(false);
+      closeCreate();
       await refresh();
       if (res.contact) setSelectedId(res.contact.id);
     } catch (e) {
@@ -111,6 +126,13 @@ export function ContactsView({
     } finally {
       setCreateBusy(false);
     }
+  }
+
+  function dupName(d: DuplicateHit): string {
+    return (
+      [d.first_name, d.last_name].filter(Boolean).join(" ").trim() ||
+      "an existing contact"
+    );
   }
 
   const empty = useMemo(() => contacts.length === 0, [contacts]);
@@ -122,17 +144,17 @@ export function ContactsView({
         <Users className="h-4 w-4 text-text-2" aria-hidden="true" />
         <h1 className="text-sm font-semibold text-text-0">Contacts</h1>
         <span className="font-mono text-2xs text-text-3">{contacts.length}</span>
-        <div className="relative ml-auto">
-          <Search className="pointer-events-none absolute left-2 top-1/2 h-3 w-3 -translate-y-1/2 text-text-3" />
+        <div className="ml-auto flex w-48 items-center gap-1.5 rounded border border-border bg-bg-2 px-2 py-1 focus-within:border-border-focus">
+          <Search className="h-3 w-3 flex-shrink-0 text-text-3" aria-hidden="true" />
           <input
             value={q}
             onChange={(e) => setQ(e.target.value)}
             placeholder="Search name, company, email…"
             aria-label="Search contacts"
-            className="w-48 rounded border border-border bg-bg-2 py-1 pl-7 pr-2 text-xs text-text-1 placeholder:text-text-3 outline-none focus:border-border-focus"
+            className="min-w-0 flex-1 bg-transparent text-xs text-text-1 placeholder:text-text-3 outline-none"
           />
         </div>
-        <Button size="sm" onClick={() => setCreating(true)}>
+        <Button size="sm" onClick={openCreate}>
           <Plus className="h-3 w-3" /> New
         </Button>
       </div>
@@ -145,7 +167,7 @@ export function ContactsView({
             {q ? "No contacts match your search." : "No contacts yet."}
           </p>
           {!q && (
-            <Button size="sm" variant="ghost" onClick={() => setCreating(true)}>
+            <Button size="sm" variant="ghost" onClick={openCreate}>
               <Plus className="h-3 w-3" /> Add your first contact
             </Button>
           )}
@@ -221,12 +243,41 @@ export function ContactsView({
 
       {/* Create modal */}
       {creating && (
-        <Modal title="New contact" onClose={() => setCreating(false)}>
+        <Modal title="New contact" onClose={closeCreate}>
+          {duplicate && (
+            <div className="mb-3 rounded border border-border bg-bg-2 p-2 text-2xs text-text-1">
+              <p>
+                Looks like a duplicate of{" "}
+                <span className="font-medium">{dupName(duplicate)}</span> (same
+                email or phone).
+              </p>
+              <div className="mt-2 flex gap-2">
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => {
+                    const id = duplicate.id;
+                    closeCreate();
+                    setSelectedId(id);
+                  }}
+                >
+                  Open existing
+                </Button>
+                <Button
+                  size="sm"
+                  disabled={createBusy || !lastPatch}
+                  onClick={() => lastPatch && create(lastPatch, true)}
+                >
+                  Create anyway
+                </Button>
+              </div>
+            </div>
+          )}
           <ContactForm
             busy={createBusy}
             error={createErr}
             submitLabel="Create"
-            onCancel={() => setCreating(false)}
+            onCancel={closeCreate}
             onSubmit={create}
           />
         </Modal>

--- a/apps/web/src/modules/contacts/components/ContactsView.tsx
+++ b/apps/web/src/modules/contacts/components/ContactsView.tsx
@@ -127,7 +127,7 @@ export function ContactsView({
           <input
             value={q}
             onChange={(e) => setQ(e.target.value)}
-            placeholder="Search name, firm, email…"
+            placeholder="Search name, company, email…"
             aria-label="Search contacts"
             className="w-48 rounded border border-border bg-bg-2 py-1 pl-7 pr-2 text-xs text-text-1 placeholder:text-text-3 outline-none focus:border-border-focus"
           />
@@ -159,16 +159,25 @@ export function ContactsView({
                 onClick={() => setSelectedId(c.id)}
                 className="flex w-full items-center gap-2.5 px-3 py-[var(--rk-row-py)] text-left hover:bg-bg-2"
               >
-                <span className="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full bg-bg-3 font-mono text-2xs text-text-1">
-                  {initials(c)}
-                </span>
+                {c.avatar_url ? (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img
+                    src={c.avatar_url}
+                    alt=""
+                    className="h-7 w-7 flex-shrink-0 rounded-full object-cover"
+                  />
+                ) : (
+                  <span className="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full bg-bg-3 font-mono text-2xs text-text-1">
+                    {initials(c)}
+                  </span>
+                )}
                 <span className="min-w-0 flex-1">
                   <span className="block truncate text-xs font-medium text-text-0">
                     {rowName(c)}
                   </span>
-                  {(c.firm || c.title) && (
+                  {(c.company || c.title) && (
                     <span className="block truncate text-2xs text-text-3">
-                      {[c.title, c.firm].filter(Boolean).join(" · ")}
+                      {[c.title, c.company].filter(Boolean).join(" · ")}
                     </span>
                   )}
                 </span>

--- a/apps/web/src/modules/contacts/lib/client-api.ts
+++ b/apps/web/src/modules/contacts/lib/client-api.ts
@@ -34,7 +34,7 @@ export type ContactListItem = Pick<
   | "avatar_url"
   | "contact_types"
   | "tags"
-  | "firm"
+  | "company"
   | "title"
   | "primary_email"
   | "primary_phone"
@@ -90,3 +90,22 @@ export const updateContact = (id: string, patch: Partial<ContactRow>) =>
 
 export const archiveContact = (id: string) =>
   req<void>(`${B}/${encodeURIComponent(id)}`, { method: "DELETE" });
+
+/**
+ * Upload a profile picture and get back its public URL. Multipart, so it
+ * bypasses the JSON `req` helper. The caller saves the returned URL on the
+ * contact's `avatar_url`.
+ */
+export async function uploadAvatar(file: File): Promise<string> {
+  const body = new FormData();
+  body.append("file", file);
+  const res = await fetch(`${B}/avatar`, { method: "POST", body });
+  const json = (await res.json().catch(() => ({}))) as {
+    data?: { url: string };
+    errors?: { code: string; message: string }[];
+  };
+  if (!res.ok || !json.data?.url) {
+    throw new Error(json.errors?.[0]?.message ?? `Upload failed (${res.status})`);
+  }
+  return json.data.url;
+}

--- a/design-lab.html
+++ b/design-lab.html
@@ -1,0 +1,509 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Rokki Design Lab</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=Geist+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
+<style>
+  * { box-sizing: border-box; }
+  html, body { margin: 0; height: 100%; }
+  body { display: flex; height: 100vh; overflow: hidden; background: #0a0a0b;
+         font-family: ui-sans-serif, system-ui, sans-serif; }
+
+  /* ============================ PREVIEW ============================ */
+  /* Tunable tokens live here as defaults; the panel overrides them
+     via inline style on this element, so the panel UI itself is never
+     affected by your tweaks. Defaults = current sandbox values. */
+  .preview {
+    --bg-0:#0a0a0b; --bg-1:#121214; --bg-2:#1a1a1d; --bg-3:#232327; --bg-4:#2d2d32;
+    --border:#2a2a2f; --border-strong:#34343b;
+    --text-0:#dadadf; --text-1:#c8c8cd; --text-2:#8a8a92; --text-3:#9099a4;
+    --accent:#f5a623; --success:#3fb950; --warning:#d29922; --danger:#f85149; --info:#58a6ff;
+    --text-2xs:10px; --text-xs:11px; --text-sm:13px; --text-base:14px;
+    --lh:1.4;
+    --divider-pct:40%;
+    --card-header-h:40px; --card-gutter:12px; --row-py:6px; --ctrl-py:8px;
+    --rail-header-h:40px; --rail-indent:12px; --rail-indent-child:32px;
+
+    flex: 1; min-width: 0; height: 100%; display: flex;
+    background: var(--bg-0); color: var(--text-1);
+    font-family: 'Geist', ui-sans-serif, system-ui, sans-serif;
+    font-size: var(--text-base); line-height: var(--lh);
+    -webkit-font-smoothing: antialiased;
+  }
+  .preview .mono { font-family: 'Geist Mono', ui-monospace, monospace; font-variant-numeric: tabular-nums; }
+  .dlist > li + li { border-top: 1px solid color-mix(in srgb, var(--border) var(--divider-pct), transparent); }
+
+  /* ---- Explorer rail ---- */
+  .rail { width: 232px; flex: none; height: 100%; display: flex; flex-direction: column;
+          background: var(--bg-0); border-right: 1px solid var(--border); }
+  .rail-header { height: var(--rail-header-h); flex: none; display: flex; align-items: center;
+                 padding: 0 12px; border-bottom: 1px solid var(--border);
+                 font-size: var(--text-xs); font-weight: 600; text-transform: uppercase;
+                 letter-spacing: .05em; color: var(--text-3); }
+  .rail-search { padding: 10px 8px; border-bottom: 1px solid var(--border); }
+  .rail-search input { height: 32px; width: 100%; background: var(--bg-1);
+                       border: 1px solid var(--border); border-radius: 4px; padding: 0 8px;
+                       color: var(--text-0); font-size: var(--text-xs); font-family: inherit; }
+  .rail-search input::placeholder { color: var(--text-3); }
+  .rail-tree { flex: 1; overflow: auto; padding: 8px 4px; }
+  .section-head { display: flex; align-items: center; gap: 4px; padding: 4px;
+                  font-size: var(--text-xs); font-weight: 600; text-transform: uppercase;
+                  letter-spacing: .05em; color: var(--text-3); }
+  .section-head.mods { margin-top: 12px; }
+  .tree-list { list-style: none; margin: 0; padding: 0 0 0 var(--rail-indent); }
+  .space-row { display: flex; align-items: center; gap: 4px; padding: 2px 4px; border-radius: 4px;
+               font-size: var(--text-xs); color: var(--text-1); }
+  .chev { color: var(--text-3); width: 14px; display: inline-block; }
+  .cog { margin-left: auto; color: var(--text-3); }
+  .term-list { list-style: none; margin: 2px 0 0; padding: 0; }
+  .term { padding: 2px 8px 2px var(--rail-indent-child); font-size: var(--text-xs);
+          color: var(--text-1); border-radius: 4px; }
+  .mod-row { display: flex; align-items: center; gap: 4px; padding: 2px 4px; border-radius: 4px;
+             font-size: var(--text-xs); color: var(--text-1); }
+  .mod-spacer { width: 14px; flex: none; }
+  .mod-label { flex: 1; }
+  .mod-bar { width: 3px; height: 12px; border-radius: 2px; background: var(--accent); flex: none; }
+  .rail-account { border-top: 1px solid var(--border); padding: 8px 12px; display: flex;
+                  align-items: center; gap: 8px; font-size: var(--text-xs); color: var(--text-0); }
+  .ava { width: 26px; height: 26px; border-radius: 50%; background: var(--bg-3); flex: none;
+         display: flex; align-items: center; justify-content: center;
+         font-size: var(--text-2xs); font-weight: 600; color: var(--text-0); }
+  .acct-mail { color: var(--text-3); font-size: var(--text-2xs); }
+
+  /* ---- Cards ---- */
+  .cards { flex: 1; min-width: 0; display: flex; gap: 12px; padding: 12px; overflow: auto; }
+  .card { flex: 1; min-width: 240px; display: flex; flex-direction: column;
+          background: var(--bg-1); border: 1px solid var(--border-strong); border-radius: 6px;
+          overflow: hidden; max-height: 100%; }
+  .card-head { height: var(--card-header-h); flex: none; display: flex; align-items: center;
+               justify-content: space-between; padding: 0 var(--card-gutter);
+               border-bottom: 1px solid var(--border); }
+  .chl { display: flex; align-items: center; gap: 8px; min-width: 0; }
+  .grip { color: var(--text-3); cursor: grab; font-size: var(--text-xs); letter-spacing: -2px; }
+  .card-title { margin: 0; font-size: var(--text-xs); font-weight: 600; text-transform: uppercase;
+                letter-spacing: .04em; color: var(--text-2); white-space: nowrap; }
+  .card-count { font-size: var(--text-2xs); color: var(--text-3); }
+  .chr { display: flex; align-items: center; gap: 8px; color: var(--text-3); }
+  .icon-btn { color: var(--text-3); cursor: pointer; }
+  .range-toggle { display: flex; border: 1px solid var(--border); border-radius: 4px; overflow: hidden;
+                  font-size: var(--text-2xs); }
+  .range-toggle span { padding: 2px 6px; text-transform: uppercase; font-weight: 600; color: var(--text-2); }
+  .range-toggle span.active { background: var(--accent); color: var(--bg-0); }
+  .card-body { flex: 1; overflow: auto; }
+  ul.lst { list-style: none; margin: 0; padding: 0; }
+
+  /* Week */
+  .day-head { display: flex; align-items: center; gap: 8px; padding: 4px var(--card-gutter); }
+  .day-label { font-size: var(--text-2xs); font-weight: 600; text-transform: uppercase;
+               letter-spacing: .04em; color: var(--text-2); }
+  .day-count { font-size: var(--text-2xs); color: var(--text-3); }
+  .event { display: flex; align-items: center; gap: 12px; padding: var(--row-py) var(--card-gutter);
+           font-size: var(--text-sm); }
+  .event .time { width: 42px; flex: none; font-size: var(--text-2xs); color: var(--text-3); }
+  .ei { width: 12px; flex: none; }
+  .ei.due { color: var(--warning); } .ei.evt { color: var(--info); }
+  .event .et { flex: 1; min-width: 0; color: var(--text-0); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+  /* Tasks */
+  .ctrl-strip { flex: none; display: flex; flex-wrap: wrap; align-items: center;
+                justify-content: space-between; gap: 8px; padding: var(--ctrl-py) var(--card-gutter);
+                border-bottom: 1px solid var(--border); }
+  .ctrl-left { display: flex; gap: 8px; align-items: center; }
+  .seg { border: 1px solid var(--border); border-radius: 4px; overflow: hidden; display: flex;
+         font-size: var(--text-2xs); }
+  .seg b { padding: 2px 6px; font-weight: 600; text-transform: uppercase; color: var(--text-3); }
+  .seg b.active { background: var(--bg-3); color: var(--text-0); }
+  .filter { height: 26px; border: 1px solid var(--border); background: var(--bg-1); border-radius: 4px;
+            padding: 0 8px; color: var(--text-0); font-size: var(--text-xs); width: 110px; font-family: inherit; }
+  .filter::placeholder { color: var(--text-3); }
+  .newtask { font-size: var(--text-xs); color: var(--text-2); white-space: nowrap; }
+  .task { display: flex; align-items: center; gap: 8px; border-left: 2px solid transparent;
+          padding: var(--row-py) var(--card-gutter) var(--row-py) calc(var(--card-gutter) - 2px);
+          font-size: var(--text-sm); }
+  .task[data-pri="1"] { border-left-color: var(--danger); }
+  .task[data-pri="2"] { border-left-color: var(--warning); }
+  .star { color: var(--warning); font-size: var(--text-xs); flex: none; }
+  .star.off { color: var(--text-3); opacity: .35; }
+  .cbx { width: 16px; height: 16px; border: 1px solid var(--border); border-radius: 3px; flex: none; }
+  .cbx.done { background: #0f2f18; border-color: var(--success); color: var(--success);
+              display: flex; align-items: center; justify-content: center; font-size: 11px; }
+  .ttl { flex: 1; min-width: 0; color: var(--text-0); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .ttl.done { color: var(--text-3); text-decoration: line-through; }
+  .due { font-size: var(--text-2xs); color: var(--text-2); flex: none; }
+  .due.warn { color: var(--warning); } .due.over { color: var(--danger); }
+  .pri { display: inline-flex; align-items: center; gap: 4px; font-size: var(--text-2xs);
+         text-transform: uppercase; color: var(--text-2); flex: none; }
+  .pri .dot { width: 6px; height: 6px; border-radius: 50%; }
+  .pill { font-size: var(--text-2xs); text-transform: uppercase; letter-spacing: .04em;
+          border-radius: 3px; padding: 2px 6px; flex: none; }
+  .pill.todo { background: var(--bg-3); color: var(--text-2); }
+  .pill.prog { background: #102b4a; color: var(--info); }
+  .pill.done { background: #0f2f18; color: var(--success); }
+
+  /* Messages */
+  .msg { display: flex; align-items: center; gap: 8px; padding: var(--row-py) var(--card-gutter);
+         font-size: var(--text-sm); }
+  .msg .ic { color: var(--text-3); width: 14px; flex: none; }
+  .msg .lbl { flex: 1; min-width: 0; color: var(--text-0); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .msg .tm { font-size: var(--text-2xs); color: var(--text-3); flex: none; }
+
+  /* ============================ PANEL ============================ */
+  .panel { width: 344px; flex: none; height: 100%; overflow: auto;
+           background: #0f0f11; border-left: 1px solid #2a2a2f; color: #e6e6ea;
+           font-family: ui-sans-serif, system-ui, sans-serif; font-size: 13px; }
+  .panel-top { position: sticky; top: 0; z-index: 5; background: #0f0f11;
+               border-bottom: 1px solid #2a2a2f; padding: 12px 14px; }
+  .panel-top h1 { margin: 0 0 2px; font-size: 14px; font-weight: 700; }
+  .panel-top p { margin: 0 0 10px; font-size: 11.5px; color: #9aa0aa; line-height: 1.4; }
+  .btns { display: flex; gap: 8px; }
+  .btn { flex: 1; cursor: pointer; border: 1px solid #34343b; background: #1a1a1d; color: #e6e6ea;
+         border-radius: 5px; padding: 7px 8px; font-size: 12px; font-weight: 600; }
+  .btn.primary { background: #f5a623; border-color: #f5a623; color: #0a0a0b; }
+  .btn:hover { filter: brightness(1.12); }
+  .group { padding: 6px 14px 12px; border-bottom: 1px solid #1c1c20; }
+  .group h2 { margin: 12px 0 8px; font-size: 11px; font-weight: 700; text-transform: uppercase;
+              letter-spacing: .08em; color: #8a8a92; }
+  .knob { margin: 9px 0; }
+  .knob .lab { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 4px; }
+  .knob .lab span:first-child { font-size: 12px; color: #cdd0d6; }
+  .knob .val { font-family: ui-monospace, monospace; font-size: 11px; color: #f5a623; }
+  .knob input[type=range] { width: 100%; accent-color: #f5a623; height: 18px; }
+  .knob .colorrow { display: flex; align-items: center; gap: 8px; }
+  .knob input[type=color] { width: 34px; height: 24px; padding: 0; border: 1px solid #34343b;
+                            border-radius: 4px; background: none; cursor: pointer; }
+  .knob .hex { flex: 1; }
+  .knob input[type=text] { width: 100%; background: #16161a; border: 1px solid #34343b; color: #e6e6ea;
+                           border-radius: 4px; padding: 5px 7px; font-family: ui-monospace, monospace; font-size: 11px; }
+
+  /* Export modal */
+  .overlay { position: fixed; inset: 0; background: rgba(0,0,0,.6); display: none;
+             align-items: center; justify-content: center; z-index: 50; }
+  .overlay.on { display: flex; }
+  .modal { width: min(620px, 92vw); max-height: 86vh; display: flex; flex-direction: column;
+           background: #121214; border: 1px solid #34343b; border-radius: 10px; overflow: hidden; }
+  .modal header { display: flex; align-items: center; justify-content: space-between;
+                  padding: 12px 16px; border-bottom: 1px solid #2a2a2f; }
+  .modal header h3 { margin: 0; font-size: 14px; color: #e6e6ea; }
+  .modal header button { cursor: pointer; background: none; border: none; color: #9aa0aa; font-size: 18px; }
+  .modal .body { padding: 14px 16px; overflow: auto; }
+  .modal .body p { margin: 0 0 10px; font-size: 12.5px; color: #9aa0aa; line-height: 1.5; }
+  .modal textarea { width: 100%; height: 280px; background: #0a0a0b; border: 1px solid #2a2a2f;
+                    border-radius: 6px; color: #d6d6da; font-family: ui-monospace, monospace;
+                    font-size: 12px; line-height: 1.5; padding: 10px; resize: vertical; }
+  .modal .row { display: flex; gap: 8px; margin-top: 10px; }
+</style>
+</head>
+<body>
+
+  <!-- ============================ PREVIEW ============================ -->
+  <div class="preview" id="preview">
+
+    <!-- Explorer rail -->
+    <div class="rail">
+      <div class="rail-header">Explorer</div>
+      <div class="rail-search"><input placeholder="Search…" /></div>
+      <div class="rail-tree">
+        <div class="section-head"><span class="chev">▾</span>Spaces</div>
+        <ul class="tree-list">
+          <li>
+            <div class="space-row"><span class="chev">▾</span><span>Trump Group</span><span class="cog">⚙</span></div>
+            <ul class="term-list">
+              <li class="term">Casablanca</li>
+              <li class="term">General</li>
+            </ul>
+          </li>
+          <li>
+            <div class="space-row"><span class="chev">▾</span><span>Helios</span><span class="cog">⚙</span></div>
+            <ul class="term-list">
+              <li class="term">Civic</li>
+              <li class="term">HD101</li>
+              <li class="term">HD102</li>
+            </ul>
+          </li>
+        </ul>
+        <div class="section-head mods"><span class="chev">▾</span>Modules</div>
+        <ul class="tree-list">
+          <li class="mod-row"><span class="mod-spacer"></span><span class="mod-label">Schedule</span><span class="mod-bar"></span></li>
+          <li class="mod-row"><span class="mod-spacer"></span><span class="mod-label">Tasks</span><span class="mod-bar"></span></li>
+          <li class="mod-row"><span class="mod-spacer"></span><span class="mod-label">Messages</span></li>
+        </ul>
+      </div>
+      <div class="rail-account">
+        <span class="ava">ZM</span>
+        <span><span style="display:block">Zack McKerley</span><span class="acct-mail mono">zackmckerley@gmail.com</span></span>
+      </div>
+    </div>
+
+    <!-- Cards -->
+    <div class="cards">
+
+      <!-- Schedule -->
+      <section class="card">
+        <header class="card-head">
+          <div class="chl"><span class="grip">⠿</span><h2 class="card-title">This week</h2><span class="card-count mono">7</span></div>
+          <div class="chr">
+            <span class="range-toggle"><span>Today</span><span class="active">Week</span><span>Month</span></span>
+            <span class="icon-btn">⤢</span>
+          </div>
+        </header>
+        <div class="card-body">
+          <ul class="lst dlist">
+            <li>
+              <div class="day-head"><span class="day-label">Today · Mon Jun 8</span><span class="day-count mono">2</span></div>
+              <ul class="lst dlist">
+                <li class="event"><span class="time mono">09:00</span><span class="ei evt">▣</span><span class="et">Standup</span></li>
+                <li class="event"><span class="time mono">14:00</span><span class="ei evt">▣</span><span class="et">Lender call — Casablanca</span></li>
+              </ul>
+            </li>
+            <li>
+              <div class="day-head"><span class="day-label">Tue Jun 9</span><span class="day-count mono">1</span></div>
+              <ul class="lst dlist">
+                <li class="event"><span class="time mono">due</span><span class="ei due">◆</span><span class="et">Title review deadline</span></li>
+              </ul>
+            </li>
+            <li>
+              <div class="day-head"><span class="day-label">Wed Jun 10</span><span class="day-count mono">1</span></div>
+              <ul class="lst dlist">
+                <li class="event"><span class="time mono">11:00</span><span class="ei evt">▣</span><span class="et">Site walk — Helios HD101</span></li>
+              </ul>
+            </li>
+          </ul>
+        </div>
+      </section>
+
+      <!-- Tasks -->
+      <section class="card">
+        <header class="card-head">
+          <div class="chl"><span class="grip">⠿</span><h2 class="card-title">Tasks</h2><span class="card-count mono">5</span></div>
+          <div class="chr"><span class="icon-btn">▁</span><span class="icon-btn">⤢</span></div>
+        </header>
+        <div class="ctrl-strip">
+          <div class="ctrl-left">
+            <span class="seg"><b class="active">Auto</b><b>Manual</b></span>
+            <span class="seg"><b>Group ▾</b></span>
+          </div>
+          <div class="ctrl-left">
+            <input class="filter" placeholder="Filter tasks…" />
+            <span class="newtask">＋ New task</span>
+          </div>
+        </div>
+        <div class="card-body">
+          <ul class="lst dlist">
+            <li class="task" data-pri="1">
+              <span class="star">★</span><span class="cbx"></span>
+              <span class="ttl">Review lender term sheet</span>
+              <span class="due over mono">1d ago</span>
+              <span class="pri"><span class="dot" style="background:var(--danger)"></span>High</span>
+              <span class="pill todo mono">todo</span>
+            </li>
+            <li class="task" data-pri="1">
+              <span class="star off">★</span><span class="cbx"></span>
+              <span class="ttl">Pull declaration — Bonne Vie</span>
+              <span class="due warn mono">2d</span>
+              <span class="pri"><span class="dot" style="background:var(--danger)"></span>High</span>
+              <span class="pill prog mono">in progress</span>
+            </li>
+            <li class="task" data-pri="2">
+              <span class="star off">★</span><span class="cbx"></span>
+              <span class="ttl">Send wire instructions to title co.</span>
+              <span class="due mono">Jun 14</span>
+              <span class="pri"><span class="dot" style="background:var(--warning)"></span>Med</span>
+              <span class="pill todo mono">todo</span>
+            </li>
+            <li class="task" data-pri="0">
+              <span class="star off">★</span><span class="cbx"></span>
+              <span class="ttl">Draft GC bid invite — Civic</span>
+              <span class="due mono">Jun 20</span>
+              <span class="pri"><span class="dot" style="background:var(--text-3)"></span>Low</span>
+              <span class="pill todo mono">todo</span>
+            </li>
+            <li class="task" data-pri="0">
+              <span class="star off">★</span><span class="cbx done">✓</span>
+              <span class="ttl done">Confirm folio — Grove Palms II</span>
+              <span class="pill done mono">done</span>
+            </li>
+          </ul>
+        </div>
+      </section>
+
+      <!-- Messages -->
+      <section class="card">
+        <header class="card-head">
+          <div class="chl"><span class="grip">⠿</span><h2 class="card-title">Messages</h2><span class="card-count mono">4</span></div>
+          <div class="chr"><span class="icon-btn">⤢</span></div>
+        </header>
+        <div class="card-body">
+          <ul class="lst dlist">
+            <li class="msg"><span class="ic">#</span><span class="lbl">casablanca-acq</span><span class="tm mono">2m</span></li>
+            <li class="msg"><span class="ic">#</span><span class="lbl">helios-dev</span><span class="tm mono">1h</span></li>
+            <li class="msg"><span class="ic">@</span><span class="lbl">Daniel — title co.</span><span class="tm mono">3h</span></li>
+            <li class="msg"><span class="ic">@</span><span class="lbl">Maria — GC</span><span class="tm mono">1d</span></li>
+          </ul>
+        </div>
+      </section>
+
+    </div>
+  </div>
+
+  <!-- ============================ PANEL ============================ -->
+  <div class="panel">
+    <div class="panel-top">
+      <h1>Rokki Design Lab</h1>
+      <p>Drag to tune the real design tokens. Live preview ← left. When it looks right, hit Export and paste it to Claude — it gets baked into the app.</p>
+      <div class="btns">
+        <button class="btn primary" id="exportBtn">Export ↗</button>
+        <button class="btn" id="resetBtn">Reset</button>
+      </div>
+    </div>
+    <div id="controls"></div>
+  </div>
+
+  <!-- Export modal -->
+  <div class="overlay" id="overlay">
+    <div class="modal">
+      <header><h3>Export — paste this to Claude</h3><button id="closeModal">✕</button></header>
+      <div class="body">
+        <p>Only the values you changed from the current app are listed. Copy and paste this whole block into chat — Claude will translate each one to the right place in the code and ship it.</p>
+        <textarea id="exportText" readonly></textarea>
+        <div class="row">
+          <button class="btn primary" id="copyBtn" style="flex:none;padding:7px 16px">Copy</button>
+          <span id="copyNote" style="align-self:center;font-size:12px;color:#9aa0aa"></span>
+        </div>
+      </div>
+    </div>
+  </div>
+
+<script>
+  const KNOBS = [
+    { group: 'Type — font size', items: [
+      { id:'--text-2xs', label:'Meta (counts, chips, times)', min:8,  max:14, step:1, unit:'px', def:'10' },
+      { id:'--text-xs',  label:'Labels & nav',                min:9,  max:16, step:1, unit:'px', def:'11' },
+      { id:'--text-sm',  label:'Content (titles, events)',    min:11, max:18, step:1, unit:'px', def:'13' },
+      { id:'--text-base',label:'Base',                        min:12, max:20, step:1, unit:'px', def:'14' },
+      { id:'--lh',       label:'Line spacing',                min:1.1,max:1.9,step:0.05,unit:'', def:'1.4' },
+    ]},
+    { group: 'Color', items: [
+      { id:'--text-0', label:'Text — brightest (the “white”)', type:'color', def:'#dadadf' },
+      { id:'--text-1', label:'Text — bright (body/nav)',       type:'color', def:'#c8c8cd' },
+      { id:'--text-2', label:'Text — muted (titles/meta)',     type:'color', def:'#8a8a92' },
+      { id:'--text-3', label:'Text — dim (timestamps)',        type:'color', def:'#9099a4' },
+      { id:'--border', label:'Border — soft (dividers)',       type:'color', def:'#2a2a2f' },
+      { id:'--border-strong', label:'Border — strong (cards)', type:'color', def:'#34343b' },
+      { id:'--accent', label:'Accent',                          type:'color', def:'#f5a623' },
+      { id:'--divider-pct', label:'Row divider strength',      min:0, max:100, step:5, unit:'%', def:'40' },
+    ]},
+    { group: 'Spacing & layout', items: [
+      { id:'--card-header-h', label:'Card header height',        min:28, max:56, step:1, unit:'px', def:'40' },
+      { id:'--card-gutter',   label:'Inner gutter (text ↔ edge)',min:6,  max:24, step:1, unit:'px', def:'12' },
+      { id:'--row-py',        label:'Row vertical padding',      min:2,  max:14, step:1, unit:'px', def:'6' },
+      { id:'--ctrl-py',       label:'Tasks controls-row padding',min:2,  max:16, step:1, unit:'px', def:'8' },
+    ]},
+    { group: 'Explorer rail', items: [
+      { id:'--rail-header-h',     label:'Rail header height', min:28, max:56, step:1, unit:'px', def:'40' },
+      { id:'--rail-indent',       label:'Item indent',        min:0,  max:28, step:1, unit:'px', def:'12' },
+      { id:'--rail-indent-child', label:'Terminal indent',    min:8,  max:48, step:1, unit:'px', def:'32' },
+    ]},
+  ];
+
+  const preview = document.getElementById('preview');
+  const STORE = 'rokki-design-lab-v1';
+  const flat = KNOBS.flatMap(g => g.items);
+  const defaults = Object.fromEntries(flat.map(k => [k.id, k.def]));
+  let state = { ...defaults };
+
+  try { const s = JSON.parse(localStorage.getItem(STORE) || '{}'); state = { ...state, ...s }; } catch (e) {}
+
+  function valueOf(k) { // returns the CSS value string (with unit)
+    const raw = state[k.id];
+    if (k.type === 'color') return raw;
+    return (k.unit ? raw + k.unit : raw);
+  }
+  function applyAll() { flat.forEach(k => preview.style.setProperty(k.id, valueOf(k))); }
+  function save() { localStorage.setItem(STORE, JSON.stringify(state)); }
+
+  // Build controls
+  const controls = document.getElementById('controls');
+  KNOBS.forEach(group => {
+    const g = document.createElement('div'); g.className = 'group';
+    const h = document.createElement('h2'); h.textContent = group.group; g.appendChild(h);
+    group.items.forEach(k => {
+      const wrap = document.createElement('div'); wrap.className = 'knob';
+      if (k.type === 'color') {
+        wrap.innerHTML =
+          '<div class="lab"><span>' + k.label + '</span></div>' +
+          '<div class="colorrow">' +
+            '<input type="color" data-id="' + k.id + '" data-kind="color" value="' + state[k.id] + '">' +
+            '<input type="text" class="hex" data-id="' + k.id + '" data-kind="hex" value="' + state[k.id] + '">' +
+          '</div>';
+      } else {
+        wrap.innerHTML =
+          '<div class="lab"><span>' + k.label + '</span><span class="val" id="v' + cssId(k.id) + '">' + state[k.id] + (k.unit||'') + '</span></div>' +
+          '<input type="range" data-id="' + k.id + '" data-kind="range" min="' + k.min + '" max="' + k.max + '" step="' + k.step + '" value="' + state[k.id] + '">';
+      }
+      g.appendChild(wrap);
+    });
+    controls.appendChild(g);
+  });
+
+  function cssId(id){ return id.replace(/[^a-z0-9]/gi,''); }
+
+  controls.addEventListener('input', e => {
+    const t = e.target; const id = t.dataset.id; if (!id) return;
+    const k = flat.find(x => x.id === id);
+    if (t.dataset.kind === 'range') {
+      state[id] = t.value;
+      const v = document.getElementById('v' + cssId(id)); if (v) v.textContent = t.value + (k.unit||'');
+    } else if (t.dataset.kind === 'color') {
+      state[id] = t.value;
+      const hex = controls.querySelector('input[data-kind=hex][data-id="' + id + '"]'); if (hex) hex.value = t.value;
+    } else if (t.dataset.kind === 'hex') {
+      if (!/^#[0-9a-f]{6}$/i.test(t.value)) return;
+      state[id] = t.value;
+      const col = controls.querySelector('input[data-kind=color][data-id="' + id + '"]'); if (col) col.value = t.value;
+    }
+    preview.style.setProperty(id, valueOf(k));
+    save();
+  });
+
+  // Reset
+  document.getElementById('resetBtn').addEventListener('click', () => {
+    state = { ...defaults }; save(); applyAll();
+    controls.querySelectorAll('input').forEach(inp => {
+      const id = inp.dataset.id, k = flat.find(x => x.id === id);
+      if (inp.dataset.kind === 'range') { inp.value = state[id]; const v = document.getElementById('v'+cssId(id)); if (v) v.textContent = state[id]+(k.unit||''); }
+      else { inp.value = state[id]; }
+    });
+  });
+
+  // Export
+  const overlay = document.getElementById('overlay');
+  document.getElementById('exportBtn').addEventListener('click', () => {
+    const changed = flat.filter(k => state[k.id] !== k.def);
+    const lines = changed.map(k => '  ' + k.id + ': ' + valueOf(k) + '   (was ' + (k.unit ? k.def + k.unit : k.def) + ')  — ' + k.label);
+    let out;
+    if (!changed.length) {
+      out = 'No changes yet — everything matches the current app.';
+    } else {
+      out = 'ROKKI DESIGN LAB — tokens to apply (' + changed.length + ' changed):\n\n' + lines.join('\n')
+          + '\n\nJSON:\n' + JSON.stringify(Object.fromEntries(changed.map(k => [k.id, valueOf(k)])), null, 2);
+    }
+    document.getElementById('exportText').value = out;
+    document.getElementById('copyNote').textContent = '';
+    overlay.classList.add('on');
+  });
+  document.getElementById('closeModal').addEventListener('click', () => overlay.classList.remove('on'));
+  overlay.addEventListener('click', e => { if (e.target === overlay) overlay.classList.remove('on'); });
+  document.getElementById('copyBtn').addEventListener('click', async () => {
+    const ta = document.getElementById('exportText'); ta.select();
+    try { await navigator.clipboard.writeText(ta.value); document.getElementById('copyNote').textContent = 'Copied ✓'; }
+    catch (e) { document.execCommand('copy'); document.getElementById('copyNote').textContent = 'Copied ✓'; }
+  });
+
+  applyAll();
+</script>
+</body>
+</html>

--- a/docs/improvement-matrix-300.md
+++ b/docs/improvement-matrix-300.md
@@ -1,0 +1,420 @@
+# Rokki — 300 ways to reach top-tier
+
+Companion to `test-matrix-300.md`. That list was correctness ("does X
+work?"). This is elevation ("is X world-class?") — polish, depth,
+performance, resilience, and product capability. Grouped by theme.
+
+## 1. Micro-interactions & motion (12)
+1. Optimistic checkbox/star animate instantly; reconcile silently.
+2. Drag ghost + drop-zone highlight with spring easing on panels/rows.
+3. Skeleton → content cross-fades as slots stream in (no hard pop).
+4. Row hover reveals actions with a subtle slide, not an opacity jump.
+5. Dialog open/close: fast scale+fade (120–180ms), reduced-motion aware.
+6. Toasts slide/stack/auto-dismiss with a progress bar; swipe to dismiss.
+7. Focus ring animates in; never jumps abruptly.
+8. Number changes (counts, prices) tween/flash, not instant swap.
+9. Ticker pauses on hover AND focus-within.
+10. Collapsible sections animate height, not a display:none snap.
+11. Buttons show inline spinner + disabled while pending.
+12. Route transitions use a consistent fast fade (no white flash).
+
+## 2. Empty / loading / error craft (12)
+13. Every list has a purposeful empty state (icon + one action).
+14. Skeletons match the real layout's shape (zero reflow on load).
+15. Per-card error boundaries (one failing card ≠ blank dashboard).
+16. Inline retry on a failed section, not a full reload.
+17. Partial failure: show what loaded, flag what didn't.
+18. Offline banner with auto-reconnect + queued actions.
+19. 404/403/500 pages are on-brand and offer a way back.
+20. Slow loads (>Ns) show "still working…", not an infinite spinner.
+21. Empty search distinguishes "no results" from "nothing yet".
+22. Rollback on optimistic failure explains what reverted (toast).
+23. No flash of unstyled/wrong-theme content on first paint.
+24. Stale data shows "updated Xs ago / refresh".
+
+## 3. Keyboard & power-user (14)
+25. Command palette (⌘K) covers every action + navigation.
+26. Palette: fuzzy match, recent, and scoped (this-terminal) results.
+27. "?" opens a searchable shortcut cheat sheet.
+28. j/k navigate rows, Enter opens, x selects, in task lists.
+29. Multi-select (shift/⌘-click) + a bulk-actions bar.
+30. Quick-switch terminals/spaces without leaving the keyboard.
+31. Every dialog fully keyboard-operable (Enter submit, Esc cancel).
+32. "g then d/t/c" go-to navigation.
+33. Inline create: type to add a task with no dialog.
+34. Undo (⌘Z) for the last destructive/edit action.
+35. Focus returns to the trigger after closing menus/dialogs.
+36. Arrow-key navigation in the explorer tree.
+37. Type-ahead to jump to a row in long lists.
+38. F-key bar fully wired + discoverable.
+
+## 4. Performance & perceived speed (14)
+39. Prefetch routes on link hover/focus (instant nav).
+40. Prefetch likely-next data (hover a task → preload its detail).
+41. Virtualize long task lists (render only visible rows).
+42. Optimistic writes everywhere; never block on the network.
+43. Code-split heavy routes/dialogs; keep the dashboard lean.
+44. Enforce LCP/INP/CLS budgets in CI.
+45. Image optimization (next/image, AVIF/WebP, right sizes).
+46. Self-host + subset fonts; preload; no FOIT/FOUT.
+47. Edge-cache safe GETs; stale-while-revalidate.
+48. Debounce/throttle realtime-driven refetches.
+49. Kill N+1 queries in dashboard/list endpoints.
+50. Audit re-render storms; memoize hot paths.
+51. Lazy-load below-the-fold cards/ticker.
+52. Stays smooth on a throttled mid-tier CPU.
+
+## 5. Onboarding & first-run (12)
+53. New-user empty workspace explains space → terminal → task.
+54. Optional one-click sample data to explore (and remove).
+55. First-run checklist (create terminal, add task, invite, connect cal).
+56. Contextual, dismissible tooltips on first encounter.
+57. "Connect your calendar" prompt when the Week card is empty.
+58. Inline shortcut hints where the action lives.
+59. Progressive disclosure of advanced controls.
+60. Skippable tour that never re-nags.
+61. Zero-terminals state guides creation (no dead buttons).
+62. Role/template selection tailors the experience.
+63. Tasteful celebration on first task completed.
+64. Empty dashboard suggests the next best action.
+
+## 6. Search & filtering depth (12)
+65. Global search: tasks, terminals, files, messages, people.
+66. Fuzzy + typo-tolerant, ranked results.
+67. Operators (terminal:HD101 status:overdue assignee:me).
+68. Saved/smart views the user can name + pin.
+69. Recent + suggested searches.
+70. Highlight matched substrings.
+71. Scope toggle: this terminal vs everything.
+72. Removable, combinable filter chips.
+73. Search-as-you-type with cancellation (no race results).
+74. Keyboard-navigable results with previews.
+75. Persist last-used filters per surface.
+76. "No results" suggests relaxing a filter.
+
+## 7. Notifications & inbox (12)
+77. Notification center: read/unread, grouped by terminal/type.
+78. Accurate unread badges that clear on view.
+79. @mentions notify + deep-link to the exact item.
+80. Per-type preferences (in-app/email/none).
+81. Opt-in daily/weekly digest email.
+82. Snooze / mark-all-read / clear.
+83. Realtime toasts for high-signal events only.
+84. Deep-links restore full context (scroll + highlight).
+85. Mute a terminal/thread.
+86. Do-not-disturb / quiet hours.
+87. PWA push notifications (opt-in).
+88. Searchable notification history.
+
+## 8. Realtime & collaboration (12)
+89. Presence avatars (who's viewing a terminal/task).
+90. "X is typing…" in comments/messages.
+91. Live updates merge without clobbering in-progress edits.
+92. Concurrent-edit conflict detection (flag last-write-wins).
+93. Optimistic edits reconcile with server truth gracefully.
+94. Offline edit queue that syncs on reconnect.
+95. "Updated by X just now" attribution on changed rows.
+96. Live cursors/selection in shared editors (where applicable).
+97. Per-terminal activity feed.
+98. Realtime respects permissions (no unauthorized leakage).
+99. Clean subscription lifecycle (no leaks/dupes).
+100. Reconnect backoff with a visible "reconnecting…" state.
+
+## 9. Mobile / responsive / PWA (12)
+101. Installable PWA (manifest, icons, splash, offline shell).
+102. Offline read of recently-viewed data.
+103. Bottom-sheet dialogs on mobile.
+104. ≥44px touch targets everywhere.
+105. Swipe gestures (complete/snooze a task).
+106. Pull-to-refresh on lists.
+107. Safe-area (notch) handling.
+108. Responsive tables → cards on narrow widths.
+109. Mobile tab bar covers core navigation.
+110. Sticky headers that don't eat the small viewport.
+111. Landscape + tablet layouts are first-class.
+112. Verified on real iOS Safari + Android Chrome.
+
+## 10. Accessibility — AAA aim (12)
+113. Full screen-reader pass on each primary flow.
+114. Focus moves to main/heading on route change.
+115. ARIA live regions announce async updates politely.
+116. Every color meaning has a non-color cue.
+117. Color-blind-safe palette check.
+118. Respect prefers-reduced-motion app-wide.
+119. A high-contrast theme (prefers-contrast).
+120. OS font-scaling to 200% without breakage.
+121. No keyboard traps; logical tab order everywhere.
+122. Dialogs aria-modal with labelled title + description.
+123. Form errors announced + tied to fields.
+124. Skip links + landmarks on every page.
+
+## 11. Data integrity & undo (12)
+125. Undo/redo stack for edits + destructive actions.
+126. Soft-delete + a Trash with restore.
+127. Destructive confirms with specific copy + counts.
+128. Autosave drafts (composer/comments) with recovery.
+129. Idempotency keys so double-submit doesn't duplicate.
+130. Reliable, explained optimistic rollback.
+131. Concurrent-edit conflict → merge/choose UI.
+132. Task history/versioning (who changed what).
+133. Bulk-action confirmation with counts.
+134. Data export (CSV/JSON) per terminal/account.
+135. Inline, immediate, forgiving validation.
+136. Guard against navigating away from unsaved edits.
+
+## 12. Settings & personalization (12)
+137. Theme (dark/light/system) + Design-Mode tokens as prefs.
+138. Density presets persisted server-side.
+139. Multiple named dashboard layouts.
+140. Default group/sort/filter per surface.
+141. Customizable keyboard shortcuts.
+142. Per-terminal defaults (assignee/priority/labels).
+143. Profile (name, avatar, timezone, working hours).
+144. Centralized notification preferences.
+145. Connected-accounts/integrations management.
+146. Language/locale + date/number format.
+147. Accent-color theming.
+148. Settings search.
+
+## 13. Files & attachments (10)
+149. Drag-drop anywhere + paste image from clipboard.
+150. Upload progress, cancel, retry, resumable for large files.
+151. Thumbnails + inline preview (images/PDF/docs).
+152. Virus-scan status + safe-quarantine UX.
+153. Dedupe identical uploads; version same-name.
+154. File search (name + OCR/RAG content).
+155. Attach picker with recent files.
+156. Bulk download / zip.
+157. Per-file permissions + share links with expiry.
+158. Storage usage + limits surfaced.
+
+## 14. Tasks & project depth (14)
+159. Dependencies (blocks/blocked-by) with cycle detection.
+160. Subtask UX: inline add, drag-reorder, progress rollup.
+161. Task templates / quick-create presets.
+162. Bulk edit on multi-select (status/priority/assignee/labels).
+163. Recurring: skip / edit-this-vs-all / end conditions.
+164. Natural-language due dates ("next fri 3pm").
+165. Time estimates + tracking (actual vs estimate).
+166. Board (kanban) view.
+167. Timeline/Gantt for dependencies + due dates.
+168. Custom fields per terminal/template.
+169. Saved task views (My overdue, Blocked, This week).
+170. Watchers/followers on a task.
+171. Task → calendar event + reminders.
+172. Link comment↔task and task↔message.
+
+## 15. Calendar depth (10)
+173. Drag to reschedule; resize to change duration.
+174. Multiple connected calendars, color-coded.
+175. Agenda/day/week/month views.
+176. Timezone display ("your time vs theirs").
+177. Recurring-event handling (edit this/all).
+178. Two-way sync (Google/Outlook) with conflict handling.
+179. Create an event inline from the dashboard.
+180. Free/busy + conflict warnings.
+181. Tasks-with-due overlay toggle.
+182. ICS subscribe/export.
+
+## 16. Messaging & comments (10)
+183. Threaded replies + collapse.
+184. Emoji reactions.
+185. @mentions with autocomplete + notification.
+186. Markdown + code blocks + link previews.
+187. Edit/delete with an edited indicator.
+188. Read receipts / seen-by.
+189. Slash commands (/task, /assign).
+190. Inline attachments + image paste.
+191. Unread dividers + jump-to-unread.
+192. In-thread search.
+
+## 17. Observability & ops (12)
+193. Sentry with source maps, releases, user context.
+194. Structured logs (request-id, user, terminal) end-to-end.
+195. Real-user web-vitals (INP/LCP/CLS) dashboard.
+196. Uptime monitoring + a status page.
+197. Alerting on error-rate / latency spikes.
+198. Feature flags + kill switches for safe rollout.
+199. Audit log (security-relevant actions) with a viewer.
+200. Slow-query monitoring.
+201. Synthetic checks for login + create-task.
+202. Distributed tracing web → API → DB.
+203. Health/readiness/liveness endpoints.
+204. Cost/usage dashboards (Supabase/Vercel/Upstash).
+
+## 18. Security hardening (14)
+205. 2FA / TOTP + recovery codes.
+206. Session/device management UI (revoke a device).
+207. Rate limiting on auth + write endpoints.
+208. CI-enforced RLS test coverage per table.
+209. Tighten CSP (no unsafe-inline; nonce/hash).
+210. Secret rotation; no secrets in client bundles.
+211. SCA/dependency scanning + auto-PRs.
+212. CSRF protection on all mutations.
+213. Audited input validation + output encoding (XSS).
+214. SSO / SAML for enterprise spaces.
+215. Per-user MCP tokens with scopes + revocation UX.
+216. Account lockout / suspicious-login detection.
+217. Encryption at rest + in transit verified.
+218. GDPR data export + account deletion.
+
+## 19. Reliability & resilience (12)
+219. Retries with backoff + jitter on transient failures.
+220. Circuit breakers around flaky externals (calendar/AI).
+221. Graceful degradation when realtime/AI is down.
+222. Idempotent webhooks + dead-letter queue.
+223. Background job queue with retry + visibility.
+224. Serverless-tuned DB connection pooling.
+225. Backups + tested restore drills.
+226. Zero-downtime migrations (expand/contract).
+227. Timeouts on every external call.
+228. Chaos test: kill realtime/DB, verify UX.
+229. Concurrency limits protecting the DB.
+230. Fast rollback from a bad deploy.
+
+## 20. AI / MCP product depth (12)
+231. AI quick-actions: summarize a terminal, draft an update.
+232. Natural-language task create from the palette.
+233. Smart scheduling / next-best-action.
+234. AI-drafted status updates (edit/approve).
+235. Streaming AI responses (token-by-token).
+236. Tool-approval UX: clear consent, scope, audit.
+237. Per-user token enforcement verified (no service key).
+238. AI rate/cost guardrails + quotas surfaced.
+239. RAG over the user's files/tasks with citations.
+240. "Explain this" / inline AI help.
+241. AI never acts destructively without confirmation.
+242. Evals to catch AI quality regressions.
+
+## 21. i18n & formatting (8)
+243. i18n scaffolding (message catalog; no hardcoded strings).
+244. Locale-aware dates/times/numbers/currency.
+245. Pluralization + gendered strings.
+246. RTL layout support.
+247. Per-user timezone correctness everywhere.
+248. Live, locale-correct relative time.
+249. Tabular figures + grouping for numerics.
+250. Translatable email templates.
+
+## 22. Content & copy craft (8)
+251. Errors explain what happened + how to fix.
+252. Empty-state copy is specific + actionable.
+253. Consistent terminology (space/terminal/task) everywhere.
+254. Verb-first, unambiguous button microcopy.
+255. Tooltips add value, not restate the label.
+256. Confirms state the consequence + count.
+257. Honest loading copy.
+258. Senior-engineer voice (no cute), per the spec.
+
+## 23. Design-system maturity (12)
+259. Restore the Tailwind spacing scale (fixes icons/dots/paddings).
+260. Storybook with every component state.
+261. Audited dark/light token parity.
+262. Icon-set consistency (size/weight/source).
+263. Elevation/shadow tokens.
+264. Z-index scale (no magic numbers).
+265. Documented + enforced spacing/type rhythm.
+266. De-duplicate reusable primitives.
+267. Centralized motion tokens (durations/easings).
+268. Consistent focus-state tokens.
+269. Density variants as first-class props.
+270. Visual snapshot tests for the system.
+
+## 24. Testing & CI maturity (14)
+271. Playwright E2E for critical flows (login→task→complete).
+272. Visual regression on key screens.
+273. RLS/integration tests with a seeded second user.
+274. Contract tests for API + MCP parity.
+275. Load tests on list/dashboard endpoints.
+276. a11y CI (axe) on every page.
+277. Meaningful coverage gates.
+278. Per-PR preview deploys with seeded data.
+279. Lighthouse/web-vitals budget gate.
+280. Flaky-test quarantine + tracking.
+281. Mutation testing on critical logic.
+282. Migration up/down tests in CI.
+283. Post-deploy prod smoke test.
+284. Test data factories/fixtures.
+
+## 25. Edge cases, delight & differentiation (16)
+285. Extremely long titles/labels/emails never break layout.
+286. 1000s of tasks stay fast (virtualization).
+287. Special chars/emoji/RTL render safely.
+288. Deleted-while-viewing handled gracefully.
+289. Pagination/infinite-scroll with stable scroll position.
+290. Stale-tab → inline re-auth on expiry.
+291. The command palette is the hero — fastest path to anything.
+292. Keyboard-first speed that feels like a real terminal.
+293. Deepen the Bloomberg aesthetic (density, mono numerics, F-keys).
+294. "It feels fast" — sub-100ms perceived on every click.
+295. Optional, tasteful sound/haptic for key actions.
+296. A brand-right loading identity (no generic spinners).
+297. Beautiful read-only share views (/r/ pages).
+298. Delight: copy-to-clipboard everywhere, smart paste, hover timestamps.
+299. Consistency audit — every list/row/dialog follows one pattern.
+300. A "what's new" changelog so users feel the product improving.
+
+## 26. Speed — 50 deep-dive optimizations (301–350)
+Goes deeper than the headline perf items (#39–52) into specific techniques.
+
+### Rendering & React
+301. Push more rendering into Server Components; ship less client JS per route.
+302. Move "use client" to the smallest interactive leaves, not whole subtrees.
+303. Wrap search/filter in useTransition + useDeferredValue so typing never blocks.
+304. Split contexts (theme/density/visibility) so a change re-renders only what's needed.
+305. React.memo hot list rows + stable useCallback handlers to stop cascade re-renders.
+306. Tune virtualization: fixed row heights + small overscan; don't measure every row.
+307. Use GPU-composited transforms/opacity for motion; never animate top/left/width.
+308. Batch DOM reads then writes; eliminate layout thrash in drag/resize handlers.
+309. Defer non-critical effects to requestIdleCallback (extend the dialog-preload pattern).
+310. Strip console/dev-only branches in prod; confirm dead code is tree-shaken.
+
+### Bundle & build
+311. Run a bundle analyzer; enforce a per-route first-load JS budget in CI.
+312. Modularize icon imports so only used lucide icons ship (not the barrel).
+313. Replace heavy deps with lighter/native (date math, lodash, moment-likes).
+314. Dynamic-import every dialog/heavy panel (extend the QuickTaskDialog split).
+315. Target modern browsers; drop legacy polyfills/transpile weight.
+316. Dedupe duplicate transitive deps (one React, one date lib).
+317. Defer/async third-party scripts (Sentry, analytics) so they never block first paint.
+318. Tune shared-chunk splitting so common code is cached across routes.
+319. Minify + Brotli all JS/CSS; verify no unminified prod bundles ship.
+
+### Network & caching
+320. `Cache-Control: immutable` + long max-age on hashed static assets.
+321. Stale-while-revalidate on safe GET data so repeat views are instant.
+322. ISR/`revalidate` on pages whose data tolerates seconds of staleness.
+323. Preconnect + dns-prefetch to Supabase, the CDN, and font origins.
+324. Verify HTTP/2/3 multiplexing; avoid head-of-line blocking from many requests.
+325. Select only the columns/fields each view needs (trim API payloads).
+326. Cursor pagination + "load more" instead of fetching everything.
+327. Batch independent dashboard queries; remove request waterfalls.
+328. Stream slow API responses (extend RSC streaming beyond the page).
+329. Edge-cache hot read-only reference data (spaces/terminals lists).
+330. Service worker caches the app shell + last-viewed data (offline-fast).
+331. Compress + paginate the ticker/activity feed; cap initial rows.
+
+### Data fetching
+332. Parallelize independent server fetches (Promise.all); no sequential awaits.
+333. Use React `cache()` to dedupe identical fetches within a render.
+334. Optimistic cache writes so a successful mutation doesn't trigger a refetch.
+335. Patch the single changed row on realtime instead of refetching the list.
+336. Prefetch the next likely view's data on hover/focus/viewport-enter.
+337. Load the first N rows immediately; stream the remainder in the background.
+338. Colocate data fetching with the component that needs it (no top-level over-fetch).
+
+### Database / Supabase
+339. Index the hot task-list filters (status, due_date, assignee, terminal_id).
+340. Index the columns RLS policies filter on (RLS without an index = full scan).
+341. EXPLAIN-analyze the dashboard + calendar queries; kill sequential scans.
+342. Materialized view / denormalized counts for dashboard aggregates.
+343. Tune Supavisor/PgBouncer pooling for serverless burst concurrency.
+344. Add covering indexes so hot reads are index-only.
+345. Batch writes (multi-row insert/update) instead of per-row round-trips.
+346. Statement timeouts on every query to protect the DB under load.
+
+### Realtime & assets
+347. Coalesce realtime bursts; send minimal diffs, not full rows, over the socket.
+348. Lazy-subscribe only to visible/active terminals' channels; unsubscribe on blur.
+349. Serve responsive AVIF/WebP with srcset; lazy-load all below-the-fold media.
+350. Add real-user web-vitals monitoring + a Lighthouse CI gate to catch regressions at the source.

--- a/scripts/_parse_review.py
+++ b/scripts/_parse_review.py
@@ -1,0 +1,33 @@
+import json, sys
+raw = open(sys.argv[1], encoding="utf-8", errors="replace").read()
+i = raw.find('{"confirmed"')
+depth = 0; end = -1; instr = False; esc = False
+for j in range(i, len(raw)):
+    c = raw[j]
+    if esc:
+        esc = False; continue
+    if c == "\\":
+        esc = True; continue
+    if c == '"':
+        instr = not instr; continue
+    if instr:
+        continue
+    if c == "{":
+        depth += 1
+    elif c == "}":
+        depth -= 1
+        if depth == 0:
+            end = j + 1; break
+data = json.loads(raw[i:end])
+print("CONFIRMED:", len(data["confirmed"]))
+for k, f in enumerate(data["confirmed"], 1):
+    print()
+    print("[%d] %s :: %s" % (k, f["severity"].upper(), f["dimension"]))
+    print("   ", f["title"])
+    print("    @", f["location"], "(conf %s)" % f.get("confidence"))
+    print("    FIX:", f["suggested_fix"][:320])
+print()
+print("REJECTED:", len(data.get("rejected_summary", [])))
+for r in data.get("rejected_summary", []):
+    print("  -", r["title"][:100])
+json.dump(data, open(sys.argv[2], "w"))

--- a/scripts/flake-hunt.sh
+++ b/scripts/flake-hunt.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Flake-hunt — run the web + sdk unit suites N times with shuffled file/test
+# order, logging any failure with its seed for reproduction.
+#
+# Run on an OTHERWISE-IDLE machine: CPU contention from other heavy processes
+# causes false timing flakes (the thing we're hunting for). Vitest's own
+# config excludes tests/rls (no Docker needed); this only runs the unit suite.
+#
+#   RUNS=80 bash scripts/flake-hunt.sh
+set -u
+ROOT="C:/Users/zack mckerley/Claude/rokki"
+RUNS="${RUNS:-60}"
+LOG="$ROOT/flake-hunt.log"
+: > "$LOG"
+fails=0
+for i in $(seq 1 "$RUNS"); do
+  seed=$RANDOM
+  webok=1
+  sdkok=1
+  (cd "$ROOT/apps/web" && pnpm exec vitest run --sequence.shuffle --sequence.seed="$seed" >"/tmp/fh_web_$i.log" 2>&1) || webok=0
+  (cd "$ROOT/packages/sdk" && pnpm exec vitest run --sequence.shuffle --sequence.seed="$seed" >"/tmp/fh_sdk_$i.log" 2>&1) || sdkok=0
+  if [ "$webok" -eq 0 ] || [ "$sdkok" -eq 0 ]; then
+    fails=$((fails + 1))
+    {
+      echo "=== RUN $i FAILED (seed=$seed web_ok=$webok sdk_ok=$sdkok) ==="
+      if [ "$webok" -eq 0 ]; then
+        echo "--- web failures ---"
+        grep -E "FAIL|AssertionError|Error:|✗|×" "/tmp/fh_web_$i.log" | head -40
+      fi
+      if [ "$sdkok" -eq 0 ]; then
+        echo "--- sdk failures ---"
+        grep -E "FAIL|AssertionError|Error:|✗|×" "/tmp/fh_sdk_$i.log" | head -40
+      fi
+      echo ""
+    } >>"$LOG"
+  fi
+  echo "run $i/$RUNS done (cumulative fails=$fails)"
+done
+echo "=== FLAKE-HUNT COMPLETE: $fails/$RUNS runs had a failure (details in flake-hunt.log) ===" | tee -a "$LOG"

--- a/scripts/mirror-prod-to-sandbox.py
+++ b/scripts/mirror-prod-to-sandbox.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""One-time snapshot mirror of production Supabase data into sandbox.
+
+Reads PRODUCTION (strictly SELECT-only) and writes ONLY to SANDBOX. Uses
+the Supabase Management API `database/query` endpoint, so it needs only a
+personal access token (SUPABASE_ACCESS_TOKEN) — no DB passwords.
+
+  Dry run (default):  SUPABASE_ACCESS_TOKEN=... python scripts/mirror-prod-to-sandbox.py
+  Execute:            SUPABASE_ACCESS_TOKEN=... python scripts/mirror-prod-to-sandbox.py --execute
+
+Loads happen with session_replication_role='replica' so FK/trigger checks
+are skipped (order-independent). Encrypted/secret + transient tables are
+NOT copied. Production is never modified.
+"""
+import os
+import sys
+import json
+import urllib.request
+import urllib.error
+
+TOKEN = os.environ.get("SUPABASE_ACCESS_TOKEN")
+if not TOKEN:
+    raise SystemExit("SUPABASE_ACCESS_TOKEN not set")
+
+PROD = "bwtmtpcgilvrkhougjdo"      # rokki-production  (READ ONLY)
+SANDBOX = "hqsdhwlokfwcitfitees"   # rokki-staging     (write target)
+assert PROD != SANDBOX, "refusing to run with prod==sandbox"
+
+EXECUTE = "--execute" in sys.argv
+TAG = "$MIRRORDATA$"  # dollar-quote tag; assumed absent from the data
+
+# User-facing tables to mirror. Order is irrelevant (replica mode). Each
+# is DELETE'd then re-filled from prod, so sandbox matches prod exactly.
+COPY = [
+    "public.profiles",
+    "public.spaces",
+    "public.space_members",
+    "public.terminals",
+    "public.terminal_members",
+    "public.folders",
+    "public.tasks",
+    "public.task_assignees",
+    "public.subtasks",
+    "public.task_watchers",
+    "public.calendar_connections",
+    "public.calendar_events",
+    "public.message_threads",
+    "public.messages",
+    "public.activity",
+]
+# Deliberately NOT copied: domain_events, rate_limit_hits,
+# session_revocations, impersonation_events (transient / audit logs);
+# access_tokens, push_subscriptions (per-env secrets; empty anyway);
+# platform_config, modules_catalog, feature_flags (env config — leave
+# sandbox's own).
+
+
+def api(ref, sql):
+    req = urllib.request.Request(
+        f"https://api.supabase.com/v1/projects/{ref}/database/query",
+        data=json.dumps({"query": sql}).encode(),
+        headers={
+            "Authorization": f"Bearer {TOKEN}",
+            "Content-Type": "application/json",
+            "User-Agent": "curl/8.5.0",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=180) as r:
+            return json.loads(r.read().decode())
+    except urllib.error.HTTPError as e:
+        raise RuntimeError(f"HTTP {e.code}: {e.read().decode()[:400]}")
+
+
+def read_prod(sql):
+    s = sql.lstrip().lower()
+    assert s.startswith("select"), "prod is read-only"
+    return api(PROD, sql)
+
+
+def write_sandbox(sql):
+    # Hard guard: writes can only ever target SANDBOX.
+    return api(SANDBOX, sql)
+
+
+def count(ref, tbl):
+    return api(ref, f"SELECT count(*)::int AS c FROM {tbl}")[0]["c"]
+
+
+def table_columns(tbl):
+    """(insertable cols, generated cols). Generated (e.g. search_vector
+    tsvector) can't take an explicit value — Postgres recomputes them."""
+    schema, name = tbl.split(".")
+    rows = read_prod(
+        "SELECT column_name, is_generated FROM information_schema.columns "
+        f"WHERE table_schema='{schema}' AND table_name='{name}' "
+        "ORDER BY ordinal_position"
+    )
+    insertable = [r["column_name"] for r in rows if r["is_generated"] != "ALWAYS"]
+    generated = [r["column_name"] for r in rows if r["is_generated"] == "ALWAYS"]
+    return insertable, generated
+
+
+def fetch_json(ref, sql):
+    return read_prod(sql)[0]["d"] if ref == PROD else api(ref, sql)[0]["d"]
+
+
+print(f"Mirror  prod({PROD})  ->  sandbox({SANDBOX})   EXECUTE={EXECUTE}\n")
+
+# ---- 1) make sure every prod user exists in sandbox (add missing) -------
+prod_users = read_prod(
+    "SELECT coalesce(json_agg(u), '[]'::json) AS d FROM auth.users u"
+)[0]["d"]
+sandbox_ids = {r["id"] for r in api(SANDBOX, "SELECT id FROM auth.users")}
+missing = [u for u in prod_users if u["id"] not in sandbox_ids]
+print(
+    f"auth.users  prod={len(prod_users)}  sandbox={len(sandbox_ids)}  "
+    f"missing={[u['email'] for u in missing]}"
+)
+if missing and EXECUTE:
+    # Minimal insert — just enough for FK integrity. The display name
+    # comes from the copied public.profiles row; the user won't log in
+    # to sandbox, so password/identity columns aren't needed.
+    vals = ",".join(
+        "('00000000-0000-0000-0000-000000000000'::uuid, "
+        f"'{u['id']}'::uuid, 'authenticated', 'authenticated', "
+        f"'{u['email']}', now(), now())"
+        for u in missing
+    )
+    try:
+        write_sandbox(
+            "SET session_replication_role='replica'; "
+            "INSERT INTO auth.users "
+            "(instance_id, id, aud, role, email, created_at, updated_at) "
+            f"VALUES {vals} ON CONFLICT (id) DO NOTHING; "
+            "SET session_replication_role='origin';"
+        )
+        print("  + added missing user(s)")
+    except Exception as e:  # noqa: BLE001
+        print(f"  ! could not add missing user(s) (continuing): {e}")
+
+# ---- 2) copy each table -------------------------------------------------
+print()
+failures = []
+for tbl in COPY:
+    try:
+        insertable, generated = table_columns(tbl)
+        rows = read_prod(
+            f"SELECT coalesce(json_agg(t), '[]'::json) AS d FROM {tbl} t"
+        )[0]["d"]
+        # Drop generated columns from the payload so json_populate_recordset
+        # never tries to set them.
+        for r in rows:
+            for g in generated:
+                r.pop(g, None)
+        before = count(SANDBOX, tbl)
+        line = f"{tbl:<28} prod={len(rows):<4} sandbox_before={before:<4}"
+        if not EXECUTE:
+            print(line + "  (dry-run)")
+            continue
+        j = json.dumps(rows)
+        assert TAG not in j, f"{TAG} present in {tbl} data"
+        cols = ", ".join(f'"{c}"' for c in insertable)
+        write_sandbox(
+            "SET session_replication_role='replica'; "
+            f"DELETE FROM {tbl}; "
+            f"INSERT INTO {tbl} ({cols}) "
+            f"SELECT {cols} FROM json_populate_recordset(null::{tbl}, {TAG}{j}{TAG}::json); "
+            "SET session_replication_role='origin';"
+        )
+        after = count(SANDBOX, tbl)
+        ok = "OK" if after == len(rows) else "MISMATCH!"
+        print(line + f" -> sandbox_after={after:<4} {ok}")
+    except urllib.error.HTTPError as e:
+        msg = e.read().decode()[:200]
+        print(f"{tbl:<28} FAILED: HTTP {e.code} {msg}")
+        failures.append((tbl, msg))
+    except Exception as e:  # noqa: BLE001
+        print(f"{tbl:<28} FAILED: {e}")
+        failures.append((tbl, str(e)))
+
+print()
+if failures:
+    print(f"{len(failures)} table(s) failed:")
+    for t, m in failures:
+        print(f"  - {t}: {m}")
+    sys.exit(1)
+print("done" + ("" if EXECUTE else "  (dry run — no writes performed)"))

--- a/scripts/overnight-watch.sh
+++ b/scripts/overnight-watch.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Overnight watchdog: re-runs the 300-assertion live matrix on an
+# interval through the night and appends a timestamped one-line verdict
+# (plus any failures) to scripts/.overnight-runs.log. Lets us catch an
+# intermittent 5xx, a bad redeploy, or a flaky origin overnight rather
+# than only at a single point in time.
+#
+# Usage: ITERS=18 INTERVAL=1800 bash scripts/overnight-watch.sh
+#        (defaults: 18 runs, 30 min apart ≈ 9 hours)
+
+set -uo pipefail
+
+ITERS="${ITERS:-18}"
+INTERVAL="${INTERVAL:-1800}"
+LOG="scripts/.overnight-runs.log"
+HERE="$(cd "$(dirname "$0")/.." && pwd)"
+
+echo "[$(date)] overnight-watch starting — $ITERS runs every ${INTERVAL}s" >> "$LOG"
+
+for i in $(seq 1 "$ITERS"); do
+  out=$(bash "$HERE/scripts/overnight-300.sh" both 2>&1)
+  rc=$?
+  line=$(echo "$out" | grep -E "^RESULTS:" | tr -s ' ')
+  if [ "$rc" -eq 0 ]; then
+    echo "[$(date)] run $i/$ITERS  OK   — $line" >> "$LOG"
+  else
+    echo "[$(date)] run $i/$ITERS  FAIL — $line" >> "$LOG"
+    echo "$out" | grep -E "^  ✗" >> "$LOG"
+  fi
+  [ "$i" -lt "$ITERS" ] && sleep "$INTERVAL"
+done
+
+echo "[$(date)] overnight-watch finished $ITERS runs" >> "$LOG"

--- a/scripts/sb-query.py
+++ b/scripts/sb-query.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Run a SQL query against a Supabase project via the Management API.
+
+Reads the access token from SUPABASE_ACCESS_TOKEN (never hard-coded here).
+Usage:  SUPABASE_ACCESS_TOKEN=... python scripts/sb-query.py <project_ref> "<sql>"
+        (or pipe the SQL on stdin)
+
+Prints the JSON result rows to stdout. Used by the prod->sandbox mirror.
+"""
+import os
+import sys
+import json
+import urllib.request
+import urllib.error
+
+token = os.environ.get("SUPABASE_ACCESS_TOKEN")
+if not token:
+    print("SUPABASE_ACCESS_TOKEN not set", file=sys.stderr)
+    sys.exit(2)
+
+ref = sys.argv[1]
+query = sys.argv[2] if len(sys.argv) > 2 else sys.stdin.read()
+
+req = urllib.request.Request(
+    f"https://api.supabase.com/v1/projects/{ref}/database/query",
+    data=json.dumps({"query": query}).encode(),
+    headers={
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+        # Cloudflare WAF (error 1010) blocks the default python-urllib UA.
+        "User-Agent": "curl/8.5.0",
+    },
+    method="POST",
+)
+try:
+    with urllib.request.urlopen(req, timeout=120) as r:
+        sys.stdout.write(r.read().decode())
+except urllib.error.HTTPError as e:
+    sys.stderr.write(f"HTTP {e.code}: {e.read().decode()}\n")
+    sys.exit(1)

--- a/supabase/migrations/20260628150000_contacts_profile_expand.sql
+++ b/supabase/migrations/20260628150000_contacts_profile_expand.sql
@@ -1,0 +1,67 @@
+-- Contacts profile build-out: richer person data + an avatar image store.
+--
+-- The contacts table already carries emails/phones/addresses/socials as JSONB
+-- arrays (so "multiple of each" needs no schema change — just UI). This adds the
+-- genuinely new fields and renames firm → company per product feedback:
+--   - firm  → company   (the org a person is affiliated with)
+--   - birthday DATE      (nullable)
+--   - family   JSONB     ([{name, relation}] — relatives to remember)
+-- Plus a public `contact-avatars` storage bucket for profile pictures, modeled
+-- on signal-media (20260618020000): owner-prefixed keys, owner-only writes.
+--
+-- The module is days old and user-scope only (no shared/prod data depends on the
+-- `firm` name), so the rename is clean. RLS for the new columns is inherited
+-- from the existing owner-scoped contacts policies — no policy change needed.
+
+BEGIN;
+
+ALTER TABLE contacts RENAME COLUMN firm TO company;
+ALTER TABLE contacts ADD COLUMN birthday DATE;
+ALTER TABLE contacts ADD COLUMN family JSONB NOT NULL DEFAULT '[]'::jsonb;
+
+-- ───────────────────────────────────────────────────────────────────
+-- contact-avatars storage bucket (public read; owner-only writes).
+-- Public so a plain <img src> renders in lists/detail without signing each
+-- URL. Keys are `<userId>/<uuid>.<ext>` — unguessable + owner-prefixed, so the
+-- write policies below pin every mutation to its owner.
+-- ───────────────────────────────────────────────────────────────────
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('contact-avatars', 'contact-avatars', true)
+ON CONFLICT (id) DO NOTHING;
+
+DROP POLICY IF EXISTS "contact_avatars_owner_write" ON storage.objects;
+CREATE POLICY "contact_avatars_owner_write" ON storage.objects
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    bucket_id = 'contact-avatars'
+    AND (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+DROP POLICY IF EXISTS "contact_avatars_owner_update" ON storage.objects;
+CREATE POLICY "contact_avatars_owner_update" ON storage.objects
+  FOR UPDATE TO authenticated
+  USING (
+    bucket_id = 'contact-avatars'
+    AND (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+DROP POLICY IF EXISTS "contact_avatars_owner_delete" ON storage.objects;
+CREATE POLICY "contact_avatars_owner_delete" ON storage.objects
+  FOR DELETE TO authenticated
+  USING (
+    bucket_id = 'contact-avatars'
+    AND (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+COMMIT;
+
+-- ROLLBACK:
+-- BEGIN;
+-- DROP POLICY IF EXISTS "contact_avatars_owner_delete" ON storage.objects;
+-- DROP POLICY IF EXISTS "contact_avatars_owner_update" ON storage.objects;
+-- DROP POLICY IF EXISTS "contact_avatars_owner_write" ON storage.objects;
+-- DELETE FROM storage.buckets WHERE id = 'contact-avatars';
+-- ALTER TABLE contacts DROP COLUMN family;
+-- ALTER TABLE contacts DROP COLUMN birthday;
+-- ALTER TABLE contacts RENAME COLUMN company TO firm;
+-- COMMIT;

--- a/supabase/migrations/20260628150000_contacts_profile_expand.sql
+++ b/supabase/migrations/20260628150000_contacts_profile_expand.sql
@@ -25,9 +25,19 @@ ALTER TABLE contacts ADD COLUMN family JSONB NOT NULL DEFAULT '[]'::jsonb;
 -- URL. Keys are `<userId>/<uuid>.<ext>` — unguessable + owner-prefixed, so the
 -- write policies below pin every mutation to its owner.
 -- ───────────────────────────────────────────────────────────────────
-INSERT INTO storage.buckets (id, name, public)
-VALUES ('contact-avatars', 'contact-avatars', true)
-ON CONFLICT (id) DO NOTHING;
+-- file_size_limit + allowed_mime_types enforce the ceiling and the image
+-- allowlist at the STORAGE layer, so a client can't bypass the API route by
+-- POSTing directly to its own avatar key. SVG is deliberately excluded (it's
+-- the stored-XSS vector for an <img>-hosted bucket).
+INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+VALUES (
+  'contact-avatars', 'contact-avatars', true, 8388608,
+  ARRAY['image/jpeg','image/png','image/webp','image/gif','image/heic','image/heif']
+)
+ON CONFLICT (id) DO UPDATE SET
+  public = EXCLUDED.public,
+  file_size_limit = EXCLUDED.file_size_limit,
+  allowed_mime_types = EXCLUDED.allowed_mime_types;
 
 DROP POLICY IF EXISTS "contact_avatars_owner_write" ON storage.objects;
 CREATE POLICY "contact_avatars_owner_write" ON storage.objects


### PR DESCRIPTION
## Why
The Phase A.3 UI only exposed a thin slice of the contact model (single email/phone, no avatar). Feedback: it needs to hold the *whole* picture of a person. The data model already stored emails/phones/addresses/socials as JSONB arrays — this surfaces them and adds the genuinely-new fields.

## Schema — `20260628150000_contacts_profile_expand.sql`
- **rename `firm` → `company`** (module is days old, user-scope only — clean rename; all 7 references updated).
- add **`birthday DATE`** + **`family JSONB`** (`[{name, relation}]`).
- public **`contact-avatars`** storage bucket — owner-prefixed keys `<userId>/<uuid>.<ext>`, owner-only write/update/delete RLS, modeled on `signal-media`. New columns inherit the existing owner-scoped contacts RLS.

## UI / API
- **ContactForm** (full rebuild): drag-&-drop or click **avatar upload**; prefix/middle/suffix/nickname; **Company**; **birthday**; repeatable **emails**/**phones** with labels; multiple **addresses** incl. **business** (Home/Business/Other); **family members**; socials; **add-custom contact types** alongside presets.
- **ContactDetail** (full rebuild): avatar, all emails/phones (mailto/tel), addresses (→ Google Maps), birthday, family, socials, tags, notes, and an **"Updated …"** stamp.
- List rows render the avatar; search + subtitle use `company`.
- **`POST /api/v1/contacts/avatar`** (multipart) → uploads to the bucket, returns the public URL the client saves on `avatar_url`.
- `lib/contacts/avatar.ts` + `lib/contacts/format.ts` — pure, unit-tested helpers (image-type/key rules; relative-time + birthday formatting).

## Tests
`avatar.test.ts`, `format.test.ts`, existing view tests updated. **18 contacts tests pass**; `tsc` + `eslint` clean.

> Follow-up PR: dashboard-rail discoverability (so Contacts shows in the home MODULES list, not just `/modules/contacts`). Visual-regression / Bundle-size checks are pre-existing non-required failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)