### PR TITLE
feat(pipeline): REST API — board, leads CRUD, create-on-first-use (Phase B.2)

### DIFF
--- a/apps/web/src/app/api/v1/pipeline/board/route.ts
+++ b/apps/web/src/app/api/v1/pipeline/board/route.ts
@@ -1,0 +1,42 @@
+import { type NextRequest } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { withObservability } from "@/lib/observability";
+import { ok, unauthorized, badRequest, forbidden } from "@/lib/pipeline/api";
+import { ensurePipelineForSpace, listLeads } from "@/lib/pipeline/queries";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/v1/pipeline/board?space_id=… — the space's pipeline + its leads.
+ * Creates the default (HELIOS) pipeline on first use. The board groups the
+ * leads into stage columns client-side.
+ */
+async function handleGet(request: NextRequest) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return unauthorized();
+
+  const spaceId = request.nextUrl.searchParams.get("space_id");
+  if (!spaceId) return badRequest("space_id is required");
+
+  // Confirm membership for a clean 403 (RLS also enforces on read/write).
+  const { data: membership } = await supabase
+    .from("space_members")
+    .select("space_id")
+    .eq("space_id", spaceId)
+    .eq("user_id", user.id)
+    .maybeSingle();
+  if (!membership) return forbidden("Not a member of this space");
+
+  try {
+    const pipeline = await ensurePipelineForSpace(supabase, spaceId, user.id);
+    const leads = await listLeads(supabase, pipeline.id);
+    return ok({ pipeline, leads });
+  } catch (e) {
+    return badRequest(e instanceof Error ? e.message : "Failed to load board");
+  }
+}
+
+export const GET = withObservability(handleGet, "GET /api/v1/pipeline/board");

--- a/apps/web/src/app/api/v1/pipeline/leads/[id]/route.ts
+++ b/apps/web/src/app/api/v1/pipeline/leads/[id]/route.ts
@@ -1,0 +1,68 @@
+import { type NextRequest } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { withObservability } from "@/lib/observability";
+import { ok, unauthorized, badRequest, notFound, noContent } from "@/lib/pipeline/api";
+import { getLead, updateLead, deleteLead } from "@/lib/pipeline/queries";
+
+interface Props {
+  params: Promise<{ id: string }>;
+}
+
+/** GET /api/v1/pipeline/leads/:id — one lead. */
+async function handleGet(_request: NextRequest, { params }: Props) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return unauthorized();
+  const { id } = await params;
+  const lead = await getLead(supabase, id);
+  if (!lead) return notFound("Lead not found");
+  return ok({ lead });
+}
+
+/**
+ * PATCH /api/v1/pipeline/leads/:id — update a lead (stage move, status change,
+ * follow-up, fields). A stage/status change bumps last_activity_at.
+ */
+async function handlePatch(request: NextRequest, { params }: Props) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return unauthorized();
+  const { id } = await params;
+  let body: Record<string, unknown>;
+  try {
+    body = (await request.json()) as Record<string, unknown>;
+  } catch {
+    return badRequest("Invalid JSON body");
+  }
+  try {
+    const lead = await updateLead(supabase, id, body);
+    if (!lead) return notFound("Lead not found");
+    return ok({ lead });
+  } catch (e) {
+    return badRequest(e instanceof Error ? e.message : "Could not update lead");
+  }
+}
+
+/** DELETE /api/v1/pipeline/leads/:id — remove a lead. */
+async function handleDelete(_request: NextRequest, { params }: Props) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return unauthorized();
+  const { id } = await params;
+  try {
+    await deleteLead(supabase, id);
+    return noContent();
+  } catch (e) {
+    return badRequest(e instanceof Error ? e.message : "Could not delete lead");
+  }
+}
+
+export const GET = withObservability<Props>(handleGet, "GET /api/v1/pipeline/leads/:id");
+export const PATCH = withObservability<Props>(handlePatch, "PATCH /api/v1/pipeline/leads/:id");
+export const DELETE = withObservability<Props>(handleDelete, "DELETE /api/v1/pipeline/leads/:id");

