### PR TITLE
feat(shell): collapsible explorer + keep desktop layout on narrow windows

### DIFF
--- a/apps/web/src/components/dashboard/DashboardShell.tsx
+++ b/apps/web/src/components/dashboard/DashboardShell.tsx
@@ -1,8 +1,11 @@
 "use client";
 
-import type { ReactNode } from "react";
+import { useEffect, useState, type ReactNode } from "react";
+import { PanelLeftClose, PanelLeftOpen } from "lucide-react";
 import { MobileTabBar } from "./MobileTabBar";
 import { ResizeHandle, useResizable } from "@/components/ResizeHandle";
+
+const LEFT_COLLAPSE_KEY = "rokki:dash-left-collapsed";
 
 /**
  * Three-rail dashboard shell, responsive.
@@ -70,28 +73,78 @@ export function DashboardShell({
     min: 240,
     max: 560,
   });
+
+  // Explorer collapse — a narrow window (or a user who just wants more room)
+  // can fold the left rail to a slim strip. Persisted across reloads.
+  const [collapsed, setCollapsed] = useState(false);
+  useEffect(() => {
+    try {
+      setCollapsed(window.localStorage.getItem(LEFT_COLLAPSE_KEY) === "1");
+    } catch {
+      /* ignore */
+    }
+  }, []);
+  function toggleCollapsed() {
+    setCollapsed((c) => {
+      const next = !c;
+      try {
+        window.localStorage.setItem(LEFT_COLLAPSE_KEY, next ? "1" : "0");
+      } catch {
+        /* ignore */
+      }
+      return next;
+    });
+  }
+
   return (
     <div className="flex h-[100dvh] flex-col overflow-hidden bg-bg-0">
       {/* Skip link is now in the root layout (app/layout.tsx) so every page
           gets it. The shell still owns #main-content as the jump target. */}
       {topBar}
       {ticker}
-      <div className="flex flex-1 min-h-0 flex-col overflow-hidden lg:flex-row">
-        <aside
-          aria-label="Explorer"
-          style={{ width: leftRail.size }}
-          className="hidden flex-shrink-0 border-r border-border lg:flex lg:flex-col"
-        >
-          {left}
-        </aside>
-        <div className="hidden flex-shrink-0 self-stretch lg:flex">
-          <ResizeHandle
-            ariaLabel="Resize explorer"
-            onMouseDown={(e) =>
-              leftRail.startDrag(e, { side: "before" })
-            }
-          />
-        </div>
+      <div className="flex flex-1 min-h-0 flex-col overflow-hidden md:flex-row">
+        {collapsed ? (
+          // Collapsed: a slim rail whose only control reopens the explorer.
+          <aside
+            aria-label="Explorer (collapsed)"
+            className="hidden w-9 flex-shrink-0 flex-col items-center border-r border-border pt-2 md:flex"
+          >
+            <button
+              type="button"
+              onClick={toggleCollapsed}
+              aria-label="Open explorer"
+              title="Open explorer"
+              className="rounded-sm p-1.5 text-text-3 hover:bg-bg-2 hover:text-text-0"
+            >
+              <PanelLeftOpen className="h-4 w-4" />
+            </button>
+          </aside>
+        ) : (
+          <>
+            <aside
+              aria-label="Explorer"
+              style={{ width: leftRail.size }}
+              className="relative hidden flex-shrink-0 border-r border-border md:flex md:flex-col"
+            >
+              {left}
+              <button
+                type="button"
+                onClick={toggleCollapsed}
+                aria-label="Collapse explorer"
+                title="Collapse explorer"
+                className="absolute right-1 top-1 z-10 rounded-sm p-1 text-text-3 opacity-60 hover:bg-bg-2 hover:text-text-0 hover:opacity-100"
+              >
+                <PanelLeftClose className="h-3.5 w-3.5" />
+              </button>
+            </aside>
+            <div className="hidden flex-shrink-0 self-stretch md:flex">
+              <ResizeHandle
+                ariaLabel="Resize explorer"
+                onMouseDown={(e) => leftRail.startDrag(e, { side: "before" })}
+              />
+            </div>
+          </>
+        )}
         <main
           id="main-content"
           tabIndex={-1}
@@ -100,14 +153,14 @@ export function DashboardShell({
         >
           {center}
           {right ? (
-            <div className="lg:hidden" aria-label="Messages">
+            <div className="md:hidden" aria-label="Messages">
               {right}
             </div>
           ) : null}
         </main>
         {right ? (
           <>
-            <div className="hidden flex-shrink-0 self-stretch lg:flex">
+            <div className="hidden flex-shrink-0 self-stretch md:flex">
               <ResizeHandle
                 ariaLabel="Resize messages"
                 onMouseDown={(e) => rightRail.startDrag(e, { side: "after" })}
@@ -116,7 +169,7 @@ export function DashboardShell({
             <aside
               aria-label="Messages"
               style={{ width: rightRail.size }}
-              className="hidden flex-shrink-0 border-l border-border lg:flex lg:flex-col"
+              className="hidden flex-shrink-0 border-l border-border md:flex md:flex-col"
             >
               {right}
             </aside>

--- a/apps/web/src/components/dashboard/MobileTabBar.tsx
+++ b/apps/web/src/components/dashboard/MobileTabBar.tsx
@@ -59,7 +59,7 @@ export function MobileTabBar() {
   return (
     <nav
       aria-label="Primary"
-      className="flex h-14 flex-shrink-0 items-stretch border-t border-border bg-bg-1 lg:hidden"
+      className="flex h-14 flex-shrink-0 items-stretch border-t border-border bg-bg-1 md:hidden"
     >
       {TABS.map((tab) => {
         const Icon = tab.icon;


### PR DESCRIPTION
Addresses: resizing a desktop window flips to the "older" phone layout (bottom Home/Tasks/Week/Inbox/More bar).

## What
- **Stop flipping to the phone layout on a narrow desktop window.** The breakpoint was `lg` (1024px), so a ~900px window became a phone. Lowered to `md` (768px): the real 3-rail desktop shell now persists down to ~768px, and the bottom tab bar only appears on true phones (<768px).
- **Collapsible explorer.** A toggle folds the left rail to a slim strip (with a reopen button), so you can reclaim horizontal room without losing the desktop layout. Collapsed state persists across reloads.

## Files
- `components/dashboard/DashboardShell.tsx` — collapse state + toggle, `lg:`→`md:` breakpoint.
- `components/dashboard/MobileTabBar.tsx` — `lg:hidden`→`md:hidden`.

`tsc` + `eslint` clean. (Shell-wide change — worth a quick look on sandbox at a few widths.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)