### PR TITLE
feat(pipeline): refine lead fields — Location group + collapsible sections + links

### DIFF
--- a/apps/web/src/lib/pipeline/db.ts
+++ b/apps/web/src/lib/pipeline/db.ts
@@ -22,13 +22,16 @@ export type PipelineFieldType =
   | "currency"
   | "select"
   | "date"
-  | "address";
+  | "address"
+  | "url";
 
 export interface PipelineField {
   key: string;
   label: string;
   type: PipelineFieldType;
   options?: string[];
+  /** Section the field renders under in the lead form (e.g. "Location"). */
+  group?: string;
 }
 
 export interface PipelineRow {

--- a/apps/web/src/lib/pipeline/queries.ts
+++ b/apps/web/src/lib/pipeline/queries.ts
@@ -4,7 +4,7 @@
  * these assemble the board and apply the writable whitelists.
  */
 import { pipelineDb, type PipelineRow, type LeadRow } from "./db";
-import { DEFAULT_PIPELINE } from "./templates";
+import { DEFAULT_PIPELINE, PIPELINE_TEMPLATES } from "./templates";
 import { defaultStageKey } from "./board";
 
 export interface SpaceLite {
@@ -43,7 +43,23 @@ export async function ensurePipelineForSpace(
     .limit(1);
   if (error) throw new Error(error.message);
   const rows = (data ?? []) as PipelineRow[];
-  if (rows.length) return rows[0];
+  if (rows.length) {
+    const existing = rows[0];
+    // Until a field editor exists, keep a template-backed pipeline's fields in
+    // sync with its template — so new fields (City/Submarket/Links) appear on an
+    // already-created pipeline. No user field edits to preserve yet.
+    const tmpl = PIPELINE_TEMPLATES.find((t) => t.kind === existing.kind);
+    if (tmpl && JSON.stringify(existing.fields) !== JSON.stringify(tmpl.fields)) {
+      const { data: upd } = await db
+        .from("pl_pipelines")
+        .update({ fields: tmpl.fields })
+        .eq("id", existing.id)
+        .select("*")
+        .maybeSingle();
+      if (upd) return upd as PipelineRow;
+    }
+    return existing;
+  }
 
   const { data: created, error: insErr } = await db
     .from("pl_pipelines")

--- a/apps/web/src/lib/pipeline/templates.ts
+++ b/apps/web/src/lib/pipeline/templates.ts
@@ -13,14 +13,30 @@ export interface PipelineTemplate {
 }
 
 const RE_FIELDS: PipelineField[] = [
-  { key: "address", label: "Address", type: "address" },
-  { key: "folio", label: "Folio / APN", type: "text" },
-  { key: "parcel_size", label: "Parcel size", type: "text" },
-  { key: "zoning", label: "Zoning", type: "text" },
-  { key: "land_use", label: "Land use", type: "text" },
-  { key: "owner", label: "Owner of record", type: "text" },
-  { key: "asking", label: "Asking", type: "currency" },
-  { key: "product_type", label: "Product type", type: "text" },
+  // Location — the filterable fields (City / Submarket drive the list view).
+  { key: "address", label: "Street address", type: "text", group: "Location" },
+  { key: "city", label: "City", type: "text", group: "Location" },
+  { key: "submarket", label: "Submarket / Neighborhood", type: "text", group: "Location" },
+  {
+    key: "county",
+    label: "County",
+    type: "select",
+    options: ["Miami-Dade", "Broward", "Palm Beach", "Other"],
+    group: "Location",
+  },
+  { key: "zip", label: "ZIP", type: "text", group: "Location" },
+  { key: "folio", label: "Folio / APN", type: "text", group: "Location" },
+  // Property & terms — kept from the original template, collapsed by default.
+  { key: "parcel_size", label: "Parcel size", type: "text", group: "Property & terms" },
+  { key: "zoning", label: "Zoning", type: "text", group: "Property & terms" },
+  { key: "land_use", label: "Land use", type: "text", group: "Property & terms" },
+  { key: "product_type", label: "Product type", type: "text", group: "Property & terms" },
+  { key: "asking", label: "Asking", type: "currency", group: "Property & terms" },
+  { key: "owner", label: "Owner of record", type: "text", group: "Property & terms" },
+  // Links.
+  { key: "listing_url", label: "Listing URL", type: "url", group: "Links" },
+  { key: "county_url", label: "County record URL", type: "url", group: "Links" },
+  { key: "maps_url", label: "Google Maps", type: "url", group: "Links" },
 ];
 
 /** Zack's HELIOS deal flow (the default for a real-estate pipeline). */

--- a/apps/web/src/modules/pipeline/components/LeadForm.tsx
+++ b/apps/web/src/modules/pipeline/components/LeadForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { ChevronDown, ChevronRight } from "lucide-react";
 import { Button } from "@/components/ui/Button";
 import type { LeadRow, PipelineRow, PipelineField } from "@/lib/pipeline/db";
 import type { LeadInput } from "../lib/client-api";
@@ -21,7 +22,23 @@ const PRIORITIES = [
 function fieldInputType(t: PipelineField["type"]): string {
   if (t === "currency" || t === "number") return "number";
   if (t === "date") return "date";
+  if (t === "url") return "url";
   return "text";
+}
+
+/** Group fields by their `group` (preserving first-seen order). */
+function groupFields(fields: PipelineField[]): { name: string; fields: PipelineField[] }[] {
+  const order: string[] = [];
+  const byGroup = new Map<string, PipelineField[]>();
+  for (const f of fields) {
+    const g = f.group ?? "Details";
+    if (!byGroup.has(g)) {
+      byGroup.set(g, []);
+      order.push(g);
+    }
+    byGroup.get(g)!.push(f);
+  }
+  return order.map((name) => ({ name, fields: byGroup.get(name)! }));
 }
 
 /** Shared create/edit form for a lead. Renders the core fields + the pipeline's
@@ -58,6 +75,20 @@ export function LeadForm({
   const [attrs, setAttrs] = useState<Record<string, unknown>>(
     (initial?.attributes as Record<string, unknown>) ?? {},
   );
+
+  const groups = groupFields(pipeline.fields);
+  // First group (Location) open; the rest collapsed so the form stays compact.
+  const [openGroups, setOpenGroups] = useState<Set<string>>(
+    () => new Set(groups.slice(0, 1).map((g) => g.name)),
+  );
+  function toggleGroup(name: string) {
+    setOpenGroups((prev) => {
+      const next = new Set(prev);
+      if (next.has(name)) next.delete(name);
+      else next.add(name);
+      return next;
+    });
+  }
 
   function setAttr(key: string, val: string) {
     setAttrs((prev) => ({ ...prev, [key]: val }));
@@ -152,41 +183,59 @@ export function LeadForm({
         </div>
       </div>
 
-      {pipeline.fields.length > 0 && (
-        <div className="flex flex-col gap-2 border-t border-border/40 pt-2">
-          <span className="text-[10px] font-semibold uppercase tracking-wide text-text-2">
-            {pipeline.name} fields
-          </span>
-          <div className="grid grid-cols-2 gap-2">
-            {pipeline.fields.map((f) => (
-              <div key={f.key}>
-                <label className={label}>{f.label}</label>
-                {f.type === "select" ? (
-                  <select
-                    className={`${select} w-full`}
-                    value={String(attrs[f.key] ?? "")}
-                    onChange={(e) => setAttr(f.key, e.target.value)}
+      {groups.map((g) => {
+        const open = openGroups.has(g.name);
+        return (
+          <div key={g.name} className="border-t border-border/40 pt-2">
+            <button
+              type="button"
+              onClick={() => toggleGroup(g.name)}
+              aria-expanded={open}
+              className="flex w-full items-center gap-1 text-[10px] font-semibold uppercase tracking-wide text-text-2 hover:text-text-0"
+            >
+              {open ? (
+                <ChevronDown className="h-3 w-3" aria-hidden="true" />
+              ) : (
+                <ChevronRight className="h-3 w-3" aria-hidden="true" />
+              )}
+              {g.name}
+            </button>
+            {open && (
+              <div className="mt-2 grid grid-cols-2 gap-2">
+                {g.fields.map((f) => (
+                  <div
+                    key={f.key}
+                    className={f.type === "url" || f.type === "address" ? "col-span-2" : ""}
                   >
-                    <option value="" />
-                    {(f.options ?? []).map((o) => (
-                      <option key={o} value={o}>
-                        {o}
-                      </option>
-                    ))}
-                  </select>
-                ) : (
-                  <input
-                    type={fieldInputType(f.type)}
-                    className={input}
-                    value={String(attrs[f.key] ?? "")}
-                    onChange={(e) => setAttr(f.key, e.target.value)}
-                  />
-                )}
+                    <label className={label}>{f.label}</label>
+                    {f.type === "select" ? (
+                      <select
+                        className={`${select} w-full`}
+                        value={String(attrs[f.key] ?? "")}
+                        onChange={(e) => setAttr(f.key, e.target.value)}
+                      >
+                        <option value="" />
+                        {(f.options ?? []).map((o) => (
+                          <option key={o} value={o}>
+                            {o}
+                          </option>
+                        ))}
+                      </select>
+                    ) : (
+                      <input
+                        type={fieldInputType(f.type)}
+                        className={input}
+                        value={String(attrs[f.key] ?? "")}
+                        onChange={(e) => setAttr(f.key, e.target.value)}
+                      />
+                    )}
+                  </div>
+                ))}
               </div>
-            ))}
+            )}
           </div>
-        </div>
-      )}
+        );
+      })}
 
       {error ? <p className="text-xs text-danger">{error}</p> : null}
 


### PR DESCRIPTION
## What
Reworks the HELIOS lead fields (your "refine the inputs" ask) and groups the form into **collapsible sections** so more inputs ≠ clutter.

- **Location** *(open by default, filterable)*: street address, **City**, **Submarket**, **County** (select), **ZIP**, Folio — City/Submarket now drive the **list-view filters**.
- **Property & terms** *(collapsed)*: parcel size, zoning, land use, product type, asking, owner — kept from before.
- **Links** *(collapsed)*: listing URL, county-record URL, Google Maps (new `url` field type).
- `LeadForm` renders fields grouped + collapsible; new `group` on `PipelineField`.
- `ensurePipelineForSpace` **syncs a template-backed pipeline's fields to its template** on load, so your already-created HELIOS pipeline picks up the new fields (no field editor yet → nothing custom to preserve).

## Test
`tsc` + `eslint` clean; 17 pipeline tests green.

> Next per your picks: contact **roles + free-text** quick-contacts, then **file attachments**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)