### PR TITLE
feat(pipeline): safety + data hygiene — orphans, delete confirm, source normalize, filters

### DIFF
--- a/apps/web/src/lib/pipeline/queries.ts
+++ b/apps/web/src/lib/pipeline/queries.ts
@@ -171,9 +171,18 @@ const LEAD_WRITABLE: (keyof LeadInput)[] = [
   "next_follow_up_at", "dead_reason", "lat", "lng", "attributes",
 ];
 
+/** Trim + collapse internal whitespace so " Broker  " and "Broker" don't become
+ *  two different sources fragmenting the board's source filter. Casing is left
+ *  alone (so "MLS" stays "MLS"); the UI dedupes the filter case-insensitively. */
+function normalizeSource(s: string): string | null {
+  const t = s.trim().replace(/\s+/g, " ");
+  return t || null;
+}
+
 function pickLead(input: LeadInput): Record<string, unknown> {
   const out: Record<string, unknown> = {};
   for (const k of LEAD_WRITABLE) if (input[k] !== undefined) out[k] = input[k];
+  if (typeof out.source === "string") out.source = normalizeSource(out.source);
   return out;
 }
 

--- a/apps/web/src/modules/pipeline/components/LeadDetail.tsx
+++ b/apps/web/src/modules/pipeline/components/LeadDetail.tsx
@@ -98,6 +98,7 @@ export function LeadDetail({
   const [ncBusy, setNcBusy] = useState(false);
 
   const [promoteMsg, setPromoteMsg] = useState<string | null>(null);
+  const [confirmDelete, setConfirmDelete] = useState(false);
 
   const [files, setFiles] = useState<LeadFile[]>([]);
   const [uploading, setUploading] = useState(false);
@@ -595,9 +596,31 @@ export function LeadDetail({
                   <Ban className="h-3 w-3" /> Mark dead
                 </Button>
               )}
-              <Button size="sm" variant="ghost" onClick={remove} disabled={busy}>
-                <Trash2 className="h-3 w-3" /> Delete
-              </Button>
+              {confirmDelete ? (
+                <div className="ml-auto flex items-center gap-1.5">
+                  <span className="text-2xs text-text-2">Delete for good?</span>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    onClick={() => setConfirmDelete(false)}
+                    disabled={busy}
+                  >
+                    Cancel
+                  </Button>
+                  <Button size="sm" variant="destructive" onClick={remove} disabled={busy}>
+                    <Trash2 className="h-3 w-3" /> Delete
+                  </Button>
+                </div>
+              ) : (
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => setConfirmDelete(true)}
+                  disabled={busy}
+                >
+                  <Trash2 className="h-3 w-3" /> Delete
+                </Button>
+              )}
             </div>
           </div>
         )}

--- a/apps/web/src/modules/pipeline/components/PipelineBoard.tsx
+++ b/apps/web/src/modules/pipeline/components/PipelineBoard.tsx
@@ -164,7 +164,7 @@ export function PipelineBoard() {
     if (isRotting(l, stages, nowMs)) coldCount++;
   }
   const visibleLeads = attentionOnly ? activeLeads.filter(needsAttention) : activeLeads;
