### PR TITLE
feat(pipeline): kanban board + dashboard module (Phase B.3)

### DIFF
--- a/apps/web/src/components/DashboardClient.tsx
+++ b/apps/web/src/components/DashboardClient.tsx
@@ -12,6 +12,7 @@ import { MessagesCard } from "./dashboard/MessagesCard";
 import { MarketsCard } from "./dashboard/MarketsCard";
 import { GoalsCard } from "./dashboard/GoalsCard";
 import { ContactsCard } from "./dashboard/ContactsCard";
+import { PipelineCard } from "./dashboard/PipelineCard";
 import { DashboardPanels } from "./dashboard/DashboardPanels";
 import { ModuleVisibilityProvider } from "./dashboard/module-visibility";
 import { PresenceProvider } from "./presence/PresenceProvider";
@@ -268,6 +269,7 @@ export function DashboardClient({
             markets={<MarketsCard />}
             goals={<GoalsCard />}
             contacts={<ContactsCard />}
+            pipeline={<PipelineCard />}
           />
         }
       />

--- a/apps/web/src/components/dashboard/DashboardPanels.test.tsx
+++ b/apps/web/src/components/dashboard/DashboardPanels.test.tsx
@@ -68,6 +68,7 @@ describe("DashboardPanels", () => {
         markets={<div>MARKETS_PANEL</div>}
         goals={<div>GOALS_PANEL</div>}
         contacts={<div>CONTACTS_PANEL</div>}
+        pipeline={<div>PIPELINE_PANEL</div>}
       />,
     );
     expect(screen.getByText("BRIEFING")).toBeTruthy();
@@ -86,6 +87,7 @@ describe("DashboardPanels", () => {
         markets={<div>mk</div>}
         goals={<div>g</div>}
         contacts={<div>c</div>}
+        pipeline={<div>p</div>}
       />,
     );
     expect(screen.getByTestId("probe").textContent).toBe("has-handle");
@@ -109,6 +111,7 @@ describe("DashboardPanels", () => {
         markets={<div>MARKETS_PANEL</div>}
         goals={<div>GOALS_PANEL</div>}
         contacts={<div>CONTACTS_PANEL</div>}
+        pipeline={<div>PIPELINE_PANEL</div>}
       />,
     );
     // Whatever the saved arrangement, no panel is ever lost.
@@ -131,6 +134,7 @@ describe("DashboardPanels", () => {
         markets={<div>mk</div>}
         goals={<div>g</div>}
         contacts={<div>c</div>}
+        pipeline={<div>p</div>}
       />,
     );
     const tasksPanel = () =>
@@ -164,6 +168,7 @@ describe("DashboardPanels", () => {
         markets={<div>mk</div>}
         goals={<div>g</div>}
         contacts={<div>c</div>}
+        pipeline={<div>p</div>}
         />
       </ModuleVisibilityProvider>,
     );

--- a/apps/web/src/components/dashboard/DashboardPanels.tsx
+++ b/apps/web/src/components/dashboard/DashboardPanels.tsx
@@ -34,6 +34,7 @@ const TITLES: Record<string, string> = {
   markets: "Markets",
   goals: "Goals",
   contacts: "Contacts",
+  pipeline: "Pipeline",
 };
 
 type DropHint =
@@ -64,6 +65,7 @@ export function DashboardPanels({
   markets,
   goals,
   contacts,
+  pipeline,
 }: {
   focus?: ReactNode;
   briefing: ReactNode;
@@ -73,6 +75,7 @@ export function DashboardPanels({
   markets: ReactNode;
   goals: ReactNode;
   contacts: ReactNode;
+  pipeline: ReactNode;
 }) {
   const nodes: Record<string, ReactNode> = {
     week,
@@ -81,6 +84,7 @@ export function DashboardPanels({
     markets,
     goals,
     contacts,
+    pipeline,
   };
 
   const [hydrated, setHydrated] = useState(false);
@@ -93,6 +97,7 @@ export function DashboardPanels({
     markets: 1,
     goals: 1,
     contacts: 1,
+    pipeline: 1,
   });
   const [centerFrac, setCenterFrac] = useState(0.6);
   const [dragId, setDragId] = useState<string | null>(null);
@@ -303,7 +308,7 @@ export function DashboardPanels({
 
   function resetLayout() {
     setLayout(normalizeLayout(DEFAULT_DASH_LAYOUT));
-    setWeights({ week: 1, tasks: 1, messages: 1, markets: 1, goals: 1, contacts: 1 });
+    setWeights({ week: 1, tasks: 1, messages: 1, markets: 1, goals: 1, contacts: 1, pipeline: 1 });
     setCenterFrac(0.6);
   }
 

--- a/apps/web/src/components/dashboard/PipelineCard.tsx
+++ b/apps/web/src/components/dashboard/PipelineCard.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { DashboardCard } from "./DashboardCard";
+import { PipelineBoard } from "@/modules/pipeline/components/PipelineBoard";
+
+/**
+ * Dashboard Pipeline panel — the deal-flow board (kanban by stage). The board
+ * carries its own space picker + add control; this just wraps it in the panel
+ * shell. Maximize the panel to see the full board side-by-side.
+ */
+export function PipelineCard() {
+  return (
+    <DashboardCard
+      title="Pipeline"
+      expandHref={null}
+      bodyClassName="flex min-h-0 flex-col overflow-hidden"
+    >
+      <PipelineBoard />
+    </DashboardCard>
+  );
+}

--- a/apps/web/src/components/dashboard/RailModules.test.tsx
+++ b/apps/web/src/components/dashboard/RailModules.test.tsx
@@ -53,7 +53,7 @@ describe("RailModules", () => {
       </ModuleVisibilityProvider>,
     );
     const labels = screen.getAllByRole("button").map((b) => b.textContent);
-    expect(labels).toEqual(["Messages", "Tasks", "Schedule", "Markets", "Goals", "Contacts"]);
+    expect(labels).toEqual(["Messages", "Tasks", "Schedule", "Markets", "Goals", "Contacts", "Pipeline"]);
   });
 
   it("does not render hidden modules", () => {
@@ -84,7 +84,7 @@ describe("RailModules", () => {
   });
 
   it("renders the all-hidden hint when every module is hidden", () => {
-    seed({ hidden: ["week", "tasks", "messages", "markets", "goals", "contacts"] });
+    seed({ hidden: ["week", "tasks", "messages", "markets", "goals", "contacts", "pipeline"] });
     render(
       <ModuleVisibilityProvider>
         <RailModules />

--- a/apps/web/src/components/dashboard/module-visibility.test.tsx
+++ b/apps/web/src/components/dashboard/module-visibility.test.tsx
@@ -88,7 +88,7 @@ describe("ModulePrefs provider", () => {
       </ModuleVisibilityProvider>,
     );
     expect(screen.getByTestId("order").textContent).toBe(
-      "week,tasks,messages,markets,goals,contacts",
+      "week,tasks,messages,markets,goals,contacts,pipeline",
     );
     expect(screen.getByTestId("layout").textContent).toBe("split");
     expect(screen.getByTestId("sync").textContent).toBe("false");
@@ -103,7 +103,7 @@ describe("ModulePrefs provider", () => {
     );
     await waitFor(() =>
       expect(screen.getByTestId("order").textContent).toBe(
-        "messages,tasks,week,markets,goals,contacts",
+        "messages,tasks,week,markets,goals,contacts,pipeline",
       ),
     );
     expect(screen.getByTestId("layout").textContent).toBe("stacked");
@@ -148,6 +148,7 @@ describe("ModulePrefs provider", () => {
       "markets",
       "goals",
       "contacts",
+      "pipeline",
     ]);
   });
 

--- a/apps/web/src/components/settings/ModuleSettingsForm.test.tsx
+++ b/apps/web/src/components/settings/ModuleSettingsForm.test.tsx
@@ -59,6 +59,7 @@ describe("ModuleSettingsForm", () => {
         "markets",
         "goals",
         "contacts",
+        "pipeline",
       ]);
     });
     it("moves a module down and persists", () => {
@@ -71,6 +72,7 @@ describe("ModuleSettingsForm", () => {
         "markets",
         "goals",
         "contacts",
+        "pipeline",
       ]);
     });
     it("disables Move up on the first module", () => {
@@ -82,7 +84,7 @@ describe("ModuleSettingsForm", () => {
     it("disables Move down on the last module", () => {
       renderForm();
       expect(
-        (screen.getByRole("button", { name: "Move Contacts down" }) as HTMLButtonElement).disabled,
+        (screen.getByRole("button", { name: "Move Pipeline down" }) as HTMLButtonElement).disabled,
       ).toBe(true);
     });
   });
@@ -113,6 +115,7 @@ describe("ModuleSettingsForm", () => {
       fireEvent.click(screen.getByRole("button", { name: "Hide Markets" }));
       fireEvent.click(screen.getByRole("button", { name: "Hide Goals" }));
       fireEvent.click(screen.getByRole("button", { name: "Hide Contacts" }));
+      fireEvent.click(screen.getByRole("button", { name: "Hide Pipeline" }));
       expect(screen.getByText(/All modules are hidden/i)).toBeTruthy();
     });
   });

--- a/apps/web/src/components/settings/ModuleSettingsForm.tsx
+++ b/apps/web/src/components/settings/ModuleSettingsForm.tsx
@@ -8,6 +8,7 @@ import {
   TrendingUp,
   Target,
   Contact,
+  KanbanSquare,
   ChevronUp,
   ChevronDown,
   EyeOff,
@@ -33,6 +34,7 @@ const ICONS: Record<string, LucideIcon> = {
   markets: TrendingUp,
   goals: Target,
   contacts: Contact,
+  pipeline: KanbanSquare,
 };
 
 /** Modules with their own settings page get a Configure gear on their row. */

--- a/apps/web/src/lib/dashboard-layout.test.ts
+++ b/apps/web/src/lib/dashboard-layout.test.ts
@@ -11,7 +11,7 @@ describe("movePanel", () => {
   it("moves a panel from one column to another at an index", () => {
     const out = movePanel(DEFAULT_DASH_LAYOUT, "messages", "center", 1);
     expect(out).toEqual({
-      center: ["week", "messages", "tasks"],
+      center: ["week", "messages", "tasks", "pipeline"],
       right: ["markets", "goals", "contacts"],
     });
   });
@@ -19,7 +19,7 @@ describe("movePanel", () => {
   it("reorders within a column (down)", () => {
     const out = movePanel(DEFAULT_DASH_LAYOUT, "week", "center", 2);
     // week removed from idx0, tasks shifts up, week appended after tasks
-    expect(out.center).toEqual(["tasks", "week"]);
+    expect(out.center).toEqual(["tasks", "week", "pipeline"]);
   });
 
   it("reorders within a column (up)", () => {
@@ -41,7 +41,7 @@ describe("movePanel", () => {
 describe("normalizeLayout", () => {
   it("returns the default-shaped layout when given nothing", () => {
     expect(normalizeLayout(null)).toEqual({
-      center: ["week", "tasks", "messages", "markets", "goals", "contacts"],
+      center: ["week", "tasks", "messages", "markets", "goals", "contacts", "pipeline"],
       right: [],
     });
   });
@@ -56,7 +56,7 @@ describe("normalizeLayout", () => {
       right: ["messages", "tasks", "messages"],
     });
     expect(out).toEqual({
-      center: ["week", "markets", "goals", "contacts"],
+      center: ["week", "markets", "goals", "contacts", "pipeline"],
       right: ["messages", "tasks"],
     });
   });
@@ -69,6 +69,7 @@ describe("normalizeLayout", () => {
       "goals",
       "markets",
       "messages",
+      "pipeline",
       "tasks",
       "week",
     ]);

--- a/apps/web/src/lib/dashboard-layout.ts
+++ b/apps/web/src/lib/dashboard-layout.ts
@@ -22,11 +22,12 @@ export const DASH_PANEL_IDS = [
   "markets",
   "goals",
   "contacts",
+  "pipeline",
 ] as const;
 export type DashPanelId = (typeof DASH_PANEL_IDS)[number];
 
 export const DEFAULT_DASH_LAYOUT: DashLayout = {
-  center: ["week", "tasks"],
+  center: ["week", "tasks", "pipeline"],
   right: ["messages", "markets", "goals", "contacts"],
 };
 

--- a/apps/web/src/lib/module-prefs.test.ts
+++ b/apps/web/src/lib/module-prefs.test.ts
@@ -52,10 +52,19 @@ describe("module catalog constants", () => {
       "markets",
       "goals",
       "contacts",
+      "pipeline",
     ]);
   });
   it("MODULE_IDS mirrors the catalog ids", () => {
-    expect(MODULE_IDS).toEqual(["week", "tasks", "messages", "markets", "goals", "contacts"]);
+    expect(MODULE_IDS).toEqual([
+      "week",
+      "tasks",
+      "messages",
+      "markets",
+      "goals",
+      "contacts",
+      "pipeline",
+    ]);
   });
   it("week is labelled Schedule", () => {
     expect(MODULE_LABELS.week).toBe("Schedule");
@@ -86,6 +95,7 @@ describe("defaultModulePrefs", () => {
       "markets",
       "goals",
       "contacts",
+      "pipeline",
     ]);
   });
   it("nothing hidden by default", () => {
@@ -116,6 +126,7 @@ describe("defaultModulePrefs", () => {
       "markets",
       "goals",
       "contacts",
+      "pipeline",
     ]);
   });
 });
@@ -141,6 +152,7 @@ describe("normalizeModulePrefs", () => {
       "markets",
       "goals",
       "contacts",
+      "pipeline",
     ]);
   });
   it("appends missing ids in catalog order", () => {
@@ -151,6 +163,7 @@ describe("normalizeModulePrefs", () => {
       "markets",
       "goals",
       "contacts",
+      "pipeline",
     ]);
   });
   it("drops unknown ids from order", () => {
@@ -161,6 +174,7 @@ describe("normalizeModulePrefs", () => {
       "markets",
       "goals",
       "contacts",
+      "pipeline",
     ]);
   });
   it("dedupes order", () => {
@@ -171,6 +185,7 @@ describe("normalizeModulePrefs", () => {
       "markets",
       "goals",
       "contacts",
+      "pipeline",
     ]);
   });
   it("non-array order → default order", () => {
@@ -181,6 +196,7 @@ describe("normalizeModulePrefs", () => {
       "markets",
       "goals",
       "contacts",
+      "pipeline",
     ]);
   });
   it("non-string order entries are dropped", () => {
@@ -191,6 +207,7 @@ describe("normalizeModulePrefs", () => {
       "markets",
       "goals",
       "contacts",
+      "pipeline",
     ]);
   });
   it("keeps known hidden ids", () => {
@@ -275,6 +292,7 @@ describe("parseModulePrefs", () => {
       "markets",
       "goals",
       "contacts",
+      "pipeline",
     ]);
   });
 });
@@ -313,6 +331,7 @@ describe("activeModuleIds", () => {
       "markets",
       "goals",
       "contacts",
+      "pipeline",
     ]);
   });
   it("respects order", () => {
@@ -329,6 +348,7 @@ describe("activeModuleIds", () => {
       "markets",
       "goals",
       "contacts",
+      "pipeline",
     ]);
   });
   it("excludes multiple hidden", () => {
@@ -337,11 +357,12 @@ describe("activeModuleIds", () => {
       "markets",
       "goals",
       "contacts",
+      "pipeline",
     ]);
   });
   it("all hidden → empty", () => {
     expect(
-      activeModuleIds(prefs({ hidden: ["week", "tasks", "messages", "markets", "goals", "contacts"] })),
+      activeModuleIds(prefs({ hidden: ["week", "tasks", "messages", "markets", "goals", "contacts", "pipeline"] })),
     ).toEqual([]);
   });
   it("hidden + reordered", () => {
@@ -367,6 +388,7 @@ describe("orderedVisibleModules", () => {
       "markets",
       "goals",
       "contacts",
+      "pipeline",
     ]);
   });
   it("carries labels", () => {
@@ -379,6 +401,7 @@ describe("orderedVisibleModules", () => {
       "markets",
       "goals",
       "contacts",
+      "pipeline",
     ]);
   });
   it("reorders", () => {
@@ -388,7 +411,7 @@ describe("orderedVisibleModules", () => {
   });
   it("empty when all hidden", () => {
     expect(
-      orderedVisibleModules(prefs({ hidden: ["week", "tasks", "messages", "markets", "goals", "contacts"] })),
+      orderedVisibleModules(prefs({ hidden: ["week", "tasks", "messages", "markets", "goals", "contacts", "pipeline"] })),
     ).toEqual([]);
   });
 });
@@ -409,8 +432,8 @@ describe("hiddenModules", () => {
   });
   it("all when everything hidden", () => {
     expect(
-      hiddenModules(prefs({ hidden: ["week", "tasks", "messages", "markets", "goals", "contacts"] })).length,
-    ).toBe(6);
+      hiddenModules(prefs({ hidden: ["week", "tasks", "messages", "markets", "goals", "contacts", "pipeline"] })).length,
+    ).toBe(7);
   });
 });
 
@@ -533,6 +556,7 @@ describe("moveModule", () => {
       "markets",
       "goals",
       "contacts",
+      "pipeline",
     ]);
   });
   it("moves to the end", () => {
@@ -543,6 +567,7 @@ describe("moveModule", () => {
       "markets",
       "goals",
       "contacts",
+      "pipeline",
     ]);
   });
   it("moves to the middle", () => {
@@ -553,6 +578,7 @@ describe("moveModule", () => {
       "markets",
       "goals",
       "contacts",
+      "pipeline",
     ]);
   });
   it("clamps a negative index to 0", () => {
@@ -563,6 +589,7 @@ describe("moveModule", () => {
       "markets",
       "goals",
       "contacts",
+      "pipeline",
     ]);
   });
   it("clamps an over-large index to the end", () => {
@@ -572,6 +599,7 @@ describe("moveModule", () => {
       "markets",
       "goals",
       "contacts",
+      "pipeline",
       "week",
     ]);
   });
@@ -583,6 +611,7 @@ describe("moveModule", () => {
       "markets",
       "goals",
       "contacts",
+      "pipeline",
     ]);
   });
   it("unknown id is a no-op (same reference)", () => {
@@ -596,7 +625,7 @@ describe("moveModule", () => {
   it("does not mutate the input order", () => {
     const p = defaultModulePrefs();
     moveModule(p, "week", 2);
-    expect(p.order).toEqual(["week", "tasks", "messages", "markets", "goals", "contacts"]);
+    expect(p.order).toEqual(["week", "tasks", "messages", "markets", "goals", "contacts", "pipeline"]);
   });
   it("preserves hidden/minimized/layout", () => {
     const p = prefs({ hidden: ["tasks"], minimized: ["week"], layout: "stacked" });
@@ -616,6 +645,7 @@ describe("moveModuleBy", () => {
       "markets",
       "goals",
       "contacts",
+      "pipeline",
     ]);
   });
   it("moves up by one", () => {
@@ -626,6 +656,7 @@ describe("moveModuleBy", () => {
       "markets",
       "goals",
       "contacts",
+      "pipeline",
     ]);
   });
   it("moves down by two", () => {
@@ -636,6 +667,7 @@ describe("moveModuleBy", () => {
       "markets",
       "goals",
       "contacts",
+      "pipeline",
     ]);
   });
   it("moving the first up is a no-op", () => {
@@ -644,11 +676,11 @@ describe("moveModuleBy", () => {
   });
   it("moving the last down is a no-op", () => {
     const p = defaultModulePrefs();
-    expect(moveModuleBy(p, "contacts", 1)).toBe(p);
+    expect(moveModuleBy(p, "pipeline", 1)).toBe(p);
   });
   it("over-shooting down clamps to no-op", () => {
     const p = defaultModulePrefs();
-    expect(moveModuleBy(p, "tasks", 5)).toBe(p);
+    expect(moveModuleBy(p, "tasks", 6)).toBe(p);
   });
   it("over-shooting up clamps to no-op", () => {
     const p = defaultModulePrefs();
@@ -671,6 +703,7 @@ describe("moveModuleBy", () => {
       "markets",
       "goals",
       "contacts",
+      "pipeline",
     ]);
   });
 });
@@ -799,7 +832,7 @@ describe("resetModulePrefs", () => {
       sectionCollapsed: true,
     });
     const reset = resetModulePrefs(messy);
-    expect(reset.order).toEqual(["week", "tasks", "messages", "markets", "goals", "contacts"]);
+    expect(reset.order).toEqual(["week", "tasks", "messages", "markets", "goals", "contacts", "pipeline"]);
     expect(reset.hidden).toEqual([]);
     expect(reset.minimized).toEqual([]);
     expect(reset.layout).toBe("split");
@@ -869,20 +902,20 @@ describe("presetToDashLayout", () => {
 describe("dashLayoutForPrefs", () => {
   it("default prefs → split of all three", () => {
     expect(dashLayoutForPrefs(defaultModulePrefs())).toEqual({
-      center: ["week", "tasks", "messages"],
-      right: ["markets", "goals", "contacts"],
+      center: ["week", "tasks", "messages", "markets"],
+      right: ["goals", "contacts", "pipeline"],
     });
   });
   it("stacked layout", () => {
     expect(dashLayoutForPrefs(prefs({ layout: "stacked" }))).toEqual({
-      center: ["week", "tasks", "messages", "markets", "goals", "contacts"],
+      center: ["week", "tasks", "messages", "markets", "goals", "contacts", "pipeline"],
       right: [],
     });
   });
   it("hidden module drops out of the layout", () => {
     expect(dashLayoutForPrefs(prefs({ hidden: ["messages"] }))).toEqual({
       center: ["week", "tasks", "markets"],
-      right: ["goals", "contacts"],
+      right: ["goals", "contacts", "pipeline"],
     });
   });
   it("reorder changes the columns", () => {
@@ -905,6 +938,7 @@ describe("serializeModulePrefs", () => {
       "markets",
       "goals",
       "contacts",
+      "pipeline",
     ]);
   });
   it("round-trips through JSON", () => {
@@ -957,7 +991,7 @@ describe("realistic sequences", () => {
   it("hide then show restores active set", () => {
     let p = defaultModulePrefs();
     p = hideModule(p, "messages");
-    expect(activeModuleIds(p)).toEqual(["week", "tasks", "markets", "goals", "contacts"]);
+    expect(activeModuleIds(p)).toEqual(["week", "tasks", "markets", "goals", "contacts", "pipeline"]);
     p = showModule(p, "messages");
     expect(activeModuleIds(p)).toEqual([
       "week",
@@ -966,12 +1000,13 @@ describe("realistic sequences", () => {
       "markets",
       "goals",
       "contacts",
+      "pipeline",
     ]);
   });
   it("reorder then hide keeps the new order on the rest", () => {
     let p = moveModule(defaultModulePrefs(), "messages", 0);
     p = hideModule(p, "week");
-    expect(activeModuleIds(p)).toEqual(["messages", "tasks", "markets", "goals", "contacts"]);
+    expect(activeModuleIds(p)).toEqual(["messages", "tasks", "markets", "goals", "contacts", "pipeline"]);
   });
   it("minimize survives a reorder", () => {
     let p = setModuleMinimized(defaultModulePrefs(), "tasks", true);
@@ -1002,7 +1037,7 @@ describe("realistic sequences", () => {
     p = setLayoutPreset(p, "stacked");
     p = hideModule(p, "week");
     expect(dashLayoutForPrefs(p)).toEqual({
-      center: ["tasks", "messages", "markets", "goals", "contacts"],
+      center: ["tasks", "messages", "markets", "goals", "contacts", "pipeline"],
       right: [],
     });
   });

--- a/apps/web/src/lib/module-prefs.ts
+++ b/apps/web/src/lib/module-prefs.ts
@@ -36,6 +36,7 @@ export const MODULE_CATALOG: readonly ModuleCatalogItem[] = [
   { id: "markets", label: "Markets" },
   { id: "goals", label: "Goals" },
   { id: "contacts", label: "Contacts" },
+  { id: "pipeline", label: "Pipeline" },
 ];
 
 export const MODULE_IDS: readonly string[] = MODULE_CATALOG.map((m) => m.id);

--- a/apps/web/src/modules/pipeline/components/LeadCard.tsx
+++ b/apps/web/src/modules/pipeline/components/LeadCard.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { Clock, Flame } from "lucide-react";
+import type { LeadRow, PipelineStage } from "@/lib/pipeline/db";
+import { isRotting, isFollowUpDue } from "@/lib/pipeline/board";
+
+const PRIORITY_DOT: Record<number, string> = {
+  1: "bg-text-3",
+  2: "bg-accent",
+  3: "bg-danger",
+};
+
+/** A draggable lead card in a board column. */
+export function LeadCard({
+  lead,
+  stages,
+  nowMs,
+  onClick,
+  onDragStart,
+}: {
+  lead: LeadRow;
+  stages: PipelineStage[];
+  nowMs: number;
+  onClick: () => void;
+  onDragStart: (e: React.DragEvent) => void;
+}) {
+  const rotting = isRotting(lead, stages, nowMs);
+  const due = isFollowUpDue(lead, nowMs);
+  const converted = lead.status === "converted";
+  return (
+    <button
+      type="button"
+      draggable
+      onDragStart={onDragStart}
+      onClick={onClick}
+      className="flex w-full flex-col gap-1 rounded border border-border bg-bg-1 px-2 py-1.5 text-left hover:border-border-focus"
+    >
+      <div className="flex items-center gap-1.5">
+        {lead.priority > 0 && PRIORITY_DOT[lead.priority] && (
+          <span
+            className={`h-1.5 w-1.5 flex-shrink-0 rounded-full ${PRIORITY_DOT[lead.priority]}`}
+            aria-hidden="true"
+          />
+        )}
+        <span className="min-w-0 flex-1 truncate text-xs font-medium text-text-0">
+          {lead.name}
+        </span>
+        {converted && (
+          <span className="flex-shrink-0 rounded-sm bg-accent/15 px-1 py-px text-[9px] font-semibold uppercase tracking-wide text-accent">
+            Terminal
+          </span>
+        )}
+      </div>
+      {lead.subtitle && (
+        <span className="truncate text-2xs text-text-3">{lead.subtitle}</span>
+      )}
+      {(lead.source || due || rotting) && (
+        <div className="flex flex-wrap items-center gap-1">
+          {lead.source && (
+            <span className="rounded-sm bg-bg-3 px-1 py-px text-[9px] uppercase tracking-wide text-text-3">
+              {lead.source}
+            </span>
+          )}
+          {due && (
+            <span className="flex items-center gap-0.5 text-[9px] font-medium text-accent">
+              <Clock className="h-2.5 w-2.5" /> Follow up
+            </span>
+          )}
+          {rotting && (
+            <span className="flex items-center gap-0.5 text-[9px] font-medium text-danger">
+              <Flame className="h-2.5 w-2.5" /> Cold
+            </span>
+          )}
+        </div>
+      )}
+    </button>
+  );
+}

--- a/apps/web/src/modules/pipeline/components/LeadDetail.tsx
+++ b/apps/web/src/modules/pipeline/components/LeadDetail.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { X, Loader2, Trash2, Ban, RotateCcw } from "lucide-react";
+import { Button } from "@/components/ui/Button";
+import type { LeadRow, PipelineRow } from "@/lib/pipeline/db";
+import { getLead, updateLead, deleteLead, type LeadInput } from "../lib/client-api";
+import { LeadForm } from "./LeadForm";
+
+/** Drawer for one lead — edit + delete + mark-dead/reopen. (Promote-to-Terminal
+ *  lands in the next phase.) */
+export function LeadDetail({
+  leadId,
+  pipeline,
+  onClose,
+  onChanged,
+}: {
+  leadId: string;
+  pipeline: PipelineRow;
+  onClose: () => void;
+  onChanged: () => void;
+}) {
+  const [lead, setLead] = useState<LeadRow | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    setLoading(true);
+    getLead(leadId)
+      .then((l) => alive && setLead(l))
+      .catch((e) => alive && setError(e instanceof Error ? e.message : "Failed"))
+      .finally(() => alive && setLoading(false));
+    return () => {
+      alive = false;
+    };
+  }, [leadId]);
+
+  async function save(patch: LeadInput) {
+    setBusy(true);
+    setError(null);
+    try {
+      await updateLead(leadId, patch);
+      onChanged();
+      onClose();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not save");
+      setBusy(false);
+    }
+  }
+
+  async function setStatus(status: LeadRow["status"]) {
+    setBusy(true);
+    try {
+      await updateLead(leadId, { status });
+      onChanged();
+      onClose();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not update");
+      setBusy(false);
+    }
+  }
+
+  async function remove() {
+    setBusy(true);
+    try {
+      await deleteLead(leadId);
+      onChanged();
+      onClose();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not delete");
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="flex flex-shrink-0 items-center gap-2 border-b border-border px-3 py-2">
+        <span className="text-[10px] font-semibold uppercase tracking-wide text-text-3">
+          Lead
+        </span>
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close"
+          className="ml-auto rounded-sm p-1 text-text-2 hover:text-text-0"
+        >
+          <X className="h-3.5 w-3.5" />
+        </button>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto p-3">
+        {loading ? (
+          <div className="flex items-center justify-center py-8 text-text-3">
+            <Loader2 className="h-5 w-5 animate-spin" aria-label="Loading" />
+          </div>
+        ) : !lead ? (
+          <p className="text-xs text-text-3">{error ?? "Not found."}</p>
+        ) : (
+          <div className="flex flex-col gap-3">
+            <LeadForm
+              pipeline={pipeline}
+              initial={lead}
+              busy={busy}
+              error={error}
+              submitLabel="Save"
+              onCancel={onClose}
+              onSubmit={save}
+            />
+            <div className="flex flex-wrap items-center gap-2 border-t border-border/40 pt-3">
+              {lead.status === "dead" ? (
+                <Button size="sm" variant="ghost" onClick={() => setStatus("open")} disabled={busy}>
+                  <RotateCcw className="h-3 w-3" /> Reopen
+                </Button>
+              ) : (
+                <Button size="sm" variant="ghost" onClick={() => setStatus("dead")} disabled={busy}>
+                  <Ban className="h-3 w-3" /> Mark dead
+                </Button>
+              )}
+              <Button size="sm" variant="ghost" onClick={remove} disabled={busy}>
+                <Trash2 className="h-3 w-3" /> Delete
+              </Button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/modules/pipeline/components/LeadForm.tsx
+++ b/apps/web/src/modules/pipeline/components/LeadForm.tsx
@@ -1,0 +1,203 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/Button";
+import type { LeadRow, PipelineRow, PipelineField } from "@/lib/pipeline/db";
+import type { LeadInput } from "../lib/client-api";
+
+const input =
+  "w-full rounded border border-border bg-bg-2 px-2 py-1 text-xs text-text-1 placeholder:text-text-3 outline-none focus:border-border-focus";
+const select =
+  "rounded border border-border bg-bg-2 px-1.5 py-1 text-xs text-text-2 outline-none focus:border-border-focus";
+const label = "text-[10px] font-semibold uppercase tracking-wide text-text-3";
+
+const PRIORITIES = [
+  { v: 0, label: "—" },
+  { v: 1, label: "Low" },
+  { v: 2, label: "Med" },
+  { v: 3, label: "High" },
+];
+
+function fieldInputType(t: PipelineField["type"]): string {
+  if (t === "currency" || t === "number") return "number";
+  if (t === "date") return "date";
+  return "text";
+}
+
+/** Shared create/edit form for a lead. Renders the core fields + the pipeline's
+ *  custom field schema (into `attributes`). */
+export function LeadForm({
+  pipeline,
+  initial,
+  busy,
+  error,
+  submitLabel,
+  defaultStage,
+  onCancel,
+  onSubmit,
+}: {
+  pipeline: PipelineRow;
+  initial?: Partial<LeadRow>;
+  busy?: boolean;
+  error?: string | null;
+  submitLabel: string;
+  defaultStage?: string;
+  onCancel: () => void;
+  onSubmit: (patch: LeadInput) => void;
+}) {
+  const [name, setName] = useState(initial?.name ?? "");
+  const [subtitle, setSubtitle] = useState(initial?.subtitle ?? "");
+  const [stage, setStage] = useState(
+    initial?.stage ?? defaultStage ?? pipeline.stages[0]?.key ?? "",
+  );
+  const [priority, setPriority] = useState<number>(initial?.priority ?? 0);
+  const [source, setSource] = useState(initial?.source ?? "");
+  const [followUp, setFollowUp] = useState(
+    (initial?.next_follow_up_at ?? "").slice(0, 10),
+  );
+  const [attrs, setAttrs] = useState<Record<string, unknown>>(
+    (initial?.attributes as Record<string, unknown>) ?? {},
+  );
+
+  function setAttr(key: string, val: string) {
+    setAttrs((prev) => ({ ...prev, [key]: val }));
+  }
+
+  function submit() {
+    const patch: LeadInput = {
+      name: name.trim(),
+      subtitle: subtitle.trim() || null,
+      stage,
+      priority,
+      source: source.trim() || null,
+      next_follow_up_at: followUp ? new Date(followUp).toISOString() : null,
+      attributes: attrs,
+    };
+    onSubmit(patch);
+  }
+
+  const canSubmit = !busy && Boolean(name.trim());
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div>
+        <label className={label}>Name</label>
+        <input
+          className={input}
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="2510 SW 16 St"
+          autoFocus
+        />
+      </div>
+      <div>
+        <label className={label}>Subtitle</label>
+        <input
+          className={input}
+          value={subtitle}
+          onChange={(e) => setSubtitle(e.target.value)}
+          placeholder="Off-market · 4-unit"
+        />
+      </div>
+
+      <div className="grid grid-cols-2 gap-2">
+        <div>
+          <label className={label}>Stage</label>
+          <select
+            className={`${select} w-full`}
+            value={stage}
+            onChange={(e) => setStage(e.target.value)}
+          >
+            {pipeline.stages.map((s) => (
+              <option key={s.key} value={s.key}>
+                {s.label}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className={label}>Priority</label>
+          <select
+            className={`${select} w-full`}
+            value={priority}
+            onChange={(e) => setPriority(Number(e.target.value))}
+          >
+            {PRIORITIES.map((p) => (
+              <option key={p.v} value={p.v}>
+                {p.label}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-2">
+        <div>
+          <label className={label}>Source</label>
+          <input
+            className={input}
+            value={source}
+            onChange={(e) => setSource(e.target.value)}
+            placeholder="Broker, cold call…"
+          />
+        </div>
+        <div>
+          <label className={label}>Next follow-up</label>
+          <input
+            type="date"
+            className={input}
+            value={followUp}
+            onChange={(e) => setFollowUp(e.target.value)}
+          />
+        </div>
+      </div>
+
+      {pipeline.fields.length > 0 && (
+        <div className="flex flex-col gap-2 border-t border-border/40 pt-2">
+          <span className="text-[10px] font-semibold uppercase tracking-wide text-text-2">
+            {pipeline.name} fields
+          </span>
+          <div className="grid grid-cols-2 gap-2">
+            {pipeline.fields.map((f) => (
+              <div key={f.key}>
+                <label className={label}>{f.label}</label>
+                {f.type === "select" ? (
+                  <select
+                    className={`${select} w-full`}
+                    value={String(attrs[f.key] ?? "")}
+                    onChange={(e) => setAttr(f.key, e.target.value)}
+                  >
+                    <option value="" />
+                    {(f.options ?? []).map((o) => (
+                      <option key={o} value={o}>
+                        {o}
+                      </option>
+                    ))}
+                  </select>
+                ) : (
+                  <input
+                    type={fieldInputType(f.type)}
+                    className={input}
+                    value={String(attrs[f.key] ?? "")}
+                    onChange={(e) => setAttr(f.key, e.target.value)}
+                  />
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {error ? <p className="text-xs text-danger">{error}</p> : null}
+
+      <div className="flex justify-end gap-2">
+        <Button size="sm" variant="ghost" onClick={onCancel}>
+          Cancel
+        </Button>
+        <Button size="sm" onClick={submit} disabled={!canSubmit}>
+          {busy ? "Saving…" : submitLabel}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/modules/pipeline/components/PipelineBoard.tsx
+++ b/apps/web/src/modules/pipeline/components/PipelineBoard.tsx
@@ -1,0 +1,282 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Plus, Loader2, X } from "lucide-react";
+import { Button } from "@/components/ui/Button";
+import type { LeadRow, PipelineRow } from "@/lib/pipeline/db";
+import { groupByStage } from "@/lib/pipeline/board";
+import {
+  getSpaces,
+  getBoard,
+  createLead,
+  updateLead,
+  type SpaceLite,
+  type LeadInput,
+} from "../lib/client-api";
+import { LeadCard } from "./LeadCard";
+import { LeadForm } from "./LeadForm";
+import { LeadDetail } from "./LeadDetail";
+
+const SPACE_KEY = "rokki:pipeline-space";
+
+export function PipelineBoard() {
+  const [spaces, setSpaces] = useState<SpaceLite[]>([]);
+  const [spaceId, setSpaceId] = useState<string | null>(null);
+  const [pipeline, setPipeline] = useState<PipelineRow | null>(null);
+  const [leads, setLeads] = useState<LeadRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const nowMs = Date.now();
+
+  const [selectedLead, setSelectedLead] = useState<string | null>(null);
+  const [createStage, setCreateStage] = useState<string | null>(null);
+  const [createBusy, setCreateBusy] = useState(false);
+  const [createErr, setCreateErr] = useState<string | null>(null);
+
+  // Spaces once.
+  useEffect(() => {
+    let alive = true;
+    getSpaces()
+      .then((sp) => {
+        if (!alive) return;
+        setSpaces(sp);
+        const saved =
+          typeof window !== "undefined" ? window.localStorage.getItem(SPACE_KEY) : null;
+        const pick = saved && sp.some((s) => s.id === saved) ? saved : sp[0]?.id ?? null;
+        setSpaceId(pick);
+        if (!pick) setLoading(false);
+      })
+      .catch(() => alive && setLoading(false));
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  // Board when the space changes.
+  useEffect(() => {
+    if (!spaceId) return;
+    let alive = true;
+    setLoading(true);
+    getBoard(spaceId)
+      .then((b) => {
+        if (!alive) return;
+        setPipeline(b.pipeline);
+        setLeads(b.leads);
+        setError(null);
+      })
+      .catch((e) => alive && setError(e instanceof Error ? e.message : "Failed to load"))
+      .finally(() => alive && setLoading(false));
+    return () => {
+      alive = false;
+    };
+  }, [spaceId]);
+
+  function selectSpace(id: string) {
+    setSpaceId(id);
+    setSelectedLead(null);
+    if (typeof window !== "undefined") window.localStorage.setItem(SPACE_KEY, id);
+  }
+
+  async function refresh() {
+    if (!spaceId) return;
+    const b = await getBoard(spaceId).catch(() => null);
+    if (b) {
+      setPipeline(b.pipeline);
+      setLeads(b.leads);
+    }
+  }
+
+  async function moveLead(leadId: string, stageKey: string) {
+    if (!pipeline) return;
+    const stage = pipeline.stages.find((s) => s.key === stageKey);
+    if (!stage) return;
+    const status: LeadRow["status"] | undefined =
+      stage.type === "won" ? "won" : stage.type === "lost" ? "lost" : undefined;
+    const prev = leads;
+    setLeads((ls) =>
+      ls.map((l) =>
+        l.id === leadId ? { ...l, stage: stageKey, ...(status ? { status } : {}) } : l,
+      ),
+    );
+    try {
+      await updateLead(leadId, { stage: stageKey, ...(status ? { status } : {}) });
+      void refresh();
+    } catch {
+      setLeads(prev); // revert on failure
+    }
+  }
+
+  async function create(patch: LeadInput) {
+    if (!pipeline || !spaceId) return;
+    setCreateBusy(true);
+    setCreateErr(null);
+    try {
+      await createLead({ ...patch, pipeline_id: pipeline.id, space_id: spaceId });
+      setCreateStage(null);
+      await refresh();
+    } catch (e) {
+      setCreateErr(e instanceof Error ? e.message : "Could not create");
+    } finally {
+      setCreateBusy(false);
+    }
+  }
+
+  const visibleLeads = leads.filter(
+    (l) => l.status !== "converted" && l.status !== "dead",
+  );
+  const { columns } = groupByStage(visibleLeads, pipeline?.stages ?? []);
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      {/* Top bar */}
+      <div className="flex flex-shrink-0 flex-wrap items-center gap-2 border-b border-border px-3 py-2">
+        {spaces.length > 1 ? (
+          <select
+            value={spaceId ?? ""}
+            onChange={(e) => selectSpace(e.target.value)}
+            aria-label="Space"
+            className="rounded border border-border bg-bg-2 px-1.5 py-1 text-xs text-text-1 outline-none focus:border-border-focus"
+          >
+            {spaces.map((s) => (
+              <option key={s.id} value={s.id}>
+                {s.name}
+              </option>
+            ))}
+          </select>
+        ) : (
+          <span className="text-xs font-semibold text-text-1">
+            {pipeline?.name ?? "Pipeline"}
+          </span>
+        )}
+        <span className="font-mono text-2xs text-text-3">{visibleLeads.length}</span>
+        <Button
+          size="sm"
+          className="ml-auto"
+          onClick={() => setCreateStage(pipeline?.stages[0]?.key ?? null)}
+          disabled={!pipeline}
+        >
+          <Plus className="h-3 w-3" /> Lead
+        </Button>
+      </div>
+
+      {/* Board */}
+      {loading ? (
+        <div className="flex flex-1 items-center justify-center text-text-3">
+          <Loader2 className="h-5 w-5 animate-spin" aria-label="Loading" />
+        </div>
+      ) : error ? (
+        <div className="flex flex-1 items-center justify-center p-6 text-center text-xs text-text-3">
+          {error}
+        </div>
+      ) : !pipeline ? (
+        <div className="flex flex-1 items-center justify-center p-6 text-center text-xs text-text-3">
+          No space available. Create or join a space to start a pipeline.
+        </div>
+      ) : (
+        <div className="flex min-h-0 flex-1 gap-2 overflow-x-auto p-2">
+          {columns.map(({ stage, leads: colLeads }) => (
+            <div
+              key={stage.key}
+              onDragOver={(e) => e.preventDefault()}
+              onDrop={(e) => {
+                e.preventDefault();
+                const id = e.dataTransfer.getData("text/plain");
+                if (id) void moveLead(id, stage.key);
+              }}
+              className="flex w-56 flex-shrink-0 flex-col rounded border border-border/60 bg-bg-2/30"
+            >
+              <div className="flex flex-shrink-0 items-center gap-1.5 border-b border-border/50 px-2 py-1.5">
+                <span className="text-2xs font-semibold uppercase tracking-wide text-text-2">
+                  {stage.label}
+                </span>
+                <span className="font-mono text-2xs text-text-3">{colLeads.length}</span>
+                {stage.is_terminal_gate && (
+                  <span className="ml-auto text-[9px] uppercase tracking-wide text-accent">
+                    gate
+                  </span>
+                )}
+              </div>
+              <div className="flex min-h-0 flex-1 flex-col gap-1.5 overflow-y-auto p-1.5">
+                {colLeads.map((lead) => (
+                  <LeadCard
+                    key={lead.id}
+                    lead={lead}
+                    stages={pipeline.stages}
+                    nowMs={nowMs}
+                    onClick={() => setSelectedLead(lead.id)}
+                    onDragStart={(e) => e.dataTransfer.setData("text/plain", lead.id)}
+                  />
+                ))}
+              </div>
+              <button
+                type="button"
+                onClick={() => setCreateStage(stage.key)}
+                className="flex flex-shrink-0 items-center gap-1 border-t border-border/40 px-2 py-1 text-2xs text-text-3 hover:text-text-1"
+              >
+                <Plus className="h-3 w-3" /> Add
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Create modal */}
+      {createStage && pipeline && (
+        <div
+          className="fixed inset-0 z-50 flex items-start justify-center bg-black/50 p-4 sm:p-8"
+          onClick={() => setCreateStage(null)}
+        >
+          <div
+            className="mt-6 flex max-h-[85vh] w-full max-w-md flex-col overflow-hidden rounded-lg border border-border bg-bg-1 shadow-xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="flex flex-shrink-0 items-center gap-2 border-b border-border px-3 py-2">
+              <span className="text-[10px] font-semibold uppercase tracking-wide text-text-3">
+                New lead
+              </span>
+              <button
+                type="button"
+                onClick={() => setCreateStage(null)}
+                aria-label="Close"
+                className="ml-auto rounded-sm p-1 text-text-2 hover:text-text-0"
+              >
+                <X className="h-3.5 w-3.5" />
+              </button>
+            </div>
+            <div className="min-h-0 flex-1 overflow-y-auto p-3">
+              <LeadForm
+                pipeline={pipeline}
+                defaultStage={createStage}
+                busy={createBusy}
+                error={createErr}
+                submitLabel="Create"
+                onCancel={() => setCreateStage(null)}
+                onSubmit={create}
+              />
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Lead drawer */}
+      {selectedLead && pipeline && (
+        <div
+          className="fixed inset-0 z-50 flex items-stretch justify-end bg-black/50"
+          onClick={() => setSelectedLead(null)}
+        >
+          <div
+            className="h-full w-full max-w-[400px] border-l border-border bg-bg-1 shadow-xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <LeadDetail
+              leadId={selectedLead}
+              pipeline={pipeline}
+              onClose={() => setSelectedLead(null)}
+              onChanged={refresh}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## What
The deal-flow **board**, registered as the 7th dashboard module **"Pipeline"** (on the B.2 API, #321).

- **PipelineBoard** — space picker + **kanban columns** by stage (your HELIOS flow), **draggable lead cards** (drag to move stage; dropping in a won/lost-type column sets the lead's status), per-column quick-add, and a lead drawer.
- **LeadCard** — priority dot, source, **"Follow up" / "Cold"** (rotting) badges, and a **"Terminal"** badge once promoted.
- **LeadForm** — core fields + the pipeline's custom field schema (→ `attributes`).
- **LeadDetail** — edit + delete + **mark-dead / reopen** (promote-to-Terminal is the next PR).
- **PipelineCard** wraps the board in a dashboard panel; registered across `MODULE_CATALOG` / `DASH_PANEL_IDS` / `DEFAULT_DASH_LAYOUT` / `DashboardPanels` / `DashboardClient` / `ModuleSettingsForm` (KanbanSquare icon).

## Test
The 7-module catalog ripples through the module-prefs / layout / panel / settings suites — all updated. **642 tests pass**, `tsc` + `eslint` clean.

> Maximize the Pipeline panel for the full board. Next: promote-to-Terminal (B.4) + lead↔contact linking. Visual-regression / Bundle-size are pre-existing non-required failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)