### PR TITLE
feat(contacts): Contacts dashboard panel — the contacts surface

### DIFF
--- a/apps/web/src/components/DashboardClient.tsx
+++ b/apps/web/src/components/DashboardClient.tsx
@@ -11,6 +11,7 @@ import { ExplorerRail } from "./dashboard/ExplorerRail";
 import { MessagesCard } from "./dashboard/MessagesCard";
 import { MarketsCard } from "./dashboard/MarketsCard";
 import { GoalsCard } from "./dashboard/GoalsCard";
+import { ContactsCard } from "./dashboard/ContactsCard";
 import { DashboardPanels } from "./dashboard/DashboardPanels";
 import { ModuleVisibilityProvider } from "./dashboard/module-visibility";
 import { PresenceProvider } from "./presence/PresenceProvider";
@@ -266,6 +267,7 @@ export function DashboardClient({
             messages={<MessagesCard />}
             markets={<MarketsCard />}
             goals={<GoalsCard />}
+            contacts={<ContactsCard />}
           />
         }
       />

--- a/apps/web/src/components/dashboard/ContactsCard.tsx
+++ b/apps/web/src/components/dashboard/ContactsCard.tsx
@@ -1,0 +1,358 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Plus, Search, Users, X, Loader2, Archive } from "lucide-react";
+import { Button } from "@/components/ui/Button";
+import { DashboardCard } from "./DashboardCard";
+import type { ContactRow } from "@/lib/contacts/db";
+import {
+  listContacts,
+  createContact,
+  updateContact,
+  getContact,
+  archiveContact,
+  type ContactListItem,
+  type DuplicateHit,
+} from "@/modules/contacts/lib/client-api";
+import { ContactForm } from "@/modules/contacts/components/ContactForm";
+
+function initials(c: Pick<ContactListItem, "first_name" | "last_name" | "nickname">) {
+  const a = (c.first_name || c.nickname || "").trim()[0] ?? "";
+  const b = (c.last_name || "").trim()[0] ?? "";
+  return (a + b).toUpperCase() || "?";
+}
+function rowName(c: ContactListItem) {
+  return (
+    c.nickname?.trim() ||
+    [c.first_name, c.last_name].filter(Boolean).join(" ").trim() ||
+    c.primary_email ||
+    "Unnamed"
+  );
+}
+
+/** Lightweight centered modal — self-contained so the card has no external deps. */
+function Modal({
+  title,
+  onClose,
+  children,
+}: {
+  title: string;
+  onClose: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-start justify-center bg-black/50 p-4 sm:p-8"
+      onClick={onClose}
+    >
+      <div
+        className="mt-6 flex max-h-[85vh] w-full max-w-md flex-col overflow-hidden rounded-lg border border-border bg-bg-1 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex flex-shrink-0 items-center gap-2 border-b border-border px-3 py-2">
+          <span className="text-[10px] font-semibold uppercase tracking-wide text-text-3">
+            {title}
+          </span>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="ml-auto rounded-sm p-1 text-text-2 hover:text-text-0"
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
+        </div>
+        <div className="min-h-0 flex-1 overflow-y-auto p-3">{children}</div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Dashboard Contacts panel — the contacts surface lives here (per Zack: "the
+ * contacts in dashboard view is all we will need"). List + search + quick-add,
+ * with click-to-edit (no separate detail page). Reuses the shared ContactForm
+ * and the contacts REST client.
+ */
+export function ContactsCard() {
+  const [contacts, setContacts] = useState<ContactListItem[]>([]);
+  const [q, setQ] = useState("");
+  const [loading, setLoading] = useState(true);
+
+  // Create
+  const [creating, setCreating] = useState(false);
+  const [createBusy, setCreateBusy] = useState(false);
+  const [createErr, setCreateErr] = useState<string | null>(null);
+  const [duplicate, setDuplicate] = useState<DuplicateHit | null>(null);
+  const [lastPatch, setLastPatch] = useState<Partial<ContactRow> | null>(null);
+
+  // Edit
+  const [editId, setEditId] = useState<string | null>(null);
+  const [editContact, setEditContact] = useState<ContactRow | null>(null);
+  const [editBusy, setEditBusy] = useState(false);
+  const [editErr, setEditErr] = useState<string | null>(null);
+
+  // Debounced load on mount + search change.
+  useEffect(() => {
+    let alive = true;
+    const t = setTimeout(() => {
+      listContacts({ q: q.trim() || undefined, limit: 200 })
+        .then((rows) => alive && setContacts(rows))
+        .catch(() => {})
+        .finally(() => alive && setLoading(false));
+    }, 200);
+    return () => {
+      alive = false;
+      clearTimeout(t);
+    };
+  }, [q]);
+
+  async function refresh() {
+    const next = await listContacts({ q: q.trim() || undefined, limit: 200 }).catch(
+      () => null,
+    );
+    if (next) setContacts(next);
+  }
+
+  function openCreate() {
+    setDuplicate(null);
+    setLastPatch(null);
+    setCreateErr(null);
+    setCreating(true);
+  }
+  function closeCreate() {
+    setCreating(false);
+    setDuplicate(null);
+    setLastPatch(null);
+  }
+
+  async function create(patch: Partial<ContactRow>, force = false) {
+    setCreateBusy(true);
+    setCreateErr(null);
+    try {
+      const res = await createContact(patch, force);
+      if (!res.contact && res.duplicate) {
+        setDuplicate(res.duplicate);
+        setLastPatch(patch);
+        return;
+      }
+      closeCreate();
+      await refresh();
+    } catch (e) {
+      setCreateErr(e instanceof Error ? e.message : "Could not create");
+    } finally {
+      setCreateBusy(false);
+    }
+  }
+
+  function openEdit(id: string) {
+    setEditId(id);
+    setEditContact(null);
+    setEditErr(null);
+    getContact(id)
+      .then(setEditContact)
+      .catch((e) => setEditErr(e instanceof Error ? e.message : "Failed to load"));
+  }
+  function closeEdit() {
+    setEditId(null);
+    setEditContact(null);
+  }
+
+  async function saveEdit(patch: Partial<ContactRow>) {
+    if (!editId) return;
+    setEditBusy(true);
+    setEditErr(null);
+    try {
+      await updateContact(editId, patch);
+      closeEdit();
+      await refresh();
+    } catch (e) {
+      setEditErr(e instanceof Error ? e.message : "Could not save");
+    } finally {
+      setEditBusy(false);
+    }
+  }
+
+  async function archive() {
+    if (!editId) return;
+    setEditBusy(true);
+    try {
+      await archiveContact(editId);
+      closeEdit();
+      await refresh();
+    } catch (e) {
+      setEditErr(e instanceof Error ? e.message : "Could not archive");
+      setEditBusy(false);
+    }
+  }
+
+  function dupName(d: DuplicateHit): string {
+    return (
+      [d.first_name, d.last_name].filter(Boolean).join(" ").trim() ||
+      "an existing contact"
+    );
+  }
+
+  return (
+    <DashboardCard
+      title="Contacts"
+      count={contacts.length}
+      expandHref={null}
+      headerRight={
+        <button
+          type="button"
+          onClick={openCreate}
+          aria-label="New contact"
+          className="rounded-sm p-1 text-text-3 hover:bg-bg-2 hover:text-text-0"
+        >
+          <Plus className="h-3.5 w-3.5" />
+        </button>
+      }
+      bodyClassName="flex flex-col"
+    >
+      {/* Search */}
+      <div className="sticky top-0 z-10 flex-shrink-0 border-b border-border/60 bg-bg-1 p-2">
+        <div className="flex items-center gap-1.5 rounded border border-border bg-bg-2 px-2 py-1 focus-within:border-border-focus">
+          <Search className="h-3 w-3 flex-shrink-0 text-text-3" aria-hidden="true" />
+          <input
+            value={q}
+            onChange={(e) => setQ(e.target.value)}
+            placeholder="Search name, company, email…"
+            aria-label="Search contacts"
+            className="min-w-0 flex-1 bg-transparent text-xs text-text-1 placeholder:text-text-3 outline-none"
+          />
+        </div>
+      </div>
+
+      {/* List */}
+      {loading ? (
+        <div className="flex flex-1 items-center justify-center py-8 text-text-3">
+          <Loader2 className="h-5 w-5 animate-spin" aria-label="Loading" />
+        </div>
+      ) : contacts.length === 0 ? (
+        <div className="flex flex-1 flex-col items-center justify-center gap-2 p-6 text-center">
+          <Users className="h-5 w-5 text-text-3" aria-hidden="true" />
+          <p className="text-xs text-text-2">
+            {q ? "No contacts match." : "No contacts yet."}
+          </p>
+          {!q && (
+            <Button size="sm" variant="ghost" onClick={openCreate}>
+              <Plus className="h-3 w-3" /> Add a contact
+            </Button>
+          )}
+        </div>
+      ) : (
+        <ul className="flex-1 divide-y divide-border/30">
+          {contacts.map((c) => (
+            <li key={c.id}>
+              <button
+                type="button"
+                onClick={() => openEdit(c.id)}
+                className="flex w-full items-center gap-2.5 px-3 py-[var(--rk-row-py)] text-left hover:bg-bg-2"
+              >
+                {c.avatar_url ? (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img
+                    src={c.avatar_url}
+                    alt=""
+                    className="h-7 w-7 flex-shrink-0 rounded-full object-cover"
+                  />
+                ) : (
+                  <span className="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full bg-bg-3 font-mono text-2xs text-text-1">
+                    {initials(c)}
+                  </span>
+                )}
+                <span className="min-w-0 flex-1">
+                  <span className="block truncate text-xs font-medium text-text-0">
+                    {rowName(c)}
+                  </span>
+                  {(c.company || c.title) && (
+                    <span className="block truncate text-2xs text-text-3">
+                      {[c.title, c.company].filter(Boolean).join(" · ")}
+                    </span>
+                  )}
+                </span>
+                <span className="hidden truncate text-2xs text-text-3 sm:block sm:max-w-[10rem]">
+                  {c.primary_email ?? c.primary_phone ?? ""}
+                </span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {/* Create modal */}
+      {creating && (
+        <Modal title="New contact" onClose={closeCreate}>
+          {duplicate && (
+            <div className="mb-3 rounded border border-border bg-bg-2 p-2 text-2xs text-text-1">
+              <p>
+                Looks like a duplicate of{" "}
+                <span className="font-medium">{dupName(duplicate)}</span> (same
+                email or phone).
+              </p>
+              <div className="mt-2 flex gap-2">
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => {
+                    const id = duplicate.id;
+                    closeCreate();
+                    openEdit(id);
+                  }}
+                >
+                  Open existing
+                </Button>
+                <Button
+                  size="sm"
+                  disabled={createBusy || !lastPatch}
+                  onClick={() => lastPatch && create(lastPatch, true)}
+                >
+                  Create anyway
+                </Button>
+              </div>
+            </div>
+          )}
+          <ContactForm
+            busy={createBusy}
+            error={createErr}
+            submitLabel="Create"
+            onCancel={closeCreate}
+            onSubmit={create}
+          />
+        </Modal>
+      )}
+
+      {/* Edit modal */}
+      {editId && (
+        <Modal title="Edit contact" onClose={closeEdit}>
+          {!editContact ? (
+            <div className="flex items-center justify-center py-8 text-text-3">
+              {editErr ? (
+                <p className="text-xs text-danger">{editErr}</p>
+              ) : (
+                <Loader2 className="h-5 w-5 animate-spin" aria-label="Loading" />
+              )}
+            </div>
+          ) : (
+            <div className="flex flex-col gap-3">
+              <ContactForm
+                initial={editContact}
+                busy={editBusy}
+                error={editErr}
+                submitLabel="Save"
+                onCancel={closeEdit}
+                onSubmit={saveEdit}
+              />
+              <div className="flex justify-end border-t border-border/40 pt-2">
+                <Button size="sm" variant="ghost" onClick={archive} disabled={editBusy}>
+                  <Archive className="h-3 w-3" /> Archive
+                </Button>
+              </div>
+            </div>
+          )}
+        </Modal>
+      )}
+    </DashboardCard>
+  );
+}

--- a/apps/web/src/components/dashboard/DashboardPanels.test.tsx
+++ b/apps/web/src/components/dashboard/DashboardPanels.test.tsx
@@ -67,6 +67,7 @@ describe("DashboardPanels", () => {
         messages={<div>MESSAGES_PANEL</div>}
         markets={<div>MARKETS_PANEL</div>}
         goals={<div>GOALS_PANEL</div>}
+        contacts={<div>CONTACTS_PANEL</div>}
       />,
     );
     expect(screen.getByText("BRIEFING")).toBeTruthy();
@@ -84,6 +85,7 @@ describe("DashboardPanels", () => {
         messages={<div>m</div>}
         markets={<div>mk</div>}
         goals={<div>g</div>}
+        contacts={<div>c</div>}
       />,
     );
     expect(screen.getByTestId("probe").textContent).toBe("has-handle");
@@ -106,6 +108,7 @@ describe("DashboardPanels", () => {
         messages={<div>MESSAGES_PANEL</div>}
         markets={<div>MARKETS_PANEL</div>}
         goals={<div>GOALS_PANEL</div>}
+        contacts={<div>CONTACTS_PANEL</div>}
       />,
     );
     // Whatever the saved arrangement, no panel is ever lost.
@@ -127,6 +130,7 @@ describe("DashboardPanels", () => {
         messages={<div>m</div>}
         markets={<div>mk</div>}
         goals={<div>g</div>}
+        contacts={<div>c</div>}
       />,
     );
     const tasksPanel = () =>
@@ -159,6 +163,7 @@ describe("DashboardPanels", () => {
           messages={<div>m</div>}
         markets={<div>mk</div>}
         goals={<div>g</div>}
+        contacts={<div>c</div>}
         />
       </ModuleVisibilityProvider>,
     );

--- a/apps/web/src/components/dashboard/DashboardPanels.tsx
+++ b/apps/web/src/components/dashboard/DashboardPanels.tsx
@@ -33,6 +33,7 @@ const TITLES: Record<string, string> = {
   messages: "Messages",
   markets: "Markets",
   goals: "Goals",
+  contacts: "Contacts",
 };
 
 type DropHint =
@@ -62,6 +63,7 @@ export function DashboardPanels({
   messages,
   markets,
   goals,
+  contacts,
 }: {
   focus?: ReactNode;
   briefing: ReactNode;
@@ -70,6 +72,7 @@ export function DashboardPanels({
   messages: ReactNode;
   markets: ReactNode;
   goals: ReactNode;
+  contacts: ReactNode;
 }) {
   const nodes: Record<string, ReactNode> = {
     week,
@@ -77,6 +80,7 @@ export function DashboardPanels({
     messages,
     markets,
     goals,
+    contacts,
   };
 
   const [hydrated, setHydrated] = useState(false);
@@ -88,6 +92,7 @@ export function DashboardPanels({
     messages: 1,
     markets: 1,
     goals: 1,
+    contacts: 1,
   });
   const [centerFrac, setCenterFrac] = useState(0.6);
   const [dragId, setDragId] = useState<string | null>(null);
@@ -298,7 +303,7 @@ export function DashboardPanels({
 
   function resetLayout() {
     setLayout(normalizeLayout(DEFAULT_DASH_LAYOUT));
-    setWeights({ week: 1, tasks: 1, messages: 1, markets: 1, goals: 1 });
+    setWeights({ week: 1, tasks: 1, messages: 1, markets: 1, goals: 1, contacts: 1 });
     setCenterFrac(0.6);
   }
 

--- a/apps/web/src/components/dashboard/RailModules.test.tsx
+++ b/apps/web/src/components/dashboard/RailModules.test.tsx
@@ -53,7 +53,7 @@ describe("RailModules", () => {
       </ModuleVisibilityProvider>,
     );
     const labels = screen.getAllByRole("button").map((b) => b.textContent);
-    expect(labels).toEqual(["Messages", "Tasks", "Schedule", "Markets", "Goals"]);
+    expect(labels).toEqual(["Messages", "Tasks", "Schedule", "Markets", "Goals", "Contacts"]);
   });
 
   it("does not render hidden modules", () => {
@@ -84,7 +84,7 @@ describe("RailModules", () => {
   });
 
   it("renders the all-hidden hint when every module is hidden", () => {
-    seed({ hidden: ["week", "tasks", "messages", "markets", "goals"] });
+    seed({ hidden: ["week", "tasks", "messages", "markets", "goals", "contacts"] });
     render(
       <ModuleVisibilityProvider>
         <RailModules />

--- a/apps/web/src/components/dashboard/module-visibility.test.tsx
+++ b/apps/web/src/components/dashboard/module-visibility.test.tsx
@@ -88,7 +88,7 @@ describe("ModulePrefs provider", () => {
       </ModuleVisibilityProvider>,
     );
     expect(screen.getByTestId("order").textContent).toBe(
-      "week,tasks,messages,markets,goals",
+      "week,tasks,messages,markets,goals,contacts",
     );
     expect(screen.getByTestId("layout").textContent).toBe("split");
     expect(screen.getByTestId("sync").textContent).toBe("false");
@@ -103,7 +103,7 @@ describe("ModulePrefs provider", () => {
     );
     await waitFor(() =>
       expect(screen.getByTestId("order").textContent).toBe(
-        "messages,tasks,week,markets,goals",
+        "messages,tasks,week,markets,goals,contacts",
       ),
     );
     expect(screen.getByTestId("layout").textContent).toBe("stacked");
@@ -147,6 +147,7 @@ describe("ModulePrefs provider", () => {
       "tasks",
       "markets",
       "goals",
+      "contacts",
     ]);
   });
 

--- a/apps/web/src/components/settings/ModuleSettingsForm.test.tsx
+++ b/apps/web/src/components/settings/ModuleSettingsForm.test.tsx
@@ -58,6 +58,7 @@ describe("ModuleSettingsForm", () => {
         "messages",
         "markets",
         "goals",
+        "contacts",
       ]);
     });
     it("moves a module down and persists", () => {
@@ -69,6 +70,7 @@ describe("ModuleSettingsForm", () => {
         "messages",
         "markets",
         "goals",
+        "contacts",
       ]);
     });
     it("disables Move up on the first module", () => {
@@ -80,7 +82,7 @@ describe("ModuleSettingsForm", () => {
     it("disables Move down on the last module", () => {
       renderForm();
       expect(
-        (screen.getByRole("button", { name: "Move Goals down" }) as HTMLButtonElement).disabled,
+        (screen.getByRole("button", { name: "Move Contacts down" }) as HTMLButtonElement).disabled,
       ).toBe(true);
     });
   });
@@ -110,6 +112,7 @@ describe("ModuleSettingsForm", () => {
       fireEvent.click(screen.getByRole("button", { name: "Hide Messages" }));
       fireEvent.click(screen.getByRole("button", { name: "Hide Markets" }));
       fireEvent.click(screen.getByRole("button", { name: "Hide Goals" }));
+      fireEvent.click(screen.getByRole("button", { name: "Hide Contacts" }));
       expect(screen.getByText(/All modules are hidden/i)).toBeTruthy();
     });
   });

--- a/apps/web/src/components/settings/ModuleSettingsForm.tsx
+++ b/apps/web/src/components/settings/ModuleSettingsForm.tsx
@@ -7,6 +7,7 @@ import {
   MessageSquare,
   TrendingUp,
   Target,
+  Contact,
   ChevronUp,
   ChevronDown,
   EyeOff,
@@ -31,6 +32,7 @@ const ICONS: Record<string, LucideIcon> = {
   messages: MessageSquare,
   markets: TrendingUp,
   goals: Target,
+  contacts: Contact,
 };
 
 /** Modules with their own settings page get a Configure gear on their row. */

--- a/apps/web/src/lib/dashboard-layout.test.ts
+++ b/apps/web/src/lib/dashboard-layout.test.ts
@@ -12,7 +12,7 @@ describe("movePanel", () => {
     const out = movePanel(DEFAULT_DASH_LAYOUT, "messages", "center", 1);
     expect(out).toEqual({
       center: ["week", "messages", "tasks"],
-      right: ["markets", "goals"],
+      right: ["markets", "goals", "contacts"],
     });
   });
 
@@ -41,7 +41,7 @@ describe("movePanel", () => {
 describe("normalizeLayout", () => {
   it("returns the default-shaped layout when given nothing", () => {
     expect(normalizeLayout(null)).toEqual({
-      center: ["week", "tasks", "messages", "markets", "goals"],
+      center: ["week", "tasks", "messages", "markets", "goals", "contacts"],
       right: [],
     });
   });
@@ -56,7 +56,7 @@ describe("normalizeLayout", () => {
       right: ["messages", "tasks", "messages"],
     });
     expect(out).toEqual({
-      center: ["week", "markets", "goals"],
+      center: ["week", "markets", "goals", "contacts"],
       right: ["messages", "tasks"],
     });
   });
@@ -65,6 +65,7 @@ describe("normalizeLayout", () => {
     const out = normalizeLayout({ center: ["tasks"], right: ["messages"] });
     expect(out.center).toContain("week");
     expect(flattenLayout(out).sort()).toEqual([
+      "contacts",
       "goals",
       "markets",
       "messages",

--- a/apps/web/src/lib/dashboard-layout.ts
+++ b/apps/web/src/lib/dashboard-layout.ts
@@ -21,12 +21,13 @@ export const DASH_PANEL_IDS = [
   "messages",
   "markets",
   "goals",
+  "contacts",
 ] as const;
 export type DashPanelId = (typeof DASH_PANEL_IDS)[number];
 
 export const DEFAULT_DASH_LAYOUT: DashLayout = {
   center: ["week", "tasks"],
-  right: ["messages", "markets", "goals"],
+  right: ["messages", "markets", "goals", "contacts"],
 };
 
 export const DASH_LAYOUT_STORAGE_KEY = "rokki:dash-panels";

--- a/apps/web/src/lib/module-prefs.test.ts
+++ b/apps/web/src/lib/module-prefs.test.ts
@@ -51,10 +51,11 @@ describe("module catalog constants", () => {
       "messages",
       "markets",
       "goals",
+      "contacts",
     ]);
   });
   it("MODULE_IDS mirrors the catalog ids", () => {
-    expect(MODULE_IDS).toEqual(["week", "tasks", "messages", "markets", "goals"]);
+    expect(MODULE_IDS).toEqual(["week", "tasks", "messages", "markets", "goals", "contacts"]);
   });
   it("week is labelled Schedule", () => {
     expect(MODULE_LABELS.week).toBe("Schedule");
@@ -84,6 +85,7 @@ describe("defaultModulePrefs", () => {
       "messages",
       "markets",
       "goals",
+      "contacts",
     ]);
   });
   it("nothing hidden by default", () => {
@@ -113,6 +115,7 @@ describe("defaultModulePrefs", () => {
       "messages",
       "markets",
       "goals",
+      "contacts",
     ]);
   });
 });
@@ -137,6 +140,7 @@ describe("normalizeModulePrefs", () => {
       "tasks",
       "markets",
       "goals",
+      "contacts",
     ]);
   });
   it("appends missing ids in catalog order", () => {
@@ -146,6 +150,7 @@ describe("normalizeModulePrefs", () => {
       "messages",
       "markets",
       "goals",
+      "contacts",
     ]);
   });
   it("drops unknown ids from order", () => {
@@ -155,6 +160,7 @@ describe("normalizeModulePrefs", () => {
       "messages",
       "markets",
       "goals",
+      "contacts",
     ]);
   });
   it("dedupes order", () => {
@@ -164,6 +170,7 @@ describe("normalizeModulePrefs", () => {
       "messages",
       "markets",
       "goals",
+      "contacts",
     ]);
   });
   it("non-array order → default order", () => {
@@ -173,6 +180,7 @@ describe("normalizeModulePrefs", () => {
       "messages",
       "markets",
       "goals",
+      "contacts",
     ]);
   });
   it("non-string order entries are dropped", () => {
@@ -182,6 +190,7 @@ describe("normalizeModulePrefs", () => {
       "messages",
       "markets",
       "goals",
+      "contacts",
     ]);
   });
   it("keeps known hidden ids", () => {
@@ -265,6 +274,7 @@ describe("parseModulePrefs", () => {
       "messages",
       "markets",
       "goals",
+      "contacts",
     ]);
   });
 });
@@ -302,6 +312,7 @@ describe("activeModuleIds", () => {
       "messages",
       "markets",
       "goals",
+      "contacts",
     ]);
   });
   it("respects order", () => {
@@ -317,6 +328,7 @@ describe("activeModuleIds", () => {
       "messages",
       "markets",
       "goals",
+      "contacts",
     ]);
   });
   it("excludes multiple hidden", () => {
@@ -324,11 +336,12 @@ describe("activeModuleIds", () => {
       "tasks",
       "markets",
       "goals",
+      "contacts",
     ]);
   });
   it("all hidden → empty", () => {
     expect(
-      activeModuleIds(prefs({ hidden: ["week", "tasks", "messages", "markets", "goals"] })),
+      activeModuleIds(prefs({ hidden: ["week", "tasks", "messages", "markets", "goals", "contacts"] })),
     ).toEqual([]);
   });
   it("hidden + reordered", () => {
@@ -353,6 +366,7 @@ describe("orderedVisibleModules", () => {
       "messages",
       "markets",
       "goals",
+      "contacts",
     ]);
   });
   it("carries labels", () => {
@@ -364,6 +378,7 @@ describe("orderedVisibleModules", () => {
       "messages",
       "markets",
       "goals",
+      "contacts",
     ]);
   });
   it("reorders", () => {
@@ -373,7 +388,7 @@ describe("orderedVisibleModules", () => {
   });
   it("empty when all hidden", () => {
     expect(
-      orderedVisibleModules(prefs({ hidden: ["week", "tasks", "messages", "markets", "goals"] })),
+      orderedVisibleModules(prefs({ hidden: ["week", "tasks", "messages", "markets", "goals", "contacts"] })),
     ).toEqual([]);
   });
 });
@@ -394,8 +409,8 @@ describe("hiddenModules", () => {
   });
   it("all when everything hidden", () => {
     expect(
-      hiddenModules(prefs({ hidden: ["week", "tasks", "messages", "markets", "goals"] })).length,
-    ).toBe(5);
+      hiddenModules(prefs({ hidden: ["week", "tasks", "messages", "markets", "goals", "contacts"] })).length,
+    ).toBe(6);
   });
 });
 
@@ -517,6 +532,7 @@ describe("moveModule", () => {
       "tasks",
       "markets",
       "goals",
+      "contacts",
     ]);
   });
   it("moves to the end", () => {
@@ -526,6 +542,7 @@ describe("moveModule", () => {
       "week",
       "markets",
       "goals",
+      "contacts",
     ]);
   });
   it("moves to the middle", () => {
@@ -535,6 +552,7 @@ describe("moveModule", () => {
       "messages",
       "markets",
       "goals",
+      "contacts",
     ]);
   });
   it("clamps a negative index to 0", () => {
@@ -544,6 +562,7 @@ describe("moveModule", () => {
       "tasks",
       "markets",
       "goals",
+      "contacts",
     ]);
   });
   it("clamps an over-large index to the end", () => {
@@ -552,6 +571,7 @@ describe("moveModule", () => {
       "messages",
       "markets",
       "goals",
+      "contacts",
       "week",
     ]);
   });
@@ -562,6 +582,7 @@ describe("moveModule", () => {
       "tasks",
       "markets",
       "goals",
+      "contacts",
     ]);
   });
   it("unknown id is a no-op (same reference)", () => {
@@ -575,7 +596,7 @@ describe("moveModule", () => {
   it("does not mutate the input order", () => {
     const p = defaultModulePrefs();
     moveModule(p, "week", 2);
-    expect(p.order).toEqual(["week", "tasks", "messages", "markets", "goals"]);
+    expect(p.order).toEqual(["week", "tasks", "messages", "markets", "goals", "contacts"]);
   });
   it("preserves hidden/minimized/layout", () => {
     const p = prefs({ hidden: ["tasks"], minimized: ["week"], layout: "stacked" });
@@ -594,6 +615,7 @@ describe("moveModuleBy", () => {
       "messages",
       "markets",
       "goals",
+      "contacts",
     ]);
   });
   it("moves up by one", () => {
@@ -603,6 +625,7 @@ describe("moveModuleBy", () => {
       "tasks",
       "markets",
       "goals",
+      "contacts",
     ]);
   });
   it("moves down by two", () => {
@@ -612,6 +635,7 @@ describe("moveModuleBy", () => {
       "week",
       "markets",
       "goals",
+      "contacts",
     ]);
   });
   it("moving the first up is a no-op", () => {
@@ -620,7 +644,7 @@ describe("moveModuleBy", () => {
   });
   it("moving the last down is a no-op", () => {
     const p = defaultModulePrefs();
-    expect(moveModuleBy(p, "goals", 1)).toBe(p);
+    expect(moveModuleBy(p, "contacts", 1)).toBe(p);
   });
   it("over-shooting down clamps to no-op", () => {
     const p = defaultModulePrefs();
@@ -646,6 +670,7 @@ describe("moveModuleBy", () => {
       "messages",
       "markets",
       "goals",
+      "contacts",
     ]);
   });
 });
@@ -774,7 +799,7 @@ describe("resetModulePrefs", () => {
       sectionCollapsed: true,
     });
     const reset = resetModulePrefs(messy);
-    expect(reset.order).toEqual(["week", "tasks", "messages", "markets", "goals"]);
+    expect(reset.order).toEqual(["week", "tasks", "messages", "markets", "goals", "contacts"]);
     expect(reset.hidden).toEqual([]);
     expect(reset.minimized).toEqual([]);
     expect(reset.layout).toBe("split");
@@ -845,19 +870,19 @@ describe("dashLayoutForPrefs", () => {
   it("default prefs → split of all three", () => {
     expect(dashLayoutForPrefs(defaultModulePrefs())).toEqual({
       center: ["week", "tasks", "messages"],
-      right: ["markets", "goals"],
+      right: ["markets", "goals", "contacts"],
     });
   });
   it("stacked layout", () => {
     expect(dashLayoutForPrefs(prefs({ layout: "stacked" }))).toEqual({
-      center: ["week", "tasks", "messages", "markets", "goals"],
+      center: ["week", "tasks", "messages", "markets", "goals", "contacts"],
       right: [],
     });
   });
   it("hidden module drops out of the layout", () => {
     expect(dashLayoutForPrefs(prefs({ hidden: ["messages"] }))).toEqual({
-      center: ["week", "tasks"],
-      right: ["markets", "goals"],
+      center: ["week", "tasks", "markets"],
+      right: ["goals", "contacts"],
     });
   });
   it("reorder changes the columns", () => {
@@ -879,6 +904,7 @@ describe("serializeModulePrefs", () => {
       "messages",
       "markets",
       "goals",
+      "contacts",
     ]);
   });
   it("round-trips through JSON", () => {
@@ -931,7 +957,7 @@ describe("realistic sequences", () => {
   it("hide then show restores active set", () => {
     let p = defaultModulePrefs();
     p = hideModule(p, "messages");
-    expect(activeModuleIds(p)).toEqual(["week", "tasks", "markets", "goals"]);
+    expect(activeModuleIds(p)).toEqual(["week", "tasks", "markets", "goals", "contacts"]);
     p = showModule(p, "messages");
     expect(activeModuleIds(p)).toEqual([
       "week",
@@ -939,12 +965,13 @@ describe("realistic sequences", () => {
       "messages",
       "markets",
       "goals",
+      "contacts",
     ]);
   });
   it("reorder then hide keeps the new order on the rest", () => {
     let p = moveModule(defaultModulePrefs(), "messages", 0);
     p = hideModule(p, "week");
-    expect(activeModuleIds(p)).toEqual(["messages", "tasks", "markets", "goals"]);
+    expect(activeModuleIds(p)).toEqual(["messages", "tasks", "markets", "goals", "contacts"]);
   });
   it("minimize survives a reorder", () => {
     let p = setModuleMinimized(defaultModulePrefs(), "tasks", true);
@@ -975,7 +1002,7 @@ describe("realistic sequences", () => {
     p = setLayoutPreset(p, "stacked");
     p = hideModule(p, "week");
     expect(dashLayoutForPrefs(p)).toEqual({
-      center: ["tasks", "messages", "markets", "goals"],
+      center: ["tasks", "messages", "markets", "goals", "contacts"],
       right: [],
     });
   });

--- a/apps/web/src/lib/module-prefs.ts
+++ b/apps/web/src/lib/module-prefs.ts
@@ -35,6 +35,7 @@ export const MODULE_CATALOG: readonly ModuleCatalogItem[] = [
   { id: "messages", label: "Messages" },
   { id: "markets", label: "Markets" },
   { id: "goals", label: "Goals" },
+  { id: "contacts", label: "Contacts" },
 ];
 
 export const MODULE_IDS: readonly string[] = MODULE_CATALOG.map((m) => m.id);


### PR DESCRIPTION
## Why
Per Zack: *"no need for a contacts detailed view — the contacts in dashboard view is all we will need."* Contacts now lives as a **first-class dashboard panel** (like Tasks / Markets / Goals), not a standalone module page with the pane-shell chrome.

## What
- **`ContactsCard`** — the contacts surface: full list + search (flex layout, fixes the icon/text overlap) + quick-add, with **click-to-edit** (no separate detail page). Reuses the shared `ContactForm` + contacts REST client; includes the dedupe "Create anyway / Open existing" banner and inline edit/archive.
- **Registered as the 6th dashboard module `contacts`:**
  - `module-prefs.ts` `MODULE_CATALOG` (drives the explorer **MODULES** rail + settings gear),
  - `dashboard-layout.ts` `DASH_PANEL_IDS` / `DEFAULT_DASH_LAYOUT` (panel placement),
  - `DashboardPanels.tsx` (TITLES / props / nodes / weights) + `DashboardClient.tsx` slot,
  - `ModuleSettingsForm.tsx` icon.
  → Contacts now appears in the home **MODULES list** and as a rearrangeable / minimizable / maximizable panel.

## Tests
Adding a 6th module ripples through the module-prefs / dashboard-layout / panel / settings suites (the "full catalog" + split-point assertions). All updated to the 6-module catalog with intent preserved. **638 tests pass**, `tsc` + `eslint` clean.

> The standalone `/modules/contacts` page still exists but isn't the surface (pane-shell is flag-gated off). Visual-regression / Bundle-size checks are pre-existing non-required failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)