### PR TITLE
fix(dashboard): don't blank the area when the maximized module is hidden

### DIFF
--- a/apps/web/src/components/dashboard/DashboardPanels.tsx
+++ b/apps/web/src/components/dashboard/DashboardPanels.tsx
@@ -127,6 +127,19 @@ export function DashboardPanels({
     );
   }
 
+  // If the maximized module stops being visible (minimized/hidden from the rail,
+  // a settings change, or a cross-device sync pull), drop out of maximize —
+  // otherwise every OTHER panel stays hiddenByMax and the whole area goes blank
+  // with no way to recover.
+  useEffect(() => {
+    if (
+      maximizedId &&
+      (!activeIds.has(maximizedId) || Boolean(mods?.minimized?.has(maximizedId)))
+    ) {
+      setMaximizedId(null);
+    }
+  }, [maximizedId, activeIds, mods]);
+
   // Track the lg breakpoint so the dynamic inline styles (panel flex,
   // grid template) only apply on desktop; mobile stays a natural stack.
   useEffect(() => {
@@ -310,6 +323,7 @@ export function DashboardPanels({
     setLayout(normalizeLayout(DEFAULT_DASH_LAYOUT));
     setWeights({ week: 1, tasks: 1, messages: 1, markets: 1, goals: 1, contacts: 1, pipeline: 1 });
     setCenterFrac(0.6);
+    setMaximizedId(null); // otherwise the grid stays maximized and the reset is invisible
   }
 
   /* ---------------- render helpers ---------------- */


### PR DESCRIPTION
High-severity bug-hunt finding. Minimizing/hiding the currently-maximized module (from the rail, settings, or a cross-device sync pull) left every other panel `hiddenByMax` → the whole dashboard area went blank with no in-UI recovery. Added a reconciliation effect that drops out of maximize when its module leaves the visible set; also clear `maximizedId` in `resetLayout`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)