### PR TITLE
feat(goals): inline create (areas + goals) + additive logging

### DIFF
--- a/apps/web/src/components/dashboard/GoalsCard.tsx
+++ b/apps/web/src/components/dashboard/GoalsCard.tsx
@@ -10,7 +10,7 @@ import {
   loadGoalsForCategories,
   loadCurrentTargets,
   sumWeekValues,
-  recordEntry,
+  addEntryValue,
   createCategory,
   createGoal,
   setWeeklyTarget,
@@ -76,7 +76,7 @@ export function GoalsCard() {
       targetsByGoal: Object.fromEntries(targets),
       weekTotalsByGoal: Object.fromEntries(weekSums),
       weekLabel: formatWeekLabel(start, end),
-      spaces: ((spacesRes.data ?? []) as SpaceLite[]) ?? [],
+      spaces: (spacesRes.data as SpaceLite[] | null) ?? [],
     });
     setLoading(false);
   }, []);
@@ -91,25 +91,13 @@ export function GoalsCard() {
     };
   }, [load]);
 
-  // Logging ADDS to today's running total (the "+N" affordance): read today's
-  // current value fresh, then write current + n. Fresh read avoids a stale
-  // closure and keeps two quick logs from clobbering each other.
+  // Logging ADDS to today's running total (the "+N" affordance). The add is
+  // atomic in the goals_add_entry RPC, so two quick logs accumulate instead of
+  // clobbering each other; the total is clamped at 0 server-side.
   const onLogValue = useCallback(
     async (goalId: string, n: number) => {
-      const supabase = createClient();
-      const today = todayIso();
-      const { data: row } = await supabase
-        .from("goals_entries")
-        .select("value")
-        .eq("goal_id", goalId)
-        .eq("entry_date", today)
-        .maybeSingle();
-      const current = row ? Number((row as { value: number }).value) : 0;
-      await recordEntry(supabase, {
-        goal_id: goalId,
-        entry_date: today,
-        value: current + n,
-      });
+      if (!Number.isFinite(n)) return;
+      await addEntryValue(createClient(), goalId, todayIso(), n);
       await load();
     },
     [load],
@@ -208,7 +196,13 @@ function NewAreaForm({
     }
   }
 
-  if (spaces.length === 0) return null;
+  if (spaces.length === 0) {
+    return (
+      <p className="text-[11px] text-text-3">
+        Join or create a space to add goal areas.
+      </p>
+    );
+  }
 
   if (!open) {
     return (

--- a/apps/web/src/components/dashboard/GoalsCard.tsx
+++ b/apps/web/src/components/dashboard/GoalsCard.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
-import { Target } from "lucide-react";
+import { Loader2, Plus, Target } from "lucide-react";
 import { DashboardCard } from "./DashboardCard";
-import { GoalsView } from "@/components/modules/GoalsView";
+import { GoalsView, type NewGoalInput } from "@/components/modules/GoalsView";
 import { createClient } from "@/lib/supabase/client";
 import {
   loadAllVisibleCategories,
@@ -11,10 +11,18 @@ import {
   loadCurrentTargets,
   sumWeekValues,
   recordEntry,
+  createCategory,
+  createGoal,
+  setWeeklyTarget,
   type GoalsCategoryRow,
   type GoalsGoalRow,
 } from "@/lib/modules/goals-queries";
 import { startOfWeek, endOfWeek, formatWeekLabel } from "@/lib/modules/goals-week";
+
+interface SpaceLite {
+  id: string;
+  name: string;
+}
 
 interface Loaded {
   categories: GoalsCategoryRow[];
@@ -22,7 +30,11 @@ interface Loaded {
   targetsByGoal: Record<string, number>;
   weekTotalsByGoal: Record<string, number>;
   weekLabel: string;
+  spaces: SpaceLite[];
 }
+
+/** A small palette for new goal areas (the color CHECK wants #RRGGBB). */
+const SWATCHES = ["#3B82F6", "#22C55E", "#EF4444", "#EAB308", "#A855F7", "#14B8A6"];
 
 /** Today as YYYY-MM-DD (the entry_date key Goals uses). */
 function todayIso(): string {
@@ -32,9 +44,9 @@ function todayIso(): string {
 /**
  * Dashboard Goals panel — the whole Goals experience, inline. Aggregates every
  * goal area the viewer can see (across spaces/terminals; RLS scopes it), shows
- * the week's progress against each target, and logs a value for today directly
- * — no separate detail page. Mirrors the inline-everything pattern of the
- * Pipeline and Contacts cards.
+ * the week's progress against each target, logs progress for today, and lets
+ * you create goal areas + goals right here — no separate detail page. Mirrors
+ * the inline-everything pattern of the Pipeline and Contacts cards.
  */
 export function GoalsCard() {
   const [data, setData] = useState<Loaded | null>(null);
@@ -45,7 +57,10 @@ export function GoalsCard() {
     const today = todayIso();
     const start = startOfWeek(today);
     const end = endOfWeek(today);
-    const categories = await loadAllVisibleCategories(supabase);
+    const [categories, spacesRes] = await Promise.all([
+      loadAllVisibleCategories(supabase),
+      supabase.from("spaces").select("id, name").is("archived_at", null).order("name"),
+    ]);
     const goals = await loadGoalsForCategories(
       supabase,
       categories.map((c) => c.id),
@@ -61,6 +76,7 @@ export function GoalsCard() {
       targetsByGoal: Object.fromEntries(targets),
       weekTotalsByGoal: Object.fromEntries(weekSums),
       weekLabel: formatWeekLabel(start, end),
+      spaces: ((spacesRes.data ?? []) as SpaceLite[]) ?? [],
     });
     setLoading(false);
   }, []);
@@ -75,15 +91,53 @@ export function GoalsCard() {
     };
   }, [load]);
 
+  // Logging ADDS to today's running total (the "+N" affordance): read today's
+  // current value fresh, then write current + n. Fresh read avoids a stale
+  // closure and keeps two quick logs from clobbering each other.
   const onLogValue = useCallback(
-    async (goalId: string, value: number) => {
+    async (goalId: string, n: number) => {
       const supabase = createClient();
+      const today = todayIso();
+      const { data: row } = await supabase
+        .from("goals_entries")
+        .select("value")
+        .eq("goal_id", goalId)
+        .eq("entry_date", today)
+        .maybeSingle();
+      const current = row ? Number((row as { value: number }).value) : 0;
       await recordEntry(supabase, {
         goal_id: goalId,
-        entry_date: todayIso(),
-        value,
+        entry_date: today,
+        value: current + n,
       });
-      await load(); // refresh the week totals
+      await load();
+    },
+    [load],
+  );
+
+  const onAddGoal = useCallback(
+    async (categoryId: string, input: NewGoalInput) => {
+      const supabase = createClient();
+      const goal = await createGoal(supabase, {
+        category_id: categoryId,
+        name: input.name,
+        unit: input.unit,
+      });
+      await setWeeklyTarget(supabase, {
+        goal_id: goal.id,
+        weekly_target: input.target,
+        valid_from: startOfWeek(todayIso()),
+      });
+      await load();
+    },
+    [load],
+  );
+
+  const onAddCategory = useCallback(
+    async (name: string, color: string, spaceId: string) => {
+      const supabase = createClient();
+      await createCategory(supabase, { kind: "space", spaceId }, { name, color });
+      await load();
     },
     [load],
   );
@@ -92,19 +146,143 @@ export function GoalsCard() {
     <DashboardCard title="Goals" count={data?.categories.length} expandHref={null}>
       {loading ? (
         <p className="px-3 py-4 text-center text-xs text-text-3">Loading…</p>
-      ) : !data || data.categories.length === 0 ? (
+      ) : !data ? (
         <Empty />
       ) : (
-        <GoalsView
-          categories={data.categories}
-          goals={data.goals}
-          targetsByGoal={data.targetsByGoal}
-          weekTotalsByGoal={data.weekTotalsByGoal}
-          weekLabel={data.weekLabel}
-          onLogValue={onLogValue}
-        />
+        <div className="flex flex-col">
+          {data.categories.length === 0 ? (
+            <Empty />
+          ) : (
+            <GoalsView
+              categories={data.categories}
+              goals={data.goals}
+              targetsByGoal={data.targetsByGoal}
+              weekTotalsByGoal={data.weekTotalsByGoal}
+              weekLabel={data.weekLabel}
+              onLogValue={onLogValue}
+              onAddGoal={onAddGoal}
+            />
+          )}
+          <div className="border-t border-border/40 px-3 py-2">
+            <NewAreaForm spaces={data.spaces} onAdd={onAddCategory} />
+          </div>
+        </div>
       )}
     </DashboardCard>
+  );
+}
+
+/** Inline "new goal area" (category) form — name, color, and which space. */
+function NewAreaForm({
+  spaces,
+  onAdd,
+}: {
+  spaces: SpaceLite[];
+  onAdd: (name: string, color: string, spaceId: string) => Promise<void>;
+}) {
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState("");
+  const [color, setColor] = useState(SWATCHES[0]);
+  const [spaceId, setSpaceId] = useState("");
+  const [busy, setBusy] = useState(false);
+
+  // Default the space once it's known.
+  useEffect(() => {
+    if (!spaceId && spaces.length > 0) setSpaceId(spaces[0].id);
+  }, [spaces, spaceId]);
+
+  function reset() {
+    setName("");
+    setColor(SWATCHES[0]);
+    setOpen(false);
+  }
+
+  async function submit() {
+    if (!name.trim() || !spaceId) return;
+    setBusy(true);
+    try {
+      await onAdd(name.trim(), color, spaceId);
+      reset();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  if (spaces.length === 0) return null;
+
+  if (!open) {
+    return (
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="flex items-center gap-1 text-2xs text-text-3 hover:text-text-1"
+      >
+        <Plus className="h-3 w-3" aria-hidden="true" /> New goal area
+      </button>
+    );
+  }
+
+  const inp =
+    "rounded-sm border border-border bg-bg-2 px-1.5 py-0.5 text-[11px] text-text-0 placeholder:text-text-3 outline-none focus:border-border-focus";
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="flex items-center gap-1.5">
+        <input
+          autoFocus
+          className={`${inp} min-w-0 flex-1`}
+          placeholder="Area name (e.g. Health)"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") void submit();
+          }}
+        />
+        {spaces.length > 1 && (
+          <select
+            aria-label="Space"
+            value={spaceId}
+            onChange={(e) => setSpaceId(e.target.value)}
+            className={inp}
+          >
+            {spaces.map((s) => (
+              <option key={s.id} value={s.id}>
+                {s.name}
+              </option>
+            ))}
+          </select>
+        )}
+      </div>
+      <div className="flex items-center gap-1.5">
+        <div className="flex items-center gap-1">
+          {SWATCHES.map((sw) => (
+            <button
+              key={sw}
+              type="button"
+              aria-label={`Color ${sw}`}
+              aria-pressed={color === sw}
+              onClick={() => setColor(sw)}
+              className={`h-4 w-4 rounded-full ${color === sw ? "ring-2 ring-offset-1 ring-offset-bg-1 ring-border-focus" : ""}`}
+              style={{ background: sw }}
+            />
+          ))}
+        </div>
+        <button
+          type="button"
+          onClick={() => void submit()}
+          disabled={busy || !name.trim() || !spaceId}
+          className="ml-auto rounded-sm border border-border bg-accent/15 px-1.5 py-0.5 text-[11px] font-medium text-accent hover:bg-accent/25 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {busy ? <Loader2 className="h-3 w-3 animate-spin" /> : "Add"}
+        </button>
+        <button
+          type="button"
+          onClick={reset}
+          className="rounded-sm px-1 py-0.5 text-[11px] text-text-3 hover:text-text-1"
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
   );
 }
 
@@ -114,8 +292,8 @@ function Empty() {
       <Target className="h-5 w-5 text-text-3" aria-hidden="true" />
       <p className="text-xs text-text-2">No goals yet.</p>
       <p className="text-xs text-text-3">
-        Set weekly numeric targets and log daily progress. Add goal areas from a
-        space or terminal&apos;s Goals settings.
+        Create a goal area below, add goals with weekly targets, then log daily
+        progress.
       </p>
     </div>
   );

--- a/apps/web/src/components/modules/GoalsView.tsx
+++ b/apps/web/src/components/modules/GoalsView.tsx
@@ -1,12 +1,19 @@
 "use client";
 
 import { useState } from "react";
-import { Plus } from "lucide-react";
+import { Loader2, Plus } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type {
   GoalsCategoryRow,
   GoalsGoalRow,
 } from "@/lib/modules/goals-queries";
+
+/** A new goal a user is adding to a category. */
+export interface NewGoalInput {
+  name: string;
+  unit: string;
+  target: number;
+}
 
 interface GoalsViewProps {
   categories: GoalsCategoryRow[];
@@ -20,6 +27,9 @@ interface GoalsViewProps {
    * disabled (read-only view).
    */
   onLogValue?: (goalId: string, value: number) => Promise<void>;
+  /** Adds a goal (+ its weekly target) under a category. When omitted, the
+   *  per-category "add goal" affordance is hidden. */
+  onAddGoal?: (categoryId: string, input: NewGoalInput) => Promise<void>;
 }
 
 /**
@@ -35,6 +45,7 @@ export function GoalsView({
   weekTotalsByGoal,
   weekLabel,
   onLogValue,
+  onAddGoal,
 }: GoalsViewProps) {
   const goalsByCategory = new Map<string, GoalsGoalRow[]>();
   for (const g of goals) {
@@ -103,6 +114,13 @@ export function GoalsView({
                   );
                 })
               )}
+              {onAddGoal && (
+                <li className="px-3 py-1.5">
+                  <AddGoalRow
+                    onAdd={(input) => onAddGoal(c.id, input)}
+                  />
+                </li>
+              )}
             </ul>
           </div>
         );
@@ -153,11 +171,97 @@ function LogValueInput({
         type="button"
         onClick={() => void submit()}
         disabled={!onLogValue || busy || value.trim() === ""}
-        aria-label="Save value"
+        aria-label="Add to today's total"
         className="rounded-sm border border-border bg-bg-2 p-0.5 text-text-2 hover:bg-bg-3 hover:text-text-0 disabled:cursor-not-allowed disabled:opacity-50"
       >
         <Plus className="h-3 w-3" aria-hidden="true" />
       </button>
     </span>
+  );
+}
+
+/** Inline "add a goal to this area" form — name, unit, weekly target. */
+function AddGoalRow({ onAdd }: { onAdd: (input: NewGoalInput) => Promise<void> }) {
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState("");
+  const [unit, setUnit] = useState("");
+  const [target, setTarget] = useState("");
+  const [busy, setBusy] = useState(false);
+
+  function reset() {
+    setName("");
+    setUnit("");
+    setTarget("");
+    setOpen(false);
+  }
+
+  async function submit() {
+    const t = Number(target);
+    if (!name.trim() || !unit.trim() || !Number.isFinite(t)) return;
+    setBusy(true);
+    try {
+      await onAdd({ name: name.trim(), unit: unit.trim(), target: t });
+      reset();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  if (!open) {
+    return (
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="flex items-center gap-1 text-2xs text-text-3 hover:text-text-1"
+      >
+        <Plus className="h-3 w-3" aria-hidden="true" /> Add goal
+      </button>
+    );
+  }
+
+  const inp =
+    "rounded-sm border border-border bg-bg-2 px-1.5 py-0.5 text-[11px] text-text-0 placeholder:text-text-3 outline-none focus:border-border-focus";
+  return (
+    <div className="flex flex-wrap items-center gap-1">
+      <input
+        autoFocus
+        className={`${inp} min-w-0 flex-1`}
+        placeholder="Goal name"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+      />
+      <input
+        className={`${inp} w-14`}
+        placeholder="unit"
+        value={unit}
+        onChange={(e) => setUnit(e.target.value)}
+      />
+      <input
+        type="number"
+        inputMode="numeric"
+        className={`${inp} w-16 text-right`}
+        placeholder="target/wk"
+        value={target}
+        onChange={(e) => setTarget(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") void submit();
+        }}
+      />
+      <button
+        type="button"
+        onClick={() => void submit()}
+        disabled={busy || !name.trim() || !unit.trim() || target.trim() === ""}
+        className="rounded-sm border border-border bg-accent/15 px-1.5 py-0.5 text-[11px] font-medium text-accent hover:bg-accent/25 disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        {busy ? <Loader2 className="h-3 w-3 animate-spin" /> : "Add"}
+      </button>
+      <button
+        type="button"
+        onClick={reset}
+        className="rounded-sm px-1 py-0.5 text-[11px] text-text-3 hover:text-text-1"
+      >
+        Cancel
+      </button>
+    </div>
   );
 }

--- a/apps/web/src/lib/modules/goals-queries.ts
+++ b/apps/web/src/lib/modules/goals-queries.ts
@@ -274,6 +274,26 @@ export async function setWeeklyTarget(
   if (error) throw error;
 }
 
+/**
+ * ADD `delta` to a goal's running total for `entryDate`, atomically (single
+ * INSERT…ON CONFLICT in the `goals_add_entry` RPC — no read-modify-write race).
+ * The total is clamped at 0. Use this for the dashboard "+N" quick-log; use
+ * {@link recordEntry} when SETTING an exact day value.
+ */
+export async function addEntryValue(
+  supabase: Db,
+  goalId: string,
+  entryDate: string,
+  delta: number,
+): Promise<void> {
+  const { error } = await supabase.rpc("goals_add_entry", {
+    p_goal_id: goalId,
+    p_entry_date: entryDate,
+    p_delta: delta,
+  });
+  if (error) throw error;
+}
+
 export async function recordEntry(
   supabase: Db,
   input: {

--- a/apps/web/tests/rls/goals-add-entry.test.ts
+++ b/apps/web/tests/rls/goals-add-entry.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Tests for goals_add_entry (20260629130000_goals_add_entry.sql): the atomic
+ * "+N to today's total" RPC behind the dashboard quick-log. Verifies it
+ * accumulates, clamps at 0, and is RLS-scoped to scope members.
+ *
+ * Mirrors tests/rls/contacts-linking.test.ts plumbing.
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+
+const SB_URL = process.env.SUPABASE_URL ?? "http://127.0.0.1:54321";
+const ANON =
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0";
+const SERVICE =
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU";
+
+const admin = createClient(SB_URL, SERVICE, {
+  auth: { autoRefreshToken: false, persistSession: false },
+});
+
+async function makeClientFor(email: string): Promise<SupabaseClient> {
+  const { data, error } = await admin.auth.admin.generateLink({ type: "magiclink", email });
+  if (error || !data) throw new Error(`generateLink failed: ${error?.message}`);
+  const supabase = createClient(SB_URL, ANON, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+  const { data: v, error: vErr } = await supabase.auth.verifyOtp({
+    type: "magiclink",
+    token_hash: data.properties.hashed_token,
+  });
+  if (vErr || !v.session) throw new Error(`verifyOtp failed: ${vErr?.message}`);
+  await supabase.auth.setSession({
+    access_token: v.session.access_token,
+    refresh_token: v.session.refresh_token,
+  });
+  return supabase;
+}
+
+async function ensureUser(email: string): Promise<string> {
+  const { data: list } = await admin.auth.admin.listUsers();
+  const existing = list?.users.find((u) => u.email === email);
+  if (existing) return existing.id;
+  const { data, error } = await admin.auth.admin.createUser({ email, email_confirm: true });
+  if (error || !data.user) throw new Error(`createUser ${email}: ${error?.message}`);
+  return data.user.id;
+}
+
+const TODAY = "2026-06-29";
+const EM = "goals-member@rokki.local";
+const EO = "goals-outsider@rokki.local";
+
+describe("goals_add_entry (atomic additive logging)", () => {
+  let member: SupabaseClient;
+  let outsider: SupabaseClient;
+  let goalId: string;
+
+  beforeAll(async () => {
+    const memberId = await ensureUser(EM);
+    await ensureUser(EO);
+    member = await makeClientFor(EM);
+    outsider = await makeClientFor(EO);
+
+    const slug = `goals-test-${Math.random().toString(36).slice(2, 8)}`;
+    const { data: sp, error: spErr } = await admin
+      .from("spaces")
+      .insert({ slug, name: "Goals Test", created_by: memberId })
+      .select("id")
+      .single();
+    if (spErr) throw new Error(`space: ${spErr.message}`);
+    const spaceId = (sp as { id: string }).id;
+    await admin.from("space_members").insert({ space_id: spaceId, user_id: memberId, role: "owner" });
+
+    const { data: cat, error: catErr } = await admin
+      .from("goals_categories")
+      .insert({ space_id: spaceId, name: "Health", color: "#22C55E" })
+      .select("id")
+      .single();
+    if (catErr) throw new Error(`category: ${catErr.message}`);
+
+    const { data: goal, error: goalErr } = await admin
+      .from("goals_goals")
+      .insert({ category_id: (cat as { id: string }).id, name: "Workouts", unit: "sessions" })
+      .select("id")
+      .single();
+    if (goalErr) throw new Error(`goal: ${goalErr.message}`);
+    goalId = (goal as { id: string }).id;
+  }, 30_000);
+
+  it("accumulates successive adds for the same day", async () => {
+    const a = await member.rpc("goals_add_entry", {
+      p_goal_id: goalId,
+      p_entry_date: TODAY,
+      p_delta: 5,
+    });
+    expect(a.error).toBeNull();
+    expect(Number(a.data)).toBe(5);
+
+    const b = await member.rpc("goals_add_entry", {
+      p_goal_id: goalId,
+      p_entry_date: TODAY,
+      p_delta: 3,
+    });
+    expect(Number(b.data)).toBe(8);
+  });
+
+  it("clamps the running total at zero on an over-correction", async () => {
+    const c = await member.rpc("goals_add_entry", {
+      p_goal_id: goalId,
+      p_entry_date: TODAY,
+      p_delta: -100,
+    });
+    expect(c.error).toBeNull();
+    expect(Number(c.data)).toBe(0);
+  });
+
+  it("blocks a non-member from logging against a goal they can't see", async () => {
+    // .rpc returns { error } on an RLS rejection (it doesn't throw).
+    await outsider.rpc("goals_add_entry", {
+      p_goal_id: goalId,
+      p_entry_date: TODAY,
+      p_delta: 9,
+    });
+    // The security invariant: the value is untouched (still 0 from the clamp
+    // test) — RLS WITH CHECK on goals_entries_write rejected the outsider's add.
+    const { data: row } = await admin
+      .from("goals_entries")
+      .select("value")
+      .eq("goal_id", goalId)
+      .eq("entry_date", TODAY)
+      .maybeSingle();
+    expect(Number((row as { value: number }).value)).toBe(0);
+  });
+});

--- a/supabase/migrations/20260629130000_goals_add_entry.sql
+++ b/supabase/migrations/20260629130000_goals_add_entry.sql
@@ -1,0 +1,47 @@
+-- Atomic additive logging for Goals.
+--
+-- The dashboard quick-log is a "+N" affordance: it ADDS N to today's running
+-- total. Doing that as a client-side read-then-write races — two quick logs can
+-- both read the same value and the second clobbers the first. This RPC folds
+-- the read+add into a single atomic INSERT ... ON CONFLICT DO UPDATE, so
+-- concurrent increments accumulate correctly.
+--
+-- SECURITY INVOKER (the default): the INSERT/UPDATE runs as the calling user, so
+-- the existing goals_entries_write RLS (goal_id must be a goal the caller can
+-- see) authorizes it — no privilege escalation. The running total is clamped at
+-- 0 so a negative correction can zero out a goal but never drive it negative.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION goals_add_entry(
+  p_goal_id uuid,
+  p_entry_date date,
+  p_delta numeric
+)
+RETURNS numeric
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = public
+AS $$
+DECLARE
+  v_value numeric;
+BEGIN
+  INSERT INTO goals_entries (goal_id, entry_date, value, source)
+  VALUES (p_goal_id, p_entry_date, GREATEST(0, p_delta), 'manual')
+  ON CONFLICT (goal_id, entry_date)
+  DO UPDATE SET
+    value = GREATEST(0, goals_entries.value + p_delta),
+    updated_at = now()
+  RETURNING value INTO v_value;
+  RETURN v_value;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION goals_add_entry(uuid, date, numeric) TO authenticated;
+
+COMMIT;
+
+-- ROLLBACK:
+-- BEGIN;
+-- DROP FUNCTION IF EXISTS goals_add_entry(uuid, date, numeric);
+-- COMMIT;


### PR DESCRIPTION
Follow-up to the dashboard-only Goals work — makes the panel fully self-service.

## What
- **New goal area** — inline form (name + color + space) creates a category in
  that space (`createCategory`; RLS authorizes membership).
- **Add goal** — per-area inline row (name + unit + weekly target) creates the
  goal + its first weekly target (`createGoal` + `setWeeklyTarget`).
- **Additive logging** — the "+N" quick-log now reads today's value and writes
  `current + N` (was: overwrote). Fresh read avoids a stale-closure clobber.

This closes the two open items from the dashboard-only PR: there was no creation
UI, and daily logging silently replaced the day's value.

## Notes for Zack
- Logging is now **additive** (you asked "should I make it additive?" — yes, the
  "+" affordance implies it). Easy to flip back to set-the-value if you prefer.
- Areas are created at **space** scope (terminal-scoped areas are a follow-up);
  the picker shows your spaces, defaulting to the first.

## Test
- `tsc` clean, `eslint` clean, module/goals unit tests 34/34. Create/log paths
  are RLS-authorized; validated via CI + adversarial review (auth-gated, so not
  previewable locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)