### PR TITLE
feat(pipeline): drag feel, keyboard shortcuts, live freshness, open-terminal link

### DIFF
--- a/apps/web/src/modules/pipeline/components/LeadCard.tsx
+++ b/apps/web/src/modules/pipeline/components/LeadCard.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import { Clock, Flame, Layers, StickyNote } from "lucide-react";
 import type { LeadRow, PipelineStage } from "@/lib/pipeline/db";
 import { isRotting, isFollowUpDue } from "@/lib/pipeline/board";
@@ -40,13 +41,20 @@ export function LeadCard({
   const converted = lead.status === "converted";
   const parcels = parcelCount(lead);
   const notes = hasNotes(lead);
+  const [dragging, setDragging] = useState(false);
   return (
     <button
       type="button"
       draggable
-      onDragStart={onDragStart}
+      onDragStart={(e) => {
+        setDragging(true);
+        onDragStart(e);
+      }}
+      onDragEnd={() => setDragging(false)}
       onClick={onClick}
-      className="flex w-full flex-col gap-1 rounded border border-border bg-bg-1 px-2 py-1.5 text-left hover:border-border-focus"
+      className={`flex w-full flex-col gap-1 rounded border border-border bg-bg-1 px-2 py-1.5 text-left hover:border-border-focus ${
+        dragging ? "opacity-50 ring-1 ring-border-focus" : ""
+      }`}
     >
       <div className="flex items-center gap-1.5">
         {lead.priority > 0 && PRIORITY_DOT[lead.priority] && (

--- a/apps/web/src/modules/pipeline/components/LeadDetail.tsx
+++ b/apps/web/src/modules/pipeline/components/LeadDetail.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState, useRef } from "react";
+import Link from "next/link";
 import {
   X,
   Loader2,
@@ -98,6 +99,7 @@ export function LeadDetail({
   const [ncBusy, setNcBusy] = useState(false);
 
   const [promoteMsg, setPromoteMsg] = useState<string | null>(null);
+  const [promotedTicker, setPromotedTicker] = useState<string | null>(null);
   const [confirmDelete, setConfirmDelete] = useState(false);
 
   const [files, setFiles] = useState<LeadFile[]>([]);
@@ -270,9 +272,9 @@ export function LeadDetail({
     try {
       const res = await promoteLead(leadId);
       setPromoteMsg(`Created terminal ${res.terminal.ticker}`);
+      setPromotedTicker(res.terminal.ticker);
       onChanged();
-      // Give the user a beat to see the ticker, then close.
-      setTimeout(onClose, 1200);
+      // Leave the drawer open so the "Open terminal" link is right there.
     } catch (e) {
       setError(e instanceof Error ? e.message : "Could not promote");
       setBusy(false);
@@ -329,9 +331,19 @@ export function LeadDetail({
             {(canPromote || alreadyTerminal) && (
               <div className="rounded border border-border bg-bg-2 p-2">
                 {alreadyTerminal ? (
-                  <p className="text-2xs text-accent">
-                    {promoteMsg ?? "This lead is now a Terminal."}
-                  </p>
+                  <div className="flex items-center gap-2">
+                    <p className="min-w-0 flex-1 text-2xs text-accent">
+                      {promoteMsg ?? "This lead is now a Terminal."}
+                    </p>
+                    {promotedTicker && (
+                      <Link
+                        href={`/p/${promotedTicker}`}
+                        className="flex items-center gap-0.5 whitespace-nowrap rounded border border-accent/40 px-1.5 py-0.5 text-2xs font-medium text-accent hover:bg-accent/10"
+                      >
+                        Open {promotedTicker} <ArrowUpRight className="h-3 w-3" />
+                      </Link>
+                    )}
+                  </div>
                 ) : (
                   <div className="flex items-center gap-2">
                     <span className="min-w-0 flex-1 text-2xs text-text-2">

--- a/apps/web/src/modules/pipeline/components/PipelineBoard.tsx
+++ b/apps/web/src/modules/pipeline/components/PipelineBoard.tsx
@@ -68,6 +68,30 @@ export function PipelineBoard() {
   useOverlay(createStage != null, () => setCreateStage(null));
   useOverlay(selectedLead != null && createStage == null, () => setSelectedLead(null));
 
+  // Board shortcuts: n = new lead, b = board view, l = list view. Ignored while
+  // typing or while an overlay is open (Esc handles those).
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+      const t = e.target as HTMLElement | null;
+      const tag = t?.tagName;
+      if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT" || t?.isContentEditable)
+        return;
+      if (createStage != null || selectedLead != null || fieldsOpen) return;
+      if (e.key === "n") {
+        e.preventDefault();
+        if (pipeline) setCreateStage(pipeline.stages[0]?.key ?? null);
+      } else if (e.key === "b") {
+        selectView("board");
+      } else if (e.key === "l") {
+        selectView("list");
+      }
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [createStage, selectedLead, fieldsOpen, pipeline]);
+
   // Spaces once.
   useEffect(() => {
     let alive = true;

--- a/apps/web/src/modules/pipeline/components/PipelineBoard.tsx
+++ b/apps/web/src/modules/pipeline/components/PipelineBoard.tsx
@@ -39,7 +39,13 @@ export function PipelineBoard() {
   const [error, setError] = useState<string | null>(null);
   const [attentionOnly, setAttentionOnly] = useState(false);
   const [view, setView] = useState<"board" | "list">("board");
-  const nowMs = Date.now();
+  // One "now" for the whole tree, ticking each minute so "cold" / "follow-up
+  // due" refresh on their own without a reload.
+  const [nowMs, setNowMs] = useState(() => Date.now());
+  useEffect(() => {
+    const t = setInterval(() => setNowMs(Date.now()), 60_000);
+    return () => clearInterval(t);
+  }, []);
 
   useEffect(() => {
     const saved =
@@ -56,6 +62,7 @@ export function PipelineBoard() {
   const [createBusy, setCreateBusy] = useState(false);
   const [createErr, setCreateErr] = useState<string | null>(null);
   const [fieldsOpen, setFieldsOpen] = useState(false);
+  const [dragOverStage, setDragOverStage] = useState<string | null>(null);
 
   // Esc closes whichever overlay is open (+ restores focus to the trigger).
   useOverlay(createStage != null, () => setCreateStage(null));
@@ -290,7 +297,15 @@ export function PipelineBoard() {
           </Button>
         </div>
       ) : (
-        <div className="flex min-h-0 flex-1 gap-2 overflow-x-auto p-2">
+        <div
+          className="flex min-h-0 flex-1 gap-2 overflow-x-auto p-2"
+          onDragLeave={(e) => {
+            // Clear the column highlight only when the cursor leaves the board.
+            if (!e.currentTarget.contains(e.relatedTarget as Node | null)) {
+              setDragOverStage(null);
+            }
+          }}
+        >
           {/* Orphans — leads whose stage was removed from the pipeline. Surface
               them in a holding column (drag into a real stage to re-home) rather
               than silently dropping them off the board. */}
@@ -323,13 +338,21 @@ export function PipelineBoard() {
             return (
             <div
               key={stage.key}
-              onDragOver={(e) => e.preventDefault()}
+              onDragOver={(e) => {
+                e.preventDefault();
+                if (dragOverStage !== stage.key) setDragOverStage(stage.key);
+              }}
               onDrop={(e) => {
                 e.preventDefault();
+                setDragOverStage(null);
                 const id = e.dataTransfer.getData("text/plain");
                 if (id) void moveLead(id, stage.key);
               }}
-              className="flex min-w-[13rem] flex-1 flex-col rounded border border-border/60 bg-bg-2/30"
+              className={`flex min-w-[13rem] flex-1 flex-col rounded border bg-bg-2/30 ${
+                dragOverStage === stage.key
+                  ? "border-border-focus bg-accent/5"
+                  : "border-border/60"
+              }`}
             >
               <div className="flex flex-shrink-0 items-center gap-1.5 border-b border-border/50 px-2 py-1.5">
                 <span className="text-2xs font-semibold uppercase tracking-wide text-text-2">

--- a/apps/web/src/modules/pipeline/components/PipelineList.tsx
+++ b/apps/web/src/modules/pipeline/components/PipelineList.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Clock, X } from "lucide-react";
 import type { LeadRow, PipelineRow } from "@/lib/pipeline/db";
 import { isFollowUpDue, isRotting } from "@/lib/pipeline/board";
@@ -76,6 +76,22 @@ export function PipelineList({
     );
   }, [stageF, statusF, sourceF, prioF]);
 
+  // "/" focuses the search (the list view is mounted, so this is list-scoped).
+  const searchRef = useRef<HTMLInputElement>(null);
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key !== "/" || e.metaKey || e.ctrlKey || e.altKey) return;
+      const t = e.target as HTMLElement | null;
+      const tag = t?.tagName;
+      if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT" || t?.isContentEditable)
+        return;
+      e.preventDefault();
+      searchRef.current?.focus();
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
+
   function clearFilters() {
     setStageF(DEFAULT_FILTERS.stage);
     setStatusF(DEFAULT_FILTERS.status);
@@ -143,9 +159,10 @@ export function PipelineList({
       {/* Filters */}
       <div className="flex flex-shrink-0 flex-wrap items-center gap-1.5 border-b border-border/60 px-3 py-1.5">
         <input
+          ref={searchRef}
           value={q}
           onChange={(e) => setQ(e.target.value)}
-          placeholder="Search name, address, city…"
+          placeholder="Search name, address, city…  ( / )"
           aria-label="Search leads"
           className="min-w-[8rem] flex-1 rounded border border-border bg-bg-2 px-2 py-1 text-2xs text-text-1 placeholder:text-text-3 outline-none focus:border-border-focus"
         />


### PR DESCRIPTION
Final overnight batch — interaction polish on the pipeline.

## Drag-and-drop feel
- The column under the cursor highlights (accent border/tint) on drag-over and
  clears when you leave the board; the dragged card lifts (50% opacity + ring).

## Keyboard-first (CLAUDE.md non-negotiable)
- `n` = new lead, `b` = board view, `l` = list view, `/` = focus the list
  search. All ignored while typing in a field or while an overlay is open.

## Live freshness
- "Now" is computed once for the board and ticks every minute, so a lead
  crossing its "going cold" / "follow-up due" threshold updates on its own
  without a reload.

## Promote → Terminal link
- After promoting a lead, the drawer stays open and shows an "Open <TICKER> ↗"
  link straight to `/p/<ticker>` instead of auto-closing.

## Test
- `tsc` clean, `eslint` clean, `vitest run src/lib/pipeline` 31/31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)