### PR TITLE
fix(dnd): task drag off-by-one + pipeline won/lost status reset

### DIFF
--- a/apps/web/src/components/TasksPane.tsx
+++ b/apps/web/src/components/TasksPane.tsx
@@ -577,11 +577,13 @@ export function TasksPane({ ticker, projectId, currentUserId }: TasksPaneProps) 
     // not from the unmoved list.
     const next = [...tasks];
     const [moved] = next.splice(fromIdx, 1);
-    // Inserting after `toIdx`: drop AT the target's position when the
-    // user dragged downward, BEFORE the target when dragging upward.
-    // Visual convention: dropping ON a row places the source ABOVE
-    // it (matches the way the highlight reads as "I'm landing here").
-    const insertAt = fromIdx < toIdx ? toIdx : toIdx;
+    // Visual convention: dropping ON a row places the source ABOVE it.
+    // After splicing `moved` out at fromIdx, every index after it shifts
+    // left by one — so for a DOWNWARD drag the target now sits at toIdx-1
+    // and we insert there to land above it; for an UPWARD drag the target
+    // is unshifted at toIdx. (The old `fromIdx < toIdx ? toIdx : toIdx`
+    // was a dead ternary that dropped downward rows one slot too low.)
+    const insertAt = fromIdx < toIdx ? toIdx - 1 : toIdx;
     next.splice(insertAt, 0, moved);
 
     const movedIdx = next.findIndex((t) => t.id === sourceId);

--- a/apps/web/src/modules/pipeline/components/PipelineBoard.tsx
+++ b/apps/web/src/modules/pipeline/components/PipelineBoard.tsx
@@ -232,8 +232,19 @@ export function PipelineBoard() {
     if (!stage) return;
     const before = leads.find((l) => l.id === leadId);
     if (before && before.stage === stageKey) return; // dropped on its own column
+    // Sync status to the destination stage type. Moving INTO won/lost sets it;
+    // moving back OUT of won/lost into an open-type stage must clear it back to
+    // "open" (previously it was left undefined, so a lead dragged out of Won
+    // stayed status:"won" forever). Leave dead/converted untouched — those are
+    // set by explicit actions, not by a drag.
     const status: LeadRow["status"] | undefined =
-      stage.type === "won" ? "won" : stage.type === "lost" ? "lost" : undefined;
+      stage.type === "won"
+        ? "won"
+        : stage.type === "lost"
+          ? "lost"
+          : before && (before.status === "won" || before.status === "lost")
+            ? "open"
+            : undefined;
     const prev = leads;
     setLeads((ls) =>
       ls.map((l) =>


### PR DESCRIPTION
## Summary
Two drag-and-drop correctness bugs from the verified hunt:

- **Manual task reorder off-by-one** — `insertAt = fromIdx < toIdx ? toIdx : toIdx` was a dead ternary (both branches identical), so dragging a row **downward** dropped it one slot too low. After the moved row is spliced out, indices after it shift left, so a downward drag must insert at `toIdx-1` to land above the target (the documented convention); upward stays at `toIdx`.
- **Pipeline won/lost status never resets** — `moveLead` set `status` only when the destination stage was won/lost, leaving it undefined otherwise. A lead dragged **out** of Won/Lost into an open stage kept `status:"won"`/`"lost"` forever (so it still counted as won/lost, rotting/follow-up logic stayed off). Now resets to `"open"` when leaving won/lost; leaves `dead`/`converted` untouched.

## Test plan
- `tsc --noEmit` + eslint clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)