### PR TITLE
feat(pipeline): file attachments on a lead

### DIFF
--- a/apps/web/src/app/api/v1/pipeline/leads/[id]/files/route.ts
+++ b/apps/web/src/app/api/v1/pipeline/leads/[id]/files/route.ts
@@ -1,0 +1,101 @@
+import { type NextRequest } from "next/server";
+import { randomUUID } from "node:crypto";
+import { createClient } from "@/lib/supabase/server";
+import { withObservability } from "@/lib/observability";
+import { ok, unauthorized, badRequest, notFound, internal } from "@/lib/pipeline/api";
+import { getLead, updateLead } from "@/lib/pipeline/queries";
+import {
+  LEAD_FILES_BUCKET,
+  LEAD_FILE_MAX_BYTES,
+  extFromName,
+  leadFileKey,
+  type LeadFile,
+} from "@/lib/pipeline/leadfiles";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+interface Props {
+  params: Promise<{ id: string }>;
+}
+
+function filesOf(attributes: Record<string, unknown> | undefined): LeadFile[] {
+  const f = attributes?.files;
+  return Array.isArray(f) ? (f as LeadFile[]) : [];
+}
+
+/** GET /api/v1/pipeline/leads/:id/files — the lead's attached files. */
+async function handleGet(_request: NextRequest, { params }: Props) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return unauthorized();
+  const { id } = await params;
+  const lead = await getLead(supabase, id);
+  if (!lead) return notFound("Lead not found");
+  return ok({ files: filesOf(lead.attributes) });
+}
+
+/** POST /api/v1/pipeline/leads/:id/files (multipart `file`) — upload + attach. */
+async function handlePost(request: NextRequest, { params }: Props) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return unauthorized();
+  const { id } = await params;
+
+  const lead = await getLead(supabase, id);
+  if (!lead) return notFound("Lead not found");
+
+  const form = await request.formData().catch(() => null);
+  const file = form?.get("file");
+  if (!(file instanceof File)) return badRequest("file is required");
+  if (file.size === 0) return badRequest("file is empty");
+  if (file.size > LEAD_FILE_MAX_BYTES) return badRequest("file too large (max 25 MB)");
+
+  const key = leadFileKey(user.id, id, randomUUID(), extFromName(file.name));
+  const bytes = new Uint8Array(await file.arrayBuffer());
+  const contentType = file.type || "application/octet-stream";
+
+  const { error: upErr } = await supabase.storage
+    .from(LEAD_FILES_BUCKET)
+    .upload(key, bytes, { contentType, upsert: false });
+  if (upErr) return internal(upErr.message);
+
+  const entry: LeadFile = {
+    key,
+    name: file.name || "file",
+    size: file.size,
+    type: contentType,
+    uploaded_at: new Date().toISOString(),
+  };
+  const files = [...filesOf(lead.attributes), entry];
+  await updateLead(supabase, id, { attributes: { ...lead.attributes, files } });
+  return ok({ files }, 201);
+}
+
+/** DELETE /api/v1/pipeline/leads/:id/files?key=… — remove an attachment. */
+async function handleDelete(request: NextRequest, { params }: Props) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return unauthorized();
+  const { id } = await params;
+  const key = request.nextUrl.searchParams.get("key");
+  if (!key) return badRequest("key is required");
+
+  const lead = await getLead(supabase, id);
+  if (!lead) return notFound("Lead not found");
+
+  await supabase.storage.from(LEAD_FILES_BUCKET).remove([key]);
+  const files = filesOf(lead.attributes).filter((f) => f.key !== key);
+  await updateLead(supabase, id, { attributes: { ...lead.attributes, files } });
+  return ok({ files });
+}
+
+export const GET = withObservability<Props>(handleGet, "GET /api/v1/pipeline/leads/:id/files");
+export const POST = withObservability<Props>(handlePost, "POST /api/v1/pipeline/leads/:id/files");
+export const DELETE = withObservability<Props>(handleDelete, "DELETE /api/v1/pipeline/leads/:id/files");