--- a/apps/web/src/app/api/v1/pipeline/leads/route.ts
+++ b/apps/web/src/app/api/v1/pipeline/leads/route.ts
@@ -1,0 +1,49 @@
+import { type NextRequest } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { withObservability } from "@/lib/observability";
+import { ok, unauthorized, badRequest, notFound } from "@/lib/pipeline/api";
+import { getPipeline, createLead, defaultStageKey } from "@/lib/pipeline/queries";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * POST /api/v1/pipeline/leads  { pipeline_id, space_id, name, stage?, … }
+ * Create a lead. Defaults the stage to the pipeline's first stage. RLS
+ * (WITH CHECK on space_id) authorizes the write.
+ */
+async function handlePost(request: NextRequest) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return unauthorized();
+
+  let body: Record<string, unknown>;
+  try {
+    body = (await request.json()) as Record<string, unknown>;
+  } catch {
+    return badRequest("Invalid JSON body");
+  }
+  const pipelineId = body.pipeline_id as string | undefined;
+  const spaceId = body.space_id as string | undefined;
+  if (!pipelineId || !spaceId) {
+    return badRequest("pipeline_id and space_id are required");
+  }
+
+  const pipeline = await getPipeline(supabase, pipelineId);
+  if (!pipeline) return notFound("Pipeline not found");
+
+  try {
+    const lead = await createLead(
+      supabase,
+      { pipeline_id: pipelineId, space_id: spaceId, defaultStage: defaultStageKey(pipeline) },
+      body,
+      user.id,
+    );
+    return ok({ lead }, 201);
+  } catch (e) {
+    return badRequest(e instanceof Error ? e.message : "Could not create lead");
+  }
+}
+
+export const POST = withObservability(handlePost, "POST /api/v1/pipeline/leads");

--- a/apps/web/src/app/api/v1/pipeline/pipelines/[id]/route.ts
+++ b/apps/web/src/app/api/v1/pipeline/pipelines/[id]/route.ts
@@ -1,0 +1,48 @@
+import { type NextRequest } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { withObservability } from "@/lib/observability";
+import { ok, unauthorized, badRequest, notFound } from "@/lib/pipeline/api";
+import { getPipeline, updatePipeline } from "@/lib/pipeline/queries";
+
+interface Props {
+  params: Promise<{ id: string }>;
+}
+
+/** GET /api/v1/pipeline/pipelines/:id */
+async function handleGet(_request: NextRequest, { params }: Props) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return unauthorized();
+  const { id } = await params;
+  const pipeline = await getPipeline(supabase, id);
+  if (!pipeline) return notFound("Pipeline not found");
+  return ok({ pipeline });
+}
+
+/** PATCH /api/v1/pipeline/pipelines/:id — edit name / stages / fields. */
+async function handlePatch(request: NextRequest, { params }: Props) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return unauthorized();
+  const { id } = await params;
+  let body: Record<string, unknown>;
+  try {
+    body = (await request.json()) as Record<string, unknown>;
+  } catch {
+    return badRequest("Invalid JSON body");
+  }
+  try {
+    const pipeline = await updatePipeline(supabase, id, body);
+    if (!pipeline) return notFound("Pipeline not found");
+    return ok({ pipeline });
+  } catch (e) {
+    return badRequest(e instanceof Error ? e.message : "Could not update pipeline");
+  }
+}
+
+export const GET = withObservability<Props>(handleGet, "GET /api/v1/pipeline/pipelines/:id");
+export const PATCH = withObservability<Props>(handlePatch, "PATCH /api/v1/pipeline/pipelines/:id");

