### PR TITLE
fix(pipeline): prevent lead-file + field-key data loss

### DIFF
--- a/apps/web/src/app/api/v1/pipeline/leads/[id]/files/route.ts
+++ b/apps/web/src/app/api/v1/pipeline/leads/[id]/files/route.ts
@@ -90,8 +90,17 @@ async function handleDelete(request: NextRequest, { params }: Props) {
   const lead = await getLead(supabase, id);
   if (!lead) return notFound("Lead not found");
 
+  // Only delete a key that actually belongs to THIS lead. Storage RLS only
+  // checks the `<userId>/` prefix, so without this a caller could pass another
+  // lead's key and delete its bytes. Require both the user+lead prefix AND that
+  // the key is one of this lead's recorded files.
+  const current = filesOf(lead.attributes);
+  if (!key.startsWith(`${user.id}/${id}/`) || !current.some((f) => f.key === key)) {
+    return badRequest("key does not belong to this lead");
+  }
+
   await supabase.storage.from(LEAD_FILES_BUCKET).remove([key]);
-  const files = filesOf(lead.attributes).filter((f) => f.key !== key);
+  const files = current.filter((f) => f.key !== key);
   await updateLead(supabase, id, { attributes: { ...lead.attributes, files } });
   return ok({ files });
 }

--- a/apps/web/src/app/api/v1/pipeline/leads/[id]/route.ts
+++ b/apps/web/src/app/api/v1/pipeline/leads/[id]/route.ts
@@ -39,6 +39,21 @@ async function handlePatch(request: NextRequest, { params }: Props) {
     return badRequest("Invalid JSON body");
   }
   try {
+    // `attributes.files` is owned by the file-upload/delete route, not the edit
+    // form. The form submits its (possibly stale) attributes snapshot, which
+    // would otherwise clobber files added during the same session — so preserve
+    // the server's current files list across any attributes update.
+    if (body.attributes && typeof body.attributes === "object") {
+      const current = await getLead(supabase, id);
+      const currentFiles = (current?.attributes as { files?: unknown } | null)
+        ?.files;
+      if (currentFiles !== undefined) {
+        body.attributes = {
+          ...(body.attributes as Record<string, unknown>),
+          files: currentFiles,
+        };
+      }
+    }
     const lead = await updateLead(supabase, id, body);
     if (!lead) return notFound("Lead not found");
     return ok({ lead });

--- a/apps/web/src/modules/pipeline/components/CustomizePanel.tsx
+++ b/apps/web/src/modules/pipeline/components/CustomizePanel.tsx
@@ -175,13 +175,18 @@ export function CustomizePanel({
   }
 
   function buildFields(): PipelineField[] {
+    const rows = fields.filter((r) => r.label.trim());
+    // Reserve every EXISTING (persisted) key up-front so a new / auto-slugged
+    // row can never steal — and thereby rename — an established field's key.
+    // Renaming an existing key would orphan every lead's stored values for it.
     const taken = new Set<string>();
-    return fields
-      .filter((r) => r.label.trim())
+    for (const r of rows) if (r.key) taken.add(r.key);
+    return rows
       .map((r) => {
-        let key = r.key || slugifyKey(r.label);
-        key = uniqueKey(key, taken);
-        taken.add(key);
+        // Existing rows keep their persisted key; only new rows (no r.key) get
+        // a freshly-slugged, de-duplicated key.
+        const key = r.key || uniqueKey(slugifyKey(r.label), taken);
+        if (!r.key) taken.add(key);
         const field: PipelineField = { key, label: r.label.trim(), type: r.type };
         if (r.group.trim()) field.group = r.group.trim();
         if (r.card) field.card = true;


### PR DESCRIPTION
From the adversarial bug hunt — the confirmed **Critical data-loss** cluster.

- **Cross-lead file deletion.** `DELETE …/files?key=` removed storage bytes by the client-supplied key; storage RLS only checks the `<userId>/` prefix, so a key from another lead deleted *its* bytes. Now the key must start with `<userId>/<leadId>/` **and** be one of this lead's recorded files.
- **Lead save wipes files.** The edit form submits a stale `attributes` snapshot that overwrote `attributes.files`, erasing files uploaded in the same session. The lead PATCH now preserves the server's current `files` list across any attributes update (files are route-owned, not form-owned).
- **Field-key collision.** `buildFields` could rename an existing field's key when a new/auto-slugged row collided, orphaning every lead's stored values for it. Existing persisted keys are reserved first; only new rows get de-duplicated keys.

tsc + eslint clean.

Deferred (medium, related): validating an arbitrary `stage`/`stages` write that can orphan leads (#20/#21) — good follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)