-  const { columns } = groupByStage(visibleLeads, stages);
+  const { columns, orphans } = groupByStage(visibleLeads, stages);
   const rollup = pipeline ? rollupField(pipeline.fields) : null;
 
   return (
@@ -291,6 +291,32 @@ export function PipelineBoard() {
         </div>
       ) : (
         <div className="flex min-h-0 flex-1 gap-2 overflow-x-auto p-2">
+          {/* Orphans — leads whose stage was removed from the pipeline. Surface
+              them in a holding column (drag into a real stage to re-home) rather
+              than silently dropping them off the board. */}
+          {orphans.length > 0 && (
+            <div className="flex min-w-[13rem] flex-1 flex-col rounded border border-danger/40 bg-danger/5">
+              <div className="flex flex-shrink-0 items-center gap-1.5 border-b border-danger/30 px-2 py-1.5">
+                <span className="text-2xs font-semibold uppercase tracking-wide text-danger">
+                  Unassigned
+                </span>
+                <span className="font-mono text-2xs text-text-3">{orphans.length}</span>
+                <span className="ml-auto text-[9px] text-text-3">stage removed</span>
+              </div>
+              <div className="flex min-h-0 flex-1 flex-col gap-1.5 overflow-y-auto p-1.5">
+                {orphans.map((lead) => (
+                  <LeadCard
+                    key={lead.id}
+                    lead={lead}
+                    stages={stages}
+                    nowMs={nowMs}
+                    onClick={() => setSelectedLead(lead.id)}
+                    onDragStart={(e) => e.dataTransfer.setData("text/plain", lead.id)}
+                  />
+                ))}
+              </div>
+            </div>
+          )}
           {columns.map(({ stage, leads: colLeads }) => {
             const colValue = rollup ? sumAttr(colLeads, rollup.key) : 0;
             const coldInCol = colLeads.filter((l) => isRotting(l, stages, nowMs)).length;

--- a/apps/web/src/modules/pipeline/components/PipelineList.tsx
+++ b/apps/web/src/modules/pipeline/components/PipelineList.tsx
@@ -1,13 +1,34 @@
 "use client";
 
-import { useMemo, useState } from "react";
-import { Clock } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { Clock, X } from "lucide-react";
 import type { LeadRow, PipelineRow } from "@/lib/pipeline/db";
 import { isFollowUpDue, isRotting } from "@/lib/pipeline/board";
 
 const PRIORITY_LABEL: Record<number, string> = { 0: "—", 1: "Low", 2: "Med", 3: "High" };
 const select =
   "rounded border border-border bg-bg-2 px-1.5 py-1 text-2xs text-text-2 outline-none focus:border-border-focus";
+
+const FILTERS_KEY = "rokki:pipeline-list-filters";
+const DEFAULT_FILTERS = { stage: "all", status: "active", source: "all", prio: "all" };
+
+/** Load persisted list filters (SSR-safe; falls back to defaults). */
+function loadFilters(): typeof DEFAULT_FILTERS {
+  if (typeof window === "undefined") return DEFAULT_FILTERS;
+  try {
+    const raw = window.localStorage.getItem(FILTERS_KEY);
+    if (!raw) return DEFAULT_FILTERS;
+    const p = JSON.parse(raw) as Partial<typeof DEFAULT_FILTERS>;
+    return {
+      stage: typeof p.stage === "string" ? p.stage : "all",
+      status: typeof p.status === "string" ? p.status : "active",
+      source: typeof p.source === "string" ? p.source : "all",
+      prio: typeof p.prio === "string" ? p.prio : "all",
+    };
+  } catch {
+    return DEFAULT_FILTERS;
+  }
+}
 
 function attr(lead: LeadRow, key: string): string {
   const v = (lead.attributes as Record<string, unknown>)?.[key];
@@ -40,20 +61,48 @@ export function PipelineList({
   nowMs: number;
   onSelect: (id: string) => void;
 }) {
-  const [stageF, setStageF] = useState("all");
-  const [statusF, setStatusF] = useState("active"); // active = open + won
-  const [sourceF, setSourceF] = useState("all");
-  const [prioF, setPrioF] = useState("all");
+  const [stageF, setStageF] = useState(() => loadFilters().stage);
+  const [statusF, setStatusF] = useState(() => loadFilters().status); // active = open + won
+  const [sourceF, setSourceF] = useState(() => loadFilters().source);
+  const [prioF, setPrioF] = useState(() => loadFilters().prio);
   const [q, setQ] = useState("");
+
+  // Persist the (non-search) filters so they survive a board⇆list toggle / reload.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    window.localStorage.setItem(
+      FILTERS_KEY,
+      JSON.stringify({ stage: stageF, status: statusF, source: sourceF, prio: prioF }),
+    );
+  }, [stageF, statusF, sourceF, prioF]);
+
+  function clearFilters() {
+    setStageF(DEFAULT_FILTERS.stage);
+    setStatusF(DEFAULT_FILTERS.status);
+    setSourceF(DEFAULT_FILTERS.source);
+    setPrioF(DEFAULT_FILTERS.prio);
+    setQ("");
+  }
+  const anyFilter =
+    stageF !== DEFAULT_FILTERS.stage ||
+    statusF !== DEFAULT_FILTERS.status ||
+    sourceF !== DEFAULT_FILTERS.source ||
+    prioF !== DEFAULT_FILTERS.prio ||
+    q.trim() !== "";
 
   const stageLabel = useMemo(
     () => new Map(pipeline.stages.map((s) => [s.key, s.label])),
     [pipeline.stages],
   );
-  const sources = useMemo(
-    () => Array.from(new Set(leads.map((l) => l.source).filter(Boolean))) as string[],
-    [leads],
-  );
+  // De-dupe sources case-insensitively, keeping the first-seen casing for display.
+  const sources = useMemo(() => {
+    const seen = new Map<string, string>();
+    for (const l of leads) {
+      const s = l.source?.trim();
+      if (s && !seen.has(s.toLowerCase())) seen.set(s.toLowerCase(), s);
+    }
+    return Array.from(seen.values());
+  }, [leads]);
 
   const rows = useMemo(() => {
     const needle = q.trim().toLowerCase();
@@ -63,7 +112,8 @@ export function PipelineList({
           return false;
         if (statusF !== "active" && statusF !== "all" && l.status !== statusF) return false;
         if (stageF !== "all" && l.stage !== stageF) return false;
-        if (sourceF !== "all" && l.source !== sourceF) return false;
+        if (sourceF !== "all" && (l.source ?? "").toLowerCase() !== sourceF.toLowerCase())
+          return false;
         if (prioF !== "all" && l.priority !== Number(prioF)) return false;
         if (needle) {
           const hay = [
@@ -126,6 +176,16 @@ export function PipelineList({
               <option key={s} value={s}>{s}</option>
             ))}
           </select>
+        )}
+        {anyFilter && (
+          <button
+            type="button"
+            onClick={clearFilters}
+            className="flex items-center gap-0.5 rounded border border-border px-1.5 py-1 text-2xs text-text-3 hover:text-text-1"
+            title="Clear all filters"
+          >
+            <X className="h-3 w-3" /> Clear
+          </button>
         )}
         <span className="font-mono text-2xs text-text-3">{rows.length}</span>
       </div>


### PR DESCRIPTION
Overnight batch (requested while you slept). Correctness + data-hygiene pass.

- **Orphaned leads** (whose stage was removed from the pipeline) now surface in
  an **"Unassigned"** holding column instead of silently dropping off the board.
  Drag one into a real stage to re-home it.
- **Delete confirmation** — a lead delete is a hard delete, so it now takes a
  two-step confirm ("Delete for good?" → Cancel / Delete, destructive variant).
- **Source normalized on write** (trim + collapse whitespace) server-side, so
  the API and MCP get it too — " Broker " and "Broker" stop fragmenting the
  board's source filter. The list also de-dupes the source dropdown
  case-insensitively and filters case-insensitively.
- **List filters persist** (stage / status / source / priority) across a
  board⇆list toggle and reload, with a **Clear** button when any is active.

## Test
- `tsc` clean, `eslint` clean, `vitest run src/lib/pipeline` 31/31.
- Orphan-collection path already unit-tested in `board.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)