### PR TITLE
feat(contacts): smart-paste a contact blob → auto-filled fields (no LLM)

### DIFF
--- a/apps/web/src/lib/contacts/merge.test.ts
+++ b/apps/web/src/lib/contacts/merge.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from "vitest";
+import {
+  mergeEmails,
+  mergePhones,
+  mergeAddresses,
+  mergeSocials,
+  addrKey,
+  parseSummary,
+} from "./merge";
+import type { ParsedContact } from "./parse";
+
+function parsed(over: Partial<ParsedContact>): ParsedContact {
+  return { emails: [], phones: [], addresses: [], socials: [], unmatched: [], ...over };
+}
+
+describe("mergeEmails", () => {
+  it("drops the seeded empty row and adds parsed", () => {
+    const out = mergeEmails([{ label: "", email: "" }], [{ email: "a@x.com", label: "work" }]);
+    expect(out).toEqual([{ label: "work", email: "a@x.com" }]);
+  });
+  it("keeps user-typed rows and appends new, deduping case-insensitively", () => {
+    const out = mergeEmails(
+      [{ label: "personal", email: "me@home.com" }],
+      [{ email: "ME@HOME.com" }, { email: "new@work.com" }],
+    );
+    expect(out.map((e) => e.email)).toEqual(["me@home.com", "new@work.com"]);
+  });
+  it("returns an empty seed row when nothing is present", () => {
+    expect(mergeEmails([{ label: "", email: "" }], [])).toEqual([{ label: "", email: "" }]);
+  });
+});
+
+describe("mergePhones — format-insensitive dedupe (Finding 2)", () => {
+  it("does not duplicate the same number written with +1", () => {
+    const out = mergePhones(
+      [{ label: "mobile", phone: "+1 305-555-0100" }],
+      [{ phone: "(305) 555-0100", label: "work" }],
+    );
+    expect(out).toHaveLength(1);
+  });
+  it("treats an extension as the same base number", () => {
+    const out = mergePhones(
+      [{ label: "work", phone: "305-555-0100" }],
+      [{ phone: "305-555-0100 x123" }],
+    );
+    expect(out).toHaveLength(1);
+  });
+  it("keeps genuinely different numbers", () => {
+    const out = mergePhones(
+      [{ label: "mobile", phone: "305-555-0100" }],
+      [{ phone: "305-555-9999" }],
+    );
+    expect(out).toHaveLength(2);
+  });
+});
+
+describe("mergeAddresses — line2/country preserved (Finding 3)", () => {
+  it("keeps an address that carries ONLY a country", () => {
+    const out = mergeAddresses([], [{ country: "Canada" }]);
+    expect(out).toEqual([{ country: "Canada" }]);
+  });
+  it("keeps an address that carries ONLY line2", () => {
+    const out = mergeAddresses([], [{ line2: "Suite 900" }]);
+    expect(out).toHaveLength(1);
+  });
+  it("drops a fully-empty address", () => {
+    const out = mergeAddresses([], [{}]);
+    expect(out).toHaveLength(0);
+  });
+  it("dedupes identical addresses", () => {
+    const a = { line1: "1 Main St", city: "Miami", state: "FL", postal: "33131" };
+    const out = mergeAddresses([a], [{ ...a }]);
+    expect(out).toHaveLength(1);
+  });
+  it("addrKey is empty-string-equivalent only when every part is blank", () => {
+    expect(addrKey({}).replace(/\|/g, "")).toBe("");
+    expect(addrKey({ country: "USA" }).replace(/\|/g, "")).not.toBe("");
+  });
+});
+
+describe("merge helpers don't share references with the parser (Finding 1)", () => {
+  it("mergeAddresses clones incoming objects", () => {
+    const src = parsed({ addresses: [{ city: "Miami" }] });
+    const out = mergeAddresses([], src.addresses);
+    out[0].city = "Tampa";
+    expect(src.addresses[0].city).toBe("Miami"); // source untouched
+  });
+  it("mergeSocials clones incoming objects", () => {
+    const src = parsed({ socials: [{ kind: "website", value: "a.com" }] });
+    const out = mergeSocials([], src.socials);
+    out[0].value = "b.com";
+    expect(src.socials[0].value).toBe("a.com");
+  });
+  it("merge helpers don't mutate the existing array", () => {
+    const existing = [{ label: "", email: "keep@x.com" }];
+    const before = existing.length;
+    mergeEmails(existing, [{ email: "new@x.com" }]);
+    expect(existing).toHaveLength(before); // input array unchanged
+  });
+});
+
+describe("mergeSocials", () => {
+  it("appends + dedupes by value", () => {
+    const out = mergeSocials(
+      [{ kind: "linkedin", value: "linkedin.com/in/me" }],
+      [{ kind: "linkedin", value: "LinkedIn.com/in/me" }, { kind: "website", value: "me.com" }],
+    );
+    expect(out).toHaveLength(2);
+  });
+});
+
+describe("parseSummary", () => {
+  it("summarizes filled fields", () => {
+    const s = parseSummary(
+      parsed({
+        first_name: "Ann",
+        company: "Acme",
+        emails: [{ email: "a@x.com" }, { email: "b@x.com" }],
+        phones: [{ phone: "305-555-0100" }],
+      }),
+    );
+    expect(s).toContain("name");
+    expect(s).toContain("company");
+    expect(s).toContain("2 emails");
+    expect(s).toContain("1 phone");
+  });
+  it("empty parse → empty summary", () => {
+    expect(parseSummary(parsed({}))).toBe("");
+  });
+});

--- a/apps/web/src/lib/contacts/merge.ts
+++ b/apps/web/src/lib/contacts/merge.ts
@@ -1,0 +1,113 @@
+/**
+ * Pure merge helpers for folding a parsed contact blob (see `parse.ts`) into an
+ * in-progress contact form. Extracted from the form component so the dedupe /
+ * clobber rules are unit-tested. Rules:
+ *   - multi-value rows (emails/phones/addresses/socials) are APPENDED + DEDUPED
+ *     against what's already there; never reordered or dropped.
+ *   - returned objects are always fresh (no shared references with the parser's
+ *     output), so later form edits can't corrupt the parsed source and React
+ *     always sees new array + element identities.
+ */
+import type { ContactAddress, ContactSocial } from "./db";
+import type { ParsedContact } from "./parse";
+import { phoneDedupeKey } from "./normalize";
+
+export interface EmailRow {
+  label: string;
+  email: string;
+  primary?: boolean;
+}
+export interface PhoneRow {
+  label: string;
+  phone: string;
+  primary?: boolean;
+}
+
+/** Append parsed emails to the existing rows, dropping empty placeholders + dups. */
+export function mergeEmails(
+  existing: EmailRow[],
+  incoming: ParsedContact["emails"],
+): EmailRow[] {
+  const real = existing.filter((e) => e.email.trim());
+  const seen = new Set(real.map((e) => e.email.trim().toLowerCase()));
+  for (const e of incoming) {
+    const key = e.email.trim().toLowerCase();
+    if (key && !seen.has(key)) {
+      seen.add(key);
+      real.push({ label: e.label ?? "", email: e.email });
+    }
+  }
+  return real.length ? real : [{ label: "", email: "" }];
+}
+
+/** Append parsed phones, deduping on the format-insensitive phone key. */
+export function mergePhones(
+  existing: PhoneRow[],
+  incoming: ParsedContact["phones"],
+): PhoneRow[] {
+  const real = existing.filter((p) => p.phone.trim());
+  const seen = new Set(real.map((p) => phoneDedupeKey(p.phone)));
+  for (const p of incoming) {
+    const key = phoneDedupeKey(p.phone);
+    if (key && !seen.has(key)) {
+      seen.add(key);
+      real.push({ label: p.label ?? "", phone: p.phone });
+    }
+  }
+  return real.length ? real : [{ label: "", phone: "" }];
+}
+
+/** Dedupe key across ALL address parts (line2/country included so they aren't lost). */
+export function addrKey(a: ContactAddress): string {
+  return [a.line1, a.line2, a.city, a.state, a.postal, a.country]
+    .map((s) => (s ?? "").trim().toLowerCase())
+    .join("|");
+}
+
+export function mergeAddresses(
+  existing: ContactAddress[],
+  incoming: ContactAddress[],
+): ContactAddress[] {
+  const seen = new Set(existing.map(addrKey));
+  const out = existing.map((a) => ({ ...a }));
+  for (const a of incoming) {
+    const key = addrKey(a);
+    // Skip only genuinely empty addresses (every part blank → all separators).
+    if (key.replace(/\|/g, "") !== "" && !seen.has(key)) {
+      seen.add(key);
+      out.push({ ...a });
+    }
+  }
+  return out;
+}
+
+export function mergeSocials(
+  existing: ContactSocial[],
+  incoming: ContactSocial[],
+): ContactSocial[] {
+  const seen = new Set(existing.map((s) => s.value.trim().toLowerCase()));
+  const out = existing.map((s) => ({ ...s }));
+  for (const s of incoming) {
+    const key = s.value.trim().toLowerCase();
+    if (key && !seen.has(key)) {
+      seen.add(key);
+      out.push({ ...s });
+    }
+  }
+  return out;
+}
+
+/** Human summary of what a parse filled, e.g. "name · 2 emails · 1 phone". */
+export function parseSummary(p: ParsedContact): string {
+  const bits: string[] = [];
+  if (p.first_name || p.last_name) bits.push("name");
+  if (p.company) bits.push("company");
+  if (p.title) bits.push("title");
+  if (p.emails.length) bits.push(`${p.emails.length} email${p.emails.length > 1 ? "s" : ""}`);
+  if (p.phones.length) bits.push(`${p.phones.length} phone${p.phones.length > 1 ? "s" : ""}`);
+  if (p.addresses.length)
+    bits.push(`${p.addresses.length} address${p.addresses.length > 1 ? "es" : ""}`);
+  if (p.socials.length) bits.push(`${p.socials.length} link${p.socials.length > 1 ? "s" : ""}`);
+  if (p.birthday) bits.push("birthday");
+  return bits.join(" · ");
+}