--- a/apps/web/src/app/api/v1/pipeline/leads/[id]/files/sign/route.ts
+++ b/apps/web/src/app/api/v1/pipeline/leads/[id]/files/sign/route.ts
@@ -1,0 +1,37 @@
+import { type NextRequest } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { withObservability } from "@/lib/observability";
+import { ok, unauthorized, badRequest } from "@/lib/pipeline/api";
+import { LEAD_FILES_BUCKET } from "@/lib/pipeline/leadfiles";
+
+export const dynamic = "force-dynamic";
+
+interface Props {
+  params: Promise<{ id: string }>;
+}
+
+/**
+ * GET /api/v1/pipeline/leads/:id/files/sign?key=… — a short-lived signed URL to
+ * download an attachment. The bucket's owner-only SELECT policy means a user can
+ * only sign their own files.
+ */
+async function handleGet(request: NextRequest, _props: Props) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return unauthorized();
+
+  const key = request.nextUrl.searchParams.get("key");
+  if (!key) return badRequest("key is required");
+
+  const { data, error } = await supabase.storage
+    .from(LEAD_FILES_BUCKET)
+    .createSignedUrl(key, 300);
+  if (error || !data?.signedUrl) {
+    return badRequest(error?.message ?? "Could not sign URL");
+  }
+  return ok({ url: data.signedUrl });
+}
+
+export const GET = withObservability<Props>(handleGet, "GET /api/v1/pipeline/leads/:id/files/sign");

--- a/apps/web/src/lib/pipeline/leadfiles.test.ts
+++ b/apps/web/src/lib/pipeline/leadfiles.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { extFromName, leadFileKey, LEAD_FILES_BUCKET } from "./leadfiles";
+
+describe("extFromName", () => {
+  it("pulls the extension", () => {
+    expect(extFromName("Offering Memo.pdf")).toBe("pdf");
+    expect(extFromName("survey.DWG")).toBe("dwg");
+    expect(extFromName("photo.jpeg")).toBe("jpeg");
+  });
+  it("falls back to bin when there's no extension", () => {
+    expect(extFromName("README")).toBe("bin");
+    expect(extFromName("")).toBe("bin");
+  });
+});
+
+describe("leadFileKey", () => {
+  it("pins the key under the uploader's user-id segment", () => {
+    const key = leadFileKey("user-1", "lead-9", "abc", "pdf");
+    expect(key).toBe("user-1/lead-9/abc.pdf");
+    expect(key.split("/")[0]).toBe("user-1"); // RLS depends on this prefix
+  });
+  it("uses a stable bucket name", () => {
+    expect(LEAD_FILES_BUCKET).toBe("lead-files");
+  });
+});

--- a/apps/web/src/lib/pipeline/leadfiles.ts
+++ b/apps/web/src/lib/pipeline/leadfiles.ts
@@ -1,0 +1,33 @@
+/**
+ * Pure helpers for lead file attachments — kept DOM/IO-free so the storage
+ * route stays thin. The bucket holds bytes; file metadata lives on the lead in
+ * `attributes.files` as `LeadFile[]`.
+ */
+
+export const LEAD_FILES_BUCKET = "lead-files";
+export const LEAD_FILE_MAX_BYTES = 25 * 1024 * 1024; // 25 MB (matches the bucket)
+
+export interface LeadFile {
+  key: string;
+  name: string;
+  size: number;
+  type: string;
+  uploaded_at: string;
+}
+
+/** Lowercase extension from a filename, or "bin" when there isn't one. */
+export function extFromName(name: string): string {
+  const m = /\.([a-z0-9]{1,8})$/i.exec(name.trim());
+  return m ? m[1].toLowerCase() : "bin";
+}
+
+/** Storage key: `<userId>/<leadId>/<uuid>.<ext>`. The leading user-id segment is
+ *  what the bucket's owner-only policies pin against, so it must be auth.uid(). */
+export function leadFileKey(
+  userId: string,
+  leadId: string,
+  uuid: string,
+  ext: string,
+): string {
+  return `${userId}/${leadId}/${uuid}.${ext}`;
+}

