### PR TITLE
feat(goals): per-goal period (daily/weekly/monthly) + edit/archive data layer

### DIFF
--- a/apps/web/src/lib/modules/goals-queries.ts
+++ b/apps/web/src/lib/modules/goals-queries.ts
@@ -24,16 +24,24 @@ export interface GoalsCategoryRow {
   archived_at: string | null;
 }
 
+/** How often a value is logged for a goal (and the window the target spans). */
+export type GoalPeriod = "daily" | "weekly" | "monthly";
+
 export interface GoalsGoalRow {
   id: string;
   category_id: string;
   name: string;
   unit: string;
+  period: GoalPeriod;
   display_order: number;
   source_type: "manual" | "auto";
   source_config: Record<string, unknown> | null;
   archived_at: string | null;
 }
+
+/** The select list for a goal row (kept in one place — it now includes period). */
+const GOAL_COLUMNS =
+  "id, category_id, name, unit, period, display_order, source_type, source_config, archived_at";
 
 export interface GoalsTargetRow {
   id: string;
@@ -102,9 +110,7 @@ export async function loadGoalsForCategories(
   if (categoryIds.length === 0) return [];
   const { data } = await supabase
     .from("goals_goals")
-    .select(
-      "id, category_id, name, unit, display_order, source_type, source_config, archived_at",
-    )
+    .select(GOAL_COLUMNS)
     .in("category_id", categoryIds)
     .is("archived_at", null)
     .order("display_order", { ascending: true });
@@ -124,9 +130,7 @@ export async function loadGoals(
   if (categories.length === 0) return [];
   const { data } = await supabase
     .from("goals_goals")
-    .select(
-      "id, category_id, name, unit, display_order, source_type, source_config, archived_at",
-    )
+    .select(GOAL_COLUMNS)
     .in(
       "category_id",
       categories.map((c) => c.id),
@@ -239,7 +243,7 @@ export async function createCategory(
 
 export async function createGoal(
   supabase: Db,
-  input: { category_id: string; name: string; unit: string },
+  input: { category_id: string; name: string; unit: string; period?: GoalPeriod },
 ): Promise<GoalsGoalRow> {
   const { data, error } = await supabase
     .from("goals_goals")
@@ -247,13 +251,93 @@ export async function createGoal(
       category_id: input.category_id,
       name: input.name.trim(),
       unit: input.unit.trim(),
+      period: input.period ?? "daily",
     } as never)
-    .select(
-      "id, category_id, name, unit, display_order, source_type, source_config, archived_at",
-    )
+    .select(GOAL_COLUMNS)
     .single();
   if (error) throw error;
   return data as GoalsGoalRow;
+}
+
+/** Rename / retype a goal (name, unit, period). RLS scopes the write. */
+export async function updateGoal(
+  supabase: Db,
+  goalId: string,
+  patch: { name?: string; unit?: string; period?: GoalPeriod },
+): Promise<void> {
+  const writable: Record<string, unknown> = { updated_at: new Date().toISOString() };
+  if (patch.name !== undefined) writable.name = patch.name.trim();
+  if (patch.unit !== undefined) writable.unit = patch.unit.trim();
+  if (patch.period !== undefined) writable.period = patch.period;
+  const { error } = await supabase.from("goals_goals").update(writable).eq("id", goalId);
+  if (error) throw error;
+}
+
+/** Rename / recolor a goal area. */
+export async function updateCategory(
+  supabase: Db,
+  categoryId: string,
+  patch: { name?: string; color?: string },
+): Promise<void> {
+  const writable: Record<string, unknown> = { updated_at: new Date().toISOString() };
+  if (patch.name !== undefined) writable.name = patch.name.trim();
+  if (patch.color !== undefined) writable.color = patch.color;
+  const { error } = await supabase
+    .from("goals_categories")
+    .update(writable)
+    .eq("id", categoryId);
+  if (error) throw error;
+}
+
+/** Archive (soft-delete) or restore a goal — sets/clears archived_at. */
+export async function setGoalArchived(
+  supabase: Db,
+  goalId: string,
+  archived: boolean,
+): Promise<void> {
+  const { error } = await supabase
+    .from("goals_goals")
+    .update({ archived_at: archived ? new Date().toISOString() : null })
+    .eq("id", goalId);
+  if (error) throw error;
+}
+
+/** Archive or restore a goal area (and, by intent, hide its goals). */
+export async function setCategoryArchived(
+  supabase: Db,
+  categoryId: string,
+  archived: boolean,
+): Promise<void> {
+  const { error } = await supabase
+    .from("goals_categories")
+    .update({ archived_at: archived ? new Date().toISOString() : null })
+    .eq("id", categoryId);
+  if (error) throw error;
+}
+
+/** Archived categories the caller can see (for the Archived tab). */
+export async function loadArchivedCategories(supabase: Db): Promise<GoalsCategoryRow[]> {
+  const { data } = await supabase
+    .from("goals_categories")
+    .select("id, name, color, icon, display_order, archived_at")
+    .not("archived_at", "is", null)
+    .order("name", { ascending: true });
+  return (data ?? []) as GoalsCategoryRow[];
+}
+
+/** Archived goals under the given (non-archived) categories. */
+export async function loadArchivedGoals(
+  supabase: Db,
+  categoryIds: string[],
+): Promise<GoalsGoalRow[]> {
+  if (categoryIds.length === 0) return [];
+  const { data } = await supabase
+    .from("goals_goals")
+    .select(GOAL_COLUMNS)
+    .in("category_id", categoryIds)
+    .not("archived_at", "is", null)
+    .order("name", { ascending: true });
+  return (data ?? []) as GoalsGoalRow[];
 }
 
 export async function setWeeklyTarget(

--- a/apps/web/src/lib/modules/goals-week.test.ts
+++ b/apps/web/src/lib/modules/goals-week.test.ts
@@ -3,8 +3,45 @@ import {
   startOfWeek,
   endOfWeek,
   formatWeekLabel,
+  startOfMonth,
+  endOfMonth,
+  periodWindow,
   DEFAULT_WEEK_START_DOW,
 } from "./goals-week";
+
+describe("goals-week — month boundaries", () => {
+  it("startOfMonth is the 1st", () => {
+    expect(startOfMonth("2026-06-29")).toBe("2026-06-01");
+    expect(startOfMonth("2026-01-15")).toBe("2026-01-01");
+  });
+  it("endOfMonth is the last day, handling lengths + leap years", () => {
+    expect(endOfMonth("2026-06-10")).toBe("2026-06-30");
+    expect(endOfMonth("2026-02-10")).toBe("2026-02-28");
+    expect(endOfMonth("2024-02-10")).toBe("2024-02-29");
+    expect(endOfMonth("2026-12-01")).toBe("2026-12-31");
+  });
+});
+
+describe("goals-week — periodWindow", () => {
+  it("daily window is the single day", () => {
+    expect(periodWindow("daily", "2026-06-25")).toEqual({
+      start: "2026-06-25",
+      end: "2026-06-25",
+    });
+  });
+  it("weekly window is Mon–Sun", () => {
+    expect(periodWindow("weekly", "2026-06-25")).toEqual({
+      start: "2026-06-22",
+      end: "2026-06-28",
+    });
+  });
+  it("monthly window is the whole month", () => {
+    expect(periodWindow("monthly", "2026-06-25")).toEqual({
+      start: "2026-06-01",
+      end: "2026-06-30",
+    });
+  });
+});
 
 describe("goals-week — startOfWeek (Monday default)", () => {
   // Reference dates so we know what to expect.

--- a/apps/web/src/lib/modules/goals-week.ts
+++ b/apps/web/src/lib/modules/goals-week.ts
@@ -47,6 +47,52 @@ export function endOfWeek(
   return date.toISOString().slice(0, 10);
 }
 
+/** First day (inclusive) of the month containing `iso`. Returns YYYY-MM-01. */
+export function startOfMonth(iso: string): string {
+  const [y, m] = iso.split("-").map(Number);
+  return `${String(y).padStart(4, "0")}-${String(m).padStart(2, "0")}-01`;
+}
+
+/** Last day (inclusive) of the month containing `iso`. */
+export function endOfMonth(iso: string): string {
+  const [y, m] = iso.split("-").map(Number);
+  // Day 0 of the next month is the last day of this one.
+  const d = new Date(Date.UTC(y, m ?? 1, 0));
+  return d.toISOString().slice(0, 10);
+}
+
+export type GoalPeriodKind = "daily" | "weekly" | "monthly";
+
+/**
+ * The [start, end] window of the bucket that `iso` falls in for a given period
+ * — a single day for daily, the Mon–Sun week for weekly, the calendar month for
+ * monthly. `start` doubles as the canonical entry_date for that bucket.
+ */
+export function periodWindow(
+  period: GoalPeriodKind,
+  iso: string,
+  weekStartDow: number = DEFAULT_WEEK_START_DOW,
+): { start: string; end: string } {
+  if (period === "weekly") {
+    return { start: startOfWeek(iso, weekStartDow), end: endOfWeek(iso, weekStartDow) };
+  }
+  if (period === "monthly") {
+    return { start: startOfMonth(iso), end: endOfMonth(iso) };
+  }
+  return { start: iso, end: iso };
+}
+
+/** A short label for the active period bucket, e.g. "This week" / "June". */
+export function periodLabel(period: GoalPeriodKind, iso: string): string {
+  if (period === "monthly") {
+    const [y, m] = iso.split("-").map(Number);
+    const d = new Date(Date.UTC(y, (m ?? 1) - 1, 1));
+    return d.toLocaleDateString(undefined, { month: "long", year: "numeric", timeZone: "UTC" });
+  }
+  if (period === "weekly") return "This week";
+  return "Today";
+}
+
 /**
  * Format the "week of" label for the UI. Returns
  * "Mon Aug 12 → Sun Aug 18" style.

--- a/apps/web/tests/rls/goals-edit.test.ts
+++ b/apps/web/tests/rls/goals-edit.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Tests for the goal `period` column (20260629140000_goals_period.sql) and the
+ * edit/archive write paths: a scope member can set a goal's cadence, rename it,
+ * and archive it; the column round-trips and the CHECK rejects bad values.
+ *
+ * Mirrors tests/rls/goals-add-entry.test.ts plumbing.
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+
+const SB_URL = process.env.SUPABASE_URL ?? "http://127.0.0.1:54321";
+const ANON =
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0";
+const SERVICE =
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU";
+
+const admin = createClient(SB_URL, SERVICE, {
+  auth: { autoRefreshToken: false, persistSession: false },
+});
+
+async function makeClientFor(email: string): Promise<SupabaseClient> {
+  const { data, error } = await admin.auth.admin.generateLink({ type: "magiclink", email });
+  if (error || !data) throw new Error(`generateLink failed: ${error?.message}`);
+  const supabase = createClient(SB_URL, ANON, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+  const { data: v, error: vErr } = await supabase.auth.verifyOtp({
+    type: "magiclink",
+    token_hash: data.properties.hashed_token,
+  });
+  if (vErr || !v.session) throw new Error(`verifyOtp failed: ${vErr?.message}`);
+  await supabase.auth.setSession({
+    access_token: v.session.access_token,
+    refresh_token: v.session.refresh_token,
+  });
+  return supabase;
+}
+
+async function ensureUser(email: string): Promise<string> {
+  const { data: list } = await admin.auth.admin.listUsers();
+  const existing = list?.users.find((u) => u.email === email);
+  if (existing) return existing.id;
+  const { data, error } = await admin.auth.admin.createUser({ email, email_confirm: true });
+  if (error || !data.user) throw new Error(`createUser ${email}: ${error?.message}`);
+  return data.user.id;
+}
+
+const EM = "goals-edit-member@rokki.local";
+
+describe("goals goal period + edit/archive", () => {
+  let member: SupabaseClient;
+  let goalId: string;
+
+  beforeAll(async () => {
+    const memberId = await ensureUser(EM);
+    member = await makeClientFor(EM);
+
+    const slug = `goals-edit-${Math.random().toString(36).slice(2, 8)}`;
+    const { data: sp } = await admin
+      .from("spaces")
+      .insert({ slug, name: "Goals Edit", created_by: memberId })
+      .select("id")
+      .single();
+    const spaceId = (sp as { id: string }).id;
+    await admin.from("space_members").insert({ space_id: spaceId, user_id: memberId, role: "owner" });
+
+    const { data: cat } = await admin
+      .from("goals_categories")
+      .insert({ space_id: spaceId, name: "Biz", color: "#4A3AA7" })
+      .select("id")
+      .single();
+    const { data: goal, error } = await admin
+      .from("goals_goals")
+      .insert({ category_id: (cat as { id: string }).id, name: "Closings", unit: "deals", period: "monthly" })
+      .select("id, period")
+      .single();
+    if (error) throw new Error(`goal: ${error.message}`);
+    goalId = (goal as { id: string }).id;
+    expect((goal as { period: string }).period).toBe("monthly");
+  }, 30_000);
+
+  it("a member can change a goal's cadence (period) and rename it", async () => {
+    const { error } = await member
+      .from("goals_goals")
+      .update({ name: "Deals closed", period: "weekly" })
+      .eq("id", goalId);
+    expect(error).toBeNull();
+    const { data } = await admin
+      .from("goals_goals")
+      .select("name, period")
+      .eq("id", goalId)
+      .single();
+    expect((data as { name: string; period: string }).name).toBe("Deals closed");
+    expect((data as { period: string }).period).toBe("weekly");
+  });
+
+  it("rejects an invalid period (CHECK constraint)", async () => {
+    const { error } = await member
+      .from("goals_goals")
+      .update({ period: "hourly" })
+      .eq("id", goalId);
+    expect(error).not.toBeNull();
+  });
+
+  it("a member can archive a goal (and restore it)", async () => {
+    await member
+      .from("goals_goals")
+      .update({ archived_at: new Date().toISOString() })
+      .eq("id", goalId);
+    const { data: archived } = await admin
+      .from("goals_goals")
+      .select("archived_at")
+      .eq("id", goalId)
+      .single();
+    expect((archived as { archived_at: string | null }).archived_at).not.toBeNull();
+
+    await member.from("goals_goals").update({ archived_at: null }).eq("id", goalId);
+    const { data: restored } = await admin
+      .from("goals_goals")
+      .select("archived_at")
+      .eq("id", goalId)
+      .single();
+    expect((restored as { archived_at: string | null }).archived_at).toBeNull();
+  });
+});

--- a/supabase/migrations/20260629140000_goals_period.sql
+++ b/supabase/migrations/20260629140000_goals_period.sql
@@ -1,0 +1,24 @@
+-- Per-goal tracking cadence — how often you log a value for a goal.
+--
+--   daily   = log each day (the week's 7 daily values roll up against the target)
+--   weekly  = log one value per week
+--   monthly = log one value per month
+--
+-- Not everything is a daily habit: some goals you only check in on weekly or
+-- monthly. The goal's target (goals_targets.weekly_target) is read as "per the
+-- goal's window" — weekly for daily/weekly goals, monthly for monthly goals.
+-- An entry's `entry_date` is the bucket start: the day for daily, the week's
+-- Monday for weekly, the 1st for monthly.
+
+BEGIN;
+
+ALTER TABLE goals_goals
+  ADD COLUMN period TEXT NOT NULL DEFAULT 'daily'
+    CHECK (period IN ('daily', 'weekly', 'monthly'));
+
+COMMIT;
+
+-- ROLLBACK:
+-- BEGIN;
+-- ALTER TABLE goals_goals DROP COLUMN IF EXISTS period;
+-- COMMIT;


### PR DESCRIPTION
Phase 1 of the Goals rebuild (your feedback: hard to edit goals/areas, unclear
logging, no history/archive, layout). This is the **data foundation**; the
tabbed UI + per-period logging + history/archive tabs follow in phase 2–3.

## What
- **`goals_goals.period`** (daily / weekly / monthly) — the cadence a goal is
  logged at. Not everything is a daily habit; some goals you check in on weekly
  or monthly. Target spans the goal's window; entry date is the bucket start.
- **Edit/archive helpers**: updateGoal (name/unit/period), updateCategory
  (name/color), setGoalArchived / setCategoryArchived (soft-delete + restore),
  loadArchived*. createGoal now takes period.
- **Date helpers**: startOfMonth / endOfMonth / periodWindow / periodLabel.

## Test
- RLS test: period round-trips, CHECK rejects bad values, a member can edit +
  archive. Month/period-window unit tests (+6). `tsc` / `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)