--- a/apps/web/src/lib/contacts/normalize.ts
+++ b/apps/web/src/lib/contacts/normalize.ts
@@ -17,6 +17,20 @@ export function normalizePhone(phone: string): string {
   return plus + p.replace(/\D/g, "");
 }
 
+/**
+ * A key for deciding whether two phone strings are the *same* number, robust to
+ * formatting: strips an extension (x123 / ext.) and a leading US country code so
+ * "(305) 555-0100", "+1 305-555-0100" and "305-555-0100 x12" all collapse to
+ * one key. Non-US 11-digit numbers (not starting with 1) are kept intact so two
+ * different ones never falsely merge.
+ */
+export function phoneDedupeKey(raw: string): string {
+  const noExt = raw.replace(/\s*(?:x|ext\.?|extension)\s*\d+\s*$/i, "");
+  let d = noExt.replace(/\D/g, "");
+  if (d.length === 11 && d.startsWith("1")) d = d.slice(1);
+  return d;
+}
+
 /** The primary email: the one flagged `primary`, else the first, else null. */
 export function primaryEmail(emails: ContactEmail[] | undefined): string | null {
   if (!Array.isArray(emails) || emails.length === 0) return null;

--- a/apps/web/src/lib/contacts/parse.test.ts
+++ b/apps/web/src/lib/contacts/parse.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect } from "vitest";
+import { parseContact, splitName } from "./parse";
+
+describe("splitName", () => {
+  it("first + last", () => {
+    expect(splitName("Carlos Mendez")).toEqual({
+      first_name: "Carlos",
+      last_name: "Mendez",
+    });
+  });
+  it("first middle last", () => {
+    expect(splitName("Ana Maria Gonzalez")).toEqual({
+      first_name: "Ana",
+      middle_name: "Maria",
+      last_name: "Gonzalez",
+    });
+  });
+  it("Last, First", () => {
+    expect(splitName("Mendez, Carlos")).toEqual({
+      first_name: "Carlos",
+      last_name: "Mendez",
+    });
+  });
+  it("prefix + suffix", () => {
+    expect(splitName("Dr. Robert King Jr.")).toEqual({
+      prefix: "Dr.",
+      first_name: "Robert",
+      last_name: "King",
+      suffix: "Jr.",
+    });
+  });
+  it("single token", () => {
+    expect(splitName("Cher")).toEqual({ first_name: "Cher" });
+  });
+  it("apostrophes + hyphens", () => {
+    expect(splitName("Jean-Luc O'Brien")).toEqual({
+      first_name: "Jean-Luc",
+      last_name: "O'Brien",
+    });
+  });
+});
+
+describe("parseContact — email signature", () => {
+  const sig = `Carlos Mendez
+Senior Broker, Compass Real Estate
+carlos.mendez@compass.com
+Mobile: (305) 555-0142
+Office: 305-555-0100
+www.compass.com`;
+
+  const r = parseContact(sig);
+
+  it("extracts the name", () => {
+    expect(r.first_name).toBe("Carlos");
+    expect(r.last_name).toBe("Mendez");
+  });
+  it("extracts title + company", () => {
+    expect(r.title).toMatch(/Senior Broker/i);
+    expect(r.company).toMatch(/Compass Real Estate/i);
+  });
+  it("extracts the email", () => {
+    expect(r.emails).toHaveLength(1);
+    expect(r.emails[0].email).toBe("carlos.mendez@compass.com");
+  });
+  it("extracts both phones with labels", () => {
+    expect(r.phones).toHaveLength(2);
+    const mobile = r.phones.find((p) => p.label === "mobile");
+    const work = r.phones.find((p) => p.label === "work");
+    expect(mobile?.phone).toContain("305");
+    expect(work?.phone).toContain("305");
+  });
+  it("captures the website as a social", () => {
+    expect(r.socials.some((s) => s.kind === "website")).toBe(true);
+  });
+});
+
+describe("parseContact — labeled key/value block", () => {
+  const block = `Name: Ana Gonzalez
+Company: Brickell Capital Partners
+Title: Managing Director
+Email: ana@brickellcap.com
+Work Phone: (786) 555-2200
+Cell: 786-555-9999
+Birthday: 03/14/1985
+Address: 1450 Brickell Ave, Suite 1900
+Miami, FL 33131
+LinkedIn: linkedin.com/in/anagonzalez`;
+
+  const r = parseContact(block);
+
+  it("name", () => {
+    expect(r.first_name).toBe("Ana");
+    expect(r.last_name).toBe("Gonzalez");
+  });
+  it("company + title", () => {
+    expect(r.company).toBe("Brickell Capital Partners");
+    expect(r.title).toBe("Managing Director");
+  });
+  it("email", () => {
+    expect(r.emails[0].email).toBe("ana@brickellcap.com");
+  });
+  it("two phones, correct labels", () => {
+    expect(r.phones.find((p) => p.label === "work")?.phone).toContain("786");
+    expect(r.phones.find((p) => p.label === "mobile")?.phone).toContain("786");
+  });
+  it("birthday → ISO", () => {
+    expect(r.birthday).toBe("1985-03-14");
+  });
+  it("address line + city/state/zip merged", () => {
+    expect(r.addresses).toHaveLength(1);
+    expect(r.addresses[0].line1).toMatch(/Brickell Ave/);
+    expect(r.addresses[0].city).toBe("Miami");
+    expect(r.addresses[0].state).toBe("FL");
+    expect(r.addresses[0].postal).toBe("33131");
+  });
+  it("linkedin social", () => {
+    expect(r.socials.find((s) => s.kind === "linkedin")?.value).toContain(
+      "anagonzalez",
+    );
+  });
+});
+
+describe("parseContact — Apple contact-card copy (label-then-value)", () => {
+  const card = `John Patel
+Sunrise Properties LLC
+mobile
+(954) 555-3000
+work
+john@sunriseprops.com`;
+  const r = parseContact(card);
+
+  it("name + company", () => {
+    expect(r.first_name).toBe("John");
+    expect(r.last_name).toBe("Patel");
+    expect(r.company).toMatch(/Sunrise Properties/i);
+  });
+  it("phone takes preceding standalone label", () => {
+    expect(r.phones[0].label).toBe("mobile");
+    expect(r.phones[0].phone).toContain("954");
+  });
+  it("email takes preceding standalone label", () => {
+    expect(r.emails[0].label).toBe("work");
+    expect(r.emails[0].email).toBe("john@sunriseprops.com");
+  });
+});
+
+describe("parseContact — vCard", () => {
+  const vcf = `BEGIN:VCARD
+VERSION:3.0
+N:Reyes;Maria;Elena;Ms.;
+FN:Ms. Maria Elena Reyes
+ORG:Coastal Title Group;
+TITLE:Closing Officer
+EMAIL;TYPE=WORK:maria@coastaltitle.com
+EMAIL;TYPE=HOME:mreyes@gmail.com
+TEL;TYPE=CELL:+1-305-555-7777
+TEL;TYPE=WORK:(305) 555-8888
+ADR;TYPE=WORK:;;200 S Biscayne Blvd;Miami;FL;33131;USA
+BDAY:1979-11-02
+URL:https://coastaltitle.com
+END:VCARD`;
+  const r = parseContact(vcf);
+
+  it("structured N name", () => {
+    expect(r.first_name).toBe("Maria");
+    expect(r.middle_name).toBe("Elena");
+    expect(r.last_name).toBe("Reyes");
+    expect(r.prefix).toBe("Ms.");
+  });
+  it("org + title", () => {
+    expect(r.company).toBe("Coastal Title Group");
+    expect(r.title).toBe("Closing Officer");
+  });
+  it("two emails w/ labels", () => {
+    expect(r.emails).toHaveLength(2);
+    expect(r.emails.find((e) => e.label === "work")?.email).toBe(
+      "maria@coastaltitle.com",
+    );
+    expect(r.emails.find((e) => e.label === "personal")?.email).toBe(
+      "mreyes@gmail.com",
+    );
+  });
+  it("two phones w/ labels", () => {
+    expect(r.phones.find((p) => p.label === "mobile")?.phone).toContain("305");
+    expect(r.phones.find((p) => p.label === "work")?.phone).toContain("305");
+  });
+  it("address", () => {
+    expect(r.addresses[0].line1).toBe("200 S Biscayne Blvd");
+    expect(r.addresses[0].city).toBe("Miami");
+    expect(r.addresses[0].state).toBe("FL");
+    expect(r.addresses[0].postal).toBe("33131");
+  });
+  it("birthday + website", () => {
+    expect(r.birthday).toBe("1979-11-02");
+    expect(r.socials.find((s) => s.kind === "website")?.value).toContain(
+      "coastaltitle.com",
+    );
+  });
+});
+
+describe("parseContact — dedupe + robustness", () => {
+  it("dedupes repeated email/phone", () => {
+    const r = parseContact(
+      "Bob Lee\nbob@x.com\nbob@x.com\n(305) 555-1212\n305-555-1212",
+    );
+    expect(r.emails).toHaveLength(1);
+    expect(r.phones).toHaveLength(1);
+  });
+  it("empty input → empty result", () => {
+    const r = parseContact("   \n  \n");
+    expect(r.emails).toHaveLength(0);
+    expect(r.phones).toHaveLength(0);
+    expect(r.first_name).toBeUndefined();
+  });
+  it("bare email only", () => {
+    const r = parseContact("someone@nowhere.com");
+    expect(r.emails[0].email).toBe("someone@nowhere.com");
+  });
+  it("does not treat a zip code as a phone", () => {
+    const r = parseContact("Jane Doe\n123 Main St\nMiami, FL 33133");
+    expect(r.phones).toHaveLength(0);
+    expect(r.addresses[0].postal).toBe("33133");
+  });
+  it("unclassifiable lines go to unmatched, not into fields", () => {
+    const r = parseContact("Tom Ray\nSome random tagline here that means nothing");
+    expect(r.first_name).toBe("Tom");
+    expect(r.unmatched.length).toBeGreaterThan(0);
+  });
+});

