### PR TITLE
feat(pipeline): assemblage parcels + full People section on a lead

### DIFF
--- a/apps/web/src/lib/pipeline/promote.ts
+++ b/apps/web/src/lib/pipeline/promote.ts
@@ -30,6 +30,8 @@ export interface LeadContact {
   role: string | null;
   name: string;
   email: string | null;
+  phone: string | null;
+  company: string | null;
 }
 
 interface ContactEmbed {
@@ -37,6 +39,8 @@ interface ContactEmbed {
   last_name: string | null;
   nickname: string | null;
   primary_email: string | null;
+  primary_phone: string | null;
+  company: string | null;
 }
 
 export async function listLeadContacts(
@@ -46,7 +50,7 @@ export async function listLeadContacts(
   const { data, error } = await pipelineDb(client)
     .from("pl_lead_contacts")
     .select(
-      "contact_id, role, contacts:contact_id(first_name, last_name, nickname, primary_email)",
+      "contact_id, role, contacts:contact_id(first_name, last_name, nickname, primary_email, primary_phone, company)",
     )
     .eq("lead_id", leadId);
   if (error) throw new Error(error.message);
@@ -58,7 +62,14 @@ export async function listLeadContacts(
       [c?.first_name, c?.last_name].filter(Boolean).join(" ").trim() ||
       c?.primary_email ||
       "Contact";
-    return { contact_id: r.contact_id, role: r.role, name, email: c?.primary_email ?? null };
+    return {
+      contact_id: r.contact_id,
+      role: r.role,
+      name,
+      email: c?.primary_email ?? null,
+      phone: c?.primary_phone ?? null,
+      company: c?.company ?? null,
+    };
   });
 }
 

--- a/apps/web/src/modules/pipeline/components/LeadDetail.tsx
+++ b/apps/web/src/modules/pipeline/components/LeadDetail.tsx
@@ -32,7 +32,11 @@ import {
   type LeadContact,
   type LeadFile,
 } from "../lib/client-api";
-import { listContacts, type ContactListItem } from "@/modules/contacts/lib/client-api";
+import {
+  listContacts,
+  createContact,
+  type ContactListItem,
+} from "@/modules/contacts/lib/client-api";
 import { LeadForm } from "./LeadForm";
 
 const sectionLabel = "text-[10px] font-semibold uppercase tracking-wide text-text-3";
@@ -60,6 +64,10 @@ export function LeadDetail({
   const [pickerOpen, setPickerOpen] = useState(false);
   const [pickerQ, setPickerQ] = useState("");
   const [pickerResults, setPickerResults] = useState<ContactListItem[]>([]);
+  // Inline "new contact" — creates a real Contact, then links it with a role.
+  const [newOpen, setNewOpen] = useState(false);
+  const [nc, setNc] = useState({ name: "", phone: "", email: "", role: "" });
+  const [ncBusy, setNcBusy] = useState(false);
 
   const [promoteMsg, setPromoteMsg] = useState<string | null>(null);
 
@@ -189,6 +197,34 @@ export function LeadDetail({
     }
   }
 
+  async function createAndLink() {
+    const name = nc.name.trim();
+    if (!name) return;
+    setNcBusy(true);
+    setError(null);
+    try {
+      const [first, ...rest] = name.split(" ");
+      const res = await createContact(
+        {
+          first_name: first,
+          last_name: rest.join(" ") || undefined,
+          emails: nc.email.trim() ? [{ email: nc.email.trim(), primary: true }] : [],
+          phones: nc.phone.trim() ? [{ phone: nc.phone.trim(), primary: true }] : [],
+        },
+        true, // skip the dedupe prompt — this is an explicit "new" person
+      );
+      if (res.contact) {
+        setContacts(await addLeadContact(leadId, res.contact.id, nc.role || null));
+      }
+      setNewOpen(false);
+      setNc({ name: "", phone: "", email: "", role: "" });
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not create contact");
+    } finally {
+      setNcBusy(false);
+    }
+  }
+
   async function setRole(contactId: string, role: string) {
     // addLeadContact upserts, so re-linking with a new role just updates it.
     try {
@@ -279,29 +315,61 @@ export function LeadDetail({
               onSubmit={save}
             />
 
-            {/* Contacts */}
+            {/* People */}
             <div className="flex flex-col gap-1.5 border-t border-border/40 pt-2">
               <div className="flex items-center gap-2">
-                <span className={sectionLabel}>Contacts</span>
+                <span className={sectionLabel}>People</span>
                 <button
                   type="button"
-                  onClick={() => setPickerOpen((o) => !o)}
+                  onClick={() => {
+                    setNewOpen((o) => !o);
+                    setPickerOpen(false);
+                  }}
                   className="ml-auto flex items-center gap-0.5 text-2xs text-text-3 hover:text-text-1"
                 >
-                  <Plus className="h-3 w-3" /> Link
+                  <Plus className="h-3 w-3" /> New
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setPickerOpen((o) => !o);
+                    setNewOpen(false);
+                  }}
+                  className="flex items-center gap-0.5 text-2xs text-text-3 hover:text-text-1"
+                >
+                  <Search className="h-3 w-3" /> Link
                 </button>
               </div>
-              {contacts.length === 0 && !pickerOpen && (
-                <p className="text-2xs text-text-3">No contacts linked.</p>
+              {contacts.length === 0 && !pickerOpen && !newOpen && (
+                <p className="text-2xs text-text-3">No people on this deal yet.</p>
               )}
               {contacts.map((c) => (
-                <div key={c.contact_id} className="flex items-center gap-2 text-xs text-text-1">
-                  <span className="min-w-0 flex-1 truncate">{c.name}</span>
+                <div key={c.contact_id} className="flex items-start gap-2 text-xs text-text-1">
+                  <span className="min-w-0 flex-1">
+                    <span className="block truncate font-medium">
+                      {c.name}
+                      {c.company && (
+                        <span className="ml-1 text-2xs font-normal text-text-3">{c.company}</span>
+                      )}
+                    </span>
+                    <span className="flex flex-wrap gap-x-2 text-2xs text-text-3">
+                      {c.phone && (
+                        <a href={`tel:${c.phone}`} className="hover:text-text-1">
+                          {c.phone}
+                        </a>
+                      )}
+                      {c.email && (
+                        <a href={`mailto:${c.email}`} className="truncate hover:text-text-1">
+                          {c.email}
+                        </a>
+                      )}
+                    </span>
+                  </span>
                   <select
                     value={c.role ?? ""}
                     onChange={(e) => setRole(c.contact_id, e.target.value)}
                     aria-label="Role"
-                    className="rounded border border-border bg-bg-2 px-1 py-0.5 text-[9px] uppercase tracking-wide text-text-3 outline-none focus:border-border-focus"
+                    className="mt-0.5 rounded border border-border bg-bg-2 px-1 py-0.5 text-[9px] uppercase tracking-wide text-text-3 outline-none focus:border-border-focus"
                   >
                     {ROLES.map((r) => (
                       <option key={r} value={r}>
@@ -313,12 +381,62 @@ export function LeadDetail({
                     type="button"
                     onClick={() => unlinkContact(c.contact_id)}
                     aria-label="Unlink"
-                    className="rounded-sm p-0.5 text-text-3 hover:text-danger"
+                    className="mt-0.5 rounded-sm p-0.5 text-text-3 hover:text-danger"
                   >
                     <X className="h-3 w-3" />
                   </button>
                 </div>
               ))}
+              {newOpen && (
+                <div className="flex flex-col gap-1 rounded border border-border bg-bg-1 p-1.5">
+                  <input
+                    autoFocus
+                    className="rounded border border-border bg-bg-2 px-2 py-1 text-xs text-text-1 placeholder:text-text-3 outline-none focus:border-border-focus"
+                    placeholder="Name"
+                    value={nc.name}
+                    onChange={(e) => setNc((s) => ({ ...s, name: e.target.value }))}
+                  />
+                  <div className="flex gap-1">
+                    <input
+                      className="min-w-0 flex-1 rounded border border-border bg-bg-2 px-2 py-1 text-xs text-text-1 placeholder:text-text-3 outline-none focus:border-border-focus"
+                      placeholder="Phone"
+                      value={nc.phone}
+                      onChange={(e) => setNc((s) => ({ ...s, phone: e.target.value }))}
+                    />
+                    <input
+                      className="min-w-0 flex-1 rounded border border-border bg-bg-2 px-2 py-1 text-xs text-text-1 placeholder:text-text-3 outline-none focus:border-border-focus"
+                      placeholder="Email"
+                      value={nc.email}
+                      onChange={(e) => setNc((s) => ({ ...s, email: e.target.value }))}
+                    />
+                  </div>
+                  <div className="flex items-center gap-1">
+                    <select
+                      value={nc.role}
+                      onChange={(e) => setNc((s) => ({ ...s, role: e.target.value }))}
+                      aria-label="Role"
+                      className="rounded border border-border bg-bg-2 px-1.5 py-1 text-2xs text-text-2 outline-none focus:border-border-focus"
+                    >
+                      {ROLES.map((r) => (
+                        <option key={r} value={r}>
+                          {r || "role"}
+                        </option>
+                      ))}
+                    </select>
+                    <Button
+                      size="sm"
+                      className="ml-auto"
+                      onClick={createAndLink}
+                      disabled={ncBusy || !nc.name.trim()}
+                    >
+                      {ncBusy ? <Loader2 className="h-3 w-3 animate-spin" /> : null} Add
+                    </Button>
+                  </div>
+                  <p className="text-[9px] text-text-3">
+                    Saved to your Contacts and linked to this deal.
+                  </p>
+                </div>
+              )}
               {pickerOpen && (
                 <div className="rounded border border-border bg-bg-1 p-1.5">
                   <div className="flex items-center gap-1.5 rounded border border-border bg-bg-2 px-2 py-1 focus-within:border-border-focus">

--- a/apps/web/src/modules/pipeline/components/LeadForm.tsx
+++ b/apps/web/src/modules/pipeline/components/LeadForm.tsx
@@ -19,11 +19,11 @@ const PRIORITIES = [
   { v: 3, label: "High" },
 ];
 
-const QC_ROLES = ["", "seller", "broker", "attorney", "title", "lender", "partner", "other"];
-interface QuickContact {
-  name: string;
-  role?: string;
-  phone?: string;
+/** A parcel in an assemblage / portfolio deal (one of several addresses/owners). */
+interface Parcel {
+  address?: string;
+  folio?: string;
+  owner?: string;
 }
 
 function fieldInputType(t: PipelineField["type"]): string {
@@ -101,19 +101,19 @@ export function LeadForm({
     setAttrs((prev) => ({ ...prev, [key]: val }));
   }
 
-  const quickContacts = (attrs.quick_contacts as QuickContact[] | undefined) ?? [];
-  function setQuickContacts(next: QuickContact[]) {
-    setAttrs((prev) => ({ ...prev, quick_contacts: next }));
+  const parcels = (attrs.parcels as Parcel[] | undefined) ?? [];
+  function setParcels(next: Parcel[]) {
+    setAttrs((prev) => ({ ...prev, parcels: next }));
   }
-  function patchQC(i: number, p: Partial<QuickContact>) {
-    setQuickContacts(quickContacts.map((q, idx) => (idx === i ? { ...q, ...p } : q)));
+  function patchParcel(i: number, p: Partial<Parcel>) {
+    setParcels(parcels.map((q, idx) => (idx === i ? { ...q, ...p } : q)));
   }
 
   function submit() {
     const cleanAttrs = { ...attrs };
-    if (Array.isArray(cleanAttrs.quick_contacts)) {
-      cleanAttrs.quick_contacts = (cleanAttrs.quick_contacts as QuickContact[]).filter(
-        (q) => q.name?.trim(),
+    if (Array.isArray(cleanAttrs.parcels)) {
+      cleanAttrs.parcels = (cleanAttrs.parcels as Parcel[]).filter(
+        (p) => p.address?.trim() || p.folio?.trim() || p.owner?.trim(),
       );
     }
     const patch: LeadInput = {
@@ -258,52 +258,56 @@ export function LeadForm({
         );
       })}
 
-      {/* Quick contacts (free-text — for one-off names; link real Contacts in the drawer) */}
+      {/* Parcels — for an assemblage / portfolio: multiple addresses, folios, owners. */}
       <div className="flex flex-col gap-1.5 border-t border-border/40 pt-2">
-        <span className="text-[10px] font-semibold uppercase tracking-wide text-text-2">
-          People (quick)
-        </span>
-        {quickContacts.map((qc, i) => (
-          <div key={i} className="flex items-center gap-1">
-            <input
-              className={`${input} flex-1`}
-              placeholder="Name"
-              value={qc.name}
-              onChange={(e) => patchQC(i, { name: e.target.value })}
-            />
-            <select
-              className={select}
-              value={qc.role ?? ""}
-              onChange={(e) => patchQC(i, { role: e.target.value })}
-            >
-              {QC_ROLES.map((r) => (
-                <option key={r} value={r}>
-                  {r || "role"}
-                </option>
-              ))}
-            </select>
-            <input
-              className={`${input} max-w-[40%]`}
-              placeholder="Phone / email"
-              value={qc.phone ?? ""}
-              onChange={(e) => patchQC(i, { phone: e.target.value })}
-            />
-            <button
-              type="button"
-              onClick={() => setQuickContacts(quickContacts.filter((_, idx) => idx !== i))}
-              aria-label="Remove"
-              className="rounded-sm p-0.5 text-text-3 hover:text-danger"
-            >
-              <X className="h-3 w-3" />
-            </button>
+        <div className="flex items-center gap-2">
+          <span className="text-[10px] font-semibold uppercase tracking-wide text-text-2">
+            Parcels {parcels.length > 1 ? "· assemblage" : ""}
+          </span>
+          <span className="text-2xs text-text-3">
+            Add a row per property when a deal spans multiple parcels/owners.
+          </span>
+        </div>
+        {parcels.map((pc, i) => (
+          <div key={i} className="flex flex-col gap-1 rounded border border-border/50 p-1.5">
+            <div className="flex items-center gap-1">
+              <input
+                className={`${input} flex-1`}
+                placeholder="Address"
+                value={pc.address ?? ""}
+                onChange={(e) => patchParcel(i, { address: e.target.value })}
+              />
+              <button
+                type="button"
+                onClick={() => setParcels(parcels.filter((_, idx) => idx !== i))}
+                aria-label="Remove parcel"
+                className="rounded-sm p-0.5 text-text-3 hover:text-danger"
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </div>
+            <div className="flex items-center gap-1">
+              <input
+                className={`${input} flex-1`}
+                placeholder="Folio / APN"
+                value={pc.folio ?? ""}
+                onChange={(e) => patchParcel(i, { folio: e.target.value })}
+              />
+              <input
+                className={`${input} flex-1`}
+                placeholder="Owner of record"
+                value={pc.owner ?? ""}
+                onChange={(e) => patchParcel(i, { owner: e.target.value })}
+              />
+            </div>
           </div>
         ))}
         <button
           type="button"
-          onClick={() => setQuickContacts([...quickContacts, { name: "" }])}
+          onClick={() => setParcels([...parcels, {}])}
           className="flex items-center gap-1 self-start text-2xs text-text-3 hover:text-text-1"
         >
-          <Plus className="h-3 w-3" /> Add person
+          <Plus className="h-3 w-3" /> Add parcel
         </button>
       </div>
 

--- a/apps/web/src/modules/pipeline/components/PipelineBoard.tsx
+++ b/apps/web/src/modules/pipeline/components/PipelineBoard.tsx
@@ -127,9 +127,11 @@ export function PipelineBoard() {
     setCreateBusy(true);
     setCreateErr(null);
     try {
-      await createLead({ ...patch, pipeline_id: pipeline.id, space_id: spaceId });
+      const lead = await createLead({ ...patch, pipeline_id: pipeline.id, space_id: spaceId });
       setCreateStage(null);
       await refresh();
+      // Open the new lead so people / parcels / files are right there.
+      setSelectedLead(lead.id);
     } catch (e) {
       setCreateErr(e instanceof Error ? e.message : "Could not create");
     } finally {

--- a/apps/web/src/modules/pipeline/lib/client-api.ts
+++ b/apps/web/src/modules/pipeline/lib/client-api.ts
@@ -85,6 +85,8 @@ export interface LeadContact {
   role: string | null;
   name: string;
   email: string | null;
+  phone: string | null;
+  company: string | null;
 }
 
 const leadBase = (id: string) => `${B}/leads/${encodeURIComponent(id)}`;


### PR DESCRIPTION
## What

Two refinements to the lead drawer/form, both requested directly:

### Assemblage support
A repeatable **Parcels** section on the lead form — address + folio/APN + owner
of record per row, stored in `attributes.parcels`. The header flags
"· assemblage" once there's more than one parcel, so a portfolio / multi-owner
deal is captured as first-class structured data instead of being crammed into
the lead name.

### Full People section (replaces the quick free-text people)
- **Link** an existing Contact via the searchable picker, **or**
- **New** — create a brand-new Contact inline (name / phone / email / role)
  that is saved to your Contacts *and* linked to the deal in one step.
- Rows now show name, company, a `tel:` phone link, a `mailto:` email link, an
  editable role dropdown, and unlink. Lead contacts carry phone + company
  through `promote` + `client-api`.

Also: creating a lead now opens its drawer immediately, so people / parcels /
files are right there.

## Test
- `tsc --noEmit` clean, `eslint` clean on pipeline dirs
- `vitest run src/lib/pipeline` — 25/25 green
- New Contact is created with `force=true` (skips the dedupe prompt — it's an
  explicit "new person"), then linked via the existing `addLeadContact` upsert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)