### PR TITLE
feat(pipeline): sort within columns + WIP soft-limits (batch 3)

### DIFF
--- a/apps/web/src/lib/pipeline/board.test.ts
+++ b/apps/web/src/lib/pipeline/board.test.ts
@@ -9,6 +9,7 @@ import {
   compactMoney,
   daysSince,
   leadHaystack,
+  sortLeads,
 } from "./board";
 import { HELIOS_PIPELINE } from "./templates";
 import type { LeadRow, PipelineField } from "./db";
@@ -173,5 +174,27 @@ describe("leadHaystack", () => {
     expect(h).toContain("3051 sw 27");
     expect(h).toContain("referral");
     expect(h).toContain("3052 sw 27"); // nested parcel address
+  });
+});
+
+describe("sortLeads", () => {
+  const rows = [
+    lead({ id: "a", attributes: { ask: 500000 }, last_activity_at: "2026-06-10T00:00:00Z", updated_at: "2026-06-25T00:00:00Z" }),
+    lead({ id: "b", attributes: { ask: 2000000 }, last_activity_at: "2026-06-01T00:00:00Z", updated_at: "2026-06-28T00:00:00Z" }),
+    lead({ id: "c", attributes: { ask: 100000 }, last_activity_at: "2026-06-20T00:00:00Z", updated_at: "2026-06-05T00:00:00Z" }),
+  ];
+  it("manual keeps the input order (same reference)", () => {
+    expect(sortLeads(rows, "manual", "ask")).toBe(rows);
+  });
+  it("value sorts high→low and doesn't mutate the input", () => {
+    const out = sortLeads(rows, "value", "ask");
+    expect(out.map((l) => l.id)).toEqual(["b", "a", "c"]);
+    expect(rows.map((l) => l.id)).toEqual(["a", "b", "c"]);
+  });
+  it("cold sorts least-recently-active first", () => {
+    expect(sortLeads(rows, "cold", "ask").map((l) => l.id)).toEqual(["b", "a", "c"]);
+  });
+  it("updated sorts most-recently-updated first", () => {
+    expect(sortLeads(rows, "updated", "ask").map((l) => l.id)).toEqual(["b", "a", "c"]);
   });
 });

--- a/apps/web/src/lib/pipeline/board.ts
+++ b/apps/web/src/lib/pipeline/board.ts
@@ -65,6 +65,38 @@ export function leadHaystack(
   return `${lead.name} ${lead.subtitle ?? ""} ${lead.source ?? ""} ${attrs}`.toLowerCase();
 }
 
