### PR TITLE
fix(admin): restore-404, 200-user cap, blank deleted-by

### DIFF
--- a/apps/web/src/app/api/v1/admin/terminals/[ticker]/archive/route.ts
+++ b/apps/web/src/app/api/v1/admin/terminals/[ticker]/archive/route.ts
@@ -60,7 +60,11 @@ async function handleDelete(request: NextRequest, { params }: Props) {
   if ("status" in gate) return gate;
   const { admin, userId: actorId } = gate;
 
-  const resolved = await resolveTerminalBySegment(admin, ticker);
+  // Restore must find the *archived* row — the default resolver filters
+  // archived terminals out, which made every restore 404.
+  const resolved = await resolveTerminalBySegment(admin, ticker, {
+    includeArchived: true,
+  });
   if (!resolved)
     return NextResponse.json(
       { errors: [{ code: "not_found", message: "Terminal not found" }] },

--- a/apps/web/src/app/api/v1/admin/trash/route.ts
+++ b/apps/web/src/app/api/v1/admin/trash/route.ts
@@ -212,14 +212,19 @@ async function handleGet(request: NextRequest) {
     for (const row of (profiles ?? []) as { user_id: string; full_name: string | null }[]) {
       if (row.full_name) actorMap.set(row.user_id, row.full_name);
     }
-    const { data: users } = await admin.auth.admin.listUsers({
-      perPage: Math.max(actorIds.length, 50),
-      page: 1,
-    });
-    for (const u of users?.users ?? []) {
-      if (actorIds.includes(u.id) && !actorMap.has(u.id) && u.email) {
-        actorMap.set(u.id, u.email);
-      }
+    // Fall back to the auth email for actors without a profile name. listUsers
+    // has no id filter — it returns an arbitrary first page of ALL users, so
+    // any actor past that page was never matched (blank "deleted by" once the
+    // instance grew past ~50 users). Look each missing actor up directly.
+    const missing = actorIds.filter((id) => !actorMap.has(id));
+    const fetched = await Promise.all(
+      missing.map((id) =>
+        admin.auth.admin.getUserById(id).catch(() => null),
+      ),
+    );
+    for (const res of fetched) {
+      const u = res?.data?.user;
+      if (u?.email) actorMap.set(u.id, u.email);
     }
   }
 

--- a/apps/web/src/app/api/v1/admin/users/route.ts
+++ b/apps/web/src/app/api/v1/admin/users/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse, type NextRequest } from "next/server";
+import type { User } from "@supabase/supabase-js";
 import { requireAdmin } from "@/lib/admin-auth";
 import { emitEvent } from "@/lib/events";
 
@@ -38,20 +39,27 @@ async function handleGet(request: NextRequest) {
     0,
   );
 
-  // Supabase listUsers supports pagination but no search — we'd have to pull
-  // everything and filter. At the volume we expect for admin UX (hundreds),
-  // that's fine. If we outgrow it, switch to a direct SQL query on auth.users.
-  const { data, error } = await admin.auth.admin.listUsers({
-    perPage: 200,
-    page: 1,
-  });
-  if (error) {
-    return NextResponse.json(
-      { errors: [{ code: "internal_error", message: error.message }] },
-      { status: 500 },
-    );
+  // Supabase listUsers supports pagination but no search — we pull every page
+  // and filter/search/paginate in memory. Loop until a short page signals the
+  // end (previously this fetched only page 1, so any instance past 200 users
+  // silently dropped everyone after #200 from the table + search). The 10k cap
+  // is a safety bound far above expected admin volume.
+  const all: User[] = [];
+  for (let page = 1; page <= 50; page++) {
+    const { data, error } = await admin.auth.admin.listUsers({
+      perPage: 200,
+      page,
+    });
+    if (error) {
+      return NextResponse.json(
+        { errors: [{ code: "internal_error", message: error.message }] },
+        { status: 500 },
+      );
+    }
+    const batch = data?.users ?? [];
+    all.push(...batch);
+    if (batch.length < 200) break;
   }
-  const all = data?.users ?? [];
 
   // Join with profiles (admin flag, full_name). Pull the whole small table.
   const { data: profs } = await admin

--- a/apps/web/src/lib/resolve-terminal.ts
+++ b/apps/web/src/lib/resolve-terminal.ts
@@ -55,8 +55,14 @@ export interface ResolvedTerminal {
 export async function resolveTerminalBySegment(
   supabase: AnySupabaseClient,
   segment: string,
+  opts: { includeArchived?: boolean } = {},
 ): Promise<ResolvedTerminal | null> {
   if (!segment) return null;
+
+  // Restore/undo flows need to find an already-archived terminal; every other
+  // caller wants only live rows. Default excludes archived.
+  const notArchived = (q: AnySupabaseClient) =>
+    opts.includeArchived ? q : q.is("archived_at", null);
 
   // Slug lookup — the common case for any link generated since the
   // 20260526010000_terminal_slug migration shipped.
@@ -69,11 +75,12 @@ export async function resolveTerminalBySegment(
   // after creating a same-named terminal. Take the most recently created
   // match instead, so a just-created terminal resolves to itself.
   {
-    const { data } = await supabase
-      .from("terminals")
-      .select("id, space_id, slug, ticker, name")
-      .eq("slug", segment)
-      .is("archived_at", null)
+    const { data } = await notArchived(
+      supabase
+        .from("terminals")
+        .select("id, space_id, slug, ticker, name")
+        .eq("slug", segment),
+    )
       .order("created_at", { ascending: false })
       .limit(1);
     const row = ((data ?? []) as ResolvedTerminal[])[0];
@@ -82,11 +89,12 @@ export async function resolveTerminalBySegment(
 
   // Fallback for shared URLs minted before the slug column existed.
   if (looksLikeLegacyTicker(segment)) {
-    const { data } = await supabase
-      .from("terminals")
-      .select("id, space_id, slug, ticker, name")
-      .eq("ticker", segment.toUpperCase())
-      .is("archived_at", null)
+    const { data } = await notArchived(
+      supabase
+        .from("terminals")
+        .select("id, space_id, slug, ticker, name")
+        .eq("ticker", segment.toUpperCase()),
+    )
       .order("created_at", { ascending: false })
       .limit(1);
     const row = ((data ?? []) as ResolvedTerminal[])[0];


### PR DESCRIPTION
## Summary
Three confirmed admin-panel bugs from the verified hunt (all code-only, no migration):

| Bug | Cause | Fix |
|-----|-------|-----|
| Terminal **restore always 404s** | Restore handler resolves the ticker via `resolveTerminalBySegment`, which filters `archived_at IS NULL` → an archived terminal never matches | Add `includeArchived` option to the resolver; use it on the restore path |
| Admin user directory **capped at 200** | `listUsers` fetched only page 1 → users #201+ absent from table, unsearchable, unreachable by offset | Loop pages until a short page ends the list (10k safety bound) |
| Trash **"deleted by" often blank** | Filtered an unfiltered `listUsers` page-1 by actor id → actors past that page never matched | Look each missing actor up directly with `getUserById` (batched) |

## Test plan
- `tsc --noEmit` clean; eslint clean on all four changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)