--- a/apps/web/src/app/api/v1/pipeline/spaces/route.ts
+++ b/apps/web/src/app/api/v1/pipeline/spaces/route.ts
@@ -1,0 +1,24 @@
+import { type NextRequest } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { withObservability } from "@/lib/observability";
+import { ok, unauthorized, badRequest } from "@/lib/pipeline/api";
+import { listSpacesForUser } from "@/lib/pipeline/queries";
+
+export const dynamic = "force-dynamic";
+
+/** GET /api/v1/pipeline/spaces — the spaces the viewer can run a pipeline in. */
+async function handleGet(_request: NextRequest) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return unauthorized();
+  try {
+    const spaces = await listSpacesForUser(supabase);
+    return ok({ spaces });
+  } catch (e) {
+    return badRequest(e instanceof Error ? e.message : "Failed to load spaces");
+  }
+}
+
+export const GET = withObservability(handleGet, "GET /api/v1/pipeline/spaces");

--- a/apps/web/src/lib/pipeline/api.ts
+++ b/apps/web/src/lib/pipeline/api.ts
@@ -1,0 +1,29 @@
+/**
+ * Shared response + error helpers for the pipeline API routes. Same envelope as
+ * the contacts/markets modules: success → `{ data }`, error →
+ * `{ errors: [{ code, message }] }`.
+ */
+import { NextResponse } from "next/server";
+
+export function ok<T>(data: T, status = 200): NextResponse {
+  return NextResponse.json({ data }, { status });
+}
+
+export function noContent(): NextResponse {
+  return new NextResponse(null, { status: 204 });
+}
+
+export function errResponse(code: string, message: string, status: number): NextResponse {
+  return NextResponse.json({ errors: [{ code, message }] }, { status });
+}
+
+export const unauthorized = () =>
+  errResponse("unauthenticated", "Sign in required", 401);
+export const badRequest = (message: string) =>
+  errResponse("invalid_request", message, 400);
+export const forbidden = (message = "Forbidden") =>
+  errResponse("forbidden", message, 403);
+export const notFound = (message = "Not found") =>
+  errResponse("not_found", message, 404);
+export const internal = (message: string) =>
+  errResponse("internal_error", message, 500);

--- a/apps/web/src/lib/pipeline/board.test.ts
+++ b/apps/web/src/lib/pipeline/board.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import { groupByStage, isRotting, isFollowUpDue, defaultStageKey } from "./board";
+import { HELIOS_PIPELINE } from "./templates";
+import type { LeadRow } from "./db";
+
+const stages = HELIOS_PIPELINE.stages;
+
+function lead(over: Partial<LeadRow>): LeadRow {
+  return {
+    id: "l1",
+    pipeline_id: "p1",
+    space_id: "s1",
+    name: "Deal",
+    subtitle: null,
+    stage: "tracking",
+    status: "open",
+    priority: 0,
+    source: null,
+    owner_id: null,
+    next_follow_up_at: null,
+    last_activity_at: "2026-06-28T12:00:00Z",
+    promoted_terminal_id: null,
+    dead_reason: null,
+    lat: null,
+    lng: null,
+    attributes: {},
+    created_by: null,
+    created_at: "2026-06-01T00:00:00Z",
+    updated_at: "2026-06-28T12:00:00Z",
+    ...over,
+  };
+}
+
+describe("defaultStageKey", () => {
+  it("is the first stage", () => {
+    expect(defaultStageKey(HELIOS_PIPELINE)).toBe("tracking");
+    expect(defaultStageKey({ stages: [] })).toBe("");
+  });
+});
+
+describe("groupByStage", () => {
+  it("places leads in their stage column, in pipeline order", () => {
+    const { columns, orphans } = groupByStage(
+      [lead({ id: "a", stage: "offer" }), lead({ id: "b", stage: "tracking" })],
+      stages,
+    );
+    expect(columns.map((c) => c.stage.key)).toEqual([
+      "tracking", "engaging", "due_diligence", "offer", "under_contract", "active_project", "closed",
+    ]);
+    expect(columns[0].leads.map((l) => l.id)).toEqual(["b"]);
+    expect(columns[3].leads.map((l) => l.id)).toEqual(["a"]);
+    expect(orphans).toEqual([]);
+  });
+  it("collects leads whose stage was removed as orphans", () => {
+    const { orphans } = groupByStage([lead({ id: "x", stage: "ghost" })], stages);
+    expect(orphans.map((l) => l.id)).toEqual(["x"]);
+  });
+});
+
+describe("isRotting", () => {
+  const now = Date.parse("2026-06-28T12:00:00Z");
+  it("flags an open lead idle past its stage rotting_days", () => {
+    // tracking = 30d. 40 days idle → rotting.
+    expect(isRotting(lead({ stage: "tracking", last_activity_at: "2026-05-19T12:00:00Z" }), stages, now)).toBe(true);
+  });
+  it("is false within the window", () => {
+    expect(isRotting(lead({ stage: "tracking", last_activity_at: "2026-06-20T12:00:00Z" }), stages, now)).toBe(false);
+  });
+  it("is false for non-open leads", () => {
+    expect(isRotting(lead({ status: "won", last_activity_at: "2026-01-01T00:00:00Z" }), stages, now)).toBe(false);
+  });
+  it("is false for a stage with no rotting_days", () => {
+    expect(isRotting(lead({ stage: "active_project", last_activity_at: "2020-01-01T00:00:00Z" }), stages, now)).toBe(false);
+  });
+});
+
+describe("isFollowUpDue", () => {
+  const now = Date.parse("2026-06-28T12:00:00Z");
+  it("is due when next_follow_up_at is past and lead is open", () => {
+    expect(isFollowUpDue(lead({ next_follow_up_at: "2026-06-27T00:00:00Z" }), now)).toBe(true);
+  });
+  it("not due in the future", () => {
+    expect(isFollowUpDue(lead({ next_follow_up_at: "2026-06-29T00:00:00Z" }), now)).toBe(false);
+  });
+  it("not due without a date or when not open", () => {
+    expect(isFollowUpDue(lead({ next_follow_up_at: null }), now)).toBe(false);
+    expect(isFollowUpDue(lead({ status: "dead", next_follow_up_at: "2026-06-27T00:00:00Z" }), now)).toBe(false);
+  });
+});

