### PR TITLE
fix(tasks): "Show done" reveals completed tasks

### DIFF
--- a/apps/web/src/components/dashboard/TasksCard.tsx
+++ b/apps/web/src/components/dashboard/TasksCard.tsx
@@ -156,9 +156,8 @@ export function TasksCard({
   const [sortMode, setSortMode] = useState<"auto" | "manual">("auto");
   void sortMode;
   const [query, setQuery] = useState("");
-  // Done tasks aren't fetched for the dashboard, so this hides nothing
-  // today — but the control is wired identically to the terminal so
-  // the interface matches, and it works the moment done tasks appear.
+  // Done tasks ARE fetched now; this toggle (hidden by default so the list
+  // stays focused on open work) reveals completed tasks via "Show done".
   const [hideDone, setHideDone] = useState(true);
   // Starred-only filter — shows just the tasks pinned with a star.
   // Persisted globally so the choice sticks across reloads.

--- a/apps/web/src/lib/dashboard-queries.ts
+++ b/apps/web/src/lib/dashboard-queries.ts
@@ -190,10 +190,11 @@ export async function loadAssignedTasks(
           starred: boolean;
         } | null;
       };
+      // Keep done tasks — the dashboard's "Show done" toggle (hidden by
+      // default) needs them available to reveal completed work.
       const rows = ((data ?? []) as unknown as Row[])
         .map((r) => r.tasks)
-        .filter((t): t is NonNullable<Row["tasks"]> => !!t)
-        .filter((t) => t.status !== "done");
+        .filter((t): t is NonNullable<Row["tasks"]> => !!t);
       // Sort: priority asc with NULL = "no priority" sinking to the
       // bottom, then due_date asc. Matches the server ORDER BY
       // semantics with NULLS LAST.
@@ -217,13 +218,13 @@ export async function loadDelegatedTasks(
     { name: "db.dashboard.delegated_tasks", op: "db.query", attributes: { table: "tasks" } },
     async () => {
       // Tasks this user created that are assigned to *someone other than* them.
+      // Done tasks are kept so the "Show done" toggle can reveal them.
       const { data } = await supabase
         .from("tasks")
         .select(
           "id, title, status, priority, due_date, terminal_id, ticker_seq, starred, task_assignees!task_assignees_task_id_fkey(user_id)",
         )
-        .eq("created_by", userId)
-        .neq("status", "done");
+        .eq("created_by", userId);
       type Row = {
         id: string;
         title: string;

--- a/apps/web/src/lib/modules/tasks-queries.ts
+++ b/apps/web/src/lib/modules/tasks-queries.ts
@@ -3,7 +3,8 @@
  *
  *   user      → tasks assigned to me + I delegated, across every terminal I see
  *   space     → every task in any terminal under this space
- *   terminal  → every task in this terminal (status != done)
+ *   terminal  → every task in this terminal (done included; the UI's
+ *               "Show done" toggle, hidden by default, filters client-side)
  *
  * Reuses the same `tasks` table the existing UI already queries — no
  * new schema. RLS handles permission scoping.
@@ -52,7 +53,6 @@ export async function loadTasksForSpace(
       "terminal_id",
       tx.map((t) => t.id),
     )
-    .neq("status", "done")
     .order("priority", { ascending: true, nullsFirst: false })
     .order("due_date", { ascending: true, nullsFirst: false })
     .limit(200);
@@ -96,7 +96,6 @@ export async function loadTasksForTerminal(
     .from("tasks")
     .select("id, title, status, priority, due_date, terminal_id, ticker_seq")
     .eq("terminal_id", terminalId)
-    .neq("status", "done")
     .order("priority", { ascending: true, nullsFirst: false })
     .order("due_date", { ascending: true, nullsFirst: false });
   type TaskRow = {


### PR DESCRIPTION
**User-reported:** clicking "Show done" makes completed tasks disappear instead of showing them.

## Cause
Completed tasks were excluded at the query level — `.neq("status","done")` in the
dashboard assigned/delegated loaders and the terminal/space loaders — so the
client "Show done" toggle filtered an already-done-free set. Nothing to reveal.

## Fix
Drop the server-side done exclusion (the loaders are scope-bounded). Done tasks
now flow through; the existing toggle (hidden by default) shows/hides them, the
"Show done (N)" count populates, and you can un-complete from the row. The client
predicates in TasksCard/TasksPane were already correct.

`tsc` / `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)