--- a/apps/web/src/lib/contacts/parse.test.ts
+++ b/apps/web/src/lib/contacts/parse.test.ts
@@ -227,3 +227,32 @@ describe("parseContact — dedupe + robustness", () => {
     expect(r.unmatched.length).toBeGreaterThan(0);
   });
 });
+
+describe("parseContact — adversarial edge cases", () => {
+  it("company-only blob does not invent a person name", () => {
+    const r = parseContact("Brickell Capital Partners LLC\ninfo@brickellcap.com");
+    expect(r.first_name).toBeUndefined();
+    expect(r.last_name).toBeUndefined();
+    expect(r.company).toMatch(/Brickell Capital Partners/);
+    expect(r.emails[0].email).toBe("info@brickellcap.com");
+  });
+  it('"Last, First" on the name line of a signature', () => {
+    const r = parseContact("Mendez, Carlos\nBroker\ncarlos@x.com");
+    expect(r.first_name).toBe("Carlos");
+    expect(r.last_name).toBe("Mendez");
+  });
+  it("two phones on a single line are both captured", () => {
+    const r = parseContact("Pat Gomez\nO: (305) 555-1000  C: (305) 555-2000");
+    expect(r.phones).toHaveLength(2);
+  });
+  it("an ISO date in the text is not mistaken for a phone", () => {
+    const r = parseContact("Notes: contract signed 2026-06-30\njoe@x.com");
+    expect(r.phones).toHaveLength(0);
+  });
+  it("does not crash on punctuation-only / unicode input", () => {
+    expect(() => parseContact("———\n••• \n☃️")).not.toThrow();
+    expect(() => parseContact("José Niño-García\njose@x.com")).not.toThrow();
+    const r = parseContact("José Niño\njose@x.com");
+    expect(r.first_name).toBe("José");
+  });
+});

--- a/apps/web/src/lib/contacts/parse.test.ts
+++ b/apps/web/src/lib/contacts/parse.test.ts
@@ -249,6 +249,15 @@ describe("parseContact — adversarial edge cases", () => {
     const r = parseContact("Notes: contract signed 2026-06-30\njoe@x.com");
     expect(r.phones).toHaveLength(0);
   });