--- a/apps/web/src/lib/pipeline/board.ts
+++ b/apps/web/src/lib/pipeline/board.ts
@@ -1,0 +1,62 @@
+/**
+ * Pure board logic for the pipeline — grouping leads into stage columns and the
+ * "going cold" / "follow-up due" rules. DOM/IO-free so it's unit-tested; the
+ * React board consumes these.
+ */
+import type { LeadRow, PipelineStage } from "./db";
+
+export function defaultStageKey(pipeline: { stages: PipelineStage[] }): string {
+  return pipeline.stages[0]?.key ?? "";
+}
+
+export interface StageColumn {
+  stage: PipelineStage;
+  leads: LeadRow[];
+}
+
+/**
+ * Group leads into ordered stage columns. A lead whose `stage` isn't in the
+ * pipeline (a removed stage) is dropped from the columns — `orphans` collects
+ * them so the caller can surface/reassign rather than silently lose them.
+ */
+export function groupByStage(
+  leads: LeadRow[],
+  stages: PipelineStage[],
+): { columns: StageColumn[]; orphans: LeadRow[] } {
+  const columns: StageColumn[] = stages.map((s) => ({ stage: s, leads: [] }));
+  const idx = new Map(stages.map((s, i) => [s.key, i]));
+  const orphans: LeadRow[] = [];
+  for (const lead of leads) {
+    const i = idx.get(lead.stage);
+    if (i === undefined) orphans.push(lead);
+    else columns[i].leads.push(lead);
+  }
+  return { columns, orphans };
+}
+
+/**
+ * "Going cold" — an open lead idle in its stage longer than that stage's
+ * `rotting_days`. `nowMs` is injected for testability.
+ */
+export function isRotting(
+  lead: Pick<LeadRow, "status" | "stage" | "last_activity_at">,
+  stages: PipelineStage[],
+  nowMs: number,
+): boolean {
+  if (lead.status !== "open") return false;
+  const stage = stages.find((s) => s.key === lead.stage);
+  if (!stage?.rotting_days) return false;
+  const last = Date.parse(lead.last_activity_at);
+  if (Number.isNaN(last)) return false;
+  return nowMs - last > stage.rotting_days * 86_400_000;
+}
+
+/** Follow-up due — an open lead whose `next_follow_up_at` is in the past. */
+export function isFollowUpDue(
+  lead: Pick<LeadRow, "status" | "next_follow_up_at">,
+  nowMs: number,
+): boolean {
+  if (lead.status !== "open" || !lead.next_follow_up_at) return false;
+  const due = Date.parse(lead.next_follow_up_at);
+  return !Number.isNaN(due) && due <= nowMs;
+}

