### PR TITLE
feat(pipeline): field editor — add / remove / rename / reorder lead fields

### DIFF
--- a/apps/web/src/lib/pipeline/db.ts
+++ b/apps/web/src/lib/pipeline/db.ts
@@ -41,6 +41,8 @@ export interface PipelineRow {
   kind: string;
   stages: PipelineStage[];
   fields: PipelineField[];
+  /** True once the user has edited `fields` — stops template field-sync. */
+  fields_customized: boolean;
   position: number;
   created_by: string | null;
   created_at: string;

--- a/apps/web/src/lib/pipeline/fields.test.ts
+++ b/apps/web/src/lib/pipeline/fields.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { slugifyKey, uniqueKey } from "./fields";
+
+describe("slugifyKey", () => {
+  it("lowercases and underscores", () => {
+    expect(slugifyKey("Price per door")).toBe("price_per_door");
+    expect(slugifyKey("Folio / APN")).toBe("folio_apn");
+    expect(slugifyKey("  Submarket  ")).toBe("submarket");
+  });
+  it("falls back for empty/symbol-only labels", () => {
+    expect(slugifyKey("")).toBe("field");
+    expect(slugifyKey("$$$")).toBe("field");
+  });
+});
+
+describe("uniqueKey", () => {
+  it("returns the base when free", () => {
+    expect(uniqueKey("city", new Set())).toBe("city");
+  });
+  it("suffixes when taken", () => {
+    expect(uniqueKey("city", new Set(["city"]))).toBe("city_2");
+    expect(uniqueKey("city", new Set(["city", "city_2"]))).toBe("city_3");
+  });
+});

--- a/apps/web/src/lib/pipeline/fields.ts
+++ b/apps/web/src/lib/pipeline/fields.ts
@@ -1,0 +1,23 @@
+/**
+ * Pure helpers for the pipeline field editor — turning a free-text label into a
+ * stable, unique attribute key. DOM/IO-free + unit-tested.
+ */
+
+/** A safe attribute key from a label: lowercased, non-alphanumerics → `_`. */
+export function slugifyKey(label: string): string {
+  const s = label
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .slice(0, 40);
+  return s || "field";
+}
+
+/** `base`, or `base_2`, `base_3`, … if already taken. */
+export function uniqueKey(base: string, taken: Set<string>): string {
+  if (!taken.has(base)) return base;
+  let i = 2;
+  while (taken.has(`${base}_${i}`)) i++;
+  return `${base}_${i}`;
+}

--- a/apps/web/src/lib/pipeline/queries.ts
+++ b/apps/web/src/lib/pipeline/queries.ts
@@ -49,7 +49,11 @@ export async function ensurePipelineForSpace(
     // sync with its template — so new fields (City/Submarket/Links) appear on an
     // already-created pipeline. No user field edits to preserve yet.
     const tmpl = PIPELINE_TEMPLATES.find((t) => t.kind === existing.kind);
-    if (tmpl && JSON.stringify(existing.fields) !== JSON.stringify(tmpl.fields)) {
+    if (
+      tmpl &&
+      !existing.fields_customized &&
+      JSON.stringify(existing.fields) !== JSON.stringify(tmpl.fields)
+    ) {
       const { data: upd } = await db
         .from("pl_pipelines")
         .update({ fields: tmpl.fields })
@@ -104,7 +108,11 @@ export async function updatePipeline(
   const writable: Record<string, unknown> = {};
   if (patch.name !== undefined) writable.name = patch.name;
   if (patch.stages !== undefined) writable.stages = patch.stages;
-  if (patch.fields !== undefined) writable.fields = patch.fields;
+  if (patch.fields !== undefined) {
+    writable.fields = patch.fields;
+    // Any field edit opts the pipeline out of template field-sync.
+    writable.fields_customized = true;
+  }
   if (Object.keys(writable).length === 0) return getPipeline(client, id);
   const { data, error } = await pipelineDb(client)
     .from("pl_pipelines")

--- a/apps/web/src/modules/pipeline/components/FieldsEditor.tsx
+++ b/apps/web/src/modules/pipeline/components/FieldsEditor.tsx
@@ -1,0 +1,225 @@
+"use client";
+
+import { useState } from "react";
+import { X, Plus, Trash2, ChevronUp, ChevronDown, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/Button";
+import type { PipelineRow, PipelineField, PipelineFieldType } from "@/lib/pipeline/db";
+import { slugifyKey, uniqueKey } from "@/lib/pipeline/fields";
+import { updatePipeline } from "../lib/client-api";
+
+const TYPES: { v: PipelineFieldType; label: string }[] = [
+  { v: "text", label: "Text" },
+  { v: "number", label: "Number" },
+  { v: "currency", label: "Currency" },
+  { v: "date", label: "Date" },
+  { v: "select", label: "Select" },
+  { v: "url", label: "URL" },
+];
+
+const input =
+  "w-full rounded border border-border bg-bg-2 px-2 py-1 text-xs text-text-1 placeholder:text-text-3 outline-none focus:border-border-focus";
+const select =
+  "rounded border border-border bg-bg-2 px-1 py-1 text-2xs text-text-2 outline-none focus:border-border-focus";
+
+interface Row {
+  key: string; // "" for a new field; assigned on save
+  label: string;
+  type: PipelineFieldType;
+  group: string;
+  optionsText: string;
+}
+
+function fromField(f: PipelineField): Row {
+  return {
+    key: f.key,
+    label: f.label,
+    type: f.type,
+    group: f.group ?? "",
+    optionsText: (f.options ?? []).join(", "),
+  };
+}
+
+/** Add / remove / rename / reorder the lead fields on a pipeline. Saving marks
+ *  the pipeline customized so template sync no longer overwrites it. */
+export function FieldsEditor({
+  pipeline,
+  onClose,
+  onSaved,
+}: {
+  pipeline: PipelineRow;
+  onClose: () => void;
+  onSaved: () => void;
+}) {
+  const [rows, setRows] = useState<Row[]>(pipeline.fields.map(fromField));
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  function patch(i: number, p: Partial<Row>) {
+    setRows((rs) => rs.map((r, idx) => (idx === i ? { ...r, ...p } : r)));
+  }
+  function addRow() {
+    setRows((rs) => [...rs, { key: "", label: "", type: "text", group: "", optionsText: "" }]);
+  }
+  function removeRow(i: number) {
+    setRows((rs) => rs.filter((_, idx) => idx !== i));
+  }
+  function move(i: number, dir: -1 | 1) {
+    setRows((rs) => {
+      const j = i + dir;
+      if (j < 0 || j >= rs.length) return rs;
+      const next = [...rs];
+      [next[i], next[j]] = [next[j], next[i]];
+      return next;
+    });
+  }
+
+  async function save() {
+    setBusy(true);
+    setError(null);
+    try {
+      const taken = new Set<string>();
+      const fields: PipelineField[] = rows
+        .filter((r) => r.label.trim())
+        .map((r) => {
+          let key = r.key || slugifyKey(r.label);
+          key = uniqueKey(key, taken);
+          taken.add(key);
+          const field: PipelineField = { key, label: r.label.trim(), type: r.type };
+          if (r.group.trim()) field.group = r.group.trim();
+          if (r.type === "select") {
+            field.options = r.optionsText
+              .split(",")
+              .map((s) => s.trim())
+              .filter(Boolean);
+          }
+          return field;
+        });
+      await updatePipeline(pipeline.id, { fields });
+      onSaved();
+      onClose();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not save fields");
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-start justify-center bg-black/50 p-4 sm:p-8"
+      onClick={onClose}
+    >
+      <div
+        className="mt-6 flex max-h-[85vh] w-full max-w-lg flex-col overflow-hidden rounded-lg border border-border bg-bg-1 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex flex-shrink-0 items-center gap-2 border-b border-border px-3 py-2">
+          <span className="text-[10px] font-semibold uppercase tracking-wide text-text-3">
+            Lead fields · {pipeline.name}
+          </span>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="ml-auto rounded-sm p-1 text-text-2 hover:text-text-0"
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
+        </div>
+
+        <div className="min-h-0 flex-1 overflow-y-auto p-3">
+          <div className="flex flex-col gap-1.5">
+            {/* header row */}
+            <div className="flex items-center gap-1 px-1 text-[9px] uppercase tracking-wide text-text-3">
+              <span className="w-8" />
+              <span className="flex-1">Label</span>
+              <span className="w-[72px]">Type</span>
+              <span className="w-[88px]">Section</span>
+              <span className="w-5" />
+            </div>
+            {rows.map((r, i) => (
+              <div key={i} className="flex flex-col gap-1 rounded border border-border/50 p-1.5">
+                <div className="flex items-center gap-1">
+                  <div className="flex w-8 flex-col">
+                    <button
+                      type="button"
+                      onClick={() => move(i, -1)}
+                      disabled={i === 0}
+                      aria-label="Move up"
+                      className="text-text-3 hover:text-text-0 disabled:opacity-25"
+                    >
+                      <ChevronUp className="h-3 w-3" />
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => move(i, 1)}
+                      disabled={i === rows.length - 1}
+                      aria-label="Move down"
+                      className="text-text-3 hover:text-text-0 disabled:opacity-25"
+                    >
+                      <ChevronDown className="h-3 w-3" />
+                    </button>
+                  </div>
+                  <input
+                    className={`${input} flex-1`}
+                    placeholder="Field label"
+                    value={r.label}
+                    onChange={(e) => patch(i, { label: e.target.value })}
+                  />
+                  <select
+                    className={`${select} w-[72px]`}
+                    value={r.type}
+                    onChange={(e) => patch(i, { type: e.target.value as PipelineFieldType })}
+                  >
+                    {TYPES.map((t) => (
+                      <option key={t.v} value={t.v}>{t.label}</option>
+                    ))}
+                  </select>
+                  <input
+                    className={`${input} w-[88px]`}
+                    placeholder="Section"
+                    value={r.group}
+                    onChange={(e) => patch(i, { group: e.target.value })}
+                  />
+                  <button
+                    type="button"
+                    onClick={() => removeRow(i)}
+                    aria-label="Remove field"
+                    className="rounded-sm p-0.5 text-text-3 hover:text-danger"
+                  >
+                    <Trash2 className="h-3.5 w-3.5" />
+                  </button>
+                </div>
+                {r.type === "select" && (
+                  <input
+                    className={input}
+                    placeholder="Options, comma-separated"
+                    value={r.optionsText}
+                    onChange={(e) => patch(i, { optionsText: e.target.value })}
+                  />
+                )}
+              </div>
+            ))}
+            <button
+              type="button"
+              onClick={addRow}
+              className="flex items-center gap-1 self-start text-2xs text-text-3 hover:text-text-1"
+            >
+              <Plus className="h-3 w-3" /> Add field
+            </button>
+          </div>
+
+          {error ? <p className="mt-2 text-xs text-danger">{error}</p> : null}
+        </div>
+
+        <div className="flex flex-shrink-0 items-center justify-end gap-2 border-t border-border px-3 py-2">
+          <Button size="sm" variant="ghost" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button size="sm" onClick={save} disabled={busy}>
+            {busy ? <Loader2 className="h-3 w-3 animate-spin" /> : null} Save fields
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/modules/pipeline/components/PipelineBoard.tsx
+++ b/apps/web/src/modules/pipeline/components/PipelineBoard.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Plus, Loader2, X, Clock, Flame, LayoutGrid, List } from "lucide-react";
+import { Plus, Loader2, X, Clock, Flame, LayoutGrid, List, SlidersHorizontal } from "lucide-react";
 import { Button } from "@/components/ui/Button";
 import type { LeadRow, PipelineRow } from "@/lib/pipeline/db";
 import { groupByStage, isFollowUpDue, isRotting } from "@/lib/pipeline/board";
 import { PipelineList } from "./PipelineList";
+import { FieldsEditor } from "./FieldsEditor";
 import {
   getSpaces,
   getBoard,
@@ -46,6 +47,7 @@ export function PipelineBoard() {
   const [createStage, setCreateStage] = useState<string | null>(null);
   const [createBusy, setCreateBusy] = useState(false);
   const [createErr, setCreateErr] = useState<string | null>(null);
+  const [fieldsOpen, setFieldsOpen] = useState(false);
 
   // Spaces once.
   useEffect(() => {
@@ -193,6 +195,16 @@ export function PipelineBoard() {
             <List className="h-3.5 w-3.5" />
           </button>
         </div>
+        <button
+          type="button"
+          onClick={() => setFieldsOpen(true)}
+          aria-label="Edit fields"
+          title="Add or remove lead fields"
+          disabled={!pipeline}
+          className="rounded-sm p-1 text-text-3 hover:bg-bg-2 hover:text-text-0 disabled:opacity-40"
+        >
+          <SlidersHorizontal className="h-3.5 w-3.5" />
+        </button>
         <Button
           size="sm"
           onClick={() => setCreateStage(pipeline?.stages[0]?.key ?? null)}
@@ -352,6 +364,15 @@ export function PipelineBoard() {
             />
           </div>
         </div>
+      )}
+
+      {/* Fields editor */}
+      {fieldsOpen && pipeline && (
+        <FieldsEditor
+          pipeline={pipeline}
+          onClose={() => setFieldsOpen(false)}
+          onSaved={refresh}
+        />
       )}
     </div>
   );

--- a/supabase/migrations/20260628180000_pipeline_fields_customized.sql
+++ b/supabase/migrations/20260628180000_pipeline_fields_customized.sql
@@ -1,0 +1,18 @@
+-- Lets a pipeline opt out of template field-sync once the user edits its fields.
+--
+-- ensurePipelineForSpace keeps a template-backed pipeline's `fields` in sync with
+-- its template (so new template fields appear on an already-created pipeline).
+-- Once the user adds/removes/edits fields via the field editor, that sync must
+-- stop clobbering their changes — this flag is how it knows.
+
+BEGIN;
+
+ALTER TABLE pl_pipelines
+  ADD COLUMN fields_customized BOOLEAN NOT NULL DEFAULT FALSE;
+
+COMMIT;
+
+-- ROLLBACK:
+-- BEGIN;
+-- ALTER TABLE pl_pipelines DROP COLUMN fields_customized;
+-- COMMIT;


### PR DESCRIPTION
## What
Lets you **customize your pipeline's lead fields** — without the template sync overwriting your edits.

- **migration** `pl_pipelines.fields_customized` (default false).
- `ensurePipelineForSpace` only syncs fields to the template **while not customized**; `updatePipeline` sets `fields_customized=true` on any field edit. So once you touch the fields, they stick.
- **FieldsEditor** (modal, via a sliders button in the Pipeline header): **add** fields, **remove**, **rename**, change **type** (text / number / currency / date / select / URL), set the **section**, options for selects, **reorder** up/down. Saves through the existing `PATCH /pipeline/pipelines/:id`.
- New fields get a slugified, unique key (`lib/pipeline/fields.ts`, tested); existing keys are preserved so lead data stays put when you rename a label.

## Test
`fields.test.ts` (slug + unique-key) + the pipeline suite. **21 tests**, `tsc` + `eslint` clean.

> Next per your picks: contact **roles + free-text** quick-contacts, then **file attachments**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)