### PR TITLE
feat(pipeline): board/drawer polish — a11y, empty state, value rollup, card chips

### DIFF
--- a/apps/web/src/lib/pipeline/board.test.ts
+++ b/apps/web/src/lib/pipeline/board.test.ts
@@ -1,7 +1,15 @@
 import { describe, it, expect } from "vitest";
-import { groupByStage, isRotting, isFollowUpDue, defaultStageKey } from "./board";
+import {
+  groupByStage,
+  isRotting,
+  isFollowUpDue,
+  defaultStageKey,
+  rollupField,
+  sumAttr,
+  compactMoney,
+} from "./board";
 import { HELIOS_PIPELINE } from "./templates";
-import type { LeadRow } from "./db";
+import type { LeadRow, PipelineField } from "./db";
 
 const stages = HELIOS_PIPELINE.stages;
 
@@ -85,5 +93,55 @@ describe("isFollowUpDue", () => {
   it("not due without a date or when not open", () => {
     expect(isFollowUpDue(lead({ next_follow_up_at: null }), now)).toBe(false);
     expect(isFollowUpDue(lead({ status: "dead", next_follow_up_at: "2026-06-27T00:00:00Z" }), now)).toBe(false);
+  });
+});
+
+describe("rollupField", () => {
+  const f = (over: Partial<PipelineField>): PipelineField => ({
+    key: "k",
+    label: "L",
+    type: "text",
+    ...over,
+  });
+  it("returns the first currency field", () => {
+    const fields = [
+      f({ key: "addr", type: "text" }),
+      f({ key: "ask", label: "Asking", type: "currency" }),
+      f({ key: "noi", label: "NOI", type: "currency" }),
+    ];
+    expect(rollupField(fields)?.key).toBe("ask");
+  });
+  it("is null when there's no currency field", () => {
+    expect(rollupField([f({ type: "text" }), f({ type: "number" })])).toBeNull();
+  });
+});
+
+describe("sumAttr", () => {
+  it("sums numeric attribute values, ignoring blanks and non-numbers", () => {
+    const rows = [
+      { attributes: { ask: 1_000_000 } },
+      { attributes: { ask: "500000" } },
+      { attributes: { ask: "" } },
+      { attributes: { ask: "n/a" } },
+      { attributes: {} },
+    ];
+    expect(sumAttr(rows, "ask")).toBe(1_500_000);
+  });
+  it("is 0 when no lead has the key", () => {
+    expect(sumAttr([{ attributes: {} }], "ask")).toBe(0);
+  });
+});
+
+describe("compactMoney", () => {
+  it("formats millions, thousands, and small values", () => {
+    expect(compactMoney(1_200_000)).toBe("$1.2M");
+    expect(compactMoney(12_000_000)).toBe("$12M");
+    expect(compactMoney(850_000)).toBe("$850K");
+    expect(compactMoney(1_200)).toBe("$1K");
+    expect(compactMoney(750)).toBe("$750");
+  });
+  it("is empty for zero / non-finite", () => {
+    expect(compactMoney(0)).toBe("");
+    expect(compactMoney(NaN)).toBe("");
   });
 });

--- a/apps/web/src/lib/pipeline/board.ts
+++ b/apps/web/src/lib/pipeline/board.ts
@@ -3,10 +3,39 @@
  * "going cold" / "follow-up due" rules. DOM/IO-free so it's unit-tested; the
  * React board consumes these.
  */
