### PR TITLE
fix(goals): log to the local day + re-sync LogCell to authoritative value

### DIFF
--- a/apps/web/src/components/dashboard/GoalsCard.tsx
+++ b/apps/web/src/components/dashboard/GoalsCard.tsx
@@ -50,7 +50,12 @@ const TABS: { v: Tab; label: string }[] = [
 const SWATCHES = ["#3B82F6", "#22C55E", "#EF4444", "#EAB308", "#A855F7", "#14B8A6"];
 
 function todayIso(): string {
-  return new Date().toISOString().slice(0, 10);
+  // LOCAL calendar date, not UTC. toISOString() would roll to tomorrow in the
+  // evening for negative-UTC users (e.g. UTC-4), logging entries to the wrong
+  // day and advancing the week strip a day early.
+  const d = new Date();
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
 }
 function minIso(a: string, b: string) {
   return a < b ? a : b;

--- a/apps/web/src/components/modules/GoalsTrack.tsx
+++ b/apps/web/src/components/modules/GoalsTrack.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, type DragEvent } from "react";
+import { useEffect, useRef, useState, type DragEvent } from "react";
 import { Plus, Pencil, Archive, Check, X, Loader2, GripVertical } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type {
@@ -398,6 +398,14 @@ function LogCell({
 }) {
   const [v, setV] = useState(value === 0 ? "" : String(value));
   const [busy, setBusy] = useState(false);
+  const editing = useRef(false);
+
+  // Re-sync to the authoritative value when it changes externally (a reload
+  // after a failed/normalized write), but never clobber what the user is
+  // actively typing.
+  useEffect(() => {
+    if (!editing.current) setV(value === 0 ? "" : String(value));
+  }, [value]);
 
   async function commit() {
     const n = v.trim() === "" ? 0 : Number(v);
@@ -422,7 +430,13 @@ function LogCell({
         value={v}
         disabled={busy}
         onChange={(e) => setV(e.target.value)}
-        onBlur={commit}
+        onFocus={() => {
+          editing.current = true;
+        }}
+        onBlur={() => {
+          editing.current = false;
+          void commit();
+        }}
         onKeyDown={(e) => {
           if (e.key === "Enter") (e.target as HTMLInputElement).blur();
         }}


### PR DESCRIPTION
Two high-severity bug-hunt findings in Goals.

- **UTC-date mislog** — `todayIso()` used `toISOString()` (UTC). At e.g. 10pm in Miami (UTC-4) it's already tomorrow in UTC, so a daily log wrote `entry_date`=tomorrow and the highlighted 'today' cell / week strip advanced a day early. Now derived from the **local** calendar date.
- **LogCell stale state** — the cell never re-synced its input to the `value` prop, so a failed/normalized write left a stale number that could silently overwrite the server value. Now re-syncs on external change, but never while you're actively typing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)