--- a/apps/web/src/modules/pipeline/components/LeadDetail.tsx
+++ b/apps/web/src/modules/pipeline/components/LeadDetail.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef } from "react";
 import {
   X,
   Loader2,
@@ -10,6 +10,8 @@ import {
   ArrowUpRight,
   Plus,
   Search,
+  Paperclip,
+  Download,
 } from "lucide-react";
 import { Button } from "@/components/ui/Button";
 import type { LeadRow, PipelineRow } from "@/lib/pipeline/db";
@@ -22,8 +24,13 @@ import {
   addLeadContact,
   removeLeadContact,
   promoteLead,
+  getLeadFiles,
+  uploadLeadFile,
+  deleteLeadFile,
+  signLeadFile,
   type LeadInput,
   type LeadContact,
+  type LeadFile,
 } from "../lib/client-api";
 import { listContacts, type ContactListItem } from "@/modules/contacts/lib/client-api";
 import { LeadForm } from "./LeadForm";
@@ -56,14 +63,23 @@ export function LeadDetail({
 
   const [promoteMsg, setPromoteMsg] = useState<string | null>(null);
 
+  const [files, setFiles] = useState<LeadFile[]>([]);
+  const [uploading, setUploading] = useState(false);
+  const fileRef = useRef<HTMLInputElement>(null);
+
   useEffect(() => {
     let alive = true;
     setLoading(true);
-    Promise.all([getLead(leadId), getLeadContacts(leadId).catch(() => [])])
-      .then(([l, cs]) => {
+    Promise.all([
+      getLead(leadId),
+      getLeadContacts(leadId).catch(() => []),
+      getLeadFiles(leadId).catch(() => []),
+    ])
+      .then(([l, cs, fs]) => {
         if (!alive) return;
         setLead(l);
         setContacts(cs);
+        setFiles(fs);
       })
       .catch((e) => alive && setError(e instanceof Error ? e.message : "Failed"))
       .finally(() => alive && setLoading(false));
@@ -71,6 +87,39 @@ export function LeadDetail({
       alive = false;
     };
   }, [leadId]);
+
+  async function uploadFile(file: File | undefined | null) {
+    if (!file) return;
+    setUploading(true);
+    setError(null);
+    try {
+      setFiles(await uploadLeadFile(leadId, file));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Upload failed");
+    } finally {
+      setUploading(false);
+    }
+  }
+  async function removeFile(key: string) {
+    try {
+      setFiles(await deleteLeadFile(leadId, key));
+    } catch {
+      /* non-fatal */
+    }
+  }
+  async function openFile(key: string) {
+    try {
+      const url = await signLeadFile(leadId, key);
+      window.open(url, "_blank", "noopener");
+    } catch {
+      /* non-fatal */
+    }
+  }
+  function fmtSize(bytes: number): string {
+    if (bytes < 1024) return `${bytes} B`;
+    if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
+    return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+  }
 
   // Debounced contact search for the picker.
   useEffect(() => {
@@ -306,6 +355,75 @@ export function LeadDetail({
                     )}
                   </ul>
                 </div>
+              )}
+            </div>
+
+            {/* Files */}
+            <div
+              className="flex flex-col gap-1.5 border-t border-border/40 pt-2"
+              onDragOver={(e) => e.preventDefault()}
+              onDrop={(e) => {
+                e.preventDefault();
+                void uploadFile(e.dataTransfer.files?.[0]);
+              }}
+            >
+              <div className="flex items-center gap-2">
+                <span className={sectionLabel}>Files</span>
+                <button
+                  type="button"
+                  onClick={() => fileRef.current?.click()}
+                  disabled={uploading}
+                  className="ml-auto flex items-center gap-0.5 text-2xs text-text-3 hover:text-text-1"
+                >
+                  {uploading ? (
+                    <Loader2 className="h-3 w-3 animate-spin" />
+                  ) : (
+                    <Plus className="h-3 w-3" />
+                  )}
+                  Upload
+                </button>
+                <input
+                  ref={fileRef}
+                  type="file"
+                  className="hidden"
+                  onChange={(e) => void uploadFile(e.target.files?.[0])}
+                />
+              </div>
+              {files.length === 0 ? (
+                <p className="text-2xs text-text-3">
+                  No files. Drag one here, or use Upload.
+                </p>
+              ) : (
+                files.map((f) => (
+                  <div key={f.key} className="flex items-center gap-2 text-xs text-text-1">
+                    <Paperclip className="h-3 w-3 flex-shrink-0 text-text-3" />
+                    <button
+                      type="button"
+                      onClick={() => openFile(f.key)}
+                      className="min-w-0 flex-1 truncate text-left hover:text-text-0"
+                      title={f.name}
+                    >
+                      {f.name}
+                    </button>
+                    <span className="flex-shrink-0 text-[9px] text-text-3">{fmtSize(f.size)}</span>
+                    <button
+                      type="button"
+                      onClick={() => openFile(f.key)}
+                      aria-label="Download"
+                      className="rounded-sm p-0.5 text-text-3 hover:text-text-0"
+                    >
+                      <Download className="h-3 w-3" />
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => removeFile(f.key)}
+                      aria-label="Remove file"
+                      className="rounded-sm p-0.5 text-text-3 hover:text-danger"
+                    >
+                      <X className="h-3 w-3" />
+                    </button>
+                  </div>
+                ))
               )}
             </div>
 

--- a/apps/web/src/modules/pipeline/lib/client-api.ts
+++ b/apps/web/src/modules/pipeline/lib/client-api.ts
@@ -110,3 +110,40 @@ export interface PromoteResult {
 
 export const promoteLead = (id: string) =>
   req<PromoteResult>(`${leadBase(id)}/promote`, { method: "POST" });
+
+export interface LeadFile {
+  key: string;
+  name: string;
+  size: number;
+  type: string;
+  uploaded_at: string;
+}
+
+export const getLeadFiles = (id: string) =>
+  req<{ files: LeadFile[] }>(`${leadBase(id)}/files`).then((d) => d.files);
+
+export async function uploadLeadFile(id: string, file: File): Promise<LeadFile[]> {
+  const body = new FormData();
+  body.append("file", file);
+  const res = await fetch(`${leadBase(id)}/files`, { method: "POST", body });
+  const json = (await res.json().catch(() => ({}))) as {
+    data?: { files: LeadFile[] };
+    errors?: { code: string; message: string }[];
+  };
+  if (!res.ok || !json.data) {
+    throw new Error(json.errors?.[0]?.message ?? `Upload failed (${res.status})`);
+  }
+  return json.data.files;
+}
+
+export const deleteLeadFile = (id: string, key: string) =>
+  req<{ files: LeadFile[] }>(
+    `${leadBase(id)}/files?key=${encodeURIComponent(key)}`,
+    { method: "DELETE" },
+  ).then((d) => d.files);
+
+/** Get a short-lived signed download URL for an attachment. */
+export const signLeadFile = (id: string, key: string) =>
+  req<{ url: string }>(
+    `${leadBase(id)}/files/sign?key=${encodeURIComponent(key)}`,
+  ).then((d) => d.url);

--- a/supabase/migrations/20260628190000_pipeline_lead_files.sql
+++ b/supabase/migrations/20260628190000_pipeline_lead_files.sql
@@ -1,0 +1,50 @@
+-- Storage bucket for lead attachments (OMs, surveys, photos, any file).
+--
+-- Private bucket; downloads go through short-lived signed URLs. Keys are
+-- `<userId>/<leadId>/<uuid>.<ext>` — owner-prefixed, so the policies below pin
+-- every read/write/delete to the uploader. File METADATA (name/size/type/key)
+-- lives on the lead in attributes.files; this bucket just holds the bytes.
+-- (Solo use today: per-uploader visibility is fine; a shared-lead/team variant
+-- would key on space + check space_members.)
+
+BEGIN;
+
+INSERT INTO storage.buckets (id, name, public, file_size_limit)
+VALUES ('lead-files', 'lead-files', false, 26214400) -- 25 MB
+ON CONFLICT (id) DO UPDATE SET
+  public = EXCLUDED.public,
+  file_size_limit = EXCLUDED.file_size_limit;
+
+DROP POLICY IF EXISTS "lead_files_owner_read" ON storage.objects;
+CREATE POLICY "lead_files_owner_read" ON storage.objects
+  FOR SELECT TO authenticated
+  USING (
+    bucket_id = 'lead-files'
+    AND (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+DROP POLICY IF EXISTS "lead_files_owner_write" ON storage.objects;
+CREATE POLICY "lead_files_owner_write" ON storage.objects
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    bucket_id = 'lead-files'
+    AND (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+DROP POLICY IF EXISTS "lead_files_owner_delete" ON storage.objects;
+CREATE POLICY "lead_files_owner_delete" ON storage.objects
+  FOR DELETE TO authenticated
+  USING (
+    bucket_id = 'lead-files'
+    AND (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+COMMIT;
+
+-- ROLLBACK:
+-- BEGIN;
+-- DROP POLICY IF EXISTS "lead_files_owner_delete" ON storage.objects;
+-- DROP POLICY IF EXISTS "lead_files_owner_write" ON storage.objects;
+-- DROP POLICY IF EXISTS "lead_files_owner_read" ON storage.objects;
+-- DELETE FROM storage.buckets WHERE id = 'lead-files';
+-- COMMIT;


### PR DESCRIPTION
## What
The **files** half of "Links & files" — attach OMs, surveys, photos to a lead.

- **migration** `20260628190000`: private **`lead-files`** storage bucket (owner-prefixed keys `<userId>/<leadId>/<uuid>.<ext>`, owner-only read/write/delete RLS, 25 MB cap) — mirrors `signal-media` / `contact-avatars`. Downloads go through **short-lived signed URLs**. File metadata lives on the lead in `attributes.files`.
- `lib/pipeline/leadfiles.ts` (tested) — bucket / size / ext / key helpers.
- **routes:** `GET/POST(multipart)/DELETE /pipeline/leads/:id/files` (upload appends to `attributes.files`; delete removes from storage + the list) and `GET …/files/sign` (signed URL).
- **LeadDetail** — a **Files** section: drag-or-click upload, list with size, download (signed), remove.

## Test
`leadfiles.test.ts` (ext + key) + the pipeline suite. **25 tests**, `tsc` + `eslint` clean.

> Completes the Pipeline refinement (two views · refined fields · field editor · contact roles + free-text · notes · links · files). Solo-use note: attachments are owner-prefixed (per-uploader visibility); a shared-lead/team variant would key on space.

🤖 Generated with [Claude Code](https://claude.com/claude-code)