### PR TITLE
fix(calendar): correct timezone bucketing across day/week/month

### DIFF
--- a/apps/web/src/components/calendar/CalendarClient.tsx
+++ b/apps/web/src/components/calendar/CalendarClient.tsx
@@ -23,6 +23,11 @@ import type {
   CalendarSource,
   CalendarView,
 } from "@/lib/calendar-queries";
+import {
+  localDateKey,
+  localizeItemDate,
+  weekStartLocal,
+} from "@/lib/calendar-local-date";
 
 interface Props {
   view: CalendarView;
@@ -54,12 +59,16 @@ export function CalendarClient({
   const router = useRouter();
   const searchParams = useSearchParams();
   const hiddenSet = useMemo(() => new Set(hiddenSourceIds), [hiddenSourceIds]);
+  // The loader runs on the server (UTC), so timed events arrive bucketed to
+  // their UTC calendar date. Re-key them to the browser's local day before any
+  // bucketing/filtering so evening events land on the correct day.
+  const localItems = useMemo(() => items.map(localizeItemDate), [items]);
   const selectedKey = searchParams.get("selected");
   const selectedItem = useMemo(() => {
     if (!selectedKey) return null;
     const [kind, id] = selectedKey.split(":");
-    return items.find((it) => it.kind === kind && it.id === id) ?? null;
-  }, [items, selectedKey]);
+    return localItems.find((it) => it.kind === kind && it.id === id) ?? null;
+  }, [localItems, selectedKey]);
 
   /** Push a new ?view= / ?date= / ?sources= / ?selected= without re-typing the rest. */
   function navigate(patch: {
@@ -178,7 +187,7 @@ export function CalendarClient({
       </header>
 
       {/* Body */}
-      {items.length === 0 ? (
+      {localItems.length === 0 ? (
         <EmptyState
           message={
             sources.length <= 1
@@ -187,11 +196,11 @@ export function CalendarClient({
           }
         />
       ) : view === "today" ? (
-        <DayView items={items} refDate={refDate} onOpen={openItem} />
+        <DayView items={localItems} refDate={refDate} onOpen={openItem} />
       ) : view === "week" ? (
-        <WeekView items={items} refDate={refDate} onOpen={openItem} />
+        <WeekView items={localItems} refDate={refDate} onOpen={openItem} />
       ) : (
-        <MonthView items={items} refDate={refDate} onOpen={openItem} />
+        <MonthView items={localItems} refDate={refDate} onOpen={openItem} />
       )}
 
       {/* Drawer */}
@@ -517,9 +526,18 @@ function positionEvents(items: CalendarItem[]): Positioned[] {
   type Working = { item: CalendarItem; startMin: number; endMin: number };
   const work: Working[] = sorted.map((it) => {
     const startMin = minutesIntoDay(it.when);
-    const endMin = it.ends_at
-      ? minutesIntoDay(it.ends_at)
-      : startMin + 30;
+    // minutesIntoDay discards the date, so an event ending after local midnight
+    // wraps to a tiny minute-of-day (endMin < startMin) → negative height + a
+    // broken overlap cluster. When ends_at falls on a later local day, treat it
+    // as filling the rest of this day's grid instead.
+    const crossesMidnight =
+      !!it.ends_at &&
+      localDateKey(new Date(it.ends_at)) !== localDateKey(new Date(it.when));
+    const endMin = crossesMidnight
+      ? DAY_GRID_END_HOUR * 60
+      : it.ends_at
+        ? minutesIntoDay(it.ends_at)
+        : startMin + 30;
     return {
       item: it,
       startMin: Math.max(startMin, DAY_GRID_START_HOUR * 60),
@@ -642,7 +660,10 @@ function WeekView({
   refDate: string;
   onOpen: (item: CalendarItem) => void;
 }) {
-  const days = useMemo(() => buildDayRange(refDate, 7), [refDate]);
+  // Snap to the Sunday that starts refDate's week so the 7 columns align with
+  // a calendar week (and with the Sunday-first month grid) instead of starting
+  // on whatever weekday the user happened to navigate to.
+  const days = useMemo(() => buildDayRange(weekStartLocal(refDate), 7), [refDate]);
   const itemsByDay = useMemo(() => groupByDate(items), [items]);
   const allDayByDay = useMemo(() => {
     const m = new Map<string, CalendarItem[]>();
@@ -1084,7 +1105,7 @@ function buildDayRange(
   return Array.from({ length: count }).map((_, i) => {
     const cur = new Date(start);
     cur.setDate(cur.getDate() + i);
-    const iso = cur.toISOString().slice(0, 10);
+    const iso = localDateKey(cur);
     const isToday = cur.getTime() === today.getTime();
     const fmt = cur.toLocaleDateString(undefined, {
       weekday: "short",
@@ -1117,7 +1138,7 @@ function buildMonthCells(refDate: string): MonthCell[] {
     const cur = new Date(start);
     cur.setDate(cur.getDate() + i);
     return {
-      date: cur.toISOString().slice(0, 10),
+      date: localDateKey(cur),
       dayOfMonth: cur.getDate(),
       month: cur.getMonth(),
       isToday: cur.getTime() === today.getTime(),

--- a/apps/web/src/lib/calendar-local-date.test.ts
+++ b/apps/web/src/lib/calendar-local-date.test.ts
@@ -1,0 +1,70 @@
+// Pin a UTC-negative zone (Miami/Eastern) so the tests exercise the exact
+// off-by-one the calendar cluster fixed. Must be set before any Date is built.
+process.env.TZ = "America/New_York";
+
+import { describe, it, expect } from "vitest";
+import {
+  localDateKey,
+  localizeItemDate,
+  weekStartLocal,
+} from "./calendar-local-date";
+
+describe("localDateKey", () => {
+  it("formats a locally-constructed date from its local parts", () => {
+    // Local midnight July 2 — same in any zone via the local constructor.
+    expect(localDateKey(new Date(2026, 6, 2))).toBe("2026-07-02");
+  });
+
+  it("keys an 8pm-Eastern instant (stored next-day UTC) to the local day", () => {
+    // 8pm July 2 in Miami is 00:00 July 3 UTC. The UTC slice would say July 3;
+    // the local key must say July 2.
+    const iso = "2026-07-03T00:00:00Z";
+    expect(iso.slice(0, 10)).toBe("2026-07-03"); // the old (buggy) key
+    expect(localDateKey(new Date(iso))).toBe("2026-07-02"); // the fixed key
+  });
+});
+
+describe("localizeItemDate", () => {
+  it("re-keys a timed event to its local day", () => {
+    const ev = {
+      kind: "event",
+      all_day: false,
+      when: "2026-07-03T00:00:00Z", // 8pm July 2 Eastern
+      date: "2026-07-03", // server (UTC) bucket
+    };
+    expect(localizeItemDate(ev).date).toBe("2026-07-02");
+  });
+
+  it("leaves all-day events untouched (literal date, never re-parsed)", () => {
+    const allDay = {
+      kind: "event",
+      all_day: true,
+      when: "2026-07-02T00:00:00Z",
+      date: "2026-07-02",
+    };
+    // Re-parsing this through new Date() in Eastern would shift it to July 1 —
+    // the guard must prevent that.
+    expect(localizeItemDate(allDay).date).toBe("2026-07-02");
+  });
+
+  it("leaves due-tasks untouched", () => {
+    const due = {
+      kind: "due",
+      all_day: true,
+      when: "2026-07-02T12:00:00",
+      date: "2026-07-02",
+    };
+    expect(localizeItemDate(due).date).toBe("2026-07-02");
+  });
+});
+
+describe("weekStartLocal", () => {
+  it("snaps a mid-week date back to its Sunday", () => {
+    // 2026-07-02 is a Thursday; its week starts Sunday 2026-06-28.
+    expect(weekStartLocal("2026-07-02")).toBe("2026-06-28");
+  });
+
+  it("returns a Sunday unchanged", () => {
+    expect(weekStartLocal("2026-06-28")).toBe("2026-06-28");
+  });
+});

--- a/apps/web/src/lib/calendar-local-date.ts
+++ b/apps/web/src/lib/calendar-local-date.ts
@@ -1,0 +1,51 @@
+/**
+ * Local-timezone date helpers for the calendar.
+ *
+ * The calendar loader (`calendar-queries.ts`) runs server-side, where the
+ * runtime clock is UTC (Vercel). That means any date derived there with
+ * `toISOString().slice(0,10)` — or a raw `starts_at` slice — is the *UTC*
+ * calendar date, not the viewer's. For a Miami user (UTC-4/-5) an 8pm event
+ * is stored `…T00:00:00Z` the next day, so it buckets and highlights on the
+ * wrong day. These helpers key everything off the *browser's* local zone so
+ * event buckets, grid cells, and the fetch window all agree.
+ *
+ * All functions are pure and have no React/DOM dependency so they can be unit
+ * tested directly.
+ */
+
+/** `YYYY-MM-DD` from a Date's LOCAL components (never UTC). */
+export function localDateKey(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+/**
+ * Re-derive a calendar item's bucket `date` in the browser's local zone.
+ *
+ * Timed events carry `date` computed server-side in UTC, so they must be
+ * re-keyed from the raw timestamp on the client. All-day events and due-tasks
+ * already carry a literal `YYYY-MM-DD` (never a wall-clock instant) and must
+ * NOT be re-parsed — running them through `new Date()` would shift them a day.
+ */
+export function localizeItemDate<
+  T extends { kind: string; all_day: boolean; when: string; date: string },
+>(it: T): T {
+  if (it.kind === "event" && !it.all_day && it.when.includes("T")) {
+    return { ...it, date: localDateKey(new Date(it.when)) };
+  }
+  return it;
+}
+
+/**
+ * Snap a bare `YYYY-MM-DD` back to the Sunday that starts its week, matching
+ * the month grid (which is Sunday-first). Operates purely on the date parts,
+ * so it is timezone-independent and safe to call on server or client.
+ */
+export function weekStartLocal(dateStr: string): string {
+  const [y, m, d] = dateStr.split("-").map(Number);
+  const dt = new Date(y ?? 1970, (m ?? 1) - 1, d ?? 1);
+  dt.setDate(dt.getDate() - dt.getDay()); // getDay(): 0 = Sunday
+  return localDateKey(dt);
+}

--- a/apps/web/src/lib/calendar-queries.ts
+++ b/apps/web/src/lib/calendar-queries.ts
@@ -142,15 +142,30 @@ function rangeForView(view: CalendarView, refDate: string): Range {
   if (view === "today") {
     end.setDate(end.getDate() + 1);
   } else if (view === "week") {
+    // Snap to the Sunday that starts the week so week columns align with the
+    // month grid (which is Sunday-first) instead of starting on refDate.
+    start.setDate(start.getDate() - start.getDay());
+    end.setTime(start.getTime());
     end.setDate(end.getDate() + 7);
   } else {
     start.setDate(1);
     end.setDate(1);
     end.setMonth(end.getMonth() + 1);
   }
+  // This code runs server-side, where the clock is UTC — so `start`/`end` are
+  // UTC-midnight boundaries. A viewer in a non-UTC zone has a local day that is
+  // shifted by their offset, so an evening event stored just past UTC-midnight
+  // would fall outside a tight window and never reach the client. Pad the event
+  // fetch by a day on each side (covers every real offset, ≤14h) and let the
+  // client re-bucket to the correct local day. Task date bounds stay exact —
+  // due_date is a bare calendar date with no timezone.
+  const eventStart = new Date(start);
+  eventStart.setDate(eventStart.getDate() - 1);
+  const eventEnd = new Date(end);
+  eventEnd.setDate(eventEnd.getDate() + 1);
   return {
-    startIso: start.toISOString(),
-    endIso: end.toISOString(),
+    startIso: eventStart.toISOString(),
+    endIso: eventEnd.toISOString(),
     startDate: start.toISOString().slice(0, 10),
     endDate: new Date(end.getTime() - 1).toISOString().slice(0, 10),
   };


### PR DESCRIPTION
## Summary
Five confirmed calendar bugs (adversarial hunt), all from mixing UTC and local dates. For a Miami (UTC-4/-5) user these fire **daily**.

| # | Bug | Fix |
|---|-----|-----|
| 1 | Timed events bucket to their **UTC** date but render at local time → 8pm event shows on the next day | Loader is server-side (UTC); re-key timed events to the browser's local day on the client (`localizeItemDate`). All-day/due items keep their literal date |
| 2 | Server event-fetch window is UTC-aligned → evening events fall *outside* it and never reach the client | Pad the event fetch ±1 day (covers every real offset ≤14h); client places precisely |
| 3 | Month/week grid cells keyed with `toISOString()` → off-by-one in UTC-positive zones | Key cells by local parts (`localDateKey`) |
| 4 | Timed events crossing local midnight get negative height + broken overlap columns | Detect the day change, fill to grid end |
| 5 | Week view starts on `refDate`, not the week's Sunday (disagrees with month grid) | Snap to week start in both fetch range and column builder |

## Test plan
- New `lib/calendar-local-date.ts` pure helpers + `calendar-local-date.test.ts` (7 tests) pinned to `America/New_York` so the UTC-negative off-by-one is actually exercised — **all pass**.
- `tsc --noEmit` clean; eslint clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)