### PR TITLE
feat(contacts): click opens the contact card (read + actions), not the editor

### DIFF
--- a/apps/web/src/components/dashboard/ContactsCard.tsx
+++ b/apps/web/src/components/dashboard/ContactsCard.tsx
@@ -1,24 +1,21 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Plus, Search, Users, X, Loader2, Archive, Link2, Unlink } from "lucide-react";
+import { Plus, Search, Users, X, Loader2, Link2 } from "lucide-react";
 import { Button } from "@/components/ui/Button";
 import { DashboardCard } from "./DashboardCard";
 import type { ContactRow } from "@/lib/contacts/db";
 import {
   listContacts,
   createContact,
-  updateContact,
-  getContact,
-  archiveContact,
   getLinkSuggestions,
   linkContact,
-  unlinkContact,
   type ContactListItem,
   type DuplicateHit,
   type LinkSuggestion,
 } from "@/modules/contacts/lib/client-api";
 import { ContactForm } from "@/modules/contacts/components/ContactForm";
+import { ContactDetail } from "@/modules/contacts/components/ContactDetail";
 
 function initials(c: Pick<ContactListItem, "first_name" | "last_name" | "nickname">) {
   const a = (c.first_name || c.nickname || "").trim()[0] ?? "";
@@ -34,7 +31,7 @@ function rowName(c: ContactListItem) {
   );
 }
 
