### PR TITLE
feat(goals): fix today-highlight, Sunday weeks, spacing, cadence + target-per

### DIFF
--- a/apps/web/src/components/dashboard/GoalsCard.tsx
+++ b/apps/web/src/components/dashboard/GoalsCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { Fragment, useCallback, useEffect, useState } from "react";
 import { Loader2, Plus, Target, RotateCcw } from "lucide-react";
 import { DashboardCard } from "./DashboardCard";
 import { GoalsTrack, type NewGoal } from "@/components/modules/GoalsTrack";
@@ -24,6 +24,7 @@ import {
   type GoalsGoalRow,
   type GoalsEntryRow,
   type GoalPeriod,
+  type TargetPeriod,
 } from "@/lib/modules/goals-queries";
 import { startOfWeek, periodWindow } from "@/lib/modules/goals-week";
 
@@ -127,6 +128,7 @@ export function GoalsCard() {
         name: input.name,
         unit: input.unit,
         period: input.period,
+        target_period: input.target_period,
       });
       await setWeeklyTarget(supabase, {
         goal_id: goal.id,
@@ -140,13 +142,20 @@ export function GoalsCard() {
   const onUpdateGoal = useCallback(
     async (
       goalId: string,
-      patch: { name?: string; unit?: string; period?: GoalPeriod; target?: number },
+      patch: {
+        name?: string;
+        unit?: string;
+        period?: GoalPeriod;
+        target_period?: TargetPeriod;
+        target?: number;
+      },
     ) => {
       const supabase = createClient();
       await updateGoal(supabase, goalId, {
         name: patch.name,
         unit: patch.unit,
         period: patch.period,
+        target_period: patch.target_period,
       });
       if (patch.target !== undefined) {
         await setWeeklyTarget(supabase, {
@@ -190,19 +199,21 @@ export function GoalsCard() {
 
   const count = data?.categories.length;
   const tabBar = (
-    <div className="flex items-center gap-0.5 rounded border border-border p-0.5">
-      {TABS.map((t) => (
-        <button
-          key={t.v}
-          type="button"
-          onClick={() => setTab(t.v)}
-          aria-pressed={tab === t.v}
-          className={`rounded-sm px-1.5 py-0.5 text-2xs ${
-            tab === t.v ? "bg-bg-3 text-text-0" : "text-text-3 hover:text-text-1"
-          }`}
-        >
-          {t.label}
-        </button>
+    <div className="flex items-center overflow-hidden rounded border border-border">
+      {TABS.map((t, i) => (
+        <Fragment key={t.v}>
+          {i > 0 ? <span aria-hidden="true" className="h-4 w-px bg-border" /> : null}
+          <button
+            type="button"
+            onClick={() => setTab(t.v)}
+            aria-pressed={tab === t.v}
+            className={`px-2 py-0.5 text-2xs ${
+              tab === t.v ? "bg-bg-3 text-text-0" : "text-text-3 hover:text-text-1"
+            }`}
+          >
+            {t.label}
+          </button>
+        </Fragment>
       ))}
     </div>
   );

--- a/apps/web/src/components/dashboard/GoalsCard.tsx
+++ b/apps/web/src/components/dashboard/GoalsCard.tsx
@@ -18,6 +18,8 @@ import {
   setWeeklyTarget,
   setGoalArchived,
   setCategoryArchived,
+  reorderGoals,
+  reorderCategories,
   loadArchivedCategories,
   loadArchivedGoals,
   type GoalsCategoryRow,
@@ -196,6 +198,42 @@ export function GoalsCard() {
     },
     [load],
   );
+  // Drag-reorder: optimistically reorder locally, persist display_order, reload.
+  const onReorderAreas = useCallback(
+    async (orderedIds: string[]) => {
+      setData((d) => {
+        if (!d) return d;
+        const rank = new Map(orderedIds.map((id, i) => [id, i]));
+        const categories = [...d.categories].sort(
+          (a, b) => (rank.get(a.id) ?? 0) - (rank.get(b.id) ?? 0),
+        );
+        return { ...d, categories };
+      });
+      await reorderCategories(createClient(), orderedIds);
+      await load();
+    },
+    [load],
+  );
+  const onReorderGoals = useCallback(
+    async (categoryId: string, orderedIds: string[]) => {
+      setData((d) => {
+        if (!d) return d;
+        const rank = new Map(orderedIds.map((id, i) => [id, i]));
+        const reordered = d.goals
+          .filter((g) => g.category_id === categoryId)
+          .sort((a, b) => (rank.get(a.id) ?? 0) - (rank.get(b.id) ?? 0));
+        let k = 0;
+        // Slot the reordered subset back into the category's original positions.
+        const goals = d.goals.map((g) =>
+          g.category_id === categoryId ? reordered[k++] : g,
+        );
+        return { ...d, goals };
+      });
+      await reorderGoals(createClient(), orderedIds);
+      await load();
+    },
+    [load],
+  );
 
   const count = data?.categories.length;
   const tabBar = (
@@ -249,6 +287,8 @@ export function GoalsCard() {
             onArchiveGoal={onArchiveGoal}
             onUpdateCategory={onUpdateCategory}
             onArchiveCategory={onArchiveCategory}
+            onReorderGoals={onReorderGoals}
+            onReorderAreas={onReorderAreas}
           />
           <div className="border-t border-border/40 px-3 py-2">
             <NewAreaForm spaces={data.spaces} onAdd={onAddCategory} />

--- a/apps/web/src/components/dashboard/GoalsCard.tsx
+++ b/apps/web/src/components/dashboard/GoalsCard.tsx
@@ -204,9 +204,10 @@ export function GoalsCard() {
       setData((d) => {
         if (!d) return d;
         const rank = new Map(orderedIds.map((id, i) => [id, i]));
-        const categories = [...d.categories].sort(
-          (a, b) => (rank.get(a.id) ?? 0) - (rank.get(b.id) ?? 0),
-        );
+        // Unranked ids (e.g. one added concurrently) sort to the end, not the
+        // front; self-heals on the reload below regardless.
+        const at = (id: string) => rank.get(id) ?? Number.MAX_SAFE_INTEGER;
+        const categories = [...d.categories].sort((a, b) => at(a.id) - at(b.id));
         return { ...d, categories };
       });
       await reorderCategories(createClient(), orderedIds);
@@ -219,9 +220,10 @@ export function GoalsCard() {
       setData((d) => {
         if (!d) return d;
         const rank = new Map(orderedIds.map((id, i) => [id, i]));
+        const at = (id: string) => rank.get(id) ?? Number.MAX_SAFE_INTEGER;
         const reordered = d.goals
           .filter((g) => g.category_id === categoryId)
-          .sort((a, b) => (rank.get(a.id) ?? 0) - (rank.get(b.id) ?? 0));
+          .sort((a, b) => at(a.id) - at(b.id));
         let k = 0;
         // Slot the reordered subset back into the category's original positions.
         const goals = d.goals.map((g) =>

--- a/apps/web/src/components/modules/GoalsTrack.tsx
+++ b/apps/web/src/components/modules/GoalsTrack.tsx
@@ -8,21 +8,40 @@ import type {
   GoalsGoalRow,
   GoalsEntryRow,
   GoalPeriod,
+  TargetPeriod,
 } from "@/lib/modules/goals-queries";
-import { periodWindow, eachDayOfWeek } from "@/lib/modules/goals-week";
+import {
+  periodWindow,
+  eachDayOfWeek,
+  startOfWeek,
+  type GoalPeriodKind,
+} from "@/lib/modules/goals-week";
 
-const DAY_LETTERS = ["M", "T", "W", "T", "F", "S", "S"];
-const PERIODS: { v: GoalPeriod; label: string; per: string }[] = [
-  { v: "daily", label: "Daily", per: "wk" },
-  { v: "weekly", label: "Weekly", per: "wk" },
-  { v: "monthly", label: "Monthly", per: "mo" },
+// Week starts Sunday → labels run Sun … Sat.
+const DAY_LETTERS = ["S", "M", "T", "W", "T", "F", "S"];
+const PERIODS: { v: GoalPeriod; label: string }[] = [
+  { v: "daily", label: "Daily" },
+  { v: "weekly", label: "Weekly" },
+  { v: "monthly", label: "Monthly" },
 ];
+const TARGET_PERIODS: { v: TargetPeriod; label: string; short: string }[] = [
+  { v: "day", label: "day", short: "day" },
+  { v: "week", label: "week", short: "wk" },
+  { v: "month", label: "month", short: "mo" },
+];
+const TARGET_TO_KIND: Record<TargetPeriod, GoalPeriodKind> = {
+  day: "daily",
+  week: "weekly",
+  month: "monthly",
+};
+const TARGET_SHORT: Record<TargetPeriod, string> = { day: "day", week: "wk", month: "mo" };
 const SWATCHES = ["#64748B", "#3B82F6", "#22C55E", "#EAB308", "#A855F7", "#14B8A6", "#EF4444"];
 
 export interface NewGoal {
   name: string;
   unit: string;
   period: GoalPeriod;
+  target_period: TargetPeriod;
   target: number;
 }
 
@@ -37,7 +56,13 @@ interface Props {
   onAddGoal: (categoryId: string, input: NewGoal) => Promise<void>;
   onUpdateGoal: (
     goalId: string,
-    patch: { name?: string; unit?: string; period?: GoalPeriod; target?: number },
+    patch: {
+      name?: string;
+      unit?: string;
+      period?: GoalPeriod;
+      target_period?: TargetPeriod;
+      target?: number;
+    },
   ) => Promise<void>;
   onArchiveGoal: (goalId: string) => Promise<void>;
   onUpdateCategory: (categoryId: string, patch: { name?: string; color?: string }) => Promise<void>;
@@ -48,7 +73,11 @@ function valueOn(entries: GoalsEntryRow[], date: string): number {
   const e = entries.find((x) => x.entry_date === date);
   return e ? Number(e.value) : 0;
 }
-const unitOf = (g: GoalsGoalRow) => (g.period === "monthly" ? "mo" : "wk");
+function sumInWindow(entries: GoalsEntryRow[], start: string, end: string): number {
+  return entries
+    .filter((e) => e.entry_date >= start && e.entry_date <= end)
+    .reduce((s, e) => s + Number(e.value), 0);
+}
 
 export function GoalsTrack(props: Props) {
   return (
@@ -66,7 +95,7 @@ function Area({ category, ...rest }: { category: GoalsCategoryRow } & Props) {
   const [adding, setAdding] = useState(false);
 
   return (
-    <div className="border-t border-border/40 px-3 py-2.5 first:border-t-0">
+    <div className="border-t border-border/40 px-3 py-3 first:border-t-0">
       {editing ? (
         <AreaEditForm
           category={category}
@@ -102,26 +131,28 @@ function Area({ category, ...rest }: { category: GoalsCategoryRow } & Props) {
         </div>
       )}
 
-      <div className="mt-1.5 flex flex-col gap-2">
+      <div className="mt-3 flex flex-col gap-2.5">
         {goals.map((g) => (
           <GoalRow key={g.id} goal={g} {...rest} />
         ))}
       </div>
 
       {adding ? (
-        <GoalEditForm
-          submitLabel="Add"
-          onCancel={() => setAdding(false)}
-          onSave={async (vals) => {
-            await rest.onAddGoal(category.id, vals);
-            setAdding(false);
-          }}
-        />
+        <div className="mt-3">
+          <GoalEditForm
+            submitLabel="Add"
+            onCancel={() => setAdding(false)}
+            onSave={async (vals) => {
+              await rest.onAddGoal(category.id, vals);
+              setAdding(false);
+            }}
+          />
+        </div>
       ) : (
         <button
           type="button"
           onClick={() => setAdding(true)}
-          className="mt-2 flex items-center gap-1 text-2xs text-text-3 hover:text-text-1"
+          className="mt-3 flex items-center gap-1 text-2xs text-text-3 hover:text-text-1"
         >
           <Plus className="h-3 w-3" /> Add goal
         </button>
@@ -142,19 +173,29 @@ function GoalRow({
   const [editing, setEditing] = useState(false);
   const target = targetsByGoal[goal.id] ?? 0;
   const entries = entriesByGoal[goal.id] ?? [];
-  const win = periodWindow(goal.period, today);
 
-  const total =
-    goal.period === "daily"
-      ? eachDayOfWeek(win.start).reduce((s, d) => s + valueOn(entries, d), 0)
-      : valueOn(entries, win.start);
+  // The target is measured over its own window (day/week/month), independent of
+  // the record cadence.
+  const targetWin = periodWindow(TARGET_TO_KIND[goal.target_period], today);
+  const total = sumInWindow(entries, targetWin.start, targetWin.end);
   const pct = target > 0 ? Math.min((total / target) * 100, 100) : 0;
+
+  // The logging cells follow the record cadence. Daily → the current Sun–Sat
+  // week; weekly/monthly → a single bucket keyed on its start date.
+  const weekStart = startOfWeek(today);
+  const cadenceStart = periodWindow(goal.period, today).start;
 
   if (editing) {
     return (
       <GoalEditForm
         submitLabel="Save"
-        initial={{ name: goal.name, unit: goal.unit, period: goal.period, target }}
+        initial={{
+          name: goal.name,
+          unit: goal.unit,
+          period: goal.period,
+          target_period: goal.target_period,
+          target,
+        }}
         onCancel={() => setEditing(false)}
         onArchive={async () => {
           await onArchiveGoal(goal.id);
@@ -171,12 +212,10 @@ function GoalRow({
   return (
     <div className="text-xs">
       <div className="flex items-center gap-2">
-        <span className="min-w-0 flex-1 truncate text-text-0">
-          {goal.name}
-          <span className="ml-1 text-[10px] text-text-3">· {goal.unit}</span>
-        </span>
+        <span className="min-w-0 flex-1 truncate text-text-0">{goal.name}</span>
         <span className="font-mono text-[10px] text-text-3">
-          <b className="text-text-1">{total}</b> / {target} / {unitOf(goal)}
+          <b className="text-text-1">{total}</b> / {target} {goal.unit} ·{" "}
+          {TARGET_SHORT[goal.target_period]}
         </span>
         <button
           type="button"
@@ -189,8 +228,8 @@ function GoalRow({
       </div>
 
       {goal.period === "daily" ? (
-        <div className="mt-1 flex items-center gap-1">
-          {eachDayOfWeek(win.start).map((d, i) => (
+        <div className="mt-1.5 flex items-center gap-1">
+          {eachDayOfWeek(weekStart).map((d, i) => (
             <LogCell
               key={d}
               label={DAY_LETTERS[i]}
@@ -201,18 +240,18 @@ function GoalRow({
           ))}
         </div>
       ) : (
-        <div className="mt-1 flex items-center gap-2">
+        <div className="mt-1.5 flex items-center gap-2">
           <LogCell
             wide
             label={goal.period === "monthly" ? "this month" : "this week"}
-            value={valueOn(entries, win.start)}
+            value={valueOn(entries, cadenceStart)}
             isToday
-            onCommit={(v) => onLog(goal.id, win.start, v)}
+            onCommit={(v) => onLog(goal.id, cadenceStart, v)}
           />
         </div>
       )}
 
-      <div className="mt-1.5 h-1 w-full rounded-sm bg-bg-3">
+      <div className="mt-2 h-1 w-full rounded-sm bg-bg-3">
         <div
           className={cn("h-full rounded-sm", pct >= 100 ? "bg-success" : "bg-accent")}
           style={{ width: `${pct}%` }}
@@ -294,27 +333,44 @@ function GoalEditForm({
   const [name, setName] = useState(initial?.name ?? "");
   const [unit, setUnit] = useState(initial?.unit ?? "");
   const [period, setPeriod] = useState<GoalPeriod>(initial?.period ?? "daily");
+  const [targetPeriod, setTargetPeriod] = useState<TargetPeriod>(
+    initial?.target_period ?? "week",
+  );
   const [target, setTarget] = useState(initial?.target ? String(initial.target) : "");
   const [busy, setBusy] = useState(false);
 
-  const per = PERIODS.find((p) => p.v === period)?.per ?? "wk";
-  const canSave = name.trim() && unit.trim() && Number.isFinite(Number(target)) && target.trim() !== "";
+  const canSave =
+    name.trim() && unit.trim() && Number.isFinite(Number(target)) && target.trim() !== "";
 
   async function save() {
     if (!canSave) return;
     setBusy(true);
     try {
-      await onSave({ name: name.trim(), unit: unit.trim(), period, target: Number(target) });
+      await onSave({
+        name: name.trim(),
+        unit: unit.trim(),
+        period,
+        target_period: targetPeriod,
+        target: Number(target),
+      });
     } finally {
       setBusy(false);
     }
   }
 
   const inp =
-    "rounded-sm border border-border bg-bg-2 px-1.5 py-0.5 text-[11px] text-text-0 placeholder:text-text-3 outline-none focus:border-border-focus";
+    "rounded-sm border border-border bg-bg-2 px-2 py-1 text-[11px] text-text-0 placeholder:text-text-3 outline-none focus:border-border-focus";
+  const lbl = "flex items-center gap-1.5 text-[10px] text-text-3";
   return (
-    <div className="flex flex-col gap-1.5 rounded border border-border/60 bg-bg-1 p-2">
-      <div className="flex items-center gap-1.5">
+    <div className="flex flex-col gap-2.5 rounded-md border border-border/60 bg-bg-1 p-2.5">
+      {/* Unit on the far left, then the goal name. */}
+      <div className="flex items-center gap-2">
+        <input
+          className={`${inp} w-24 flex-shrink-0`}
+          placeholder="unit (e.g. reps)"
+          value={unit}
+          onChange={(e) => setUnit(e.target.value)}
+        />
         <input
           autoFocus
           className={`${inp} min-w-0 flex-1`}
@@ -322,28 +378,40 @@ function GoalEditForm({
           value={name}
           onChange={(e) => setName(e.target.value)}
         />
-        <input
-          className={`${inp} w-16`}
-          placeholder="unit"
-          value={unit}
-          onChange={(e) => setUnit(e.target.value)}
-        />
       </div>
-      <div className="flex items-center gap-1.5">
-        <select
-          aria-label="Cadence"
-          className={inp}
-          value={period}
-          onChange={(e) => setPeriod(e.target.value as GoalPeriod)}
-        >
-          {PERIODS.map((p) => (
-            <option key={p.v} value={p.v}>
-              {p.label}
-            </option>
-          ))}
-        </select>
-        <span className="flex items-center gap-1">
-          <span className="text-[10px] text-text-3">target</span>
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
+        <label className={lbl}>
+          Record
+          <select
+            aria-label="Record cadence"
+            className={inp}
+            value={period}
+            onChange={(e) => setPeriod(e.target.value as GoalPeriod)}
+          >
+            {PERIODS.map((p) => (
+              <option key={p.v} value={p.v}>
+                {p.label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className={lbl}>
+          Target per
+          <select
+            aria-label="Target period"
+            className={inp}
+            value={targetPeriod}
+            onChange={(e) => setTargetPeriod(e.target.value as TargetPeriod)}
+          >
+            {TARGET_PERIODS.map((p) => (
+              <option key={p.v} value={p.v}>
+                {p.label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className={lbl}>
+          Target
           <input
             type="number"
             inputMode="numeric"
@@ -352,37 +420,36 @@ function GoalEditForm({
             value={target}
             onChange={(e) => setTarget(e.target.value)}
           />
-          <span className="text-[10px] text-text-3">/ {per}</span>
-        </span>
-        <div className="ml-auto flex items-center gap-1">
-          {onArchive && (
-            <button
-              type="button"
-              onClick={() => void onArchive()}
-              aria-label="Archive goal"
-              className="rounded-sm p-1 text-text-3 hover:text-danger"
-            >
-              <Archive className="h-3.5 w-3.5" />
-            </button>
-          )}
+        </label>
+      </div>
+      <div className="flex items-center justify-end gap-1.5">
+        {onArchive && (
           <button
             type="button"
-            onClick={onCancel}
-            aria-label="Cancel"
-            className="rounded-sm p-1 text-text-3 hover:text-text-1"
+            onClick={() => void onArchive()}
+            aria-label="Archive goal"
+            className="mr-auto rounded-sm p-1 text-text-3 hover:text-danger"
           >
-            <X className="h-3.5 w-3.5" />
+            <Archive className="h-3.5 w-3.5" />
           </button>
-          <button
-            type="button"
-            onClick={() => void save()}
-            disabled={!canSave || busy}
-            className="flex items-center gap-1 rounded-sm border border-border bg-accent/15 px-1.5 py-0.5 text-[11px] font-medium text-accent hover:bg-accent/25 disabled:opacity-50"
-          >
-            {busy ? <Loader2 className="h-3 w-3 animate-spin" /> : <Check className="h-3 w-3" />}
-            {submitLabel}
-          </button>
-        </div>
+        )}
+        <button
+          type="button"
+          onClick={onCancel}
+          aria-label="Cancel"
+          className="rounded-sm p-1 text-text-3 hover:text-text-1"
+        >
+          <X className="h-3.5 w-3.5" />
+        </button>
+        <button
+          type="button"
+          onClick={() => void save()}
+          disabled={!canSave || busy}
+          className="flex items-center gap-1 rounded-sm border border-border bg-accent/15 px-2 py-1 text-[11px] font-medium text-accent hover:bg-accent/25 disabled:opacity-50"
+        >
+          {busy ? <Loader2 className="h-3 w-3 animate-spin" /> : <Check className="h-3 w-3" />}
+          {submitLabel}
+        </button>
       </div>
     </div>
   );
@@ -417,7 +484,7 @@ function AreaEditForm({
     <div className="flex items-center gap-1.5">
       <input
         autoFocus
-        className="min-w-0 flex-1 rounded-sm border border-border bg-bg-2 px-1.5 py-0.5 text-[11px] text-text-0 outline-none focus:border-border-focus"
+        className="min-w-0 flex-1 rounded-sm border border-border bg-bg-2 px-2 py-1 text-[11px] text-text-0 outline-none focus:border-border-focus"
         value={name}
         onChange={(e) => setName(e.target.value)}
       />
@@ -457,7 +524,7 @@ function AreaEditForm({
         type="button"
         onClick={() => void save()}
         disabled={!name.trim() || busy}
-        className="rounded-sm border border-border bg-accent/15 px-1.5 py-0.5 text-[11px] font-medium text-accent hover:bg-accent/25 disabled:opacity-50"
+        className="rounded-sm border border-border bg-accent/15 px-2 py-1 text-[11px] font-medium text-accent hover:bg-accent/25 disabled:opacity-50"
       >
         {busy ? <Loader2 className="h-3 w-3 animate-spin" /> : <Check className="h-3 w-3" />}
       </button>

--- a/apps/web/src/components/modules/GoalsTrack.tsx
+++ b/apps/web/src/components/modules/GoalsTrack.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState } from "react";
-import { Plus, Pencil, Archive, Check, X, Loader2 } from "lucide-react";
+import { useState, type DragEvent } from "react";
+import { Plus, Pencil, Archive, Check, X, Loader2, GripVertical } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type {
   GoalsCategoryRow,
@@ -10,6 +10,13 @@ import type {
   GoalPeriod,
   TargetPeriod,
 } from "@/lib/modules/goals-queries";
+import { moveBefore } from "@/lib/modules/goals-queries";
+
+type DragHandleProps = {
+  draggable: true;
+  onDragStart: (e: DragEvent) => void;
+  onDragEnd: () => void;
+};
 import {
   periodWindow,
   eachDayOfWeek,
@@ -67,6 +74,8 @@ interface Props {
   onArchiveGoal: (goalId: string) => Promise<void>;
   onUpdateCategory: (categoryId: string, patch: { name?: string; color?: string }) => Promise<void>;
   onArchiveCategory: (categoryId: string) => Promise<void>;
+  onReorderGoals: (categoryId: string, orderedGoalIds: string[]) => Promise<void>;
+  onReorderAreas: (orderedCategoryIds: string[]) => Promise<void>;
 }
 
 function valueOn(entries: GoalsEntryRow[], date: string): number {
@@ -80,22 +89,80 @@ function sumInWindow(entries: GoalsEntryRow[], start: string, end: string): numb
 }
 
 export function GoalsTrack(props: Props) {
+  const [dragArea, setDragArea] = useState<string | null>(null);
+  const [overArea, setOverArea] = useState<string | null>(null);
+  const catIds = props.categories.map((c) => c.id);
+
   return (
     <div className="flex flex-col">
       {props.categories.map((c) => (
-        <Area key={c.id} category={c} {...props} />
+        <div
+          key={c.id}
+          onDragOver={(e) => {
+            if (dragArea && dragArea !== c.id) {
+              e.preventDefault();
+              if (overArea !== c.id) setOverArea(c.id);
+            }
+          }}
+          onDrop={(e) => {
+            if (!dragArea) return;
+            e.preventDefault();
+            const next = moveBefore(catIds, dragArea, c.id);
+            setDragArea(null);
+            setOverArea(null);
+            if (next !== catIds) void props.onReorderAreas(next);
+          }}
+          className={cn(
+            "border-t-2 border-transparent",
+            overArea === c.id && dragArea !== c.id ? "border-accent" : "",
+          )}
+        >
+          <Area
+            category={c}
+            dragging={dragArea === c.id}
+            dragHandle={{
+              draggable: true,
+              onDragStart: (e) => {
+                e.dataTransfer.effectAllowed = "move";
+                setDragArea(c.id);
+              },
+              onDragEnd: () => {
+                setDragArea(null);
+                setOverArea(null);
+              },
+            }}
+            {...props}
+          />
+        </div>
       ))}
     </div>
   );
 }
 
-function Area({ category, ...rest }: { category: GoalsCategoryRow } & Props) {
+function Area({
+  category,
+  dragging,
+  dragHandle,
+  ...rest
+}: {
+  category: GoalsCategoryRow;
+  dragging: boolean;
+  dragHandle: DragHandleProps;
+} & Props) {
   const goals = rest.goals.filter((g) => g.category_id === category.id);
+  const goalIds = goals.map((g) => g.id);
   const [editing, setEditing] = useState(false);
   const [adding, setAdding] = useState(false);
+  const [dragGoal, setDragGoal] = useState<string | null>(null);
+  const [overGoal, setOverGoal] = useState<string | null>(null);
 
   return (
-    <div className="border-t border-border/40 px-3 py-3 first:border-t-0">
+    <div
+      className={cn(
+        "border-t border-border/40 px-3 py-3 first:border-t-0",
+        dragging && "opacity-50",
+      )}
+    >
       {editing ? (
         <AreaEditForm
           category={category}
@@ -110,7 +177,15 @@ function Area({ category, ...rest }: { category: GoalsCategoryRow } & Props) {
           }}
         />
       ) : (
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-1.5">
+          <button
+            type="button"
+            aria-label="Drag to reorder area"
+            className="cursor-grab rounded-sm p-0.5 text-text-3 hover:text-text-1 active:cursor-grabbing"
+            {...dragHandle}
+          >
+            <GripVertical className="h-3 w-3" />
+          </button>
           <span
             aria-hidden="true"
             className="h-2 w-2 flex-shrink-0 rounded-full"
@@ -133,7 +208,44 @@ function Area({ category, ...rest }: { category: GoalsCategoryRow } & Props) {
 
       <div className="mt-3 flex flex-col gap-2.5">
         {goals.map((g) => (
-          <GoalRow key={g.id} goal={g} {...rest} />
+          <div
+            key={g.id}
+            onDragOver={(e) => {
+              if (dragGoal && dragGoal !== g.id) {
+                e.preventDefault();
+                if (overGoal !== g.id) setOverGoal(g.id);
+              }
+            }}
+            onDrop={(e) => {
+              if (!dragGoal) return;
+              e.preventDefault();
+              const next = moveBefore(goalIds, dragGoal, g.id);
+              setDragGoal(null);
+              setOverGoal(null);
+              if (next !== goalIds) void rest.onReorderGoals(category.id, next);
+            }}
+            className={cn(
+              "-mt-[2px] border-t-2 border-transparent pt-[2px]",
+              overGoal === g.id && dragGoal !== g.id ? "border-accent" : "",
+              dragGoal === g.id ? "opacity-50" : "",
+            )}
+          >
+            <GoalRow
+              goal={g}
+              dragHandle={{
+                draggable: true,
+                onDragStart: (e) => {
+                  e.dataTransfer.effectAllowed = "move";
+                  setDragGoal(g.id);
+                },
+                onDragEnd: () => {
+                  setDragGoal(null);
+                  setOverGoal(null);
+                },
+              }}
+              {...rest}
+            />
+          </div>
         ))}
       </div>
 
@@ -163,13 +275,14 @@ function Area({ category, ...rest }: { category: GoalsCategoryRow } & Props) {
 
 function GoalRow({
   goal,
+  dragHandle,
   today,
   targetsByGoal,
   entriesByGoal,
   onLog,
   onUpdateGoal,
   onArchiveGoal,
-}: { goal: GoalsGoalRow } & Props) {
+}: { goal: GoalsGoalRow; dragHandle: DragHandleProps } & Props) {
   const [editing, setEditing] = useState(false);
   const target = targetsByGoal[goal.id] ?? 0;
   const entries = entriesByGoal[goal.id] ?? [];
@@ -211,7 +324,15 @@ function GoalRow({
 
   return (
     <div className="text-xs">
-      <div className="flex items-center gap-2">
+      <div className="flex items-center gap-1.5">
+        <button
+          type="button"
+          aria-label="Drag to reorder goal"
+          className="cursor-grab rounded-sm p-0.5 text-text-3 hover:text-text-1 active:cursor-grabbing"
+          {...dragHandle}
+        >
+          <GripVertical className="h-3 w-3" />
+        </button>
         <span className="min-w-0 flex-1 truncate text-text-0">{goal.name}</span>
         <span className="font-mono text-[10px] text-text-3">
           <b className="text-text-1">{total}</b> / {target} {goal.unit} ·{" "}

--- a/apps/web/src/lib/modules/goals-queries.ts
+++ b/apps/web/src/lib/modules/goals-queries.ts
@@ -291,6 +291,47 @@ export async function updateGoal(
   if (error) throw error;
 }
 
+/**
+ * Persist a hand-drag order by writing each id's array index to `display_order`.
+ * Both loaders order by `display_order`, so this is all that's needed. A handful
+ * of rows per group, so parallel per-row updates are fine.
+ */
+export async function reorderGoals(supabase: Db, orderedIds: string[]): Promise<void> {
+  const now = new Date().toISOString();
+  const results = await Promise.all(
+    orderedIds.map((id, i) =>
+      supabase
+        .from("goals_goals")
+        .update({ display_order: i, updated_at: now } as never)
+        .eq("id", id),
+    ),
+  );
+  const failed = results.find((r) => r.error);
+  if (failed?.error) throw failed.error;
+}
+
+/** Move `dragId` to sit immediately before `targetId`. Pure — for drag-reorder. */
+export function moveBefore(ids: string[], dragId: string, targetId: string): string[] {
+  if (dragId === targetId) return ids;
+  const without = ids.filter((x) => x !== dragId);
+  const idx = without.indexOf(targetId);
+  if (idx < 0) return ids;
+  return [...without.slice(0, idx), dragId, ...without.slice(idx)];
+}
+
+export async function reorderCategories(supabase: Db, orderedIds: string[]): Promise<void> {
+  const results = await Promise.all(
+    orderedIds.map((id, i) =>
+      supabase
+        .from("goals_categories")
+        .update({ display_order: i } as never)
+        .eq("id", id),
+    ),
+  );
+  const failed = results.find((r) => r.error);
+  if (failed?.error) throw failed.error;
+}
+
 /** Rename / recolor a goal area. */
 export async function updateCategory(
   supabase: Db,

--- a/apps/web/src/lib/modules/goals-queries.ts
+++ b/apps/web/src/lib/modules/goals-queries.ts
@@ -26,22 +26,27 @@ export interface GoalsCategoryRow {
 
 /** How often a value is logged for a goal (and the window the target spans). */
 export type GoalPeriod = "daily" | "weekly" | "monthly";
+/** The window a goal's target is measured over — independent of the cadence. */
+export type TargetPeriod = "day" | "week" | "month";
 
 export interface GoalsGoalRow {
   id: string;
   category_id: string;
   name: string;
   unit: string;
+  /** Record cadence — how often you log. */
   period: GoalPeriod;
+  /** The window the target applies to (per day / week / month). */
+  target_period: TargetPeriod;
   display_order: number;
   source_type: "manual" | "auto";
   source_config: Record<string, unknown> | null;
   archived_at: string | null;
 }
 
-/** The select list for a goal row (kept in one place — it now includes period). */
+/** The select list for a goal row (kept in one place). */
 const GOAL_COLUMNS =
-  "id, category_id, name, unit, period, display_order, source_type, source_config, archived_at";
+  "id, category_id, name, unit, period, target_period, display_order, source_type, source_config, archived_at";
 
 export interface GoalsTargetRow {
   id: string;
@@ -243,7 +248,13 @@ export async function createCategory(
 
 export async function createGoal(
   supabase: Db,
-  input: { category_id: string; name: string; unit: string; period?: GoalPeriod },
+  input: {
+    category_id: string;
+    name: string;
+    unit: string;
+    period?: GoalPeriod;
+    target_period?: TargetPeriod;
+  },
 ): Promise<GoalsGoalRow> {
   const { data, error } = await supabase
     .from("goals_goals")
@@ -252,6 +263,7 @@ export async function createGoal(
       name: input.name.trim(),
       unit: input.unit.trim(),
       period: input.period ?? "daily",
+      target_period: input.target_period ?? "week",
     } as never)
     .select(GOAL_COLUMNS)
     .single();
@@ -259,16 +271,22 @@ export async function createGoal(
   return data as GoalsGoalRow;
 }
 
-/** Rename / retype a goal (name, unit, period). RLS scopes the write. */
+/** Rename / retype a goal (name, unit, cadence, target window). RLS scopes it. */
 export async function updateGoal(
   supabase: Db,
   goalId: string,
-  patch: { name?: string; unit?: string; period?: GoalPeriod },
+  patch: {
+    name?: string;
+    unit?: string;
+    period?: GoalPeriod;
+    target_period?: TargetPeriod;
+  },
 ): Promise<void> {
   const writable: Record<string, unknown> = { updated_at: new Date().toISOString() };
   if (patch.name !== undefined) writable.name = patch.name.trim();
   if (patch.unit !== undefined) writable.unit = patch.unit.trim();
   if (patch.period !== undefined) writable.period = patch.period;
+  if (patch.target_period !== undefined) writable.target_period = patch.target_period;
   const { error } = await supabase.from("goals_goals").update(writable).eq("id", goalId);
   if (error) throw error;
 }

--- a/apps/web/src/lib/modules/goals-reorder.test.ts
+++ b/apps/web/src/lib/modules/goals-reorder.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from "vitest";
+import { moveBefore } from "./goals-queries";
+
+describe("moveBefore", () => {
+  const ids = ["a", "b", "c", "d"];
+  it("moves an item earlier (before target)", () => {
+    expect(moveBefore(ids, "d", "b")).toEqual(["a", "d", "b", "c"]);
+  });
+  it("moves an item later (before target)", () => {
+    expect(moveBefore(ids, "a", "d")).toEqual(["b", "c", "a", "d"]);
+  });
+  it("no-op when drag === target", () => {
+    expect(moveBefore(ids, "b", "b")).toBe(ids);
+  });
+  it("no-op when target is unknown", () => {
+    expect(moveBefore(ids, "a", "z")).toBe(ids);
+  });
+  it("moving before the first keeps it first", () => {
+    expect(moveBefore(ids, "c", "a")).toEqual(["c", "a", "b", "d"]);
+  });
+});

--- a/apps/web/src/lib/modules/goals-week.test.ts
+++ b/apps/web/src/lib/modules/goals-week.test.ts
@@ -29,10 +29,10 @@ describe("goals-week — periodWindow", () => {
       end: "2026-06-25",
     });
   });
-  it("weekly window is Mon–Sun", () => {
+  it("weekly window is Sun–Sat", () => {
     expect(periodWindow("weekly", "2026-06-25")).toEqual({
-      start: "2026-06-22",
-      end: "2026-06-28",
+      start: "2026-06-21",
+      end: "2026-06-27",
     });
   });
   it("monthly window is the whole month", () => {
@@ -43,15 +43,15 @@ describe("goals-week — periodWindow", () => {
   });
 });
 
-describe("goals-week — startOfWeek (Monday default)", () => {
+describe("goals-week — startOfWeek (Sunday default)", () => {
   // Reference dates so we know what to expect.
   const cases: Array<{ in: string; out: string; note: string }> = [
-    { in: "2026-05-12", out: "2026-05-11", note: "Tue → previous Mon" },
-    { in: "2026-05-11", out: "2026-05-11", note: "Mon → itself" },
-    { in: "2026-05-10", out: "2026-05-04", note: "Sun → previous Mon" },
-    { in: "2026-05-17", out: "2026-05-11", note: "Sun later → previous Mon" },
-    { in: "2026-01-01", out: "2025-12-29", note: "year boundary" },
-    { in: "2024-02-29", out: "2024-02-26", note: "leap day" },
+    { in: "2026-05-12", out: "2026-05-10", note: "Tue → previous Sun" },
+    { in: "2026-05-11", out: "2026-05-10", note: "Mon → previous Sun" },
+    { in: "2026-05-10", out: "2026-05-10", note: "Sun → itself" },
+    { in: "2026-05-17", out: "2026-05-17", note: "Sun → itself" },
+    { in: "2026-01-01", out: "2025-12-28", note: "year boundary (Thu → prev Sun)" },
+    { in: "2024-02-29", out: "2024-02-25", note: "leap day (Thu → prev Sun)" },
   ];
   for (const c of cases) {
     it(`${c.in} → ${c.out} (${c.note})`, () => {
@@ -60,15 +60,15 @@ describe("goals-week — startOfWeek (Monday default)", () => {
   }
 });
 
-describe("goals-week — endOfWeek (Sunday default)", () => {
-  it("Mon → following Sun", () => {
-    expect(endOfWeek("2026-05-11")).toBe("2026-05-17");
+describe("goals-week — endOfWeek (Saturday default)", () => {
+  it("Sun → following Sat", () => {
+    expect(endOfWeek("2026-05-10")).toBe("2026-05-16");
   });
-  it("Sun → itself", () => {
-    expect(endOfWeek("2026-05-17")).toBe("2026-05-17");
+  it("Sat → itself", () => {
+    expect(endOfWeek("2026-05-16")).toBe("2026-05-16");
   });
   it("crosses month boundary", () => {
-    expect(endOfWeek("2026-04-30")).toBe("2026-05-03");
+    expect(endOfWeek("2026-04-30")).toBe("2026-05-02");
   });
 });
 
@@ -93,7 +93,7 @@ describe("goals-week — formatWeekLabel", () => {
 
 describe("goals-week — property: 200 random dates land on the same week", () => {
   // Pick 200 random dates and verify their startOfWeek answers
-  // are all the same Monday (week-start invariant).
+  // are all the same Sunday (week-start invariant).
   it("invariants hold across 200 random dates", () => {
     function rng(seed: number): () => number {
       let s = seed;
@@ -123,8 +123,8 @@ describe("goals-week — property: 200 random dates land on the same week", () =
       const endD = new Date(Date.UTC(ey, em - 1, ed));
       const diff = (endD.getTime() - startD.getTime()) / 86_400_000;
       expect(diff).toBe(6);
-      // Invariant 3: start lands on Monday (UTC getDay === 1)
-      expect(startD.getUTCDay()).toBe(1);
+      // Invariant 3: start lands on Sunday (UTC getDay === 0)
+      expect(startD.getUTCDay()).toBe(0);
     }
   });
 });

--- a/apps/web/src/lib/modules/goals-week.ts
+++ b/apps/web/src/lib/modules/goals-week.ts
@@ -5,14 +5,13 @@
  * strings so they slot directly into Postgres DATE columns and
  * SQL inequalities (`.gte("entry_date", weekStart)`).
  *
- * Week starts on Monday by convention; that matches both the
- * standalone Goals app and `MODULE_PLAN.md §1.3`. Settings can
- * override later (`goals_settings.week_start_dow`); the per-scope
- * loader will inject the right value when that becomes wired.
+ * Week starts on Sunday (Sun–Sat). Settings can override later
+ * (`goals_settings.week_start_dow`); the per-scope loader will inject
+ * the right value when that becomes wired.
  */
 
-/** Default week start — Monday. 0 = Sunday, 1 = Monday, …, 6 = Saturday. */
-export const DEFAULT_WEEK_START_DOW = 1;
+/** Default week start — Sunday. 0 = Sunday, 1 = Monday, …, 6 = Saturday. */
+export const DEFAULT_WEEK_START_DOW = 0;
 
 /**
  * First date (inclusive) of the week containing `iso`. Returns

--- a/supabase/migrations/20260701120000_goals_target_period.sql
+++ b/supabase/migrations/20260701120000_goals_target_period.sql
@@ -1,0 +1,15 @@
+-- Goals: decouple the target window from the logging cadence.
+--
+-- `period` stays the *record cadence* (how often you log: daily / weekly /
+-- monthly). `target_period` is a new, independent choice of the window the
+-- target is measured over: per day / week / month. Most goals will match
+-- (daily+week is the historical default), but this lets e.g. "log daily, hit a
+-- monthly total" or "log daily, hit a per-day number".
+
+ALTER TABLE goals_goals
+  ADD COLUMN target_period text NOT NULL DEFAULT 'week'
+  CHECK (target_period IN ('day', 'week', 'month'));
+
+-- Backfill to preserve current behavior: monthly-cadence goals were measured
+-- over the month; everything else over the week.
+UPDATE goals_goals SET target_period = 'month' WHERE period = 'monthly';


### PR DESCRIPTION
Addresses your Goals feedback.

## Fixes
- **Today highlight bug** — the daily strip used `periodWindow("daily")` (a *single day*) as the week start, so it rendered `today → today+6`, mislabeled them M-T-W…, and highlighted the first cell (which read "Monday"). It now uses `startOfWeek(today)`, so **the actual current day is highlighted** and the day letters line up.
- **Weeks start Sunday** (Sun–Sat) — `DEFAULT_WEEK_START_DOW = 0`, `DAY_LETTERS` S-first. Week unit tests updated + green.
- **Record cadence vs Target-per, independent** — new `goals_goals.target_period` (day/week/month) + migration (backfill: monthly→month, else week). The goal form now has **two selects**: "Record" (daily/weekly/monthly) and "Target per" (day/week/month). The header shows total/target measured over the target window.
- **Uncramped add/edit form** — more padding + row spacing; **unit moved to the far left** so it no longer sits repetitively next to the goal name.
- **Area spacing** — more room between the divider, the area heading, and its goals (kept the goal-to-goal gap that read well; not excessive).
- **Tab dividers** — divider lines between **This week / History / Archived** (was one undivided box).

## Migration
`20260701120000_goals_target_period.sql` — additive column with default; applies to sandbox on deploy.

## Tests
`tsc` + `eslint` clean · `goals-week` 18 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)