### PR TITLE
feat(contacts): every Rokki user is a self-contact in their own book

### DIFF
--- a/apps/web/src/components/dashboard/ContactsCard.tsx
+++ b/apps/web/src/components/dashboard/ContactsCard.tsx
@@ -294,7 +294,12 @@ export function ContactsCard() {
         </div>
       ) : (
         <ul className="min-h-0 flex-1 divide-y divide-border/30 overflow-y-auto">
-          {contacts.map((c) => {
+          {[...contacts]
+            .sort(
+              (a, b) =>
+                (b.source === "self" ? 1 : 0) - (a.source === "self" ? 1 : 0),
+            )
+            .map((c) => {
             const active = split && c.id === selectedId;
             return (
               <li key={c.id}>
@@ -321,10 +326,16 @@ export function ContactsCard() {
                   <span className="min-w-0 flex-1">
                     <span className="block truncate text-xs font-medium text-text-0">
                       {rowName(c)}
-                      {c.user_id && (
+                      {c.source === "self" ? (
                         <span className="ml-1 inline-block rounded-sm bg-accent/15 px-1 py-px align-middle text-[9px] font-semibold uppercase tracking-wide text-accent">
-                          Rokki
+                          You
                         </span>
+                      ) : (
+                        c.user_id && (
+                          <span className="ml-1 inline-block rounded-sm bg-accent/15 px-1 py-px align-middle text-[9px] font-semibold uppercase tracking-wide text-accent">
+                            Rokki
+                          </span>
+                        )
                       )}
                     </span>
                     {(c.company || c.title) && (

--- a/apps/web/src/lib/contacts/db.ts
+++ b/apps/web/src/lib/contacts/db.ts
@@ -105,7 +105,7 @@ export interface InteractionRow {
 /** Columns a contact card needs in a list (keeps payloads lean). */
 export const CONTACT_LIST_COLUMNS =
   "id, first_name, last_name, nickname, avatar_url, contact_types, tags, company, " +
-  "title, primary_email, primary_phone, status, strength, user_id, updated_at";
+  "title, primary_email, primary_phone, status, strength, user_id, source, updated_at";
 
 /**
  * Loosely-typed Supabase client for the contacts tables. Same `any`-boundary

--- a/apps/web/src/modules/contacts/components/ContactDetail.tsx
+++ b/apps/web/src/modules/contacts/components/ContactDetail.tsx
@@ -185,10 +185,16 @@ export function ContactDetail({
                   <span className="truncate text-sm font-semibold text-text-0">
                     {fullName || contact.nickname || "Unnamed"}
                   </span>
-                  {contact.user_id && (
+                  {contact.source === "self" ? (
                     <span className="flex-shrink-0 rounded-sm bg-accent/15 px-1 py-px text-[9px] font-semibold uppercase tracking-wide text-accent">
-                      Rokki
+                      You
                     </span>
+                  ) : (
+                    contact.user_id && (
+                      <span className="flex-shrink-0 rounded-sm bg-accent/15 px-1 py-px text-[9px] font-semibold uppercase tracking-wide text-accent">
+                        Rokki
+                      </span>
+                    )
                   )}
                 </div>
                 {contact.nickname && fullName && (

--- a/apps/web/src/modules/contacts/components/ContactsView.test.tsx
+++ b/apps/web/src/modules/contacts/components/ContactsView.test.tsx
@@ -21,6 +21,7 @@ const { items } = vi.hoisted(() => ({
       status: "active",
       strength: 0,
       user_id: null,
+      source: null,
       updated_at: "2026-06-24T00:00:00Z",
     },
   ],

--- a/apps/web/src/modules/contacts/components/ContactsView.tsx
+++ b/apps/web/src/modules/contacts/components/ContactsView.tsx
@@ -136,6 +136,12 @@ export function ContactsView({
   }
 
   const empty = useMemo(() => contacts.length === 0, [contacts]);
+  // Pin the viewer's own self-contact ("You") to the top, keep server order below.
+  const ordered = useMemo(() => {
+    const self = contacts.filter((c) => c.source === "self");
+    if (self.length === 0) return contacts;
+    return [...self, ...contacts.filter((c) => c.source !== "self")];
+  }, [contacts]);
 
   return (
     <div className="flex h-full min-h-0 flex-col">
@@ -174,7 +180,7 @@ export function ContactsView({
         </div>
       ) : (
         <ul className="min-h-0 flex-1 divide-y divide-border/30 overflow-y-auto">
-          {contacts.map((c) => (
+          {ordered.map((c) => (
             <li key={c.id}>
               <button
                 type="button"
@@ -194,8 +200,15 @@ export function ContactsView({
                   </span>
                 )}
                 <span className="min-w-0 flex-1">
-                  <span className="block truncate text-xs font-medium text-text-0">
-                    {rowName(c)}
+                  <span className="flex items-center gap-1.5">
+                    <span className="truncate text-xs font-medium text-text-0">
+                      {rowName(c)}
+                    </span>
+                    {c.source === "self" && (
+                      <span className="flex-shrink-0 rounded-sm bg-accent/15 px-1 py-px text-[9px] font-semibold uppercase tracking-wide text-accent">
+                        You
+                      </span>
+                    )}
                   </span>
                   {(c.company || c.title) && (
                     <span className="block truncate text-2xs text-text-3">

--- a/apps/web/src/modules/contacts/lib/client-api.ts
+++ b/apps/web/src/modules/contacts/lib/client-api.ts
@@ -41,6 +41,7 @@ export type ContactListItem = Pick<
   | "status"
   | "strength"
   | "user_id"
+  | "source"
   | "updated_at"
 >;
 

--- a/apps/web/tests/rls/contacts-self.test.ts
+++ b/apps/web/tests/rls/contacts-self.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Tests for the self-contact (20260629120000_contacts_self_contact.sql):
+ * every Rokki user gets exactly one Contact representing themselves
+ * (owner_id = user_id = the user), created at signup, visible only to its owner,
+ * and not duplicable.
+ *
+ * Mirrors tests/rls/contacts-linking.test.ts plumbing.
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+
+const SB_URL = process.env.SUPABASE_URL ?? "http://127.0.0.1:54321";
+const ANON =
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0";
+const SERVICE =
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU";
+
+const admin = createClient(SB_URL, SERVICE, {
+  auth: { autoRefreshToken: false, persistSession: false },
+});
+
+async function makeClientFor(email: string): Promise<SupabaseClient> {
+  const { data, error } = await admin.auth.admin.generateLink({
+    type: "magiclink",
+    email,
+  });
+  if (error || !data) throw new Error(`generateLink failed: ${error?.message}`);
+  const supabase = createClient(SB_URL, ANON, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+  const { data: v, error: vErr } = await supabase.auth.verifyOtp({
+    type: "magiclink",
+    token_hash: data.properties.hashed_token,
+  });
+  if (vErr) throw new Error(`verifyOtp failed: ${vErr.message}`);
+  if (!v.session) throw new Error("no session after verifyOtp");
+  await supabase.auth.setSession({
+    access_token: v.session.access_token,
+    refresh_token: v.session.refresh_token,
+  });
+  return supabase;
+}
+
+async function ensureUser(email: string): Promise<string> {
+  const { data: list } = await admin.auth.admin.listUsers();
+  const existing = list?.users.find((u) => u.email === email);
+  if (existing) return existing.id;
+  const { data, error } = await admin.auth.admin.createUser({ email, email_confirm: true });
+  if (error || !data.user) throw new Error(`createUser ${email}: ${error?.message}`);
+  return data.user.id;
+}
+
+const ES = "self-a@rokki.local";
+const EO = "self-other@rokki.local";
+
+describe("self-contact", () => {
+  let userS: string;
+  let userO: string;
+  let clientS: SupabaseClient;
+  let clientO: SupabaseClient;
+
+  beforeAll(async () => {
+    userS = await ensureUser(ES);
+    userO = await ensureUser(EO);
+    clientS = await makeClientFor(ES);
+    clientO = await makeClientFor(EO);
+  }, 30_000);
+
+  async function selfRows(uid: string): Promise<Record<string, unknown>[]> {
+    const { data } = await admin
+      .from("contacts")
+      .select("*")
+      .eq("owner_id", uid)
+      .eq("user_id", uid);
+    return (data ?? []) as Record<string, unknown>[];
+  }
+
+  it("creates exactly one self-contact at signup", async () => {
+    expect((await selfRows(userS)).length).toBe(1);
+  });
+
+  it("is owned by AND linked to the same user", async () => {
+    const [c] = await selfRows(userS);
+    expect(c.owner_id).toBe(userS);
+    expect(c.user_id).toBe(userS);
+  });
+
+  it("mirrors the user's identity (email + name) and is marked source=self", async () => {
+    const [c] = await selfRows(userS);
+    expect(c.primary_email).toBe(ES);
+    // full_name defaults to the email local-part at signup → first_name.
+    expect(c.first_name).toBe(ES.split("@")[0]);
+    expect(c.source).toBe("self");
+  });
+
+  it("is visible to its owner via RLS", async () => {
+    const { data } = await clientS.from("contacts").select("id").eq("user_id", userS);
+    expect((data ?? []).length).toBe(1);
+  });
+
+  it("is NOT visible to other users", async () => {
+    const { data } = await clientO.from("contacts").select("id").eq("owner_id", userS);
+    expect((data ?? []).length).toBe(0);
+  });
+
+  it("the partial unique index blocks a second self-contact", async () => {
+    const { error } = await admin
+      .from("contacts")
+      .insert({ owner_id: userS, user_id: userS, first_name: "Dup" });
+    expect(error).not.toBeNull();
+  });
+});

--- a/supabase/migrations/20260629120000_contacts_self_contact.sql
+++ b/supabase/migrations/20260629120000_contacts_self_contact.sql
@@ -1,0 +1,126 @@
+-- Self-contact — every Rokki user is a Contact in their own contact book.
+--
+-- "My own contact should already be in Contacts because I'm a Rokki user."
+-- We create exactly one self-contact per user: a row owned by the user AND
+-- linked to the user (owner_id = user_id = the user). That single identity lets
+-- the user be referenced like anyone else (assigned, messaged, shown on a deal),
+-- and the existing teammate-linking machinery already understands a linked
+-- contact.
+--
+-- `owner_id = user_id` IS the self-contact marker — no new column. contacts.user_id
+-- is only ever set to OTHER accounts by the link API (the link functions match on
+-- id <> auth.uid()), so a row where owner_id = user_id can only be a self-contact.
+-- A partial unique index enforces at most one per user.
+--
+-- Creation bypasses the contacts_guard_user_id trigger (which blocks only the
+-- `authenticated` role from writing user_id) because ensure_self_contact() is
+-- SECURITY DEFINER and runs as the table owner. Fired at signup via a trigger on
+-- profiles (so full_name/avatar are available), and backfilled for existing users.
+
+BEGIN;
+
+-- At most one self-contact per owner.
+CREATE UNIQUE INDEX IF NOT EXISTS contacts_self_uniq
+  ON contacts (owner_id)
+  WHERE owner_id = user_id;
+
+-- Create p_user_id's self-contact if absent. INTERNAL — never granted to clients
+-- (the param is a user id, so a client must not be able to forge one). Idempotent.
+CREATE OR REPLACE FUNCTION ensure_self_contact(p_user_id uuid)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_email  text;
+  v_full   text;
+  v_avatar text;
+  v_first  text;
+  v_last   text;
+BEGIN
+  IF p_user_id IS NULL THEN RETURN; END IF;
+  IF EXISTS (
+    SELECT 1 FROM contacts WHERE owner_id = p_user_id AND user_id = p_user_id
+  ) THEN
+    RETURN;
+  END IF;
+
+  SELECT email INTO v_email FROM auth.users WHERE id = p_user_id;
+  SELECT full_name, avatar_url INTO v_full, v_avatar
+    FROM profiles WHERE user_id = p_user_id;
+
+  -- first name = first word of full_name, else the email local-part, else 'Me'.
+  v_first := NULLIF(split_part(coalesce(v_full, ''), ' ', 1), '');
+  IF v_first IS NULL THEN
+    v_first := NULLIF(split_part(coalesce(v_email, ''), '@', 1), '');
+  END IF;
+  IF v_first IS NULL THEN
+    v_first := 'Me';
+  END IF;
+
+  -- last name = everything after the first space of full_name (empty if none).
+  IF position(' ' in coalesce(v_full, '')) > 0 THEN
+    v_last := trim(substring(v_full FROM position(' ' in v_full) + 1));
+  ELSE
+    v_last := '';
+  END IF;
+
+  INSERT INTO contacts (
+    owner_id, user_id, first_name, last_name, avatar_url,
+    source, primary_email, emails
+  )
+  VALUES (
+    p_user_id, p_user_id, v_first, coalesce(v_last, ''), v_avatar,
+    'self', v_email,
+    CASE
+      WHEN v_email IS NULL THEN '[]'::jsonb
+      ELSE jsonb_build_array(jsonb_build_object('email', v_email, 'primary', true))
+    END
+  )
+  ON CONFLICT DO NOTHING;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION ensure_self_contact(uuid) FROM PUBLIC;
+
+-- Fire at signup: handle_new_user() inserts the profile → this creates the
+-- matching self-contact in the same transaction.
+CREATE OR REPLACE FUNCTION trg_ensure_self_contact()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  PERFORM ensure_self_contact(NEW.user_id);
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS ensure_self_contact_on_profile ON profiles;
+CREATE TRIGGER ensure_self_contact_on_profile
+  AFTER INSERT ON profiles
+  FOR EACH ROW EXECUTE FUNCTION trg_ensure_self_contact();
+
+-- One-time backfill for everyone who already has a profile.
+DO $$
+DECLARE
+  r record;
+BEGIN
+  FOR r IN SELECT user_id FROM profiles LOOP
+    PERFORM ensure_self_contact(r.user_id);
+  END LOOP;
+END;
+$$;
+
+COMMIT;
+
+-- ROLLBACK:
+-- BEGIN;
+-- DROP TRIGGER IF EXISTS ensure_self_contact_on_profile ON profiles;
+-- DROP FUNCTION IF EXISTS trg_ensure_self_contact();
+-- DROP FUNCTION IF EXISTS ensure_self_contact(uuid);
+-- DELETE FROM contacts WHERE owner_id = user_id AND source = 'self';
+-- DROP INDEX IF EXISTS contacts_self_uniq;
+-- COMMIT;


### PR DESCRIPTION
## Why
"My own contact should already be in Contacts because I'm a Rokki user."

## What
Adds a **self-contact**: exactly one Contact per user where `owner_id = user_id =
the user`, created at signup and backfilled for existing users.

- **Migration `20260629120000`** — `ensure_self_contact(user_id)` is `SECURITY
  DEFINER`, so it bypasses the `contacts_guard_user_id` guard (which blocks the
  `authenticated` role from writing `user_id`). Fired by an `AFTER INSERT`
  trigger on `profiles` (name/avatar available) + a one-time backfill. A partial
  unique index `(owner_id) WHERE owner_id = user_id` enforces exactly one.
  `owner_id = user_id` is the self marker — no new column — since the link API
  only ever sets `user_id` to *other* accounts.
- **RLS test** (`contacts-self.test.ts`): self-contact exists at signup, is
  owner-only visible, mirrors identity (email/name), and can't be duplicated.
- **UI**: the self-contact is pinned to the top of the contacts list (dashboard
  card + module view) and badged **"You"** instead of "Rokki". `source` added to
  the list payload to detect it.

## Test
- `tsc` clean, `eslint` clean, contacts vitest 6/6.
- Migration validated by the new RLS test in CI (can't run migrations locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)