### PR TITLE
fix(explorer): match search box height to the TopBar search (h-7)

### DIFF
--- a/apps/web/src/components/dashboard/ExplorerRail.tsx
+++ b/apps/web/src/components/dashboard/ExplorerRail.tsx
@@ -344,7 +344,7 @@ export function ExplorerRail({
                   paddingLeft: "var(--rk-search-px)",
                   paddingRight: "var(--rk-search-px)",
                 }}
-                className="h-[var(--rk-search-h)] w-full rounded-sm border border-border bg-bg-1 text-text-0 placeholder:text-text-3 focus:border-border-focus focus:outline-none focus-visible:ring-2 focus-visible:ring-border-focus"
+                className="h-7 w-full rounded-sm border border-border bg-bg-1 text-text-0 placeholder:text-text-3 focus:border-border-focus focus:outline-none focus-visible:ring-2 focus-visible:ring-border-focus"
               />
               {filter ? (
                 <button


### PR DESCRIPTION
The explorer filter box used `--rk-search-h`, so it was a different height than the TopBar "Search commands…" box and the Focus control (both `h-7`). Set it to `h-7` so all three match. The container padding and the thin divider lines above/below are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)