-/** Lightweight centered modal — self-contained so the card has no external deps. */
+/** Lightweight centered modal — used for the create form. */
 function Modal({
   title,
   onClose,
@@ -73,15 +70,17 @@ function Modal({
 }
 
 /**
- * Dashboard Contacts panel — the contacts surface lives here (per Zack: "the
- * contacts in dashboard view is all we will need"). List + search + quick-add,
- * with click-to-edit (no separate detail page). Reuses the shared ContactForm
- * and the contacts REST client.
+ * Dashboard Contacts panel — the contacts surface. List + search + quick-add.
+ * Clicking a contact opens its CARD (read view with Call/Text/Email/Message
+ * actions); editing is a button inside the card, not the default click.
  */
 export function ContactsCard() {
   const [contacts, setContacts] = useState<ContactListItem[]>([]);
   const [q, setQ] = useState("");
   const [loading, setLoading] = useState(true);
+
+  // The open contact card (read-first), by id.
+  const [viewId, setViewId] = useState<string | null>(null);
 
   // Create
   const [creating, setCreating] = useState(false);
@@ -90,13 +89,7 @@ export function ContactsCard() {
   const [duplicate, setDuplicate] = useState<DuplicateHit | null>(null);
   const [lastPatch, setLastPatch] = useState<Partial<ContactRow> | null>(null);
 
-  // Edit
-  const [editId, setEditId] = useState<string | null>(null);
-  const [editContact, setEditContact] = useState<ContactRow | null>(null);
-  const [editBusy, setEditBusy] = useState(false);
-  const [editErr, setEditErr] = useState<string | null>(null);
-
-  // Rokki-user link suggestions (email matches an account you don't share a space with).
+  // Rokki-user link suggestions.
   const [suggestions, setSuggestions] = useState<LinkSuggestion[]>([]);
   const [showSuggestions, setShowSuggestions] = useState(false);
 
@@ -108,31 +101,6 @@ export function ContactsCard() {
   useEffect(() => {
     loadSuggestions();
   }, []);
-
-  async function acceptSuggestion(s: LinkSuggestion) {
-    try {
-      await linkContact(s.contact_id);
-      setSuggestions((prev) => prev.filter((x) => x.contact_id !== s.contact_id));
-      await refresh();
-    } catch {
-      /* leave the suggestion in place on failure */
-    }
-  }
-
-  async function unlink() {
-    if (!editId) return;
-    setEditBusy(true);
-    try {
-      const updated = await unlinkContact(editId);
-      setEditContact(updated);
-      await refresh();
-      loadSuggestions();
-    } catch (e) {
-      setEditErr(e instanceof Error ? e.message : "Could not unlink");
-    } finally {
-      setEditBusy(false);
-    }
-  }
 
   // Debounced load on mount + search change.
   useEffect(() => {
@@ -188,53 +156,21 @@ export function ContactsCard() {
     }
   }
 
-  function openEdit(id: string) {
-    setEditId(id);
-    setEditContact(null);
-    setEditErr(null);
-    getContact(id)
-      .then(setEditContact)
-      .catch((e) => setEditErr(e instanceof Error ? e.message : "Failed to load"));
-  }
-  function closeEdit() {
-    setEditId(null);
-    setEditContact(null);
-  }
-
-  async function saveEdit(patch: Partial<ContactRow>) {
-    if (!editId) return;
-    setEditBusy(true);
-    setEditErr(null);
-    try {
-      await updateContact(editId, patch);
-      closeEdit();
-      await refresh();
-      loadSuggestions();
-    } catch (e) {
-      setEditErr(e instanceof Error ? e.message : "Could not save");
-    } finally {
-      setEditBusy(false);
-    }
-  }
-
-  async function archive() {
-    if (!editId) return;
-    setEditBusy(true);
-    try {
-      await archiveContact(editId);
-      closeEdit();
-      await refresh();
-    } catch (e) {
-      setEditErr(e instanceof Error ? e.message : "Could not archive");
-      setEditBusy(false);
-    }
-  }
-
   function dupName(d: DuplicateHit): string {
     return (
       [d.first_name, d.last_name].filter(Boolean).join(" ").trim() ||
       "an existing contact"
     );
+  }
+
+  async function acceptSuggestion(s: LinkSuggestion) {
+    try {
+      await linkContact(s.contact_id);
+      setSuggestions((prev) => prev.filter((x) => x.contact_id !== s.contact_id));
+      await refresh();
+    } catch {
+      /* leave the suggestion in place on failure */
+    }
   }
 
   return (
@@ -323,7 +259,7 @@ export function ContactsCard() {
             <li key={c.id}>
               <button
                 type="button"
-                onClick={() => openEdit(c.id)}
+                onClick={() => setViewId(c.id)}
                 className="flex w-full items-center gap-2.5 px-3 py-[var(--rk-row-py)] text-left hover:bg-bg-2"
               >
                 {c.avatar_url ? (
@@ -362,6 +298,28 @@ export function ContactsCard() {
         </ul>
       )}
 
+      {/* Contact card (read-first drawer) */}
+      {viewId && (
+        <div
+          className="fixed inset-0 z-50 flex items-stretch justify-end bg-black/50"
+          onClick={() => setViewId(null)}
+        >
+          <div
+            className="h-full w-full max-w-[400px] border-l border-border bg-bg-1 shadow-xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <ContactDetail
+              contactId={viewId}
+              onClose={() => setViewId(null)}
+              onChanged={() => {
+                void refresh();
+                loadSuggestions();
+              }}
+            />
+          </div>
+        </div>
+      )}
+
       {/* Create modal */}
       {creating && (
         <Modal title="New contact" onClose={closeCreate}>
@@ -379,7 +337,7 @@ export function ContactsCard() {
                   onClick={() => {
                     const id = duplicate.id;
                     closeCreate();
-                    openEdit(id);
+                    setViewId(id);
                   }}
                 >
                   Open existing
@@ -401,51 +359,6 @@ export function ContactsCard() {
             onCancel={closeCreate}
             onSubmit={create}
           />
-        </Modal>
-      )}
-
-      {/* Edit modal */}
-      {editId && (
-        <Modal title="Edit contact" onClose={closeEdit}>
-          {!editContact ? (
-            <div className="flex items-center justify-center py-8 text-text-3">
-              {editErr ? (
-                <p className="text-xs text-danger">{editErr}</p>
-              ) : (
-                <Loader2 className="h-5 w-5 animate-spin" aria-label="Loading" />
-              )}
-            </div>
-          ) : (
-            <div className="flex flex-col gap-3">
-              <ContactForm
-                initial={editContact}
-                busy={editBusy}
-                error={editErr}
-                submitLabel="Save"
-                onCancel={closeEdit}
-                onSubmit={saveEdit}
-              />
-              <div className="flex items-center justify-between border-t border-border/40 pt-2">
-                {editContact.user_id ? (
-                  <span className="flex items-center gap-1 text-2xs text-accent">
-                    <Link2 className="h-3 w-3" /> Linked to Rokki
-                  </span>
-                ) : (
-                  <span />
-                )}
-                <div className="flex gap-2">
-                  {editContact.user_id && (
-                    <Button size="sm" variant="ghost" onClick={unlink} disabled={editBusy}>
-                      <Unlink className="h-3 w-3" /> Unlink
-                    </Button>
-                  )}
-                  <Button size="sm" variant="ghost" onClick={archive} disabled={editBusy}>
-                    <Archive className="h-3 w-3" /> Archive
-                  </Button>
-                </div>
-              </div>
-            </div>
-          )}
         </Modal>
       )}
     </DashboardCard>

--- a/apps/web/src/modules/contacts/components/ContactDetail.tsx
+++ b/apps/web/src/modules/contacts/components/ContactDetail.tsx
@@ -8,15 +8,23 @@ import {
   Cake,
   Users,
   Link as LinkIcon,
+  MessageSquare,
+  Send,
   Pencil,
   Archive,
+  Unlink,
   X,
   Loader2,
 } from "lucide-react";
 import { Button } from "@/components/ui/Button";
 import type { ContactRow, ContactAddress } from "@/lib/contacts/db";
 import { timeAgo, formatBirthday } from "@/lib/contacts/format";
-import { getContact, updateContact, archiveContact } from "../lib/client-api";
+import {
+  getContact,
+  updateContact,
+  archiveContact,
+  unlinkContact,
+} from "../lib/client-api";
 import { ContactForm } from "./ContactForm";
 
 function initials(c: {
@@ -102,6 +110,21 @@ export function ContactDetail({
     }
   }
 
+  async function unlink() {
+    setBusy(true);
+    try {
+      const updated = await unlinkContact(contactId);
+      setContact(updated);
+      onChanged();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not unlink");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const phone = contact?.primary_phone ?? contact?.phones?.[0]?.phone ?? null;
+  const email = contact?.primary_email ?? contact?.emails?.[0]?.email ?? null;
   const fullName = contact
     ? [contact.prefix, contact.first_name, contact.middle_name, contact.last_name, contact.suffix]
         .filter(Boolean)
@@ -158,8 +181,15 @@ export function ContactDetail({
                 </span>
               )}
               <div className="min-w-0">
-                <div className="truncate text-sm font-semibold text-text-0">
-                  {fullName || contact.nickname || "Unnamed"}
+                <div className="flex items-center gap-1.5">
+                  <span className="truncate text-sm font-semibold text-text-0">
+                    {fullName || contact.nickname || "Unnamed"}
+                  </span>
+                  {contact.user_id && (
+                    <span className="flex-shrink-0 rounded-sm bg-accent/15 px-1 py-px text-[9px] font-semibold uppercase tracking-wide text-accent">
+                      Rokki
+                    </span>
+                  )}
                 </div>
                 {contact.nickname && fullName && (
                   <div className="truncate text-xs text-text-3">“{contact.nickname}”</div>
@@ -182,6 +212,33 @@ export function ContactDetail({
                     {t}
                   </span>
                 ))}
+              </div>
+            )}
+
+            {/* Quick actions */}
+            {(phone || email || contact.user_id) && (
+              <div className="grid grid-cols-4 gap-1">
+                <ActionButton
+                  icon={<Phone className="h-4 w-4" />}
+                  label="Call"
+                  href={phone ? `tel:${phone}` : undefined}
+                />
+                <ActionButton
+                  icon={<MessageSquare className="h-4 w-4" />}
+                  label="Text"
+                  href={phone ? `sms:${phone}` : undefined}
+                />
+                <ActionButton
+                  icon={<Mail className="h-4 w-4" />}
+                  label="Email"
+                  href={email ? `mailto:${email}` : undefined}
+                />
+                <ActionButton
+                  icon={<Send className="h-4 w-4" />}
+                  label="Message"
+                  href={contact.user_id ? "/messages" : undefined}
+                  title={contact.user_id ? "Message in Rokki" : "Not a Rokki user"}
+                />
               </div>
             )}
 
@@ -300,10 +357,15 @@ export function ContactDetail({
               </p>
             )}
 
-            <div className="mt-1 flex items-center gap-2 border-t border-border/40 pt-3">
+            <div className="mt-1 flex flex-wrap items-center gap-2 border-t border-border/40 pt-3">
               <Button size="sm" variant="ghost" onClick={() => setEditing(true)}>
                 <Pencil className="h-3 w-3" /> Edit
               </Button>
+              {contact.user_id && (
+                <Button size="sm" variant="ghost" onClick={unlink} disabled={busy}>
+                  <Unlink className="h-3 w-3" /> Unlink
+                </Button>
+              )}
               <Button size="sm" variant="ghost" onClick={archive} disabled={busy}>
                 <Archive className="h-3 w-3" /> Archive
               </Button>
@@ -332,5 +394,46 @@ function Tag({ children }: { children: React.ReactNode }) {
     <span className="ml-1 rounded-sm bg-bg-3 px-1 py-px text-[9px] uppercase tracking-wide text-text-3">
       {children}
     </span>
+  );
+}
+
+/** A quick-action tile (Call / Text / Email / Message). Disabled when the
+ *  contact has no value for it (e.g. no phone → Call/Text are inert). */
+function ActionButton({
+  icon,
+  label,
+  href,
+  title,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  href?: string;
+  title?: string;
+}) {
+  const base =
+    "flex flex-col items-center justify-center gap-1 rounded border py-2 text-2xs";
+  if (!href) {
+    return (
+      <span
+        className={`${base} border-border/50 text-text-3 opacity-50`}
+        title={title ?? `No ${label.toLowerCase()}`}
+        aria-disabled="true"
+      >
+        {icon}
+        {label}
+      </span>
+    );
+  }
+  const external = href.startsWith("/");
+  return (
+    <a
+      href={href}
+      title={title ?? label}
+      {...(external ? {} : { rel: "noopener noreferrer" })}
+      className={`${base} border-border bg-bg-2 text-text-1 hover:border-border-focus hover:text-text-0`}
+    >
+      {icon}
+      {label}
+    </a>
   );
 }


### PR DESCRIPTION
## Why
Feedback: clicking a contact went **straight to Edit**. It should open a **read-first card** with quick actions; editing should be a button.

## What
- **ContactsCard** — row click now opens the **ContactDetail card** (right drawer) instead of the edit form.
- **ContactDetail** — added a quick-action row:
  - **Call** (`tel:`), **Text** (`sms:`), **Email** (`mailto:`) — from the primary phone/email,
  - **Message** → `/messages` for a **linked Rokki account** (inert otherwise),
  - each tile greys out when the contact has no value for it.
  - Plus the **"Rokki" badge** in the header and an **Unlink** action next to Edit / Archive.

Editing is now a button *inside* the card, not the default click.

## Test
`tsc` + `eslint` clean; contacts + dashboard vitest green (42 tests).

> A clean deep-link "compose to this number/thread" doesn't exist yet, so **Message** routes to `/messages` for linked accounts; per-thread deep-link is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)