### PR TITLE
fix(messages): videos play inline in Messenger

### DIFF
--- a/apps/web/src/components/messages/ChatThread.tsx
+++ b/apps/web/src/components/messages/ChatThread.tsx
@@ -206,8 +206,9 @@ export function ChatMessageList({
                             key={`v${k}`}
                             src={a.url}
                             controls
+                            playsInline
                             preload="metadata"
-                            className="block max-h-60 max-w-[260px]"
+                            className="block max-h-60 max-w-[260px] rounded-[5px] bg-black"
                           />
                         ) : null,
                       )}
@@ -481,11 +482,20 @@ export function linkify(text: string, mine: boolean): ReactNode[] {
   return out;
 }
 
+/** Extension fallback — Signal media often arrives with a missing or generic
+ *  content_type, so a .mp4 would otherwise render as a download link. */
+function extOf(att: ChatAttachment): string {
+  const m = /\.([a-z0-9]+)$/i.exec(att.filename ?? "");
+  return m ? m[1].toLowerCase() : "";
+}
+const IMAGE_EXT = new Set(["jpg", "jpeg", "png", "gif", "webp", "heic", "heif", "bmp", "avif"]);
+const VIDEO_EXT = new Set(["mp4", "mov", "m4v", "webm", "mkv", "avi", "3gp", "ogv"]);
+
 function isImage(att: ChatAttachment): boolean {
-  return (att.content_type ?? "").startsWith("image/");
+  return (att.content_type ?? "").startsWith("image/") || IMAGE_EXT.has(extOf(att));
 }
 function isVideo(att: ChatAttachment): boolean {
-  return (att.content_type ?? "").startsWith("video/");
+  return (att.content_type ?? "").startsWith("video/") || VIDEO_EXT.has(extOf(att));
 }
 
 /** Two messages are in the same "run" when from the same side within 5 min. */

--- a/apps/web/src/components/messages/SignalThreadView.tsx
+++ b/apps/web/src/components/messages/SignalThreadView.tsx
@@ -586,12 +586,17 @@ function MediaGallery({
   onOpenImage: (url: string) => void;
   onBack: () => void;
 }) {
-  const images = items.filter((x) =>
-    (x.att.content_type ?? "").startsWith("image/"),
-  );
-  const files = items.filter(
-    (x) => !(x.att.content_type ?? "").startsWith("image/"),
-  );
+  // Detect by content_type OR filename extension — Signal media often arrives
+  // with a missing/generic type, which would otherwise dump videos into Files.
+  const isImg = (x: MediaEntry) =>
+    (x.att.content_type ?? "").startsWith("image/") ||
+    /\.(jpe?g|png|gif|webp|heic|heif|bmp|avif)$/i.test(x.att.filename ?? "");
+  const isVid = (x: MediaEntry) =>
+    (x.att.content_type ?? "").startsWith("video/") ||
+    /\.(mp4|mov|m4v|webm|mkv|avi|3gp|ogv)$/i.test(x.att.filename ?? "");
+  const images = items.filter(isImg);
+  const videos = items.filter((x) => !isImg(x) && isVid(x));
+  const files = items.filter((x) => !isImg(x) && !isVid(x));
   return (
     <div className="flex-1 overflow-y-auto px-3 py-2 text-xs">
       <button
@@ -628,6 +633,27 @@ function MediaGallery({
                         className="h-full w-full cursor-zoom-in object-cover transition-transform hover:scale-105"
                       />
                     </button>
+                  ) : null,
+                )}
+              </div>
+            </section>
+          ) : null}
+          {videos.length > 0 ? (
+            <section className="mb-4">
+              <h3 className="mb-1.5 text-[10px] font-semibold uppercase tracking-wide text-text-3">
+                Videos · {videos.length}
+              </h3>
+              <div className="grid grid-cols-2 gap-1.5">
+                {videos.map((x, i) =>
+                  x.att.url ? (
+                    <video
+                      key={x.att.url ?? x.att.filename ?? i}
+                      src={x.att.url}
+                      controls
+                      playsInline
+                      preload="metadata"
+                      className="aspect-video w-full rounded-sm bg-black object-cover"
+                    />
                   ) : null,
                 )}
               </div>


### PR DESCRIPTION
**User-reported:** videos sent/received in Messenger don't auto-load or play.

## Cause
Signal media frequently arrives with a missing or generic `content_type`, so the
`startsWith("video/")` detection failed and videos rendered as a download link
instead of a `<video>` player.

## Fix
Detect image/video by `content_type` **or** filename extension
(`.mp4/.mov/.webm/.m4v/…`). Videos now render as an inline
`<video controls playsInline preload="metadata">` in the message bubbles (both
the dashboard Messages card and the Signal thread), and the media gallery gets a
dedicated **Videos** section with inline players instead of download-only links.
`playsInline` keeps playback inline on iOS. `crossOrigin` deliberately omitted —
it can break playback of signed storage URLs without CORS headers.

Follow-up (noted): mint a signed URL for the optimistic *outgoing* video bubble
so it plays before a reload.

`tsc` / `eslint` clean, signal tests 22/22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)