### PR TITLE
fix(highsev): explorer white-screen crash + signal-media stored-XSS

### DIFF
--- a/apps/web/src/app/api/v1/signal/threads/[id]/route.ts
+++ b/apps/web/src/app/api/v1/signal/threads/[id]/route.ts
@@ -56,9 +56,13 @@ async function handleGet(_req: NextRequest, { params }: Props) {
       const withUrls = await Promise.all(
         atts.map(async (a) => {
           if (!a.storage_key) return { ...a, url: null };
+          // download:true → Content-Disposition: attachment. Inline <img>/<video>
+          // still render (subresource loads ignore the header), but an
+          // attacker-controlled text/html attachment downloads instead of
+          // executing inline on the storage origin (stored-XSS mitigation).
           const { data: signed } = await supabase.storage
             .from("signal-media")
-            .createSignedUrl(a.storage_key, 60 * 60);
+            .createSignedUrl(a.storage_key, 60 * 60, { download: true });
           return { ...a, url: signed?.signedUrl ?? null };
         }),
       );

--- a/apps/web/src/components/dashboard/ExplorerRail.tsx
+++ b/apps/web/src/components/dashboard/ExplorerRail.tsx
@@ -155,7 +155,16 @@ export function ExplorerRail({
       if (t) {
         const parsed = JSON.parse(t) as unknown;
         if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-          setTerminalOrder(parsed as Record<string, string[]>);
+          // Validate each value is a string[] — a corrupt/legacy entry (e.g. a
+          // bare string) would otherwise reach applyOrder().map() and throw
+          // during render, white-screening the rail and every page that uses it.
+          const clean: Record<string, string[]> = {};
+          for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
+            if (Array.isArray(v)) {
+              clean[k] = v.filter((x): x is string => typeof x === "string");
+            }
+          }
+          setTerminalOrder(clean);
         }
       }
     } catch {

--- a/apps/web/src/lib/explorer-order.ts
+++ b/apps/web/src/lib/explorer-order.ts
@@ -24,7 +24,9 @@ export function applyOrder<T>(
   idOf: (x: T) => string,
   order: string[],
 ): T[] {
-  if (order.length === 0) return items;
+  // Defensive: a corrupt localStorage value could hand us a non-array. Coerce
+  // rather than throw on `.map` mid-render (which white-screens the rail).
+  if (!Array.isArray(order) || order.length === 0) return items;
   const pos = new Map(order.map((id, i) => [id, i] as const));
   return items
     .map((item, i) => ({ item, i }))


### PR DESCRIPTION
Two high-severity bug-hunt findings.

**Explorer white-screen** — a corrupt/legacy `rokki_explorer_terminal_order` value (e.g. a bare string instead of `string[]`) reached `applyOrder().map()` during render and threw, white-screening the rail and every page that renders it. Hydration now validates each value is a `string[]`; `applyOrder` also treats a non-array order as a no-op.

**Signal-media stored-XSS** — the signed URL lacked `download:true`, so an attacker-controlled `text/html` attachment (rendered as a doc link) executed inline on the storage origin. Now signed with `{download:true}` (Content-Disposition: attachment), mirroring lead files. Inline `<img>/<video>` still render — subresource loads ignore the header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)