--- a/apps/web/src/lib/pipeline/queries.ts
+++ b/apps/web/src/lib/pipeline/queries.ts
@@ -1,0 +1,208 @@
+/**
+ * Server-side data access for the pipeline module. Thin over the Supabase
+ * client — RLS does the authorization (pipelines + leads are space-scoped);
+ * these assemble the board and apply the writable whitelists.
+ */
+import { pipelineDb, type PipelineRow, type LeadRow } from "./db";
+import { DEFAULT_PIPELINE } from "./templates";
+import { defaultStageKey } from "./board";
+
+export interface SpaceLite {
+  id: string;
+  name: string;
+  slug: string;
+}
+
+/** The spaces the caller is a member of (RLS-scoped), for the board's picker. */
+export async function listSpacesForUser(client: unknown): Promise<SpaceLite[]> {
+  const { data, error } = await pipelineDb(client)
+    .from("spaces")
+    .select("id, name, slug")
+    .is("archived_at", null)
+    .order("name", { ascending: true });
+  if (error) throw new Error(error.message);
+  return (data ?? []) as SpaceLite[];
+}
+
+/**
+ * The space's pipeline, creating the default (HELIOS) one on first use. One
+ * pipeline per space for now; the schema allows more, picked by position.
+ */
+export async function ensurePipelineForSpace(
+  client: unknown,
+  spaceId: string,
+  userId: string,
+): Promise<PipelineRow> {
+  const db = pipelineDb(client);
+  const { data, error } = await db
+    .from("pl_pipelines")
+    .select("*")
+    .eq("space_id", spaceId)
+    .order("position", { ascending: true })
+    .order("created_at", { ascending: true })
+    .limit(1);
+  if (error) throw new Error(error.message);
+  const rows = (data ?? []) as PipelineRow[];
+  if (rows.length) return rows[0];
+
+  const { data: created, error: insErr } = await db
+    .from("pl_pipelines")
+    .insert({
+      space_id: spaceId,
+      name: DEFAULT_PIPELINE.name,
+      kind: DEFAULT_PIPELINE.kind,
+      stages: DEFAULT_PIPELINE.stages,
+      fields: DEFAULT_PIPELINE.fields,
+      created_by: userId,
+    })
+    .select("*")
+    .single();
+  if (insErr) throw new Error(insErr.message);
+  return created as PipelineRow;
+}
+
+export async function getPipeline(
+  client: unknown,
+  id: string,
+): Promise<PipelineRow | null> {
+  const { data, error } = await pipelineDb(client)
+    .from("pl_pipelines")
+    .select("*")
+    .eq("id", id)
+    .maybeSingle();
+  if (error) throw new Error(error.message);
+  return (data ?? null) as PipelineRow | null;
+}
+
+export interface PipelinePatch {
+  name?: string;
+  stages?: PipelineRow["stages"];
+  fields?: PipelineRow["fields"];
+}
+
+export async function updatePipeline(
+  client: unknown,
+  id: string,
+  patch: PipelinePatch,
+): Promise<PipelineRow | null> {
+  const writable: Record<string, unknown> = {};
+  if (patch.name !== undefined) writable.name = patch.name;
+  if (patch.stages !== undefined) writable.stages = patch.stages;
+  if (patch.fields !== undefined) writable.fields = patch.fields;
+  if (Object.keys(writable).length === 0) return getPipeline(client, id);
+  const { data, error } = await pipelineDb(client)
+    .from("pl_pipelines")
+    .update(writable)
+    .eq("id", id)
+    .select("*")
+    .maybeSingle();
+  if (error) throw new Error(error.message);
+  return (data ?? null) as PipelineRow | null;
+}
+
+/** All leads on a pipeline (lightweight; the board groups them client-side). */
+export async function listLeads(
+  client: unknown,
+  pipelineId: string,
+): Promise<LeadRow[]> {
+  const { data, error } = await pipelineDb(client)
+    .from("pl_leads")
+    .select("*")
+    .eq("pipeline_id", pipelineId)
+    .order("priority", { ascending: false })
+    .order("updated_at", { ascending: false });
+  if (error) throw new Error(error.message);
+  return (data ?? []) as LeadRow[];
+}
+
+export async function getLead(
+  client: unknown,
+  id: string,
+): Promise<LeadRow | null> {
+  const { data, error } = await pipelineDb(client)
+    .from("pl_leads")
+    .select("*")
+    .eq("id", id)
+    .maybeSingle();
+  if (error) throw new Error(error.message);
+  return (data ?? null) as LeadRow | null;
+}
+
+export interface LeadInput {
+  name?: string;
+  subtitle?: string | null;
+  stage?: string;
+  status?: LeadRow["status"];
+  priority?: number;
+  source?: string | null;
+  next_follow_up_at?: string | null;
+  dead_reason?: string | null;
+  lat?: number | null;
+  lng?: number | null;
+  attributes?: Record<string, unknown>;
+}
+
+const LEAD_WRITABLE: (keyof LeadInput)[] = [
+  "name", "subtitle", "stage", "status", "priority", "source",
+  "next_follow_up_at", "dead_reason", "lat", "lng", "attributes",
+];
+
+function pickLead(input: LeadInput): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const k of LEAD_WRITABLE) if (input[k] !== undefined) out[k] = input[k];
+  return out;
+}
+
+export async function createLead(
+  client: unknown,
+  args: { pipeline_id: string; space_id: string; defaultStage: string },
+  input: LeadInput,
+  userId: string,
+): Promise<LeadRow> {
+  if (!input.name || !input.name.trim()) throw new Error("A lead needs a name");
+  const row = {
+    pipeline_id: args.pipeline_id,
+    space_id: args.space_id,
+    owner_id: userId,
+    created_by: userId,
+    ...pickLead(input),
+    stage: input.stage?.trim() || args.defaultStage,
+  };
+  const { data, error } = await pipelineDb(client)
+    .from("pl_leads")
+    .insert(row)
+    .select("*")
+    .single();
+  if (error) throw new Error(error.message);
+  return data as LeadRow;
+}
+
+export async function updateLead(
+  client: unknown,
+  id: string,
+  input: LeadInput,
+): Promise<LeadRow | null> {
+  const patch = pickLead(input);
+  if (Object.keys(patch).length === 0) return getLead(client, id);
+  // Moving stages (or any explicit touch) counts as activity → un-rot the lead.
+  if (input.stage !== undefined || input.status !== undefined) {
+    patch.last_activity_at = new Date().toISOString();
+  }
+  const { data, error } = await pipelineDb(client)
+    .from("pl_leads")
+    .update(patch)
+    .eq("id", id)
+    .select("*")
+    .maybeSingle();
+  if (error) throw new Error(error.message);
+  return (data ?? null) as LeadRow | null;
+}
+
+/** Hard-delete a lead (they're lightweight; "Dead" is a status, delete is a
+ *  true remove). RLS limits it to the owning space's members. */
+export async function deleteLead(client: unknown, id: string): Promise<void> {
+  const { error } = await pipelineDb(client).from("pl_leads").delete().eq("id", id);
+  if (error) throw new Error(error.message);
+}
+
+export { defaultStageKey };

