### PR TITLE
fix(dashboard): stop module flicker on reload (hydrate prefs before paint)

### DIFF
--- a/apps/web/src/components/dashboard/DashboardPanels.tsx
+++ b/apps/web/src/components/dashboard/DashboardPanels.tsx
@@ -487,6 +487,32 @@ export function DashboardPanels({
     !maximizedId &&
     (forceTwo || (visLayout.center.length > 0 && visLayout.right.length > 0));
 
+  // Hold the panels back until BOTH the saved arrangement (this component) and
+  // the module prefs (which modules are visible/ordered) have hydrated from
+  // localStorage — otherwise the default all-modules layout flashes for a frame
+  // before collapsing to the user's saved one.
+  const prefsReady = hydrated && (mods?.ready ?? true);
+  if (!prefsReady) {
+    return (
+      <div className="flex min-h-0 flex-col gap-2 p-2 sm:p-3 lg:h-full" aria-hidden="true">
+        <div className="grid grid-cols-1 gap-2 lg:grid-cols-[1.6fr_9px_1fr] lg:gap-0">
+          <div className="flex flex-col gap-2">
+            {[0, 1].map((k) => (
+              <div
+                key={k}
+                className="h-40 animate-pulse rounded-lg border border-border/60 bg-bg-2/40"
+              />
+            ))}
+          </div>
+          <div className="hidden lg:block" />
+          <div className="hidden flex-col gap-2 lg:flex">
+            <div className="h-40 animate-pulse rounded-lg border border-border/60 bg-bg-2/40" />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div
       ref={containerRef}

--- a/apps/web/src/components/dashboard/module-visibility.tsx
+++ b/apps/web/src/components/dashboard/module-visibility.tsx
@@ -54,6 +54,10 @@ import {
  */
 export interface ModulePrefsContextValue {
   prefs: ModulePrefs;
+  /** False until the persisted prefs have been read from localStorage. Consumers
+   *  should hold off rendering the module layout until this is true, so the
+   *  default all-modules layout never flashes before the saved one. */
+  ready: boolean;
 
   /* visibility — back-compat surface used by RailModules + DashboardPanels */
   minimized: Set<string>;
@@ -175,6 +179,7 @@ export function ModulePrefsProvider({ children }: { children: ReactNode }) {
   const value = useMemo<ModulePrefsContextValue>(
     () => ({
       prefs,
+      ready: hydrated,
       minimized,
       isMinimized: (id) => minimized.has(id),
       toggle,
@@ -190,7 +195,7 @@ export function ModulePrefsProvider({ children }: { children: ReactNode }) {
       visibleModules: orderedVisibleModules(prefs),
       hiddenModules: selectHiddenModules(prefs),
     }),
-    [prefs, minimized, toggle],
+    [prefs, hydrated, minimized, toggle],
   );
 
   return <Ctx.Provider value={value}>{children}</Ctx.Provider>;


### PR DESCRIPTION
**User-reported:** on reload, modules pop in and out before settling.

## Cause
Two localStorage hydration chains — the ModulePrefs provider (which modules are
visible/ordered) and DashboardPanels' saved arrangement — both initialize to
defaults (all modules) and load the persisted values in `useEffect` after first
paint, so the default layout flashes before collapsing to the saved one.

## Fix
Expose `ready` from the module-prefs context (true once prefs are read from
localStorage) and gate the panel render on `hydrated && mods.ready`, showing a
brief shape-matched skeleton until then. The saved layout is now correct on
first paint — no flicker.

`tsc` / `eslint` clean, module-prefs tests 174/174.

🤖 Generated with [Claude Code](https://claude.com/claude-code)