### PR TITLE
fix(tools): scope Bearer tool listing (cross-tenant leak)

### DIFF
--- a/apps/web/src/app/api/v1/tools/route.ts
+++ b/apps/web/src/app/api/v1/tools/route.ts
@@ -25,13 +25,27 @@ async function handleGet(request: NextRequest) {
     if (!user) return unauth();
   }
 
-  const { data, error } = await supabase
+  let query = supabase
     .from("tools")
     .select(
       "id, slug, name, description, visibility, owner_user_id, owner_space_id, current_version, tags, timeout_seconds, created_at, updated_at",
     )
-    .is("deleted_at", null)
-    .order("name", { ascending: true });
+    .is("deleted_at", null);
+
+  // The Bearer path uses the service-role client, which BYPASSES the
+  // tools_select RLS policy — without an explicit scope it returned every
+  // private tool in every space (cross-tenant leak). Re-scope it to what the
+  // token's user may see: public tools plus tools they own. This is a
+  // conservative subset of the RLS predicate (org-/grant-shared tools aren't
+  // enumerated via PAT); the cookie path keeps full RLS visibility. userId is
+  // a validated UUID from the token, so the interpolation is injection-safe.
+  if (bearer) {
+    query = query.or(
+      `visibility.eq.public,owner_user_id.eq.${bearer.userId}`,
+    );
+  }
+
+  const { data, error } = await query.order("name", { ascending: true });
   if (error) return internal(error.message);
   return NextResponse.json({ data });
 }


### PR DESCRIPTION
## Summary
`GET /api/v1/tools` with an `Authorization: Bearer rk_…` token used `bearer.admin` (the **service-role** client, which bypasses RLS) with no visibility filter — so the response leaked **every private tool in every space**, not just the caller's.

Re-scope the Bearer path to `visibility = public OR owner_user_id = <token user>` — a conservative subset of the `tools_select` RLS predicate. The cookie/session path is untouched and keeps full RLS visibility. `userId` is a validated UUID from the token, so the `.or()` interpolation is injection-safe.

**Note:** org-/grant-shared tools aren't enumerated via a PAT under this fix (the safe subset); if PAT users need those, a follow-up can replicate the full RLS predicate once the post-rename column/enum names (`owner_space_id`, `visibility` values) are pinned.

## Test plan
- `tsc --noEmit` + eslint clean.

## Deferred (needs Zack)
Rate-limit `x-forwarded-for` uses the leftmost (client-spoofable) entry — but the correct fix depends on whether Vercel replaces vs appends XFF; guessing wrong risks a global sign-in lockout. Flagged for confirmation of Vercel's proxy semantics before changing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)