### PR TITLE
fix(files): folder-delete authz + duplicate laundering + share-link visibility gate

### DIFF
--- a/apps/web/src/app/api/v1/files/[id]/share-links/route.ts
+++ b/apps/web/src/app/api/v1/files/[id]/share-links/route.ts
@@ -13,6 +13,26 @@ interface Props {
  *   { label?, expires_in_days?, max_views?, require_email? }
  */
 
+/**
+ * Confirms the caller can actually see this file before we list or mint share
+ * links for it. share_links RLS only checks terminal membership, not
+ * can_see_file — so without this a member could share (or enumerate shares of)
+ * an owners-only / custom-visibility file they cannot read. can_see_file
+ * governs files_select, so a non-visible file returns null here.
+ */
+async function callerCanSeeFile(
+  supabase: Awaited<ReturnType<typeof createClient>>,
+  fileId: string,
+): Promise<boolean> {
+  const { data } = await supabase
+    .from("files")
+    .select("id")
+    .eq("id", fileId)
+    .is("deleted_at", null)
+    .maybeSingle();
+  return !!data;
+}
+
 async function handleGet(_req: NextRequest, { params }: Props) {
   const { id } = await params;
   const supabase = await createClient();
@@ -20,6 +40,7 @@ async function handleGet(_req: NextRequest, { params }: Props) {
     data: { user },
   } = await supabase.auth.getUser();
   if (!user) return unauth();
+  if (!(await callerCanSeeFile(supabase, id))) return notFound();
 
   const { data, error } = await supabase
     .from("share_links")
@@ -62,6 +83,7 @@ async function handlePost(request: NextRequest, { params }: Props) {
     data: { user },
   } = await supabase.auth.getUser();
   if (!user) return unauth();
+  if (!(await callerCanSeeFile(supabase, id))) return notFound();
 
   const body = (await request.json().catch(() => ({}))) as {
     label?: string;
@@ -100,6 +122,12 @@ function unauth() {
   return NextResponse.json(
     { errors: [{ code: "unauthenticated", message: "Sign in required" }] },
     { status: 401 },
+  );
+}
+function notFound() {
+  return NextResponse.json(
+    { errors: [{ code: "not_found", message: "File not found" }] },
+    { status: 404 },
   );
 }
 function internal(msg: string) {

--- a/apps/web/src/app/api/v1/folders/[id]/duplicate/route.ts
+++ b/apps/web/src/app/api/v1/folders/[id]/duplicate/route.ts
@@ -111,12 +111,20 @@ async function handlePost(_req: NextRequest, { params }: Props) {
   const { data: files } = await admin
     .from("files")
     .select(
-      "id, folder, filename, mime_type, size_bytes, blob_key, visibility, sha256",
+      "id, folder, filename, mime_type, size_bytes, blob_key, visibility, visibility_users, visibility_roles, virus_scan_status, sha256",
     )
     .eq("terminal_id", src.terminal_id)
     .is("deleted_at", null)
     .or(`folder.eq.${src.path},folder.like.${oldPrefix}%`);
 
+  type VisibilityRole =
+    | "owner"
+    | "manager"
+    | "architect"
+    | "gc"
+    | "lender"
+    | "family"
+    | "guest";
   type FileToCopy = {
     id: string;
     folder: string;
@@ -125,10 +133,20 @@ async function handlePost(_req: NextRequest, { params }: Props) {
     size_bytes: number;
     blob_key: string;
     visibility: "project" | "owners" | "custom";
+    visibility_users: string[] | null;
+    visibility_roles: VisibilityRole[] | null;
+    virus_scan_status: "pending" | "clean" | "infected" | "skipped";
     sha256: string | null;
   };
   let copied = 0;
+  let skippedInfected = 0;
   for (const f of (files ?? []) as FileToCopy[]) {
+    // Never propagate a virus-flagged file — otherwise the copy inherited
+    // virus_scan_status:'skipped' and became downloadable past the scanner.
+    if (f.virus_scan_status === "infected") {
+      skippedInfected++;
+      continue;
+    }
     const newId = crypto.randomUUID();
     const newKey = buildBlobKey({
       projectId: src.terminal_id,
@@ -150,8 +168,14 @@ async function handlePost(_req: NextRequest, { params }: Props) {
       size_bytes: f.size_bytes,
       blob_key: newKey,
       visibility: f.visibility,
+      // Preserve the custom-visibility scope — dropping these left 'custom'
+      // files visible to no one (silent loss), and blanking them on a copy of
+      // a re-scoped file would be a scope leak in the other direction.
+      visibility_users: f.visibility_users ?? undefined,
+      visibility_roles: f.visibility_roles ?? undefined,
       version: 1,
-      virus_scan_status: "skipped",
+      // Carry the source's real scan status instead of laundering to 'skipped'.
+      virus_scan_status: f.virus_scan_status,
       sha256: f.sha256,
       uploaded_by: user.id,
     });

--- a/apps/web/src/app/api/v1/folders/[id]/route.ts
+++ b/apps/web/src/app/api/v1/folders/[id]/route.ts
@@ -154,6 +154,20 @@ async function handleDelete(_req: NextRequest, { params }: Props) {
     { auth: { autoRefreshToken: false, persistSession: false } },
   );
 
+  // folders_delete RLS is manager-only (is_project_manager), but this route
+  // cascades via the service-role client, which bypasses that policy — so a
+  // plain member could delete an entire folder tree. Re-enforce manager rights
+  // explicitly. The trg_terminal_init_members trigger seeds every space owner
+  // into terminal_members as role='owner', so this also covers space owners.
+  const { data: membership } = await admin
+    .from("terminal_members")
+    .select("role")
+    .eq("terminal_id", folder.terminal_id)
+    .eq("user_id", user.id)
+    .maybeSingle();
+  const role = (membership as { role: string } | null)?.role;
+  if (role !== "owner" && role !== "manager") return forbidden();
+
   const stamp = new Date().toISOString();
   const prefix = folder.path + "/";
 
@@ -220,6 +234,19 @@ function notFound() {
   return NextResponse.json(
     { errors: [{ code: "not_found", message: "Folder not found" }] },
     { status: 404 },
+  );
+}
+function forbidden() {
+  return NextResponse.json(
+    {
+      errors: [
+        {
+          code: "forbidden",
+          message: "Only a terminal manager or owner can delete a folder.",
+        },
+      ],
+    },
+    { status: 403 },
   );
 }
 function internal(msg: string) {


### PR DESCRIPTION
## Summary
Three more service-role-cascade holes from the same bug-hunt as #374, each where a route bypasses a check RLS would otherwise enforce:

| Route | Hole | Fix |
|---|---|---|
| `folders/[id]` DELETE | `folders_delete` RLS is **manager-only**, but the soft-delete cascade runs through service-role → any plain member could trash a whole folder tree | Re-check `terminal_members` role (owner/manager) before cascading. The `trg_terminal_init_members` trigger seeds space owners as terminal owners, so they stay covered |
| `folders/[id]/duplicate` | Copies inherited `virus_scan_status:'skipped'` (laundered an infected/unscanned original into a downloadable copy); also dropped `visibility_users`/`visibility_roles` so `custom` files copied with no scope | Skip infected sources, carry the real scan status, preserve the visibility scope |
| `files/[id]/share-links` | `share_links` RLS only checks terminal membership, not `can_see_file` → a member could mint a public link to an owners-only/custom file they can't read | Gate GET+POST on the file being visible to the caller (`can_see_file`-governed select) |

## Test plan
- `npx tsc --noEmit` — clean
- eslint on the three changed files — clean
- Manager gate uses the same `terminal_members` role-lookup pattern as `admin/.../transfer-owner`

## Out of scope (tools follow-up)
The Tools findings from this hunt — `tool_invocations`/`quotas`/`tool_versions` RLS gaps (#7–#9, need migrations) and the Bearer-path private-tool leak (#10) — are bundled into a separate tools PR where the live (post-rename) schema can be verified once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)