### PR TITLE
fix(highsev): dead image lightbox + due-date tz + stale task override

### DIFF
--- a/apps/web/src/components/dashboard/TasksCard.tsx
+++ b/apps/web/src/components/dashboard/TasksCard.tsx
@@ -411,6 +411,22 @@ function DashboardTaskRow({
   const [override, setOverride] = useState<
     Partial<Pick<AssignedTask, "status" | "starred">>
   >({});
+  // Drop each optimistic override once the server prop catches up to it,
+  // otherwise a successful PATCH's override lingers forever and masks later
+  // server changes (e.g. another user starring the task) until unmount.
+  useEffect(() => {
+    setOverride((o) => {
+      let changed = false;
+      const next = { ...o };
+      for (const k of Object.keys(next) as (keyof typeof next)[]) {
+        if (task[k] === next[k]) {
+          delete next[k];
+          changed = true;
+        }
+      }
+      return changed ? next : o;
+    });
+  }, [task]);
   const merged: AssignedTask = { ...task, ...override };
 
   function rollback(patch: Partial<Pick<AssignedTask, "status" | "starred">>) {

--- a/apps/web/src/components/messages/SignalThreadView.tsx
+++ b/apps/web/src/components/messages/SignalThreadView.tsx
@@ -416,7 +416,15 @@ export function SignalThreadView({
   );
   const imageItems = useMemo(
     () =>
-      mediaItems.filter((x) => (x.att.content_type ?? "").startsWith("image/")),
+      // MUST match the isImage() predicate the clickable tiles use (content_type
+      // OR extension) — otherwise an extension-only image (null content_type,
+      // "photo.jpg") renders as a clickable tile but isn't in this index, so
+      // openLightbox's findIndex returns -1 and the click does nothing.
+      mediaItems.filter(
+        (x) =>
+          (x.att.content_type ?? "").startsWith("image/") ||
+          /\.(jpe?g|png|gif|webp|heic|heif|bmp|avif)$/i.test(x.att.filename ?? ""),
+      ),
     [mediaItems],
   );
   // Map to the ChatMessageList shape once per messages change — NOT on every

--- a/apps/web/src/components/primitives.tsx
+++ b/apps/web/src/components/primitives.tsx
@@ -142,7 +142,14 @@ export function DueChip({
       />
     );
   }
-  const d = new Date(date);
+  // Parse a date-only value to LOCAL midnight (not UTC) so the day-diff against
+  // local-midnight `today` is correct — new Date("2026-07-15") would be UTC
+  // midnight and shift the label/overdue by a day for non-UTC users. (Matches
+  // bucketByDue's date-only handling so the row chip and group header agree.)
+  const ymd = /^(\d{4})-(\d{2})-(\d{2})/.exec(date);
+  const d = ymd
+    ? new Date(Number(ymd[1]), Number(ymd[2]) - 1, Number(ymd[3]))
+    : new Date(date);
   const today = new Date();
   today.setHours(0, 0, 0, 0);
   const diff = Math.round((d.getTime() - today.getTime()) / 86_400_000);


### PR DESCRIPTION
Three high-severity bug-hunt findings.

- **Dead image click** — `imageItems`/`openLightbox` filtered on `content_type` only, but tiles render via `isImage()` (content_type OR extension). An extension-only image (null type, `photo.jpg`) was clickable but not in the lightbox index → `findIndex`=-1 → nothing happened. Predicate aligned.
- **Due-date off-by-one** — `DueChip` parsed the date-only string as UTC midnight vs local-midnight today, shifting the label/overdue by a day for non-UTC users (and disagreeing with the group header). Now parsed to local midnight.
- **Stale task override** — the optimistic done/star override never cleared on success, masking later server changes forever. Now reconciles against the server prop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)