-import type { LeadRow, PipelineStage } from "./db";
+import type { LeadRow, PipelineStage, PipelineField } from "./db";
 
 export function defaultStageKey(pipeline: { stages: PipelineStage[] }): string {
   return pipeline.stages[0]?.key ?? "";
+}
+
+/**
+ * The field the board sums per column for the "value in this stage" rollup —
+ * the first currency field on the pipeline (vertical-agnostic; a real-estate
+ * pipeline's "Asking" or "Price", a generic one's "Deal value"). Null if none.
+ */
+export function rollupField(fields: PipelineField[]): PipelineField | null {
+  return fields.find((f) => f.type === "currency") ?? null;
+}
+
+/** Sum a numeric attribute across leads, ignoring blanks / non-numbers. */
+export function sumAttr(leads: Pick<LeadRow, "attributes">[], key: string): number {
+  let total = 0;
+  for (const l of leads) {
+    const raw = (l.attributes as Record<string, unknown>)?.[key];
+    const n = typeof raw === "number" ? raw : parseFloat(String(raw ?? ""));
+    if (Number.isFinite(n)) total += n;
+  }
+  return total;
+}
+
+/** Compact money label for a column total: $1.2M / $850K / $1,200. */
+export function compactMoney(n: number): string {
+  if (!Number.isFinite(n) || n === 0) return "";
+  const abs = Math.abs(n);
+  if (abs >= 1_000_000) return `$${(n / 1_000_000).toFixed(abs >= 10_000_000 ? 0 : 1)}M`;
+  if (abs >= 1_000) return `$${Math.round(n / 1_000)}K`;
+  return `$${Math.round(n)}`;
 }
 
 export interface StageColumn {

--- a/apps/web/src/modules/pipeline/components/FieldsEditor.tsx
+++ b/apps/web/src/modules/pipeline/components/FieldsEditor.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/Button";
 import type { PipelineRow, PipelineField, PipelineFieldType } from "@/lib/pipeline/db";
 import { slugifyKey, uniqueKey } from "@/lib/pipeline/fields";
 import { updatePipeline } from "../lib/client-api";
+import { useOverlay } from "../lib/use-overlay";
 
 const TYPES: { v: PipelineFieldType; label: string }[] = [
   { v: "text", label: "Text" },
@@ -53,6 +54,8 @@ export function FieldsEditor({
   const [rows, setRows] = useState<Row[]>(pipeline.fields.map(fromField));
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  useOverlay(true, onClose);
 
   function patch(i: number, p: Partial<Row>) {
     setRows((rs) => rs.map((r, idx) => (idx === i ? { ...r, ...p } : r)));
@@ -109,6 +112,9 @@ export function FieldsEditor({
       onClick={onClose}
     >
       <div
+        role="dialog"
+        aria-modal="true"
+        aria-label={`Lead fields for ${pipeline.name}`}
         className="mt-6 flex max-h-[85vh] w-full max-w-lg flex-col overflow-hidden rounded-lg border border-border bg-bg-1 shadow-xl"
         onClick={(e) => e.stopPropagation()}
       >

--- a/apps/web/src/modules/pipeline/components/LeadCard.tsx
+++ b/apps/web/src/modules/pipeline/components/LeadCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Clock, Flame } from "lucide-react";
+import { Clock, Flame, Layers, StickyNote } from "lucide-react";
 import type { LeadRow, PipelineStage } from "@/lib/pipeline/db";
 import { isRotting, isFollowUpDue } from "@/lib/pipeline/board";
 
@@ -9,6 +9,17 @@ const PRIORITY_DOT: Record<number, string> = {
   2: "bg-accent",
   3: "bg-danger",
 };
+
+/** Count of non-empty parcels on a lead (an assemblage has >1). */
+function parcelCount(lead: LeadRow): number {
+  const p = (lead.attributes as Record<string, unknown>)?.parcels;
+  return Array.isArray(p) ? p.length : 0;
+}
+/** Whether the lead has any notes text. */
+function hasNotes(lead: LeadRow): boolean {
+  const n = (lead.attributes as Record<string, unknown>)?.notes;
+  return typeof n === "string" && n.trim().length > 0;
+}
 
 /** A draggable lead card in a board column. */
 export function LeadCard({
@@ -27,6 +38,8 @@ export function LeadCard({
   const rotting = isRotting(lead, stages, nowMs);
   const due = isFollowUpDue(lead, nowMs);
   const converted = lead.status === "converted";
+  const parcels = parcelCount(lead);
+  const notes = hasNotes(lead);
   return (
     <button
       type="button"
@@ -42,7 +55,10 @@ export function LeadCard({
             aria-hidden="true"
           />
         )}
-        <span className="min-w-0 flex-1 truncate text-xs font-medium text-text-0">
+        <span
+          className="min-w-0 flex-1 truncate text-xs font-medium text-text-0"
+          title={lead.name}
+        >
           {lead.name}
         </span>
         {converted && (
@@ -54,12 +70,23 @@ export function LeadCard({
       {lead.subtitle && (
         <span className="truncate text-2xs text-text-3">{lead.subtitle}</span>
       )}
-      {(lead.source || due || rotting) && (
+      {(lead.source || due || rotting || parcels > 1 || notes) && (
         <div className="flex flex-wrap items-center gap-1">
           {lead.source && (
             <span className="rounded-sm bg-bg-3 px-1 py-px text-[9px] uppercase tracking-wide text-text-3">
               {lead.source}
             </span>
+          )}
+          {parcels > 1 && (
+            <span
+              className="flex items-center gap-0.5 text-[9px] text-text-3"
+              title={`Assemblage — ${parcels} parcels`}
+            >
+              <Layers className="h-2.5 w-2.5" /> {parcels}
+            </span>
+          )}
+          {notes && (
+            <StickyNote className="h-2.5 w-2.5 text-text-3" aria-label="Has notes" />
           )}
           {due && (
             <span className="flex items-center gap-0.5 text-[9px] font-medium text-accent">

--- a/apps/web/src/modules/pipeline/components/LeadDetail.tsx
+++ b/apps/web/src/modules/pipeline/components/LeadDetail.tsx
@@ -42,6 +42,34 @@ import { LeadForm } from "./LeadForm";
 const sectionLabel = "text-[10px] font-semibold uppercase tracking-wide text-text-3";
 const ROLES = ["", "seller", "broker", "attorney", "title", "lender", "partner", "other"];
 
+/** Compact "3d ago" / "just now" relative time; falls back to a date past ~30d. */
+function relTime(iso: string | null | undefined): string {
+  if (!iso) return "";
+  const t = Date.parse(iso);
+  if (Number.isNaN(t)) return "";
+  const diff = Date.now() - t;
+  const mins = Math.round(diff / 60_000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.round(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  const days = Math.round(hrs / 24);
+  if (days < 30) return `${days}d ago`;
+  return new Date(t).toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
+
+/** "Jun 12, 2026" — used for the static "added" date. */
+function fmtDay(iso: string | null | undefined): string {
+  if (!iso) return "";
+  const t = Date.parse(iso);
+  if (Number.isNaN(t)) return "";
+  return new Date(t).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
 /** Drawer for one lead — edit, linked contacts, promote-to-Terminal, and the
  *  dead/reopen/delete actions. */
 export function LeadDetail({
@@ -285,6 +313,17 @@ export function LeadDetail({
           <p className="text-xs text-text-3">{error ?? "Not found."}</p>
         ) : (
           <div className="flex flex-col gap-3">
+            {/* Provenance — how fresh is this lead? */}
+            <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5 text-[10px] text-text-3">
+              {lead.created_at && <span>Added {fmtDay(lead.created_at)}</span>}
+              {lead.last_activity_at && (
+                <>
+                  <span aria-hidden="true">·</span>
+                  <span>Last activity {relTime(lead.last_activity_at)}</span>
+                </>
+              )}
+            </div>
+
             {/* Promote banner */}
             {(canPromote || alreadyTerminal) && (
               <div className="rounded border border-border bg-bg-2 p-2">

--- a/apps/web/src/modules/pipeline/components/PipelineBoard.tsx
+++ b/apps/web/src/modules/pipeline/components/PipelineBoard.tsx
@@ -18,6 +18,7 @@ import {
 import { LeadCard } from "./LeadCard";
 import { LeadForm } from "./LeadForm";
 import { LeadDetail } from "./LeadDetail";
+import { useOverlay } from "../lib/use-overlay";
 
 const SPACE_KEY = "rokki:pipeline-space";
 const VIEW_KEY = "rokki:pipeline-view";
@@ -48,6 +49,10 @@ export function PipelineBoard() {
   const [createBusy, setCreateBusy] = useState(false);
   const [createErr, setCreateErr] = useState<string | null>(null);
   const [fieldsOpen, setFieldsOpen] = useState(false);
+
+  // Esc closes whichever overlay is open (+ restores focus to the trigger).
+  useOverlay(createStage != null, () => setCreateStage(null));
+  useOverlay(selectedLead != null && createStage == null, () => setSelectedLead(null));
 
   // Spaces once.
   useEffect(() => {
@@ -262,6 +267,20 @@ export function PipelineBoard() {
           nowMs={nowMs}
           onSelect={(id) => setSelectedLead(id)}
         />
+      ) : leads.length === 0 ? (
+        <div className="flex flex-1 flex-col items-center justify-center gap-3 p-6 text-center">
+          <LayoutGrid className="h-8 w-8 text-text-3" aria-hidden="true" />
+          <div className="space-y-1">
+            <p className="text-sm font-medium text-text-1">No leads yet</p>
+            <p className="text-xs text-text-3">
+              Track a property, owner, or assemblage from first contact through to a
+              Terminal.
+            </p>
+          </div>
+          <Button size="sm" onClick={() => setCreateStage(pipeline.stages[0]?.key ?? null)}>
+            <Plus className="h-3 w-3" /> Add your first lead
+          </Button>
+        </div>
       ) : (
         <div className="flex min-h-0 flex-1 gap-2 overflow-x-auto p-2">
           {columns.map(({ stage, leads: colLeads }) => (
@@ -317,6 +336,9 @@ export function PipelineBoard() {
           onClick={() => setCreateStage(null)}
         >
           <div
+            role="dialog"
+            aria-modal="true"
+            aria-label="New lead"
             className="mt-6 flex max-h-[85vh] w-full max-w-md flex-col overflow-hidden rounded-lg border border-border bg-bg-1 shadow-xl"
             onClick={(e) => e.stopPropagation()}
           >
@@ -355,6 +377,9 @@ export function PipelineBoard() {
           onClick={() => setSelectedLead(null)}
         >
           <div
+            role="dialog"
+            aria-modal="true"
+            aria-label="Lead detail"
             className="h-full w-full max-w-[400px] border-l border-border bg-bg-1 shadow-xl"
             onClick={(e) => e.stopPropagation()}
           >

--- a/apps/web/src/modules/pipeline/components/PipelineBoard.tsx
+++ b/apps/web/src/modules/pipeline/components/PipelineBoard.tsx
@@ -4,7 +4,14 @@ import { useEffect, useState } from "react";
 import { Plus, Loader2, X, Clock, Flame, LayoutGrid, List, SlidersHorizontal } from "lucide-react";
 import { Button } from "@/components/ui/Button";
 import type { LeadRow, PipelineRow } from "@/lib/pipeline/db";
-import { groupByStage, isFollowUpDue, isRotting } from "@/lib/pipeline/board";
+import {
+  groupByStage,
+  isFollowUpDue,
+  isRotting,
+  rollupField,
+  sumAttr,
+  compactMoney,
+} from "@/lib/pipeline/board";
 import { PipelineList } from "./PipelineList";
 import { FieldsEditor } from "./FieldsEditor";
 import {
@@ -158,6 +165,7 @@ export function PipelineBoard() {
   }
   const visibleLeads = attentionOnly ? activeLeads.filter(needsAttention) : activeLeads;
   const { columns } = groupByStage(visibleLeads, stages);
+  const rollup = pipeline ? rollupField(pipeline.fields) : null;
 
   return (
     <div className="flex h-full min-h-0 flex-col">
@@ -283,7 +291,10 @@ export function PipelineBoard() {
         </div>
       ) : (
         <div className="flex min-h-0 flex-1 gap-2 overflow-x-auto p-2">
-          {columns.map(({ stage, leads: colLeads }) => (
+          {columns.map(({ stage, leads: colLeads }) => {
+            const colValue = rollup ? sumAttr(colLeads, rollup.key) : 0;
+            const coldInCol = colLeads.filter((l) => isRotting(l, stages, nowMs)).length;
+            return (
             <div
               key={stage.key}
               onDragOver={(e) => e.preventDefault()}
@@ -299,11 +310,30 @@ export function PipelineBoard() {
                   {stage.label}
                 </span>
                 <span className="font-mono text-2xs text-text-3">{colLeads.length}</span>
-                {stage.is_terminal_gate && (
-                  <span className="ml-auto text-[9px] uppercase tracking-wide text-accent">
-                    gate
-                  </span>
-                )}
+                <div className="ml-auto flex items-center gap-1.5">
+                  {colValue > 0 && (
+                    <span
+                      className="font-mono text-2xs text-text-3"
+                      title={`${rollup?.label ?? "Value"} in ${stage.label}`}
+                    >
+                      {compactMoney(colValue)}
+                    </span>
+                  )}
+                  {coldInCol > 0 && (
+                    <span
+                      className="flex items-center gap-0.5 text-[9px] text-danger"
+                      title={`${coldInCol} going cold`}
+                    >
+                      <Flame className="h-2.5 w-2.5" />
+                      {coldInCol}
+                    </span>
+                  )}
+                  {stage.is_terminal_gate && (
+                    <span className="text-[9px] uppercase tracking-wide text-accent">
+                      gate
+                    </span>
+                  )}
+                </div>
               </div>
               <div className="flex min-h-0 flex-1 flex-col gap-1.5 overflow-y-auto p-1.5">
                 {colLeads.map((lead) => (
@@ -325,7 +355,8 @@ export function PipelineBoard() {
                 <Plus className="h-3 w-3" /> Add
               </button>
             </div>
-          ))}
+            );
+          })}
         </div>
       )}
 

--- a/apps/web/src/modules/pipeline/components/PipelineList.tsx
+++ b/apps/web/src/modules/pipeline/components/PipelineList.tsx
@@ -158,7 +158,9 @@ export function PipelineList({
                     className="cursor-pointer border-b border-border/30 hover:bg-bg-2"
                   >
                     <td className="px-3 py-1.5">
-                      <span className="block truncate font-medium text-text-0">{l.name}</span>
+                      <span className="block truncate font-medium text-text-0" title={l.name}>
+                        {l.name}
+                      </span>
                       {l.subtitle && (
                         <span className="block truncate text-2xs text-text-3">{l.subtitle}</span>
                       )}

--- a/apps/web/src/modules/pipeline/components/PipelineList.tsx
+++ b/apps/web/src/modules/pipeline/components/PipelineList.tsx
@@ -13,12 +13,18 @@ function attr(lead: LeadRow, key: string): string {
   const v = (lead.attributes as Record<string, unknown>)?.[key];
   return v == null ? "" : String(v);
 }
-function fmtDate(iso: string | null): string {
+function fmtDate(iso: string | null, nowMs: number): string {
   if (!iso) return "";
   const d = new Date(iso);
-  return Number.isNaN(d.getTime())
-    ? ""
-    : d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+  if (Number.isNaN(d.getTime())) return "";
+  // Show the year only when it differs from "now" so next-year follow-ups read
+  // unambiguously without cluttering this-year dates.
+  const sameYear = d.getFullYear() === new Date(nowMs).getFullYear();
+  return d.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    ...(sameYear ? {} : { year: "numeric" }),
+  });
 }
 
 /** Filterable table view of the pipeline — the list alternative to the board.
@@ -170,7 +176,7 @@ export function PipelineList({
                       {l.next_follow_up_at ? (
                         <span className={`flex items-center gap-1 ${due ? "text-accent" : "text-text-3"}`}>
                           {due && <Clock className="h-2.5 w-2.5" />}
-                          {fmtDate(l.next_follow_up_at)}
+                          {fmtDate(l.next_follow_up_at, nowMs)}
                         </span>
                       ) : (
                         <span className="text-text-3">—</span>

--- a/apps/web/src/modules/pipeline/lib/use-overlay.ts
+++ b/apps/web/src/modules/pipeline/lib/use-overlay.ts
@@ -1,0 +1,30 @@
+"use client";
+
+import { useEffect } from "react";
+
+/**
+ * Shared behavior for the module's modal/drawer overlays: while `active`, close
+ * on Escape and, on close, return focus to whatever was focused when the overlay
+ * opened (so keyboard users aren't dumped at the top of the page). Pair with
+ * `role="dialog" aria-modal` on the panel for screen readers.
+ */
+export function useOverlay(active: boolean, onClose: () => void): void {
+  useEffect(() => {
+    if (!active) return;
+    const restoreTo = document.activeElement as HTMLElement | null;
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        onClose();
+      }
+    }
+    window.addEventListener("keydown", onKey);
+    return () => {
+      window.removeEventListener("keydown", onKey);
+      // Only pull focus back if it's still inside the (now-closing) overlay.
+      if (restoreTo && typeof restoreTo.focus === "function") restoreTo.focus();
+    };
+    // onClose is stable enough in practice; re-running on `active` is what matters.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [active]);
+}


### PR DESCRIPTION
Quality pass on the pipeline module (overnight batch, requested while you slept).

## Keyboard-first & states (commit 1)
- **Esc** closes the lead drawer, create-lead modal, and fields editor; focus
  returns to the trigger on close (new `useOverlay` hook). All three panels get
  `role="dialog"` + `aria-modal` + an `aria-label`.
- Board shows a real **empty state** ("No leads yet" + Add-your-first CTA)
  instead of bare empty columns.
- Lead drawer shows **provenance**: "Added <date> · Last activity <relative>".
- List follow-up dates show the **year** when it isn't the current year.

## Board density (commit 2)
- Each stage column header sums the first **currency field** across its leads
  (vertical-agnostic: "Asking" / "Deal value"), shown compact ($1.2M / $850K),
  plus a flame + **count of cold leads** in that column.
- Lead cards gain an **assemblage chip** (parcel count when >1) and a **notes
  glyph**; long names get a title tooltip on board + list.
- New pure helpers `rollupField` / `sumAttr` / `compactMoney` in `board.ts`,
  unit-tested (+6).

## Test
- `tsc` clean, `eslint` clean on pipeline dirs, `vitest run src/lib/pipeline` 31/31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)