### PR TITLE
fix(pipeline): new-lead Save is one step (don't auto-open the drawer)

### DIFF
--- a/apps/web/src/modules/pipeline/components/PipelineBoard.tsx
+++ b/apps/web/src/modules/pipeline/components/PipelineBoard.tsx
@@ -286,11 +286,12 @@ export function PipelineBoard() {
     setCreateBusy(true);
     setCreateErr(null);
     try {
-      const lead = await createLead({ ...patch, pipeline_id: pipeline.id, space_id: spaceId });
+      await createLead({ ...patch, pipeline_id: pipeline.id, space_id: spaceId });
+      // Just save and close — the new lead lands on the board in one step.
+      // (We used to auto-open the detail drawer here, but that read as the
+      // entry form "cutting out" and forced a needless second Save.)
       setCreateStage(null);
       await refresh();
-      // Open the new lead so people / parcels / files are right there.
-      setSelectedLead(lead.id);
     } catch (e) {
       setCreateErr(e instanceof Error ? e.message : "Could not create");
     } finally {


### PR DESCRIPTION
**Reported:** "pipeline cuts out when I'm making an entry" + "I click Save in the small window, then instead of saving it takes me to the big window and I click Save again."

**Cause:** after `createLead`, `create()` called `setSelectedLead(lead.id)`, auto-opening the full detail drawer. The compact form vanishing + a second window reads as the entry 'cutting out' and a mandatory second step.

**Fix:** Save now just creates the lead and closes the form — it appears on the board in one step. Click the card to open detail when you actually want it. (No hard crash was found in the create/board/detail render paths; this was the disruptive auto-open.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)