### PR TITLE
fix(files): close three file/share data-exposure holes

### DIFF
--- a/apps/web/src/app/api/v1/files/[id]/duplicate/route.ts
+++ b/apps/web/src/app/api/v1/files/[id]/duplicate/route.ts
@@ -32,7 +32,7 @@ async function handlePost(request: NextRequest, { params }: Props) {
   const { data } = await supabase
     .from("files")
     .select(
-      "id, terminal_id, folder, filename, mime_type, size_bytes, blob_key, visibility, sha256",
+      "id, terminal_id, folder, filename, mime_type, size_bytes, blob_key, visibility, sha256, virus_scan_status",
     )
     .eq("id", id)
     .is("deleted_at", null)
@@ -48,9 +48,22 @@ async function handlePost(request: NextRequest, { params }: Props) {
         blob_key: string;
         visibility: "project" | "owners" | "custom";
         sha256: string | null;
+        virus_scan_status: "pending" | "clean" | "infected" | "skipped";
       }
     | null;
   if (!src) return notFound();
+  // Never duplicate a virus-flagged (or not-yet-scanned) file — otherwise the
+  // copy inherited virus_scan_status:'skipped' and became downloadable.
+  if (src.virus_scan_status === "infected")
+    return NextResponse.json(
+      { errors: [{ code: "virus_detected", message: "Cannot duplicate a file flagged by virus scanning." }] },
+      { status: 403 },
+    );
+  if (src.virus_scan_status === "pending")
+    return NextResponse.json(
+      { errors: [{ code: "scan_pending", message: "File is still being scanned; try again shortly." }] },
+      { status: 202 },
+    );
 
   const destFolder = body.folder ?? src.folder;
   if (destFolder !== "/" && destFolder !== src.folder) {
@@ -95,7 +108,9 @@ async function handlePost(request: NextRequest, { params }: Props) {
       blob_key: newBlobKey,
       visibility: src.visibility,
       version: 1,
-      virus_scan_status: "skipped",
+      // Carry the source's (clean/skipped) status — infected/pending were
+      // already rejected above — instead of blindly marking the copy skipped.
+      virus_scan_status: src.virus_scan_status,
       sha256: src.sha256,
       uploaded_by: user.id,
     })

--- a/apps/web/src/app/api/v1/files/[id]/signed-url/route.ts
+++ b/apps/web/src/app/api/v1/files/[id]/signed-url/route.ts
@@ -29,16 +29,36 @@ async function handleGet(_req: NextRequest, { params }: Props) {
 
   const { data } = await supabase
     .from("files")
-    .select("id, blob_key, mime_type, filename")
+    .select("id, blob_key, mime_type, filename, deleted_at, virus_scan_status")
     .eq("id", id)
     .maybeSingle();
   const file = data as
-    | { id: string; blob_key: string; mime_type: string; filename: string }
+    | {
+        id: string;
+        blob_key: string;
+        mime_type: string;
+        filename: string;
+        deleted_at: string | null;
+        virus_scan_status: "pending" | "clean" | "infected" | "skipped";
+      }
     | null;
-  if (!file)
+  // can_see_file RLS deliberately does NOT filter soft-deleted rows or scan
+  // status, so guard here exactly like the download route — otherwise this
+  // preview URL hands out bytes of a trashed or virus-flagged file.
+  if (!file || file.deleted_at)
     return NextResponse.json(
       { errors: [{ code: "not_found", message: "File not found" }] },
       { status: 404 },
+    );
+  if (file.virus_scan_status === "infected")
+    return NextResponse.json(
+      { errors: [{ code: "virus_detected", message: "File was flagged by virus scanning." }] },
+      { status: 403 },
+    );
+  if (file.virus_scan_status === "pending")
+    return NextResponse.json(
+      { errors: [{ code: "scan_pending", message: "File is still being scanned." }] },
+      { status: 202 },
     );
 
   const url = await getSignedDownloadUrl(file.blob_key, 300);

--- a/apps/web/src/app/api/v1/share/[token]/route.ts
+++ b/apps/web/src/app/api/v1/share/[token]/route.ts
@@ -47,11 +47,12 @@ async function handleGet(request: NextRequest, { params }: Props) {
   if (new Date(l.expires_at).getTime() < Date.now()) return denied("expired");
 
   if (l.max_views != null) {
+    // Count ALL accesses (view AND download) against the cap — counting only
+    // `view` let `?download=1` fetch the file unlimited times past max_views.
     const { count } = await admin
       .from("share_link_accesses")
       .select("id", { count: "exact", head: true })
-      .eq("share_link_id", l.id)
-      .eq("kind", "view");
+      .eq("share_link_id", l.id);
     if ((count ?? 0) >= l.max_views) return denied("max_views_reached");
   }
 


### PR DESCRIPTION
## Summary
Three routes that hand out storage bytes skipped the guards that `can_see_file` RLS deliberately delegates to route code (it does **not** filter `deleted_at` or `virus_scan_status`). Found during the third adversarial bug-hunt.

| Route | Hole | Fix |
|---|---|---|
| `files/[id]/signed-url` | Preview URL signed for trashed / infected / unscanned files | Add `deleted_at` + `virus_scan_status` guards matching the download route (404 deleted / 403 infected / 202 pending) |
| `files/[id]/duplicate` | Copy inherited `virus_scan_status:'skipped'` → infected/unscanned original became a downloadable copy | Reject infected (403) / pending (202) source; carry source's real scan status onto the copy |
| `share/[token]` | `max_views` counted only `kind='view'`, so `?download=1` fetched unlimited past the cap | Count **all** access kinds against the cap |

## Test plan
- `npx tsc --noEmit` — clean
- `eslint` on the three changed files — clean
- Guards mirror the already-shipped `download/route.ts` pattern (43–74)

## Out of scope (follow-up)
The folders authz-bypass (service-role cascade after member-level SELECT), share-links `can_see_file` gate, and the Tools RLS-policy gaps (`tool_invocations`/`quotas`/`tool_versions`) from the same hunt need permission-model verification and DB migrations — tracked for a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)