--- a/apps/web/src/modules/pipeline/lib/client-api.ts
+++ b/apps/web/src/modules/pipeline/lib/client-api.ts
@@ -1,0 +1,81 @@
+/**
+ * Client-side typed wrappers around the pipeline REST API. Browser-safe (plain
+ * fetch); unwraps `{ data }` or throws the server's first error message.
+ */
+"use client";
+
+import type { PipelineRow, LeadRow } from "@/lib/pipeline/db";
+
+async function req<T>(url: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(url, {
+    ...init,
+    headers: { "content-type": "application/json", ...(init?.headers ?? {}) },
+  });
+  if (res.status === 204) return undefined as T;
+  const json = (await res.json().catch(() => ({}))) as {
+    data?: T;
+    errors?: { code: string; message: string }[];
+  };
+  if (!res.ok) {
+    throw new Error(json.errors?.[0]?.message ?? `Request failed (${res.status})`);
+  }
+  return json.data as T;
+}
+
+const B = "/api/v1/pipeline";
+
+export interface SpaceLite {
+  id: string;
+  name: string;
+  slug: string;
+}
+
+export interface Board {
+  pipeline: PipelineRow;
+  leads: LeadRow[];
+}
+
+export const getSpaces = () =>
+  req<{ spaces: SpaceLite[] }>(`${B}/spaces`).then((d) => d.spaces);
+
+export const getBoard = (spaceId: string) =>
+  req<Board>(`${B}/board?space_id=${encodeURIComponent(spaceId)}`);
+
+export interface LeadInput {
+  name?: string;
+  subtitle?: string | null;
+  stage?: string;
+  status?: LeadRow["status"];
+  priority?: number;
+  source?: string | null;
+  next_follow_up_at?: string | null;
+  dead_reason?: string | null;
+  attributes?: Record<string, unknown>;
+}
+
+export const createLead = (input: LeadInput & { pipeline_id: string; space_id: string }) =>
+  req<{ lead: LeadRow }>(`${B}/leads`, {
+    method: "POST",
+    body: JSON.stringify(input),
+  }).then((d) => d.lead);
+
+export const getLead = (id: string) =>
+  req<{ lead: LeadRow }>(`${B}/leads/${encodeURIComponent(id)}`).then((d) => d.lead);
+
+export const updateLead = (id: string, patch: LeadInput) =>
+  req<{ lead: LeadRow }>(`${B}/leads/${encodeURIComponent(id)}`, {
+    method: "PATCH",
+    body: JSON.stringify(patch),
+  }).then((d) => d.lead);
+
+export const deleteLead = (id: string) =>
+  req<void>(`${B}/leads/${encodeURIComponent(id)}`, { method: "DELETE" });
+
+export const updatePipeline = (
+  id: string,
+  patch: { name?: string; stages?: PipelineRow["stages"]; fields?: PipelineRow["fields"] },
+) =>
+  req<{ pipeline: PipelineRow }>(`${B}/pipelines/${encodeURIComponent(id)}`, {
+    method: "PATCH",
+    body: JSON.stringify(patch),
+  }).then((d) => d.pipeline);


### PR DESCRIPTION
## What
The backend for the Pipeline deal-flow board, on the merged foundation ([#314](https://github.com/zackmckerley/rokki/pull/314)).

- **`lib/pipeline/board.ts`** (pure, tested) — group leads into stage columns (+ orphan collection for removed stages), **going-cold** (`rotting_days`) and **follow-up-due** rules.
- **`lib/pipeline/queries.ts`** — `ensurePipelineForSpace` (seeds the **HELIOS default** pipeline on first use), pipeline get/update, lead list/get/create/update/delete, and the caller's spaces for the board picker. A stage/status change bumps `last_activity_at`.
- **Routes:** `GET /pipeline/board?space_id` · `GET /pipeline/spaces` · `POST /pipeline/leads` · `GET|PATCH|DELETE /pipeline/leads/:id` · `GET|PATCH /pipeline/pipelines/:id`.
- **`client-api.ts`** — typed wrappers for the board UI (next PR).

## Test
`board.test.ts` (group/rotting/follow-up) + the foundation's `templates.test.ts` + RLS suite. **13 unit tests**, `tsc` + `eslint` clean. RLS (space-scoping) is from #314.

> Next: the kanban board UI + dashboard registration (B.3), then promote-to-Terminal (B.4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)