### PR TITLE
feat(pipeline): board search, value rollup, card aging, drop hint (batch 2)

### DIFF
--- a/apps/web/src/lib/pipeline/board.test.ts
+++ b/apps/web/src/lib/pipeline/board.test.ts
@@ -7,6 +7,8 @@ import {
   rollupField,
   sumAttr,
   compactMoney,
+  daysSince,
+  leadHaystack,
 } from "./board";
 import { HELIOS_PIPELINE } from "./templates";
 import type { LeadRow, PipelineField } from "./db";
@@ -143,5 +145,33 @@ describe("compactMoney", () => {
   it("is empty for zero / non-finite", () => {
     expect(compactMoney(0)).toBe("");
     expect(compactMoney(NaN)).toBe("");
+  });
+});
+
+describe("daysSince", () => {
+  const now = Date.parse("2026-06-30T12:00:00Z");
+  it("floors whole days", () => {
+    expect(daysSince("2026-06-27T12:00:00Z", now)).toBe(3);
+    expect(daysSince("2026-06-30T00:00:00Z", now)).toBe(0);
+  });
+  it("never negative; 0 for null/invalid", () => {
+    expect(daysSince("2026-07-05T00:00:00Z", now)).toBe(0);
+    expect(daysSince(null, now)).toBe(0);
+    expect(daysSince("nonsense", now)).toBe(0);
+  });
+});
+
+describe("leadHaystack", () => {
+  it("includes name, subtitle, source and nested attribute values", () => {
+    const h = leadHaystack({
+      name: "Grove Palms",
+      subtitle: "3051 SW 27 Ave",
+      source: "Referral",
+      attributes: { parcels: [{ address: "3052 SW 27 Ave" }], asking: 1200000 },
+    });
+    expect(h).toContain("grove palms");
+    expect(h).toContain("3051 sw 27");
+    expect(h).toContain("referral");
+    expect(h).toContain("3052 sw 27"); // nested parcel address
   });
 });

--- a/apps/web/src/lib/pipeline/board.ts
+++ b/apps/web/src/lib/pipeline/board.ts
@@ -43,6 +43,28 @@ export function compactMoney(n: number): string {
   return `$${Math.round(n)}`;
 }
 
+/** Whole days between an ISO timestamp and `nowMs` (floored, never negative). */
+export function daysSince(iso: string | null | undefined, nowMs: number): number {
+  if (!iso) return 0;
+  const t = Date.parse(iso);
+  if (Number.isNaN(t)) return 0;
+  return Math.max(0, Math.floor((nowMs - t) / 86_400_000));
+}
+
+/** Lower-cased searchable text for a lead — name, subtitle, source + every
+ *  attribute value (JSON so nested parcels/addresses are covered too). */
+export function leadHaystack(
+  lead: Pick<LeadRow, "name" | "subtitle" | "source" | "attributes">,
+): string {
+  let attrs = "";
+  try {
+    attrs = JSON.stringify(lead.attributes ?? {});
+  } catch {
+    attrs = "";
+  }
+  return `${lead.name} ${lead.subtitle ?? ""} ${lead.source ?? ""} ${attrs}`.toLowerCase();
+}
+
 export interface StageColumn {
   stage: PipelineStage;
   leads: LeadRow[];

--- a/apps/web/src/modules/pipeline/components/LeadCard.tsx
+++ b/apps/web/src/modules/pipeline/components/LeadCard.tsx
@@ -7,6 +7,7 @@ import {
   isRotting,
   isFollowUpDue,
   compactMoney,
+  daysSince,
   CARD_FIELD_CAP,
 } from "@/lib/pipeline/board";
 
@@ -60,6 +61,11 @@ export function LeadCard({
   const converted = lead.status === "converted";
   const parcels = parcelCount(lead);
   const notes = hasNotes(lead);
+  // Days since last activity — a lightweight "aging" cue on every card. Hidden
+  // when the lead is already flagged Cold (that flame says the same thing) or
+  // when it's fresh (< 1 day).
+  const age = daysSince(lead.last_activity_at, nowMs);
+  const showAge = age >= 1 && !rotting;
   const [dragging, setDragging] = useState(false);
 
   // Up to CARD_FIELD_CAP non-empty card fields, formatted. Keyed by the field's
@@ -118,11 +124,19 @@ export function LeadCard({
           ))}
         </div>
       )}