+export type LeadSort = "manual" | "value" | "cold" | "updated";
+
+/** Safe epoch-ms parse — invalid/empty dates sort as 0 (oldest). */
+function ms(iso: string | null | undefined): number {
+  const t = Date.parse(iso ?? "");
+  return Number.isNaN(t) ? 0 : t;
+}
+
+/**
+ * Sort a column's leads. `manual` keeps the server order. Returns a new array;
+ * never mutates the input.
+ *   value   — highest rollup-field value first
+ *   cold    — least-recently-active first (most likely going cold)
+ *   updated — most-recently-updated first
+ */
+export function sortLeads(
+  leads: LeadRow[],
+  sort: LeadSort,
+  rollupKey: string | null,
+): LeadRow[] {
+  if (sort === "manual") return leads;
+  const arr = [...leads];
+  if (sort === "value" && rollupKey) {
+    arr.sort((a, b) => sumAttr([b], rollupKey) - sumAttr([a], rollupKey));
+  } else if (sort === "cold") {
+    arr.sort((a, b) => ms(a.last_activity_at) - ms(b.last_activity_at));
+  } else if (sort === "updated") {
+    arr.sort((a, b) => ms(b.updated_at) - ms(a.updated_at));
+  }
+  return arr;
+}
+
 export interface StageColumn {
   stage: PipelineStage;
   leads: LeadRow[];

--- a/apps/web/src/lib/pipeline/db.ts
+++ b/apps/web/src/lib/pipeline/db.ts
@@ -14,6 +14,8 @@ export interface PipelineStage {
   rotting_days?: number;
   /** Reaching this stage promotes the lead to a Terminal. */
   is_terminal_gate?: boolean;
+  /** Soft cap on lead count — over it, the column header flags amber. */
+  wip_limit?: number;
 }
 
 export type PipelineFieldType =

--- a/apps/web/src/modules/pipeline/components/CustomizePanel.tsx
+++ b/apps/web/src/modules/pipeline/components/CustomizePanel.tsx
@@ -62,6 +62,7 @@ interface StageRow {
   type: PipelineStage["type"];
   gate: boolean;
   rottingDays: string;
+  wipLimit: string;
 }
 
 function fieldToRow(f: PipelineField): FieldRow {
@@ -82,6 +83,7 @@ function stageToRow(s: PipelineStage): StageRow {
     type: s.type,
     gate: Boolean(s.is_terminal_gate),
     rottingDays: s.rotting_days ? String(s.rotting_days) : "",
+    wipLimit: s.wip_limit ? String(s.wip_limit) : "",
   };
 }
 
@@ -113,7 +115,7 @@ export function CustomizePanel({
   function addStage() {
     setStages((rs) => [
       ...rs,
-      { key: "", label: "", color: "", type: "open", gate: false, rottingDays: "" },
+      { key: "", label: "", color: "", type: "open", gate: false, rottingDays: "", wipLimit: "" },
     ]);
   }
   function removeStage(i: number) {
@@ -164,6 +166,8 @@ export function CustomizePanel({
       if (r.color) st.color = r.color;
       const rd = Number(r.rottingDays);
       if (r.rottingDays.trim() && Number.isFinite(rd) && rd > 0) st.rotting_days = rd;
+      const wl = Number(r.wipLimit);
+      if (r.wipLimit.trim() && Number.isFinite(wl) && wl > 0) st.wip_limit = Math.floor(wl);
       if (r.gate) st.is_terminal_gate = true;
       out.push(st);
     }
@@ -322,10 +326,21 @@ export function CustomizePanel({
                     type="number"
                     min={0}
                     aria-label="Cold after days"
+                    title="Cold after N days idle"
                     className={`${input} w-10 px-1 text-center`}
                     placeholder="—"
                     value={r.rottingDays}
                     onChange={(e) => patchStage(i, { rottingDays: e.target.value })}
+                  />
+                  <input
+                    type="number"
+                    min={0}
+                    aria-label="WIP limit"
+                    title="WIP limit — the column header flags amber over this count"
+                    className={`${input} w-10 px-1 text-center`}
+                    placeholder="WIP"
+                    value={r.wipLimit}
+                    onChange={(e) => patchStage(i, { wipLimit: e.target.value })}
                   />
                   <button
                     type="button"

--- a/apps/web/src/modules/pipeline/components/PipelineBoard.tsx
+++ b/apps/web/src/modules/pipeline/components/PipelineBoard.tsx
@@ -25,6 +25,8 @@ import {
   sumAttr,
   compactMoney,
   leadHaystack,
+  sortLeads,
+  type LeadSort,
 } from "@/lib/pipeline/board";
 import { PipelineList } from "./PipelineList";
 import { CustomizePanel } from "./CustomizePanel";
@@ -44,6 +46,13 @@ import { useOverlay } from "../lib/use-overlay";
 const SPACE_KEY = "rokki:pipeline-space";
 const VIEW_KEY = "rokki:pipeline-view";
 const COLLAPSE_KEY = "rokki:pipeline-collapsed";
+const SORT_KEY = "rokki:pipeline-sort";
+const SORTS: { v: LeadSort; label: string }[] = [
+  { v: "manual", label: "Default order" },
+  { v: "value", label: "Value ↓" },
+  { v: "cold", label: "Going cold" },
+  { v: "updated", label: "Recently updated" },
+];
 
 export function PipelineBoard() {
   const [spaces, setSpaces] = useState<SpaceLite[]>([]);
@@ -54,7 +63,18 @@ export function PipelineBoard() {
   const [error, setError] = useState<string | null>(null);
   const [attentionOnly, setAttentionOnly] = useState(false);
   const [query, setQuery] = useState("");
+  const [sort, setSort] = useState<LeadSort>("manual");
   const [view, setView] = useState<"board" | "list">("board");
+
+  useEffect(() => {
+    const saved =
+      typeof window !== "undefined" ? window.localStorage.getItem(SORT_KEY) : null;
+    if (saved && SORTS.some((s) => s.v === saved)) setSort(saved as LeadSort);
+  }, []);
+  function selectSort(s: LeadSort) {
+    setSort(s);
+    if (typeof window !== "undefined") window.localStorage.setItem(SORT_KEY, s);
+  }
   // One "now" for the whole tree, ticking each minute so "cold" / "follow-up
   // due" refresh on their own without a reload.
   const [nowMs, setNowMs] = useState(() => Date.now());
@@ -309,6 +329,21 @@ export function PipelineBoard() {
             ) : null}
           </div>
         ) : null}
+        {view === "board" && pipeline ? (
+          <select
+            value={sort}
+            onChange={(e) => selectSort(e.target.value as LeadSort)}
+            aria-label="Sort leads within columns"
+            title="Sort leads within each column"
+            className="h-7 rounded-sm border border-border bg-bg-2 px-1.5 text-2xs text-text-1 outline-none focus:border-border-focus"
+          >
+            {SORTS.map((s) => (
+              <option key={s.v} value={s.v}>
+                {s.label}
+              </option>
+            ))}
+          </select>
+        ) : null}
         <div className="ml-auto flex items-center gap-0.5 rounded border border-border p-0.5">
           <button
             type="button"
@@ -467,6 +502,11 @@ export function PipelineBoard() {
           {columns.map(({ stage, leads: colLeads }) => {
             const colValue = rollup ? sumAttr(colLeads, rollup.key) : 0;
             const coldInCol = colLeads.filter((l) => isRotting(l, stages, nowMs)).length;
+            const sortedLeads = sortLeads(colLeads, sort, rollup?.key ?? null);
+            const overWip =
+              typeof stage.wip_limit === "number" &&
+              stage.wip_limit > 0 &&
+              colLeads.length > stage.wip_limit;
             // Drop handlers are shared by the full and collapsed column so you
             // can drag a card onto a minimized stage too.
             const onDragOver = (e: DragEvent) => {
@@ -523,7 +563,17 @@ export function PipelineBoard() {
                 <span className="text-2xs font-semibold uppercase tracking-wide text-text-2">
                   {stage.label}
                 </span>
-                <span className="font-mono text-2xs text-text-3">{colLeads.length}</span>
+                <span
+                  className={`font-mono text-2xs ${overWip ? "font-semibold text-warning" : "text-text-3"}`}
+                  title={
+                    overWip
+                      ? `Over WIP limit — ${colLeads.length} of ${stage.wip_limit}`
+                      : undefined
+                  }
+                >
+                  {colLeads.length}
+                  {overWip ? `/${stage.wip_limit}` : ""}
+                </span>
                 <div className="ml-auto flex items-center gap-1.5">
                   {colValue > 0 && (
                     <span
@@ -559,7 +609,7 @@ export function PipelineBoard() {
                 </div>
               </div>
               <div className="flex min-h-0 flex-1 flex-col gap-1.5 overflow-y-auto p-1.5">
-                {colLeads.map((lead) => (
+                {sortedLeads.map((lead) => (
                   <LeadCard
                     key={lead.id}
                     lead={lead}


### PR DESCRIPTION
Third slice of the pipeline board quality batch.

## Items
6. **Sort within columns** — a toolbar dropdown orders leads inside every stage by **Default**, **Value ↓**, **Going cold** (least-recently-active first), or **Recently updated**. Persisted per browser.
11. **WIP soft-limits** — set an optional per-stage cap in Customize; when a column exceeds it, the header count turns **amber** and shows `N/limit`. Stored on the stage (JSONB), no migration.

## Files
- `lib/pipeline/board.ts` — pure `sortLeads()` (+ unit tests) and `LeadSort` type.
- `lib/pipeline/db.ts` — `wip_limit?` on `PipelineStage`.
- `modules/pipeline/components/PipelineBoard.tsx` — sort dropdown, per-column sort, amber over-WIP header.
- `modules/pipeline/components/CustomizePanel.tsx` — WIP input in the stage editor.

`tsc` + `eslint` clean · board tests 23 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)