### PR TITLE
fix(messages): video poster frame + auto-loop GIFs (no more black box)

### DIFF
--- a/apps/web/src/components/messages/ChatThread.tsx
+++ b/apps/web/src/components/messages/ChatThread.tsx
@@ -15,6 +15,7 @@ import {
   AlertCircle,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { VideoAttachment } from "./VideoAttachment";
 
 /**
  * Shared chat rendering used by BOTH the dashboard Messages card
@@ -202,12 +203,11 @@ export function ChatMessageList({
                       ) : null}
                       {vids.map((a, k) =>
                         a.url ? (
-                          <video
+                          <VideoAttachment
                             key={`v${k}`}
-                            src={a.url}
-                            controls
-                            playsInline
-                            preload="metadata"
+                            url={a.url}
+                            contentType={a.content_type}
+                            filename={a.filename}
                             className="block max-h-60 max-w-[260px] rounded-[5px] bg-black"
                           />
                         ) : null,

--- a/apps/web/src/components/messages/SignalThreadView.tsx
+++ b/apps/web/src/components/messages/SignalThreadView.tsx
@@ -23,6 +23,7 @@ import {
   composerKeyDown,
 } from "./composer-utils";
 import { ChatMessageList, formatBytes } from "./ChatThread";
+import { VideoAttachment } from "./VideoAttachment";
 import { Lightbox } from "./Lightbox";
 
 type SignalStatus = "sending" | "sent" | "delivered" | "read" | "failed";
@@ -646,12 +647,11 @@ function MediaGallery({
               <div className="grid grid-cols-2 gap-1.5">
                 {videos.map((x, i) =>
                   x.att.url ? (
-                    <video
+                    <VideoAttachment
                       key={x.att.url ?? x.att.filename ?? i}
-                      src={x.att.url}
-                      controls
-                      playsInline
-                      preload="metadata"
+                      url={x.att.url}
+                      contentType={x.att.content_type}
+                      filename={x.att.filename}
                       className="aspect-video w-full rounded-sm bg-black object-cover"
                     />
                   ) : null,

--- a/apps/web/src/components/messages/VideoAttachment.test.tsx
+++ b/apps/web/src/components/messages/VideoAttachment.test.tsx
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { posterSrc, isGifLike, VideoAttachment } from "./VideoAttachment";
+
+describe("posterSrc", () => {
+  it("appends #t=0.1 so the first frame paints as a poster", () => {
+    expect(posterSrc("https://x/v.mp4")).toBe("https://x/v.mp4#t=0.1");
+  });
+  it("preserves a signed-URL query string (fragment is client-only)", () => {
+    expect(posterSrc("https://x/v.mp4?token=abc")).toBe(
+      "https://x/v.mp4?token=abc#t=0.1",
+    );
+  });
+  it("does not double-append when a fragment already exists", () => {
+    expect(posterSrc("https://x/v.mp4#t=5")).toBe("https://x/v.mp4#t=5");
+  });
+});
+
+describe("isGifLike", () => {
+  it("true for image/gif and video/gif content types", () => {
+    expect(isGifLike("image/gif", "a.mp4")).toBe(true);
+    expect(isGifLike("video/gif", null)).toBe(true);
+  });
+  it("true for a .gif filename even under a video content type", () => {
+    expect(isGifLike("video/mp4", "funny.gif")).toBe(true);
+  });
+  it("false for a normal video", () => {
+    expect(isGifLike("video/mp4", "clip.mp4")).toBe(false);
+    expect(isGifLike(null, null)).toBe(false);
+  });
+});
+
+describe("VideoAttachment", () => {
+  it("auto-loops a GIF (muted, looping, no controls)", () => {
+    const { container } = render(
+      <VideoAttachment url="https://x/g.mp4" contentType="video/mp4" filename="a.gif" />,
+    );
+    const v = container.querySelector("video") as HTMLVideoElement;
+    expect(v.loop).toBe(true);
+    expect(v.muted).toBe(true);
+    expect(v.autoplay).toBe(true);
+    expect(v.controls).toBe(false);
+    expect(v.getAttribute("src")).toContain("#t=0.1");
+  });
+  it("a normal video gets controls + a poster frame", () => {
+    const { container } = render(
+      <VideoAttachment url="https://x/v.mp4" contentType="video/mp4" filename="clip.mp4" />,
+    );
+    const v = container.querySelector("video") as HTMLVideoElement;
+    expect(v.controls).toBe(true);
+    expect(v.loop).toBe(false);
+    expect(v.getAttribute("src")).toBe("https://x/v.mp4#t=0.1");
+  });
+});

--- a/apps/web/src/components/messages/VideoAttachment.tsx
+++ b/apps/web/src/components/messages/VideoAttachment.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+/**
+ * Inline video/GIF renderer shared by the chat bubble (ChatThread) and the media
+ * gallery (SignalThreadView).
+ *
+ * Two problems this fixes:
+ *   1. A plain <video> shows a BLACK box until the user hits play — it looks
+ *      broken / "not loading". Appending the `#t=0.1` media fragment tells the
+ *      browser to seek to 0.1s on load (with preload="metadata") and paint that
+ *      frame as the poster, so the first frame shows immediately.
+ *   2. GIFs sent through Signal arrive as muted looping video (or image/gif).
+ *      A GIF should animate on its own, not sit behind a play button — so when
+ *      we can tell it's a GIF we autoplay it muted + looping with no controls.
+ *
+ * Signal (via signal-cli) does not expose the protocol GIF flag, so a GIF that
+ * arrives as `video/mp4` with no `.gif` name can't be detected here — it falls
+ * back to the poster-frame + controls path (first frame + one tap to play),
+ * which is still correct, just not auto-looping.
+ */
+
+/** Add the `#t=0.1` fragment so the browser paints the first frame as a poster.
+ *  Fragments are client-only, so this never touches a signed-URL query string. */
+export function posterSrc(url: string): string {
+  return url.includes("#") ? url : `${url}#t=0.1`;
+}
+
+/** Whether an attachment should be treated as an animated GIF (auto-loop). */
+export function isGifLike(
+  contentType: string | null | undefined,
+  filename: string | null | undefined,
+): boolean {
+  const ct = (contentType ?? "").toLowerCase();
+  const fn = (filename ?? "").toLowerCase();
+  return ct === "image/gif" || ct === "video/gif" || fn.endsWith(".gif");
+}
+
+export function VideoAttachment({
+  url,
+  contentType,
+  filename,
+  className,
+}: {
+  url: string;
+  contentType: string | null | undefined;
+  filename: string | null | undefined;
+  className?: string;
+}) {
+  if (isGifLike(contentType, filename)) {
+    return (
+      <span className="relative block">
+        {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
+        <video
+          src={posterSrc(url)}
+          autoPlay
+          loop
+          muted
+          playsInline
+          preload="metadata"
+          aria-label={filename ?? "GIF"}
+          className={className}
+        />
+        <span className="pointer-events-none absolute bottom-1 left-1 rounded bg-black/55 px-1 py-px text-[9px] font-semibold uppercase tracking-wide text-white">
+          GIF
+        </span>
+      </span>
+    );
+  }
+  return (
+    // eslint-disable-next-line jsx-a11y/media-has-caption
+    <video
+      src={posterSrc(url)}
+      controls
+      playsInline
+      preload="metadata"
+      aria-label={filename ?? "video"}
+      className={className}
+    />
+  );
+}


### PR DESCRIPTION
## Problem
Videos in Messenger rendered as a **black box stuck at 0:00** (looked like "not loading"), and a **GIF someone sent didn't animate** — because Signal delivers GIFs as muted looping *video*, which sat behind a play button.

## Fix
New shared **`VideoAttachment`** component used by both the chat bubble and the media gallery:
- **Poster frame** — appends the `#t=0.1` media fragment so the browser paints the first frame instead of a black box (loads via `preload="metadata"`). Fragments are client-only, so signed-URL query strings are untouched.
- **Auto-loop GIFs** — `image/gif` / `video/gif` / `.gif` attachments autoplay muted + looping with no controls, like a real GIF (with a GIF badge).

## Known limitation
`signal-cli` doesn't expose Signal's protocol GIF flag, so a GIF that arrives as `video/mp4` with no `.gif` filename can't be identified — it falls back to poster-frame + tap-to-play (correct, just not auto-looping). Carrying that flag through the Fly bridge is a possible follow-up if you want *every* Signal GIF to auto-animate.

## Tests
- `VideoAttachment.test.tsx` — 8 tests (poster fragment, GIF detection, GIF auto-loop attrs, normal-video controls+poster).
- Full `src/components/messages/` suite → 47 passed · `tsc` + `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)