### PR TITLE
fix(security): open-redirect, PAT scopes, upload sniffing, cron timing

### DIFF
--- a/apps/web/src/app/api/v1/contacts/avatar/route.ts
+++ b/apps/web/src/app/api/v1/contacts/avatar/route.ts
@@ -9,6 +9,7 @@ import {
   imageExtFromType,
   avatarStorageKey,
 } from "@/lib/contacts/avatar";
+import { sniffImageMime } from "@/lib/file-sniff";
 
 export const dynamic = "force-dynamic";
 // Profile pictures are small, but give image processing a little headroom.
@@ -36,15 +37,21 @@ async function handlePost(request: NextRequest) {
   if (file.size === 0) return badRequest("file is empty");
   if (file.size > AVATAR_MAX_BYTES) return badRequest("image too large (max 8 MB)");
 
-  const ext = imageExtFromType(file.type);
+  // Trust the bytes, not the client's Content-Type. The avatar bucket is
+  // PUBLIC and rendered via <img src>, so an SVG/HTML uploaded as "image/png"
+  // would be stored XSS. Sniff the real type from magic bytes; text-based
+  // formats (SVG) have none and are rejected.
+  const bytes = new Uint8Array(await file.arrayBuffer());
+  const sniffed = sniffImageMime(bytes);
+  if (!sniffed) return badRequest("file is not a supported image");
+  const ext = imageExtFromType(sniffed);
   if (!ext) return badRequest("unsupported image type");
 
   const key = avatarStorageKey(user.id, randomUUID(), ext);
-  const bytes = new Uint8Array(await file.arrayBuffer());
 
   const { error } = await supabase.storage
     .from(AVATAR_BUCKET)
-    .upload(key, bytes, { contentType: file.type, upsert: false });
+    .upload(key, bytes, { contentType: sniffed, upsert: false });
   if (error) return internal(error.message);
 
   const { data } = supabase.storage.from(AVATAR_BUCKET).getPublicUrl(key);

--- a/apps/web/src/app/api/v1/cron/calendar-sync/route.ts
+++ b/apps/web/src/app/api/v1/cron/calendar-sync/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { runCalendarSyncTick } from "@/lib/calendar-sync";
 import { withObservability } from "@/lib/observability";
+import { verifyCronSecret } from "@/lib/cron-auth";
 
 /**
  * POST /api/v1/cron/calendar-sync
@@ -46,13 +47,7 @@ export const GET = withObservability(
 );
 
 function authorize(request: NextRequest): boolean {
-  const expected = process.env.CRON_SECRET;
-  if (!expected) return false; // no secret configured = endpoint disabled
-  const cronHeader = request.headers.get("x-cron-secret");
-  if (cronHeader === expected) return true;
-  const auth = request.headers.get("authorization") ?? "";
-  if (auth === `Bearer ${expected}`) return true;
-  return false;
+  return verifyCronSecret(request);
 }
 
 function unauthorized(): NextResponse {

--- a/apps/web/src/app/api/v1/cron/evaluate-price-alerts/route.ts
+++ b/apps/web/src/app/api/v1/cron/evaluate-price-alerts/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { withObservability } from "@/lib/observability";
 import { evaluatePriceAlerts } from "@/lib/markets/evaluate-alerts";
+import { verifyCronSecret } from "@/lib/cron-auth";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 300;
@@ -12,11 +13,7 @@ export const maxDuration = 300;
  * Actions (see docs/09_ENVIRONMENTS.md / cron workflows).
  */
 function authorize(request: NextRequest): boolean {
-  const expected = process.env.CRON_SECRET;
-  if (!expected) return false; // no secret configured ⇒ endpoint disabled
-  if (request.headers.get("x-cron-secret") === expected) return true;
-  if (request.headers.get("authorization") === `Bearer ${expected}`) return true;
-  return false;
+  return verifyCronSecret(request);
 }
 
 function unauthorized(): NextResponse {

--- a/apps/web/src/app/api/v1/cron/reminders/route.ts
+++ b/apps/web/src/app/api/v1/cron/reminders/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { createClient as createAdminClient } from "@supabase/supabase-js";
 import { withObservability } from "@/lib/observability";
+import { verifyCronSecret } from "@/lib/cron-auth";
 import type { Database } from "@rokki/db";
 
 /**
@@ -189,13 +190,7 @@ async function refreshOne(
 }
 
 function authorize(request: NextRequest): boolean {
-  const expected = process.env.CRON_SECRET;
-  if (!expected) return false; // no secret configured = endpoint disabled
-  const cronHeader = request.headers.get("x-cron-secret");
-  if (cronHeader === expected) return true;
-  const auth = request.headers.get("authorization") ?? "";
-  if (auth === `Bearer ${expected}`) return true;
-  return false;
+  return verifyCronSecret(request);
 }
 
 function unauthorized(): NextResponse {

--- a/apps/web/src/app/api/v1/pipeline/leads/[id]/files/sign/route.ts
+++ b/apps/web/src/app/api/v1/pipeline/leads/[id]/files/sign/route.ts
@@ -15,19 +15,27 @@ interface Props {
  * download an attachment. The bucket's owner-only SELECT policy means a user can
  * only sign their own files.
  */
-async function handleGet(request: NextRequest, _props: Props) {
+async function handleGet(request: NextRequest, props: Props) {
   const supabase = await createClient();
   const {
     data: { user },
   } = await supabase.auth.getUser();
   if (!user) return unauthorized();
 
+  const { id: leadId } = await props.params;
   const key = request.nextUrl.searchParams.get("key");
   if (!key) return badRequest("key is required");
+  // Scope the key to this user + lead; don't sign an arbitrary storage path.
+  if (!key.startsWith(`${user.id}/${leadId}/`)) {
+    return badRequest("key does not belong to this lead");
+  }
 
+  // `download: true` forces Content-Disposition: attachment, so an uploaded
+  // HTML/SVG downloads instead of rendering inline on the storage origin
+  // (prevents stored-XSS via a signed lead-file URL).
   const { data, error } = await supabase.storage
     .from(LEAD_FILES_BUCKET)
-    .createSignedUrl(key, 300);
+    .createSignedUrl(key, 300, { download: true });
   if (error || !data?.signedUrl) {
     return badRequest(error?.message ?? "Could not sign URL");
   }

--- a/apps/web/src/app/api/v1/tools/route.ts
+++ b/apps/web/src/app/api/v1/tools/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { createClient } from "@/lib/supabase/server";
-import { validateBearer } from "@/lib/api-auth";
+import { validateBearer, hasScope } from "@/lib/api-auth";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@rokki/db";
 
@@ -43,6 +43,17 @@ async function handlePost(request: NextRequest) {
   let userId: string;
   const bearer = await validateBearer(request);
   if (bearer) {
+    // Publishing a tool is a write — a read-only PAT must not be allowed to.
+    if (!hasScope(bearer, "write")) {
+      return NextResponse.json(
+        {
+          errors: [
+            { code: "forbidden", message: "This token lacks the `write` scope." },
+          ],
+        },
+        { status: 403 },
+      );
+    }
     supabase = bearer.admin;
     userId = bearer.userId;
   } else {

--- a/apps/web/src/app/auth/callback/finalize/route.ts
+++ b/apps/web/src/app/auth/callback/finalize/route.ts
@@ -2,6 +2,7 @@ import { NextResponse, type NextRequest } from "next/server";
 import { createClient as createAdminClient } from "@supabase/supabase-js";
 import { createClient } from "@/lib/supabase/server";
 import type { Database, OrgRole, ProjectRole } from "@rokki/db";
+import { safeRedirectPath } from "@/lib/safe-redirect";
 
 /**
  * Second leg of the invite / magic-link flow. The hash-fragment shim in
@@ -15,7 +16,7 @@ import type { Database, OrgRole, ProjectRole } from "@rokki/db";
  */
 export async function GET(request: NextRequest) {
   const { origin, searchParams } = new URL(request.url);
-  const redirectTo = searchParams.get("redirect_to") ?? "/";
+  const redirectTo = safeRedirectPath(searchParams.get("redirect_to"));
 
   const supabase = await createClient();
   const {

--- a/apps/web/src/app/auth/callback/route.ts
+++ b/apps/web/src/app/auth/callback/route.ts
@@ -6,6 +6,7 @@ import {
 import type { EmailOtpType } from "@supabase/supabase-js";
 import type { Database, OrgRole, ProjectRole } from "@rokki/db";
 import { withObservability } from "@/lib/observability";
+import { safeRedirectPath } from "@/lib/safe-redirect";
 
 type ServerClient = ReturnType<typeof createServerClient<Database>>;
 
@@ -41,7 +42,8 @@ async function handleGet(request: NextRequest) {
   const code = searchParams.get("code");
   const tokenHash = searchParams.get("token_hash");
   const rawType = searchParams.get("type");
-  const redirectTo = searchParams.get("redirect_to") ?? "/";
+  // Same-origin path only — never redirect a just-authenticated user off-site.
+  const redirectTo = safeRedirectPath(searchParams.get("redirect_to"));
 
   // Build the response up-front so the Supabase client can bind cookies to it.
   const response = NextResponse.redirect(`${origin}${redirectTo}`);

--- a/apps/web/src/app/login/LoginForm.tsx
+++ b/apps/web/src/app/login/LoginForm.tsx
@@ -5,6 +5,7 @@ import { useSearchParams, useRouter } from "next/navigation";
 import { Button } from "@/components/ui/Button";
 import { Input } from "@/components/ui/Input";
 import { FormError } from "@/components/ui/FormError";
+import { safeRedirectPath } from "@/lib/safe-redirect";
 
 /**
  * Login form. Closed system — accounts are created by platform admins
@@ -23,7 +24,8 @@ import { FormError } from "@/components/ui/FormError";
 export function LoginForm() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const redirectTo = searchParams.get("redirect_to") ?? "/";
+  // Only ever navigate to a same-origin path — never an attacker-supplied URL.
+  const redirectTo = safeRedirectPath(searchParams.get("redirect_to"));
   const callbackError = searchParams.get("error");
 
   const [identifier, setIdentifier] = useState("");

--- a/apps/web/src/lib/admin-auth.ts
+++ b/apps/web/src/lib/admin-auth.ts
@@ -2,7 +2,7 @@ import { NextResponse, type NextRequest } from "next/server";
 import { createClient as createAdminClient } from "@supabase/supabase-js";
 import type { Database } from "@rokki/db";
 import { createClient } from "@/lib/supabase/server";
-import { validateBearer } from "@/lib/api-auth";
+import { validateBearer, hasScope } from "@/lib/api-auth";
 
 export interface AdminContext {
   /** The admin user's auth id. */
@@ -55,6 +55,22 @@ export async function requireAdmin(
   let email: string | undefined;
 
   if (bearer) {
+    // A PAT may only drive admin tooling if it carries the `admin` scope —
+    // otherwise a narrow read/write token owned by an admin could perform
+    // destructive cross-tenant operations.
+    if (!hasScope(bearer, "admin")) {
+      return NextResponse.json(
+        {
+          errors: [
+            {
+              code: "forbidden",
+              message: "This token lacks the required `admin` scope.",
+            },
+          ],
+        },
+        { status: 403 },
+      );
+    }
     userId = bearer.userId;
   } else {
     const supabase = await createClient();

--- a/apps/web/src/lib/api-auth.test.ts
+++ b/apps/web/src/lib/api-auth.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { hasScope } from "./api-auth";
+
+describe("hasScope", () => {
+  it("read scope can read but not write/admin", () => {
+    const b = { scopes: ["read"] };
+    expect(hasScope(b, "read")).toBe(true);
+    expect(hasScope(b, "write")).toBe(false);
+    expect(hasScope(b, "admin")).toBe(false);
+  });
+  it("write scope implies read but not admin", () => {
+    const b = { scopes: ["write"] };
+    expect(hasScope(b, "read")).toBe(true);
+    expect(hasScope(b, "write")).toBe(true);
+    expect(hasScope(b, "admin")).toBe(false);
+  });
+  it("admin scope grants everything", () => {
+    const b = { scopes: ["admin"] };
+    expect(hasScope(b, "read")).toBe(true);
+    expect(hasScope(b, "write")).toBe(true);
+    expect(hasScope(b, "admin")).toBe(true);
+  });
+  it("empty / missing scopes grant nothing", () => {
+    expect(hasScope({ scopes: [] }, "read")).toBe(false);
+    expect(hasScope({ scopes: [] }, "write")).toBe(false);
+    // @ts-expect-error — exercise the ?? [] guard
+    expect(hasScope({ scopes: undefined }, "read")).toBe(false);
+  });
+});

--- a/apps/web/src/lib/api-auth.ts
+++ b/apps/web/src/lib/api-auth.ts
@@ -74,3 +74,21 @@ export async function validateBearer(
     admin,
   };
 }
+
+/**
+ * Whether a bearer token carries the required capability. `admin` implies
+ * everything; `write` implies `read`. A `read`-only token can NOT write, and
+ * only an explicit `admin` scope grants admin. Every write/admin route must
+ * gate on this — validateBearer only proves *who* the token is, not *what* it
+ * may do.
+ */
+export function hasScope(
+  bearer: Pick<BearerAuth, "scopes">,
+  needed: "read" | "write" | "admin",
+): boolean {
+  const s = bearer.scopes ?? [];
+  if (s.includes("admin")) return true;
+  if (needed === "admin") return false;
+  if (needed === "write") return s.includes("write");
+  return s.includes("read") || s.includes("write");
+}

--- a/apps/web/src/lib/cron-auth.ts
+++ b/apps/web/src/lib/cron-auth.ts
@@ -1,0 +1,28 @@
+import { createHash, timingSafeEqual } from "crypto";
+
+/**
+ * Constant-time comparison of two strings. Both are SHA-256'd first so the
+ * comparison is over equal-length buffers (timingSafeEqual throws on unequal
+ * lengths and would otherwise leak the secret's length).
+ */
+function safeEqual(a: string, b: string): boolean {
+  const ha = createHash("sha256").update(a).digest();
+  const hb = createHash("sha256").update(b).digest();
+  return timingSafeEqual(ha, hb);
+}
+
+/**
+ * Authorize a public cron endpoint. Accepts either `x-cron-secret: <CRON_SECRET>`
+ * or `Authorization: Bearer <CRON_SECRET>`. The secret is compared in constant
+ * time so the early-exit `===` can't be used as a timing oracle to recover it.
+ * Returns false when CRON_SECRET is unset (fail closed).
+ */
+export function verifyCronSecret(request: Request): boolean {
+  const expected = process.env.CRON_SECRET;
+  if (!expected) return false;
+  const cronHeader = request.headers.get("x-cron-secret");
+  if (cronHeader && safeEqual(cronHeader, expected)) return true;
+  const auth = request.headers.get("authorization");
+  if (auth && safeEqual(auth, `Bearer ${expected}`)) return true;
+  return false;
+}

--- a/apps/web/src/lib/file-sniff.ts
+++ b/apps/web/src/lib/file-sniff.ts
@@ -1,0 +1,52 @@
+/**
+ * Content-sniffing helpers — never trust a client-supplied Content-Type for
+ * anything that will later be served back to a browser. We derive the real type
+ * from the file's magic bytes. Text-based "images" like SVG have no magic bytes
+ * and return null, so they're rejected (they're the stored-XSS vector).
+ */
+
+/** Real raster-image MIME from magic bytes, or null if it isn't one. */
+export function sniffImageMime(bytes: Uint8Array): string | null {
+  const b = bytes;
+  if (b.length < 12) return null;
+  // JPEG: FF D8 FF
+  if (b[0] === 0xff && b[1] === 0xd8 && b[2] === 0xff) return "image/jpeg";
+  // PNG: 89 50 4E 47 0D 0A 1A 0A
+  if (b[0] === 0x89 && b[1] === 0x50 && b[2] === 0x4e && b[3] === 0x47) {
+    return "image/png";
+  }
+  // GIF: 47 49 46 38 ("GIF8")
+  if (b[0] === 0x47 && b[1] === 0x49 && b[2] === 0x46 && b[3] === 0x38) {
+    return "image/gif";
+  }
+  // WEBP: "RIFF"...."WEBP"
+  if (
+    b[0] === 0x52 && b[1] === 0x49 && b[2] === 0x46 && b[3] === 0x46 &&
+    b[8] === 0x57 && b[9] === 0x45 && b[10] === 0x42 && b[11] === 0x50
+  ) {
+    return "image/webp";
+  }
+  // BMP: "BM"
+  if (b[0] === 0x42 && b[1] === 0x4d) return "image/bmp";
+  // HEIC/HEIF: ISO-BMFF "ftyp" box (offset 4) with a heic/heif-family brand.
+  if (b[4] === 0x66 && b[5] === 0x74 && b[6] === 0x79 && b[7] === 0x70) {
+    const brand = String.fromCharCode(b[8], b[9], b[10], b[11]).toLowerCase();
+    if (["heic", "heix", "hevc", "heif", "mif1", "msf1"].includes(brand)) {
+      return "image/heic";
+    }
+  }
+  return null;
+}
+
+/** Content types that browsers will execute/render inline — never serve these
+ *  inline from user uploads. Used to force a download disposition. */
+export function isActiveContentType(type: string | null | undefined): boolean {
+  const t = (type ?? "").toLowerCase();
+  return (
+    t.includes("html") ||
+    t.includes("svg") ||
+    t.includes("xml") ||
+    t.includes("javascript") ||
+    t.includes("ecmascript")
+  );
+}

--- a/apps/web/src/lib/safe-redirect.test.ts
+++ b/apps/web/src/lib/safe-redirect.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { safeRedirectPath } from "./safe-redirect";
+
+describe("safeRedirectPath", () => {
+  it("allows same-origin absolute paths", () => {
+    expect(safeRedirectPath("/")).toBe("/");
+    expect(safeRedirectPath("/dashboard")).toBe("/dashboard");
+    expect(safeRedirectPath("/p/ACME?tab=files#x")).toBe("/p/ACME?tab=files#x");
+  });
+  it("blocks absolute URLs and protocol-relative targets", () => {
+    expect(safeRedirectPath("https://evil.com")).toBe("/");
+    expect(safeRedirectPath("http://evil.com")).toBe("/");
+    expect(safeRedirectPath("//evil.com")).toBe("/");
+    expect(safeRedirectPath("javascript:alert(1)")).toBe("/");
+  });
+  it("blocks backslash and encoded-slash tricks", () => {
+    expect(safeRedirectPath("/\\evil.com")).toBe("/");
+    expect(safeRedirectPath("/path\\x")).toBe("/");
+    expect(safeRedirectPath("/%2f%2fevil.com")).toBe("/");
+    expect(safeRedirectPath("/%5cevil.com")).toBe("/");
+  });
+  it("blocks control characters", () => {
+    expect(safeRedirectPath("/a\nb")).toBe("/");
+    expect(safeRedirectPath("/a\tb")).toBe("/");
+  });
+  it("falls back for empty / non-string", () => {
+    expect(safeRedirectPath(null)).toBe("/");
+    expect(safeRedirectPath(undefined)).toBe("/");
+    expect(safeRedirectPath("")).toBe("/");
+    expect(safeRedirectPath("relative/no/slash")).toBe("/");
+  });
+  it("honors a custom fallback", () => {
+    expect(safeRedirectPath("https://evil.com", "/login")).toBe("/login");
+  });
+});

--- a/apps/web/src/lib/safe-redirect.ts
+++ b/apps/web/src/lib/safe-redirect.ts
@@ -1,0 +1,28 @@
+/**
+ * Guard against open-redirects: only allow a redirect target that is a
+ * same-origin ABSOLUTE PATH. Everything else (absolute URLs, protocol-relative
+ * `//host`, backslash tricks `/\host`, encoded-slash `/%2f`, control chars)
+ * falls back to `fallback`. Used by the login form and every auth-callback
+ * redirect so an attacker can't send a freshly-authenticated user off-site.
+ */
+export function safeRedirectPath(
+  raw: string | null | undefined,
+  fallback = "/",
+): string {
+  if (typeof raw !== "string" || raw.length === 0) return fallback;
+  // Must be an absolute path on this origin.
+  if (raw[0] !== "/") return fallback;
+  // Reject protocol-relative ("//host") and backslash-relative ("/\host").
+  if (raw[1] === "/" || raw[1] === "\\") return fallback;
+  // A stray backslash anywhere can be normalized to "/" by browsers.
+  if (raw.includes("\\")) return fallback;
+  // Encoded slash/backslash right after the leading slash → still off-origin.
+  const lower = raw.toLowerCase();
+  if (lower.startsWith("/%2f") || lower.startsWith("/%5c")) return fallback;
+  // Reject control characters / newlines (header-splitting, normalization).
+  for (let i = 0; i < raw.length; i++) {
+    const code = raw.charCodeAt(i);
+    if (code < 0x20 || code === 0x7f) return fallback;
+  }
+  return raw;
+}


### PR DESCRIPTION
From the adversarial bug hunt — the confirmed **Critical security** cluster, all live on rokki.ai.

| # | Fix |
|---|-----|
| Open redirect | `redirect_to` validated to a same-origin path (shared `safeRedirectPath`) in LoginForm + auth/callback + finalize. Blocks `https://evil.com`, `//host`, `/\host`, `/%2f`, control chars. |
| PAT scopes | `hasScope()` added; the tools write handler now requires `write`, `requireAdmin` requires `admin` (403 otherwise). A read-only PAT can no longer write or drive admin ops. |
| Upload XSS | Avatars sniff magic bytes and reject SVG/HTML (store sniffed type); lead-file signed URLs force download + are scoped to `<userId>/<leadId>/`. |
| Cron timing | `verifyCronSecret()` uses `crypto.timingSafeEqual` over hashed buffers across all 3 cron routes. |

**New tests:** safe-redirect (11), hasScope (4). tsc + eslint clean.

Note: a broader sweep to gate *every* bearer write route on `write` is a good follow-up; this covers the two the hunt flagged (tool publish + admin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)