-      {(lead.source || due || rotting || parcels > 1 || notes) && (
+      {(lead.source || due || rotting || parcels > 1 || notes || showAge) && (
         <div className="flex flex-wrap items-center gap-1">
           {lead.source && (
             <span className="rounded-sm bg-bg-3 px-1 py-px text-[9px] uppercase tracking-wide text-text-3">
               {lead.source}
+            </span>
+          )}
+          {showAge && (
+            <span
+              className="flex items-center gap-0.5 text-[9px] text-text-3"
+              title={`${age} day${age === 1 ? "" : "s"} since last activity`}
+            >
+              <Clock className="h-2.5 w-2.5" /> {age}d
             </span>
           )}
           {parcels > 1 && (

--- a/apps/web/src/modules/pipeline/components/PipelineBoard.tsx
+++ b/apps/web/src/modules/pipeline/components/PipelineBoard.tsx
@@ -13,6 +13,7 @@ import {
   ChevronRight,
   ChevronsLeftRight,
   ChevronsRightLeft,
+  Search,
 } from "lucide-react";
 import { Button } from "@/components/ui/Button";
 import type { LeadRow, PipelineRow } from "@/lib/pipeline/db";
@@ -23,6 +24,7 @@ import {
   rollupField,
   sumAttr,
   compactMoney,
+  leadHaystack,
 } from "@/lib/pipeline/board";
 import { PipelineList } from "./PipelineList";
 import { CustomizePanel } from "./CustomizePanel";
@@ -51,6 +53,7 @@ export function PipelineBoard() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [attentionOnly, setAttentionOnly] = useState(false);
+  const [query, setQuery] = useState("");
   const [view, setView] = useState<"board" | "list">("board");
   // One "now" for the whole tree, ticking each minute so "cold" / "follow-up
   // due" refresh on their own without a reload.
@@ -237,10 +240,19 @@ export function PipelineBoard() {
     if (isFollowUpDue(l, nowMs)) fuCount++;
     if (isRotting(l, stages, nowMs)) coldCount++;
   }
-  const visibleLeads = attentionOnly ? activeLeads.filter(needsAttention) : activeLeads;
+  const q = query.trim().toLowerCase();
+  const queriedActive = q
+    ? activeLeads.filter((l) => leadHaystack(l).includes(q))
+    : activeLeads;
+  const visibleLeads = attentionOnly
+    ? queriedActive.filter(needsAttention)
+    : queriedActive;
   const { columns, orphans } = groupByStage(visibleLeads, stages);
   const rollup = pipeline ? rollupField(pipeline.fields) : null;
   const cardFields = pipeline ? pipeline.fields.filter((f) => f.card) : [];
+  const boardValue = rollup ? sumAttr(visibleLeads, rollup.key) : 0;
+  // The list view honors the same search box (attention-focus is board-only).
+  const listLeads = q ? leads.filter((l) => leadHaystack(l).includes(q)) : leads;
   const allCollapsed =
     columns.length > 0 && columns.every((c) => collapsed.has(c.stage.key));
 
@@ -267,6 +279,36 @@ export function PipelineBoard() {
           </span>
         )}
         <span className="font-mono text-2xs text-text-3">{visibleLeads.length}</span>
+        {boardValue > 0 ? (
+          <span
+            className="font-mono text-2xs text-text-2"
+            title="Total value across the leads shown"
+          >
+            {compactMoney(boardValue)}
+          </span>
+        ) : null}
+        {pipeline ? (
+          <div className="flex h-7 w-40 items-center gap-1.5 rounded-sm border border-border bg-bg-2 px-2 focus-within:border-border-focus">
+            <Search className="h-3 w-3 flex-shrink-0 text-text-3" aria-hidden="true" />
+            <input
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search leads…"
+              aria-label="Search leads"
+              className="min-w-0 flex-1 bg-transparent text-xs text-text-1 placeholder:text-text-3 outline-none"
+            />
+            {query ? (
+              <button
+                type="button"
+                onClick={() => setQuery("")}
+                aria-label="Clear search"
+                className="rounded-sm p-0.5 text-text-3 hover:text-text-1"
+              >
+                <X className="h-3 w-3" />
+              </button>
+            ) : null}
+          </div>
+        ) : null}
         <div className="ml-auto flex items-center gap-0.5 rounded border border-border p-0.5">
           <button
             type="button"
@@ -366,7 +408,7 @@ export function PipelineBoard() {
         </div>
       ) : view === "list" ? (
         <PipelineList
-          leads={leads}
+          leads={listLeads}
           pipeline={pipeline}
           nowMs={nowMs}
           onSelect={(id) => setSelectedLead(id)}
@@ -528,6 +570,11 @@ export function PipelineBoard() {
                     onDragStart={(e) => e.dataTransfer.setData("text/plain", lead.id)}
                   />
                 ))}
+                {colLeads.length === 0 ? (
+                  <div className="flex flex-1 items-center justify-center rounded border border-dashed border-border/40 px-2 py-4 text-center text-[10px] text-text-3">
+                    {q ? "No matches" : "Drop a lead here"}
+                  </div>
+                ) : null}
               </div>
               <button
                 type="button"


### PR DESCRIPTION
Second slice of the pipeline board quality batch.

## Items
5. **Per-pipeline search box** in the board toolbar — filters leads by name, subtitle, source, and any attribute value (including nested parcel addresses). Applies to both board and list views; clearable.
8. **Board-wide value rollup** — total of the pipeline's currency field across the leads shown, in the toolbar next to the count.
10. **Card aging cue** — a subtle "Nd" (days since last activity) on each card, hidden when the lead is already flagged Cold or is fresh (<1d).
16. **Empty-column drop hint** — empty stages show a faint "Drop a lead here" (or "No matches" while searching), so drop targets read clearly.

## Files
- `lib/pipeline/board.ts` — pure `daysSince()` + `leadHaystack()` helpers (+ unit tests).
- `modules/pipeline/components/PipelineBoard.tsx` — search box, value rollup, list-view wiring, drop hint.
- `modules/pipeline/components/LeadCard.tsx` — aging chip.

`tsc` + `eslint` clean · board tests 19 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)