+  it("classifies socials by host, not substring (CodeQL: incomplete URL check)", () => {
+    const fb = parseContact("Web: https://facebook.com/acme");
+    expect(fb.socials.find((s) => s.kind === "facebook")?.value).toContain("facebook.com");
+    // A host that merely contains "fb.com" in its path must NOT be facebook.
+    const evil = parseContact("Web: https://evil.com/fb.com/phish");
+    expect(evil.socials.some((s) => s.kind === "facebook")).toBe(false);
+    expect(evil.socials.some((s) => s.kind === "website")).toBe(true);
+    expect(parseContact("https://x.com/jack").socials[0].kind).toBe("x");
+  });
   it("does not crash on punctuation-only / unicode input", () => {
     expect(() => parseContact("———\n••• \n☃️")).not.toThrow();
     expect(() => parseContact("José Niño-García\njose@x.com")).not.toThrow();

--- a/apps/web/src/lib/contacts/parse.ts
+++ b/apps/web/src/lib/contacts/parse.ts
@@ -116,15 +116,33 @@ function emailLabel(context: string): string | undefined {
   return undefined;
 }
 
+/**
+ * Extract the host from a URL-ish string ("https://x.com/u", "www.x.com/u",
+ * "x.com/u" → "x.com"). Returns "" when there's no host part. Matching socials
+ * on the parsed host (not a substring) avoids the "fb.com anywhere in the
+ * string" false-positive that a naive `.includes()` would accept.
+ */
+function hostOf(v: string): string {
+  return v
+    .replace(/^[a-z][a-z0-9+.-]*:\/\//i, "")
+    .replace(/^www\./i, "")
+    .split(/[/?#]/)[0]
+    .toLowerCase();
+}
+/** Host equals the domain or is a subdomain of it. */
+function hostIs(host: string, domain: string): boolean {
+  return host === domain || host.endsWith("." + domain);
+}
+
 function classifySocial(raw: string): ContactSocial | null {
   const v = raw.trim().replace(/^@/, "");
   if (!v) return null;
-  const low = v.toLowerCase();
-  if (low.includes("linkedin.")) return { kind: "linkedin", value: v };
-  if (low.includes("instagram.")) return { kind: "instagram", value: v };
-  if (low.includes("facebook.") || low.includes("fb.com"))
+  const host = hostOf(v);
+  if (hostIs(host, "linkedin.com")) return { kind: "linkedin", value: v };
+  if (hostIs(host, "instagram.com")) return { kind: "instagram", value: v };
+  if (hostIs(host, "facebook.com") || hostIs(host, "fb.com"))
     return { kind: "facebook", value: v };
-  if (low.includes("twitter.") || /(^|\/)x\.com/.test(low))
+  if (hostIs(host, "twitter.com") || hostIs(host, "x.com"))
     return { kind: "x", value: v };
   // bare domain or http(s) → website
   if (/^(https?:\/\/|www\.)/i.test(v) || /\.[a-z]{2,}(\/|$)/i.test(v))

--- a/apps/web/src/lib/contacts/parse.ts
+++ b/apps/web/src/lib/contacts/parse.ts
@@ -14,6 +14,7 @@ import type {
   ContactPhone,
   ContactSocial,
 } from "./db";
+import { phoneDedupeKey } from "./normalize";
 
 export interface ParsedContact {
   prefix?: string;
@@ -180,8 +181,16 @@ function looksLikeName(line: string): boolean {
   if (TITLE_RE.test(t)) return false;
   const words = t.split(/\s+/);
   if (words.length < 1 || words.length > 5) return false;
-  // Mostly alphabetic words, each starting upper (allow O'Brien, Jean-Luc, accents).
-  return words.every((w) => /^[\p{Lu}][\p{L}'’.-]*$/u.test(w) || PREFIXES.has(cleanWord(w)) || SUFFIXES.has(cleanWord(w)));
+  // Mostly alphabetic words, each starting upper (allow O'Brien, Jean-Luc,
+  // accents, and a trailing comma as in "Mendez, Carlos").
+  return words.every((w) => {
+    const c = w.replace(/,$/, "");
+    return (
+      /^[\p{Lu}][\p{L}'’.-]*$/u.test(c) ||
+      PREFIXES.has(cleanWord(c)) ||
+      SUFFIXES.has(cleanWord(c))
+    );
+  });
 }
 
 const US_STATE =
@@ -237,9 +246,9 @@ function pushEmail(out: ParsedContact, email: string, label?: string) {
 function pushPhone(out: ParsedContact, phone: string, label?: string) {
   const norm = phone.trim();
   if (!norm) return;
-  const digits = norm.replace(/\D/g, "");
-  if (digits.length < 7) return;
-  if (out.phones.some((p) => p.phone.replace(/\D/g, "") === digits)) return;
+  if (norm.replace(/\D/g, "").length < 7) return;
+  const key = phoneDedupeKey(norm);
+  if (out.phones.some((p) => phoneDedupeKey(p.phone) === key)) return;
   out.phones.push(label ? { phone: norm, label } : { phone: norm });
 }
 function pushSocial(out: ParsedContact, social: ContactSocial | null) {

--- a/apps/web/src/lib/contacts/parse.ts
+++ b/apps/web/src/lib/contacts/parse.ts
@@ -1,0 +1,570 @@
+/**
+ * Deterministic contact-blob parser — turns a pasted/dropped chunk of text
+ * (an email signature, an Apple/Google contact-card copy, a vCard, or just a
+ * few labeled lines) into structured contact fields.
+ *
+ * NO LLM / network — pure regex + heuristics, so it's fast, offline, unit-tested
+ * and reused by the create/edit form. When a line can't be classified with
+ * confidence it goes to `unmatched` rather than being guessed into the wrong
+ * field; the UI shows those for the user to place by hand.
+ */
+import type {
+  ContactAddress,
+  ContactEmail,
+  ContactPhone,
+  ContactSocial,
+} from "./db";
+
+export interface ParsedContact {
+  prefix?: string;
+  first_name?: string;
+  middle_name?: string;
+  last_name?: string;
+  suffix?: string;
+  nickname?: string;
+  company?: string;
+  title?: string;
+  birthday?: string; // yyyy-mm-dd
+  emails: ContactEmail[];
+  phones: ContactPhone[];
+  addresses: ContactAddress[];
+  socials: ContactSocial[];
+  notes?: string;
+  /** Lines we couldn't confidently classify — surfaced for manual placement. */
+  unmatched: string[];
+}
+
+function empty(): ParsedContact {
+  return { emails: [], phones: [], addresses: [], socials: [], unmatched: [] };
+}
+
+// ── token regexes ─────────────────────────────────────────────────────────
+const EMAIL_RE = /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi;
+// US/intl phone: optional +cc, area code (paren or not), 7-digit local, optional ext.
+const PHONE_RE =
+  /(\+?\d{1,3}[\s.\-]?)?(\(\d{3}\)|\d{3})[\s.\-]\d{3}[\s.\-]\d{4}(\s?(?:x|ext\.?|extension)\s?\d{1,6})?/gi;
+const URL_RE = /\b((?:https?:\/\/|www\.)[^\s,;]+|[a-z0-9-]+\.(?:com|net|org|io|co|me|us|biz)(?:\/[^\s,;]*)?)/gi;
+
+// ── label vocabularies ──────────────────────────────────────────────────────
+const PHONE_LABEL_WORDS: Array<[RegExp, string]> = [
+  [/\b(mobile|cell(ular)?|cel|mob|iphone)\b/i, "mobile"],
+  [/\b(work|office|business|direct|tel|telephone|desk)\b/i, "work"],
+  [/\b(home|residence|landline)\b/i, "home"],
+  [/\b(fax|facsimile)\b/i, "other"],
+  [/\b(main|other)\b/i, "other"],
+];
+const EMAIL_LABEL_WORDS: Array<[RegExp, string]> = [
+  [/\b(work|office|business)\b/i, "work"],
+  [/\b(personal|home)\b/i, "personal"],
+];
+
+const CORP_RE =
+  /\b(inc\.?|incorporated|llc|l\.l\.c\.?|llp|lllp|ltd\.?|limited|corp\.?|corporation|co\.|company|group|partners|capital|holdings|ventures|properties|property|realty|realtors?|associates|advisors|advisory|consulting|consultants|bank|trust|pllc|p\.?l\.?l\.?c\.?|p\.?a\.?|p\.?c\.?|management|development|builders|construction|enterprises|industries|solutions|systems|services|agency|studios?|design|media|labs?|technologies|tech)\b/i;
+
+const TITLE_RE =
+  /\b(ceo|cfo|coo|cto|cmo|cio|president|vice[- ]president|vp|svp|evp|director|managing director|manager|broker|realtor|real estate (agent|broker)|sales associate|associate broker|agent|partner|managing partner|associate|founder|co[- ]?founder|principal|owner|proprietor|attorney|lawyer|counsel|general counsel|paralegal|analyst|consultant|advisor|adviser|engineer|architect|developer|head of [a-z ]+|chief [a-z ]+ officer|chief|executive|administrator|coordinator|specialist|representative|rep|officer|supervisor|lead|account executive)\b/i;
+
+// Known labeled-field keys, normalized.
+const FIELD_KEYS: Array<[RegExp, string]> = [
+  [/^(name|full name|contact)$/i, "name"],
+  [/^(first ?name|given name)$/i, "first"],
+  [/^(last ?name|surname|family name)$/i, "last"],
+  [/^(nick ?name|goes by)$/i, "nickname"],
+  [/^(company|organi[sz]ation|org|employer|business name|firm)$/i, "company"],
+  [/^(title|job title|position|role)$/i, "title"],
+  [/^(e[- ]?mail( address)?|mail)$/i, "email"],
+  [/^(work e[- ]?mail|office e[- ]?mail)$/i, "email:work"],
+  [/^(personal e[- ]?mail|home e[- ]?mail)$/i, "email:personal"],
+  [/^(phone( number)?|tel(ephone)?|number|ph)$/i, "phone"],
+  [/^(mobile( phone)?|cell( phone)?|cellular|mob)$/i, "phone:mobile"],
+  [/^(work phone|office( phone)?|business phone|direct( line)?)$/i, "phone:work"],
+  [/^(home phone|landline)$/i, "phone:home"],
+  [/^(fax)$/i, "phone:other"],
+  [/^(address|addr|location|mailing address|street)$/i, "address"],
+  [/^(birth ?day|d\.?o\.?b\.?|date of birth|born)$/i, "birthday"],
+  [/^(web( ?site)?|url|homepage|site)$/i, "website"],
+  [/^(linked ?in)$/i, "linkedin"],
+  [/^(insta(gram)?|ig)$/i, "instagram"],
+  [/^(twitter|x)$/i, "x"],
+  [/^(facebook|fb)$/i, "facebook"],
+  [/^(notes?|memo|comments?)$/i, "notes"],
+];
+
+// Apple/Google "label on its own line, value on the next" copy format.
+const STANDALONE_PHONE_LABEL =
+  /^(mobile|cell|iphone|work|office|home|main|fax|other|business|direct)$/i;
+const STANDALONE_EMAIL_LABEL = /^(work|personal|home|other|email)$/i;
+
+const PREFIXES = new Set(["mr", "mrs", "ms", "mx", "dr", "prof", "sir", "madam", "miss"]);
+const SUFFIXES = new Set([
+  "jr", "sr", "ii", "iii", "iv", "v", "phd", "md", "esq", "esquire", "cpa",
+  "mba", "jd", "pe", "ra", "aia", "pa", "dds", "rn",
+]);
+
+// ── small helpers ───────────────────────────────────────────────────────────
+function cleanWord(s: string): string {
+  return s.replace(/[.,]/g, "").trim().toLowerCase();
+}
+
+function phoneLabel(context: string): string | undefined {
+  for (const [re, label] of PHONE_LABEL_WORDS) if (re.test(context)) return label;
+  return undefined;
+}
+function emailLabel(context: string): string | undefined {
+  for (const [re, label] of EMAIL_LABEL_WORDS) if (re.test(context)) return label;
+  return undefined;
+}
+
+function classifySocial(raw: string): ContactSocial | null {
+  const v = raw.trim().replace(/^@/, "");
+  if (!v) return null;
+  const low = v.toLowerCase();
+  if (low.includes("linkedin.")) return { kind: "linkedin", value: v };
+  if (low.includes("instagram.")) return { kind: "instagram", value: v };
+  if (low.includes("facebook.") || low.includes("fb.com"))
+    return { kind: "facebook", value: v };
+  if (low.includes("twitter.") || /(^|\/)x\.com/.test(low))
+    return { kind: "x", value: v };
+  // bare domain or http(s) → website
+  if (/^(https?:\/\/|www\.)/i.test(v) || /\.[a-z]{2,}(\/|$)/i.test(v))
+    return { kind: "website", value: v };
+  return null;
+}
+
+/** Split a free-form full name into structured pieces. */
+export function splitName(full: string): {
+  prefix?: string;
+  first_name?: string;
+  middle_name?: string;
+  last_name?: string;
+  suffix?: string;
+} {
+  let s = full.trim().replace(/\s+/g, " ");
+  if (!s) return {};
+  // "Last, First Middle" → "First Middle Last"
+  const comma = s.indexOf(",");
+  if (comma > 0 && s.indexOf(",") === s.lastIndexOf(",")) {
+    const before = s.slice(0, comma).trim();
+    const after = s.slice(comma + 1).trim();
+    // Only flip when the part after the comma isn't itself a suffix (e.g. "Bob, Jr").
+    if (after && !SUFFIXES.has(cleanWord(after))) s = `${after} ${before}`;
+    else s = before;
+  }
+  const tokens = s.split(" ").filter(Boolean);
+  const out: ReturnType<typeof splitName> = {};
+  // Leading prefix.
+  if (tokens.length > 1 && PREFIXES.has(cleanWord(tokens[0]))) {
+    out.prefix = tokens.shift()!.replace(/,$/, "");
+  }
+  // Trailing suffix.
+  if (tokens.length > 1 && SUFFIXES.has(cleanWord(tokens[tokens.length - 1]))) {
+    out.suffix = tokens.pop()!.replace(/,$/, "");
+  }
+  if (tokens.length === 0) return out;
+  if (tokens.length === 1) {
+    out.first_name = tokens[0];
+    return out;
+  }
+  out.first_name = tokens[0];
+  out.last_name = tokens[tokens.length - 1];
+  if (tokens.length > 2) out.middle_name = tokens.slice(1, -1).join(" ");
+  return out;
+}
+
+/** Does this residual line look like a person's name (vs a company/title)? */
+function looksLikeName(line: string): boolean {
+  const t = line.trim();
+  if (!t || t.length > 60) return false;
+  if (/[@\d]/.test(t)) return false; // emails/phones/street numbers excluded
+  if (CORP_RE.test(t)) return false;
+  if (TITLE_RE.test(t)) return false;
+  const words = t.split(/\s+/);
+  if (words.length < 1 || words.length > 5) return false;
+  // Mostly alphabetic words, each starting upper (allow O'Brien, Jean-Luc, accents).
+  return words.every((w) => /^[\p{Lu}][\p{L}'’.-]*$/u.test(w) || PREFIXES.has(cleanWord(w)) || SUFFIXES.has(cleanWord(w)));
+}
+
+const US_STATE =
+  "AL|AK|AZ|AR|CA|CO|CT|DE|FL|GA|HI|ID|IL|IN|IA|KS|KY|LA|ME|MD|MA|MI|MN|MS|MO|MT|NE|NV|NH|NJ|NM|NY|NC|ND|OH|OK|OR|PA|RI|SC|SD|TN|TX|UT|VT|VA|WA|WV|WI|WY|DC";
+const CITY_STATE_ZIP_RE = new RegExp(
+  `^(.+?),?\\s+(${US_STATE})\\.?\\s+(\\d{5}(?:-\\d{4})?)$`,
+  "i",
+);
+const STREET_RE =
+  /^\d+[\w.-]*\s+\w+|\b(street|st\.?|avenue|ave\.?|boulevard|blvd\.?|road|rd\.?|drive|dr\.?|lane|ln\.?|court|ct\.?|place|pl\.?|terrace|ter\.?|way|circle|cir\.?|highway|hwy\.?|suite|ste\.?|unit|apt\.?|#)\b/i;
+
+function parseBirthday(raw: string): string | undefined {
+  const s = raw.trim();
+  // ISO yyyy-mm-dd
+  let m = /^(\d{4})-(\d{1,2})-(\d{1,2})$/.exec(s);
+  if (m) return `${m[1]}-${pad(m[2])}-${pad(m[3])}`;
+  // mm/dd/yyyy or mm-dd-yyyy
+  m = /^(\d{1,2})[/\-.](\d{1,2})[/\-.](\d{2,4})$/.exec(s);
+  if (m) {
+    const yyyy = m[3].length === 2 ? `19${m[3]}` : m[3];
+    return `${yyyy}-${pad(m[1])}-${pad(m[2])}`;
+  }
+  // "Month D, YYYY" / "D Month YYYY"
+  const months = "jan feb mar apr may jun jul aug sep oct nov dec".split(" ");
+  const lower = s.toLowerCase();
+  for (let i = 0; i < 12; i++) {
+    if (lower.includes(months[i])) {
+      const dm = /(\d{1,2})/.exec(s);
+      const ym = /(\d{4})/.exec(s);
+      if (dm && ym) return `${ym[1]}-${pad(String(i + 1))}-${pad(dm[1])}`;
+    }
+  }
+  return undefined;
+}
+function pad(n: string | number): string {
+  return String(n).padStart(2, "0");
+}
+
+// ── main entry ──────────────────────────────────────────────────────────────
+export function parseContact(text: string): ParsedContact {
+  if (!text || !text.trim()) return empty();
+  if (/BEGIN:VCARD/i.test(text)) return parseVCard(text);
+  return parsePlain(text);
+}
+
+/** Add an email if not already present (case-insensitive). */
+function pushEmail(out: ParsedContact, email: string, label?: string) {
+  const norm = email.trim();
+  if (!norm) return;
+  if (out.emails.some((e) => e.email.toLowerCase() === norm.toLowerCase())) return;
+  out.emails.push(label ? { email: norm, label } : { email: norm });
+}
+function pushPhone(out: ParsedContact, phone: string, label?: string) {
+  const norm = phone.trim();
+  if (!norm) return;
+  const digits = norm.replace(/\D/g, "");
+  if (digits.length < 7) return;
+  if (out.phones.some((p) => p.phone.replace(/\D/g, "") === digits)) return;
+  out.phones.push(label ? { phone: norm, label } : { phone: norm });
+}
+function pushSocial(out: ParsedContact, social: ContactSocial | null) {
+  if (!social) return;
+  if (out.socials.some((s) => s.value.toLowerCase() === social.value.toLowerCase()))
+    return;
+  out.socials.push(social);
+}
+
+function parsePlain(text: string): ParsedContact {
+  const out = empty();
+  const rawLines = text
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0);
+
+  const nameCandidates: string[] = [];
+  const residual: string[] = []; // lines that may hold company / title / address
+  let pendingPhoneLabel: string | undefined;
+  let pendingEmailLabel: string | undefined;
+
+  for (let i = 0; i < rawLines.length; i++) {
+    const line = rawLines[i];
+
+    // Apple-style "label on its own line", value follows. A bare label like
+    // "work" can apply to either the next phone OR the next email, so set both
+    // pending hints and let the value's type pick the right one.
+    if (
+      !/[@\d]/.test(line) &&
+      line.length <= 12 &&
+      (STANDALONE_PHONE_LABEL.test(line) || STANDALONE_EMAIL_LABEL.test(line))
+    ) {
+      pendingPhoneLabel = phoneLabel(line);
+      pendingEmailLabel = emailLabel(line);
+      continue;
+    }
+
+    // Labeled "Key: value".
+    const kv = /^([A-Za-z][A-Za-z /]{1,28}?)\s*[:\t]\s*(.+)$/.exec(line);
+    let key: string | null = null;
+    let value = line;
+    if (kv) {
+      const normKey = resolveKey(kv[1].trim());
+      if (normKey) {
+        key = normKey;
+        value = kv[2].trim();
+      }
+    }
+
+    // Pull tokens out of the value (or whole line).
+    const emails = value.match(EMAIL_RE) ?? [];
+    const phones = value.match(PHONE_RE) ?? [];
+    let residualText = value;
+    for (const e of emails) residualText = residualText.replace(e, " ");
+    for (const p of phones) residualText = residualText.replace(p, " ");
+
+    // URLs / socials (run before residual classification so a bare domain
+    // doesn't get mistaken for a company name).
+    const urls = residualText.match(URL_RE) ?? [];
+    for (const u of urls) {
+      residualText = residualText.replace(u, " ");
+      pushSocial(out, classifySocial(u));
+    }
+    residualText = residualText.replace(/\s{2,}/g, " ").trim();
+
+    // Assign emails/phones with the best available label.
+    const lineLabelCtx = key ? key : line;
+    for (const e of emails) {
+      const lbl =
+        key && key.startsWith("email:")
+          ? key.slice(6)
+          : emailLabel(lineLabelCtx) ?? pendingEmailLabel;
+      pushEmail(out, e, lbl);
+    }
+    for (const p of phones) {
+      const lbl =
+        key && key.startsWith("phone:")
+          ? key.slice(6)
+          : phoneLabel(lineLabelCtx) ?? pendingPhoneLabel;
+      pushPhone(out, p, lbl);
+    }
+    // A standalone label hint applies to the very next value only — clear both
+    // once any token on this line has consumed them.
+    if (emails.length || phones.length) {
+      pendingEmailLabel = undefined;
+      pendingPhoneLabel = undefined;
+    }
+
+    // Explicit non-token fields.
+    if (key && !key.startsWith("email") && !key.startsWith("phone")) {
+      applyKeyed(out, key, residualText || value, nameCandidates);
+      continue;
+    }
+
+    if (!residualText) continue;
+
+    // City/State/ZIP → close out an address.
+    const csz = CITY_STATE_ZIP_RE.exec(residualText);
+    if (csz) {
+      const addr: ContactAddress =
+        out.addresses[out.addresses.length - 1] &&
+        !out.addresses[out.addresses.length - 1].city
+          ? out.addresses[out.addresses.length - 1]
+          : (() => {
+              const a: ContactAddress = {};
+              out.addresses.push(a);
+              return a;
+            })();
+      addr.city = csz[1].trim();
+      addr.state = csz[2].toUpperCase();
+      addr.postal = csz[3];
+      continue;
+    }
+    // Street line → start an address.
+    if (STREET_RE.test(residualText)) {
+      out.addresses.push({ line1: residualText });
+      continue;
+    }
+
+    if (looksLikeName(residualText)) nameCandidates.push(residualText);
+    else residual.push(residualText);
+  }
+
+  // ── name ──────────────────────────────────────────────────────────────────
+  if (!out.first_name && !out.last_name) {
+    const chosen = nameCandidates[0];
+    if (chosen) {
+      Object.assign(out, stripUndef(splitName(chosen)));
+      nameCandidates.shift();
+    }
+  }
+  // Any extra name-like lines that weren't the chosen name are likely noise
+  // (a duplicate or a colleague) — keep them visible.
+  out.unmatched.push(...nameCandidates);
+
+  // ── company / title from residual lines ────────────────────────────────────
+  for (const line of residual) {
+    if (!out.company && CORP_RE.test(line)) {
+      const split = splitTitleCompany(line);
+      if (split.title && !out.title) out.title = split.title;
+      out.company = split.company;
+    } else if (!out.title && TITLE_RE.test(line)) {
+      const split = splitTitleCompany(line);
+      out.title = split.title ?? line;
+      if (split.company && !out.company) out.company = split.company;
+    } else {
+      out.unmatched.push(line);
+    }
+  }
+
+  return out;
+}
+
+/** "VP of Sales, Acme Realty" / "VP of Sales | Acme Realty" → {title, company}. */
+function splitTitleCompany(line: string): { title?: string; company?: string } {
+  const parts = line.split(/\s*[,|·•–—]\s*/).filter(Boolean);
+  if (parts.length >= 2) {
+    const titlePart = parts.find((p) => TITLE_RE.test(p));
+    const companyPart = parts.find((p) => CORP_RE.test(p)) ?? parts.find((p) => p !== titlePart);
+    return {
+      title: titlePart?.trim(),
+      company: companyPart && companyPart !== titlePart ? companyPart.trim() : undefined,
+    };
+  }
+  if (CORP_RE.test(line)) return { company: line.trim() };
+  if (TITLE_RE.test(line)) return { title: line.trim() };
+  return {};
+}
+
+function resolveKey(raw: string): string | null {
+  const k = raw.trim();
+  for (const [re, norm] of FIELD_KEYS) if (re.test(k)) return norm;
+  return null;
+}
+
+function applyKeyed(
+  out: ParsedContact,
+  key: string,
+  value: string,
+  nameCandidates: string[],
+) {
+  const v = value.trim();
+  if (!v) return;
+  switch (key) {
+    case "name":
+      if (!out.first_name && !out.last_name) {
+        Object.assign(out, stripUndef(splitName(v)));
+      } else nameCandidates.push(v);
+      break;
+    case "first":
+      out.first_name = v;
+      break;
+    case "last":
+      out.last_name = v;
+      break;
+    case "nickname":
+      out.nickname = v;
+      break;
+    case "company":
+      out.company = v;
+      break;
+    case "title":
+      out.title = v;
+      break;
+    case "address":
+      if (STREET_RE.test(v) || /\d/.test(v)) out.addresses.push({ line1: v });
+      else out.unmatched.push(v);
+      break;
+    case "birthday": {
+      const bday = parseBirthday(v);
+      if (bday) out.birthday = bday;
+      else out.unmatched.push(value);
+      break;
+    }
+    case "website":
+      pushSocial(out, { kind: "website", value: v });
+      break;
+    case "linkedin":
+      pushSocial(out, { kind: "linkedin", value: v });
+      break;
+    case "instagram":
+      pushSocial(out, { kind: "instagram", value: v.replace(/^@/, "") });
+      break;
+    case "x":
+      pushSocial(out, { kind: "x", value: v.replace(/^@/, "") });
+      break;
+    case "facebook":
+      pushSocial(out, { kind: "facebook", value: v });
+      break;
+    case "notes":
+      out.notes = out.notes ? `${out.notes}\n${v}` : v;
+      break;
+    default:
+      out.unmatched.push(value);
+  }
+}
+
+function stripUndef<T extends Record<string, unknown>>(o: T): Partial<T> {
+  const r: Partial<T> = {};
+  for (const k in o) if (o[k] !== undefined && o[k] !== "") r[k] = o[k];
+  return r;
+}
+
+// ── vCard ───────────────────────────────────────────────────────────────────
+function parseVCard(text: string): ParsedContact {
+  const out = empty();
+  // Unfold continued lines (RFC 6350: a leading space/tab continues the prior).
+  const unfolded = text.replace(/\r?\n[ \t]/g, "");
+  for (const rawLine of unfolded.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || /^(BEGIN|END|VERSION):/i.test(line)) continue;
+    const colon = line.indexOf(":");
+    if (colon < 0) continue;
+    const spec = line.slice(0, colon);
+    const value = line.slice(colon + 1).trim();
+    const [name, ...paramParts] = spec.split(";");
+    const params = paramParts.join(";").toLowerCase();
+    const upper = name.toUpperCase();
+
+    switch (upper) {
+      case "N": {
+        // N:Last;First;Middle;Prefix;Suffix
+        const [last, first, middle, prefix, suffix] = value.split(";");
+        if (first) out.first_name = vunesc(first);
+        if (last) out.last_name = vunesc(last);
+        if (middle) out.middle_name = vunesc(middle);
+        if (prefix) out.prefix = vunesc(prefix);
+        if (suffix) out.suffix = vunesc(suffix);
+        break;
+      }
+      case "FN":
+        if (!out.first_name && !out.last_name)
+          Object.assign(out, stripUndef(splitName(vunesc(value))));
+        break;
+      case "NICKNAME":
+        out.nickname = vunesc(value);
+        break;
+      case "ORG":
+        out.company = vunesc(value.split(";")[0]);
+        break;
+      case "TITLE":
+        out.title = vunesc(value);
+        break;
+      case "EMAIL":
+        pushEmail(out, vunesc(value), vcardLabel(params, EMAIL_LABEL_WORDS));
+        break;
+      case "TEL":
+        pushPhone(out, vunesc(value), vcardLabel(params, PHONE_LABEL_WORDS));
+        break;
+      case "BDAY": {
+        const bday = parseBirthday(value);
+        if (bday) out.birthday = bday;
+        break;
+      }
+      case "URL":
+        pushSocial(out, classifySocial(value) ?? { kind: "website", value });
+        break;
+      case "ADR": {
+        // ADR:;;street;city;state;postal;country
+        const parts = value.split(";").map(vunesc);
+        const addr: ContactAddress = {};
+        if (parts[2]) addr.line1 = parts[2];
+        if (parts[3]) addr.city = parts[3];
+        if (parts[4]) addr.state = parts[4];
+        if (parts[5]) addr.postal = parts[5];
+        if (parts[6]) addr.country = parts[6];
+        const label = /home/.test(params) ? "home" : /work/.test(params) ? "business" : undefined;
+        if (label) addr.label = label;
+        if (Object.keys(addr).length) out.addresses.push(addr);
+        break;
+      }
+      case "NOTE":
+        out.notes = vunesc(value);
+        break;
+      default:
+        break;
+    }
+  }
+  return out;
+}
+
+function vunesc(s: string): string {
+  return s.replace(/\\n/gi, " ").replace(/\\,/g, ",").replace(/\\;/g, ";").replace(/\\\\/g, "\\").trim();
+}
+function vcardLabel(params: string, words: Array<[RegExp, string]>): string | undefined {
+  for (const [re, label] of words) if (re.test(params)) return label;
+  return undefined;
+}

--- a/apps/web/src/modules/contacts/components/ContactForm.tsx
+++ b/apps/web/src/modules/contacts/components/ContactForm.tsx
@@ -10,6 +10,13 @@ import type {
   ContactFamilyMember,
 } from "@/lib/contacts/db";
 import { parseContact, type ParsedContact } from "@/lib/contacts/parse";
+import {
+  mergeEmails,
+  mergePhones,
+  mergeAddresses,
+  mergeSocials,
+  parseSummary,
+} from "@/lib/contacts/merge";
 import { uploadAvatar } from "../lib/client-api";
 
 const PRESET_TYPES = [
@@ -158,7 +165,11 @@ export function ContactForm({
       next.phones = mergePhones(prev.phones, p.phones);
       next.addresses = mergeAddresses(prev.addresses, p.addresses);
       next.socials = mergeSocials(prev.socials, p.socials);
-      if (p.notes) next.notes = prev.notes ? `${prev.notes}\n${p.notes}` : p.notes;
+      // Append notes, but idempotently — re-running a paste (or clicking "Fill
+      // fields" twice) must not duplicate the same note text.
+      if (p.notes && !(prev.notes ?? "").includes(p.notes)) {
+        next.notes = prev.notes ? `${prev.notes}\n${p.notes}` : p.notes;
+      }
       return next;
     });
   }
@@ -686,74 +697,6 @@ export function ContactForm({
   );
 }
 
-// ── smart-paste merge helpers ────────────────────────────────────────────────
-function mergeEmails(existing: EmailRow[], incoming: ParsedContact["emails"]): EmailRow[] {
-  const real = existing.filter((e) => e.email.trim());
-  const seen = new Set(real.map((e) => e.email.trim().toLowerCase()));
-  for (const e of incoming) {
-    const key = e.email.trim().toLowerCase();
-    if (key && !seen.has(key)) {
-      seen.add(key);
-      real.push({ label: e.label ?? "", email: e.email });
-    }
-  }
-  return real.length ? real : [{ label: "", email: "" }];
-}
-function mergePhones(existing: PhoneRow[], incoming: ParsedContact["phones"]): PhoneRow[] {
-  const digits = (s: string) => s.replace(/\D/g, "");
-  const real = existing.filter((p) => p.phone.trim());
-  const seen = new Set(real.map((p) => digits(p.phone)));
-  for (const p of incoming) {
-    const key = digits(p.phone);
-    if (key && !seen.has(key)) {
-      seen.add(key);
-      real.push({ label: p.label ?? "", phone: p.phone });
-    }
-  }
-  return real.length ? real : [{ label: "", phone: "" }];
-}
-function addrKey(a: ContactAddress): string {
-  return [a.line1, a.city, a.state, a.postal].map((s) => (s ?? "").trim().toLowerCase()).join("|");
-}
-function mergeAddresses(existing: ContactAddress[], incoming: ContactAddress[]): ContactAddress[] {
-  const seen = new Set(existing.map(addrKey));
-  const out = [...existing];
-  for (const a of incoming) {
-    const key = addrKey(a);
-    if (key !== "|||" && !seen.has(key)) {
-      seen.add(key);
-      out.push(a);
-    }
-  }
-  return out;
-}
-function mergeSocials(existing: ContactSocial[], incoming: ContactSocial[]): ContactSocial[] {
-  const seen = new Set(existing.map((s) => s.value.trim().toLowerCase()));
-  const out = [...existing];
-  for (const s of incoming) {
-    const key = s.value.trim().toLowerCase();
-    if (key && !seen.has(key)) {
-      seen.add(key);
-      out.push(s);
-    }
-  }
-  return out;
-}
-
-/** Human summary of what a parse filled, e.g. "name · 2 emails · 1 phone". */
-function parseSummary(p: ParsedContact): string {
-  const bits: string[] = [];
-  if (p.first_name || p.last_name) bits.push("name");
-  if (p.company) bits.push("company");
-  if (p.title) bits.push("title");
-  if (p.emails.length) bits.push(`${p.emails.length} email${p.emails.length > 1 ? "s" : ""}`);
-  if (p.phones.length) bits.push(`${p.phones.length} phone${p.phones.length > 1 ? "s" : ""}`);
-  if (p.addresses.length) bits.push(`${p.addresses.length} address${p.addresses.length > 1 ? "es" : ""}`);
-  if (p.socials.length) bits.push(`${p.socials.length} link${p.socials.length > 1 ? "s" : ""}`);
-  if (p.birthday) bits.push("birthday");
-  return bits.join(" · ");
-}
-
 /**
  * Paste/drop a contact blob (email signature, vCard, Apple contact-card copy,
  * or labeled lines) → it's parsed deterministically (no LLM) and the fields
@@ -824,10 +767,13 @@ function SmartPasteBox({ onParsed }: { onParsed: (p: ParsedContact) => void }) {
         }}
         onDragLeave={() => setDragOver(false)}
         onDrop={(e) => {
+          // Always preventDefault: otherwise a file (or non-text) dropped on
+          // this large top-of-form target makes the browser navigate to it and
+          // discards the unsaved form.
+          e.preventDefault();
+          setDragOver(false);
           const dropped = e.dataTransfer.getData("text");
           if (dropped.trim()) {
-            e.preventDefault();
-            setDragOver(false);
             setText(dropped);
             run(dropped);
           }

--- a/apps/web/src/modules/contacts/components/ContactForm.tsx
+++ b/apps/web/src/modules/contacts/components/ContactForm.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRef, useState } from "react";
-import { Plus, X, Upload, Loader2 } from "lucide-react";
+import { Plus, X, Upload, Loader2, ClipboardPaste } from "lucide-react";
 import { Button } from "@/components/ui/Button";
 import type {
   ContactRow,
@@ -9,6 +9,7 @@ import type {
   ContactSocial,
   ContactFamilyMember,
 } from "@/lib/contacts/db";
+import { parseContact, type ParsedContact } from "@/lib/contacts/parse";
 import { uploadAvatar } from "../lib/client-api";
 
 const PRESET_TYPES = [
@@ -131,6 +132,37 @@ export function ContactForm({
     setV((prev) => ({ ...prev, [k]: val }));
   }
 
+  /**
+   * Merge a parsed contact blob into the form. Scalars only fill when empty
+   * (never clobber what the user typed); multi-value rows are appended +
+   * deduped against existing entries.
+   */
+  function applyParsed(p: ParsedContact) {
+    setV((prev) => {
+      const next = { ...prev };
+      const fillScalar = (k: keyof FormState, val: string | undefined) => {
+        if (val && !String(prev[k] ?? "").trim()) {
+          (next as Record<string, unknown>)[k] = val;
+        }
+      };
+      fillScalar("prefix", p.prefix);
+      fillScalar("first_name", p.first_name);
+      fillScalar("middle_name", p.middle_name);
+      fillScalar("last_name", p.last_name);
+      fillScalar("suffix", p.suffix);
+      fillScalar("nickname", p.nickname);
+      fillScalar("company", p.company);
+      fillScalar("title", p.title);
+      fillScalar("birthday", p.birthday);
+      next.emails = mergeEmails(prev.emails, p.emails);
+      next.phones = mergePhones(prev.phones, p.phones);
+      next.addresses = mergeAddresses(prev.addresses, p.addresses);
+      next.socials = mergeSocials(prev.socials, p.socials);
+      if (p.notes) next.notes = prev.notes ? `${prev.notes}\n${p.notes}` : p.notes;
+      return next;
+    });
+  }
+
   // ── avatar ────────────────────────────────────────────────────────
   async function handleFile(file: File | undefined | null) {
     if (!file) return;
@@ -245,6 +277,9 @@ export function ContactForm({
 
   return (
     <div className="flex flex-col gap-4">
+      {/* Smart paste — drop/paste a blob, fields auto-fill (no LLM) */}
+      <SmartPasteBox onParsed={applyParsed} />
+
       {/* Avatar + identity */}
       <div className="flex gap-3">
         <div
@@ -647,6 +682,188 @@ export function ContactForm({
           {busy ? "Saving…" : submitLabel}
         </Button>
       </div>
+    </div>
+  );
+}
+
+// ── smart-paste merge helpers ────────────────────────────────────────────────
+function mergeEmails(existing: EmailRow[], incoming: ParsedContact["emails"]): EmailRow[] {
+  const real = existing.filter((e) => e.email.trim());
+  const seen = new Set(real.map((e) => e.email.trim().toLowerCase()));
+  for (const e of incoming) {
+    const key = e.email.trim().toLowerCase();
+    if (key && !seen.has(key)) {
+      seen.add(key);
+      real.push({ label: e.label ?? "", email: e.email });
+    }
+  }
+  return real.length ? real : [{ label: "", email: "" }];
+}
+function mergePhones(existing: PhoneRow[], incoming: ParsedContact["phones"]): PhoneRow[] {
+  const digits = (s: string) => s.replace(/\D/g, "");
+  const real = existing.filter((p) => p.phone.trim());
+  const seen = new Set(real.map((p) => digits(p.phone)));
+  for (const p of incoming) {
+    const key = digits(p.phone);
+    if (key && !seen.has(key)) {
+      seen.add(key);
+      real.push({ label: p.label ?? "", phone: p.phone });
+    }
+  }
+  return real.length ? real : [{ label: "", phone: "" }];
+}
+function addrKey(a: ContactAddress): string {
+  return [a.line1, a.city, a.state, a.postal].map((s) => (s ?? "").trim().toLowerCase()).join("|");
+}
+function mergeAddresses(existing: ContactAddress[], incoming: ContactAddress[]): ContactAddress[] {
+  const seen = new Set(existing.map(addrKey));
+  const out = [...existing];
+  for (const a of incoming) {
+    const key = addrKey(a);
+    if (key !== "|||" && !seen.has(key)) {
+      seen.add(key);
+      out.push(a);
+    }
+  }
+  return out;
+}
+function mergeSocials(existing: ContactSocial[], incoming: ContactSocial[]): ContactSocial[] {
+  const seen = new Set(existing.map((s) => s.value.trim().toLowerCase()));
+  const out = [...existing];
+  for (const s of incoming) {
+    const key = s.value.trim().toLowerCase();
+    if (key && !seen.has(key)) {
+      seen.add(key);
+      out.push(s);
+    }
+  }
+  return out;
+}
+
+/** Human summary of what a parse filled, e.g. "name · 2 emails · 1 phone". */
+function parseSummary(p: ParsedContact): string {
+  const bits: string[] = [];
+  if (p.first_name || p.last_name) bits.push("name");
+  if (p.company) bits.push("company");
+  if (p.title) bits.push("title");
+  if (p.emails.length) bits.push(`${p.emails.length} email${p.emails.length > 1 ? "s" : ""}`);
+  if (p.phones.length) bits.push(`${p.phones.length} phone${p.phones.length > 1 ? "s" : ""}`);
+  if (p.addresses.length) bits.push(`${p.addresses.length} address${p.addresses.length > 1 ? "es" : ""}`);
+  if (p.socials.length) bits.push(`${p.socials.length} link${p.socials.length > 1 ? "s" : ""}`);
+  if (p.birthday) bits.push("birthday");
+  return bits.join(" · ");
+}
+
+/**
+ * Paste/drop a contact blob (email signature, vCard, Apple contact-card copy,
+ * or labeled lines) → it's parsed deterministically (no LLM) and the fields
+ * below are auto-filled. Parses on paste/drop; a button covers typed/edited text.
+ */
+function SmartPasteBox({ onParsed }: { onParsed: (p: ParsedContact) => void }) {
+  const [open, setOpen] = useState(false);
+  const [text, setText] = useState("");
+  const [dragOver, setDragOver] = useState(false);
+  const [result, setResult] = useState<{ summary: string; unmatched: string[] } | null>(null);
+
+  function run(raw: string) {
+    const trimmed = raw.trim();
+    if (!trimmed) return;
+    const parsed = parseContact(trimmed);
+    const summary = parseSummary(parsed);
+    setResult({ summary: summary || "nothing recognized", unmatched: parsed.unmatched });
+    if (summary) onParsed(parsed);
+  }
+
+  if (!open) {
+    return (
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="flex items-center gap-1.5 self-start rounded border border-dashed border-border px-2 py-1 text-2xs font-medium text-text-2 hover:border-border-focus hover:text-text-0"
+      >
+        <ClipboardPaste className="h-3 w-3" /> Paste contact info to auto-fill
+      </button>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-1.5 rounded border border-border bg-bg-2 p-2">
+      <div className="flex items-center gap-1.5">
+        <ClipboardPaste className="h-3 w-3 text-text-3" />
+        <span className="text-[10px] font-semibold uppercase tracking-wide text-text-3">
+          Smart paste
+        </span>
+        <button
+          type="button"
+          onClick={() => {
+            setOpen(false);
+            setText("");
+            setResult(null);
+          }}
+          aria-label="Close smart paste"
+          className="ml-auto rounded-sm p-0.5 text-text-3 hover:text-text-0"
+        >
+          <X className="h-3 w-3" />
+        </button>
+      </div>
+      <textarea
+        autoFocus
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        onPaste={(e) => {
+          const pasted = e.clipboardData.getData("text");
+          if (pasted.trim()) {
+            e.preventDefault();
+            setText(pasted);
+            run(pasted);
+          }
+        }}
+        onDragOver={(e) => {
+          e.preventDefault();
+          setDragOver(true);
+        }}
+        onDragLeave={() => setDragOver(false)}
+        onDrop={(e) => {
+          const dropped = e.dataTransfer.getData("text");
+          if (dropped.trim()) {
+            e.preventDefault();
+            setDragOver(false);
+            setText(dropped);
+            run(dropped);
+          }
+        }}
+        placeholder="Paste or drag a contact — an email signature, a vCard, or a copied contact card. Fields fill automatically."
+        className={`min-h-[68px] w-full resize-y rounded border bg-bg-1 px-2 py-1 text-xs text-text-1 placeholder:text-text-3 outline-none ${
+          dragOver ? "border-accent" : "border-border focus:border-border-focus"
+        }`}
+      />
+      <div className="flex items-center gap-2">
+        <Button size="sm" variant="ghost" onClick={() => run(text)} disabled={!text.trim()}>
+          Fill fields
+        </Button>
+        {text && (
+          <button
+            type="button"
+            onClick={() => {
+              setText("");
+              setResult(null);
+            }}
+            className="text-2xs text-text-3 hover:text-text-1"
+          >
+            Clear
+          </button>
+        )}
+        {result?.summary && (
+          <span className="ml-auto truncate text-2xs text-text-2">
+            Filled: {result.summary}
+          </span>
+        )}
+      </div>
+      {result && result.unmatched.length > 0 && (
+        <p className="text-2xs text-text-3">
+          Couldn&apos;t place: {result.unmatched.join(" · ")}
+        </p>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## What

Paste or drag a contact into a new **Smart paste** box at the top of the create/edit contact form and the fields fill themselves. Parsing is **fully deterministic — regex + heuristics, no LLM, no network.**

Handles the formats a contact actually arrives in:
- **Email signatures** — `Name / Title, Company / email / Mobile: … / Office: … / website`
- **vCard (.vcf)** — `BEGIN:VCARD` with structured `N`/`FN`/`ORG`/`TITLE`/`EMAIL;TYPE=`/`TEL;TYPE=`/`ADR`/`BDAY`/`URL`
- **Apple/Google contact-card copy** — label on its own line (`mobile` ⏎ `(305) 555-1234`)
- **Labeled lines** — `Name:`, `Company:`, `Work Phone:`, `Birthday:`, `Address:`, `LinkedIn:` …

## How it behaves
- Parses on **paste** and on **drag-drop** of text (plus a "Fill fields" button for typed/edited text).
- **Never clobbers** what you typed: scalar fields fill only when empty; emails/phones/addresses/socials are appended and **deduped**.
- Labels are inferred (mobile / work / home; work / personal email).
- Anything it can't confidently classify is shown as **"Couldn't place: …"** rather than guessed into the wrong field.

## Files
- `lib/contacts/parse.ts` — `parseContact()` + `splitName()` (pure, no I/O)
- `lib/contacts/parse.test.ts` — 32 unit tests
- `modules/contacts/components/ContactForm.tsx` — `SmartPasteBox` + `applyParsed` merge

## Tests
- `vitest run src/lib/contacts/` → **47 passed**
- `tsc --noEmit` clean · `eslint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)