### PR TITLE
fix(pipeline): stage-rename data-loss + performance batch

### DIFF
--- a/apps/web/src/app/api/v1/briefing/route.ts
+++ b/apps/web/src/app/api/v1/briefing/route.ts
@@ -72,21 +72,22 @@ async function handleGet() {
     nextUp = upcoming[0] ?? null;
   }
 
-  // Unread mentions in the last 24h.
-  const { count: mentionCount } = await supabase
-    .from("notifications")
-    .select("id", { count: "exact", head: true })
-    .eq("kind", "mention")
-    .gte("created_at", in24h.toISOString())
-    .is("read_at", null);
-
-  // Activity highlights in the last 24h (scoped by RLS).
-  const { data: acts } = await supabase
-    .from("activity")
-    .select("action, metadata, created_at")
-    .gte("created_at", in24h.toISOString())
-    .order("created_at", { ascending: false })
-    .limit(100);
+  // Unread mentions + activity highlights in the last 24h — independent
+  // queries, so run them concurrently instead of one-after-the-other.
+  const [{ count: mentionCount }, { data: acts }] = await Promise.all([
+    supabase
+      .from("notifications")
+      .select("id", { count: "exact", head: true })
+      .eq("kind", "mention")
+      .gte("created_at", in24h.toISOString())
+      .is("read_at", null),
+    supabase
+      .from("activity")
+      .select("action, metadata, created_at")
+      .gte("created_at", in24h.toISOString())
+      .order("created_at", { ascending: false })
+      .limit(100),
+  ]);
   type Act = {
     action: string;
     metadata: Record<string, unknown> | null;

--- a/apps/web/src/app/api/v1/folders/[id]/duplicate/route.ts
+++ b/apps/web/src/app/api/v1/folders/[id]/duplicate/route.ts
@@ -97,14 +97,18 @@ async function handlePost(_req: NextRequest, { params }: Props) {
     name: string;
     parent_path: string;
   };
-  for (const row of (descendants ?? []) as FolderDescendant[]) {
-    await admin.from("folders").insert({
-      terminal_id: src.terminal_id,
-      path: rewritePath(row.path),
-      name: row.name,
-      parent_path: rewritePath(row.parent_path),
-      created_by: user.id,
-    });
+  // One batched insert instead of N sequential round-trips. Folders use a
+  // string path/parent_path model (no parent-id FK), so insert order is
+  // irrelevant and a single array insert is referentially safe.
+  const folderRows = ((descendants ?? []) as FolderDescendant[]).map((row) => ({
+    terminal_id: src.terminal_id,
+    path: rewritePath(row.path),
+    name: row.name,
+    parent_path: rewritePath(row.parent_path),
+    created_by: user.id,
+  }));
+  if (folderRows.length > 0) {
+    await admin.from("folders").insert(folderRows);
   }
 
   // 3. Copy every file — blob copy server-side + new DB row
@@ -138,6 +142,10 @@ async function handlePost(_req: NextRequest, { params }: Props) {
     virus_scan_status: "pending" | "clean" | "infected" | "skipped";
     sha256: string | null;
   };
+  // Blob copies must stay per-object (storage has no bulk copy), but the DB
+  // rows are accumulated and inserted in ONE round-trip after the copy loop
+  // instead of one insert per file.
+  const fileRows = [];
   let copied = 0;
   let skippedInfected = 0;
   for (const f of (files ?? []) as FileToCopy[]) {
@@ -159,7 +167,7 @@ async function handlePost(_req: NextRequest, { params }: Props) {
       console.error("[folders.duplicate] copy error for", f.filename, e);
       continue;
     }
-    await admin.from("files").insert({
+    fileRows.push({
       id: newId,
       terminal_id: src.terminal_id,
       folder: rewritePath(f.folder),
@@ -180,6 +188,9 @@ async function handlePost(_req: NextRequest, { params }: Props) {
       uploaded_by: user.id,
     });
     copied++;
+  }
+  if (fileRows.length > 0) {
+    await admin.from("files").insert(fileRows);
   }
 
   await supabase

--- a/apps/web/src/app/api/v1/messages/threads/[id]/route.ts
+++ b/apps/web/src/app/api/v1/messages/threads/[id]/route.ts
@@ -19,6 +19,9 @@ async function handleGet(_req: NextRequest, { params }: Props) {
   } = await supabase.auth.getUser();
   if (!user) return unauth();
 
+  // Cap at the most recent 200 messages — an unbounded fetch grew linearly
+  // with thread length and dominated inbox load on long threads. Fetch newest
+  // first with a limit, then flip back to oldest-first for rendering.
   const { data } = await supabase
     .from("messages")
     .select(
@@ -26,7 +29,8 @@ async function handleGet(_req: NextRequest, { params }: Props) {
     )
     .eq("thread_id", id)
     .is("deleted_at", null)
-    .order("created_at", { ascending: true });
+    .order("created_at", { ascending: false })
+    .limit(200);
 
   type Row = {
     id: string;
@@ -37,7 +41,7 @@ async function handleGet(_req: NextRequest, { params }: Props) {
     deleted_at: string | null;
     pinging_task_id: string | null;
   };
-  const rows = (data ?? []) as Row[];
+  const rows = ((data ?? []) as Row[]).slice().reverse();
   const authorIds = Array.from(new Set(rows.map((r) => r.author_id)));
   const { data: profiles } = authorIds.length
     ? await supabase

--- a/apps/web/src/components/SessionGuard.tsx
+++ b/apps/web/src/components/SessionGuard.tsx
@@ -30,6 +30,10 @@ export function SessionGuard() {
   useEffect(() => {
     const supabase = createClient();
     let active = true;
+    // Hoisted so the effect's OWN cleanup can remove the channel. Previously the
+    // removeChannel lived in a cleanup returned from the .then() callback, which
+    // React never sees — so every mount/unmount leaked a realtime channel.
+    let channel: ReturnType<typeof supabase.channel> | null = null;
 
     // Only subscribe if we're authenticated. Otherwise we'd open a channel
     // on the login page for no reason.
@@ -40,7 +44,7 @@ export function SessionGuard() {
       // Unique suffix so remounts don't collide with a still-closing
       // channel of the same name — same class of bug as useRealtimeTable.
       const channelName = `session-revocations:${userId}:${Date.now()}`;
-      const channel = supabase
+      channel = supabase
         .channel(channelName)
         .on(
           "postgres_changes" as never,
@@ -88,15 +92,11 @@ export function SessionGuard() {
                 : "info",
           });
         });
-
-      return () => {
-        active = false;
-        void supabase.removeChannel(channel);
-      };
     });
 
     return () => {
       active = false;
+      if (channel) void supabase.removeChannel(channel);
     };
   }, [router]);
 

--- a/apps/web/src/modules/contacts/components/ContactsView.tsx
+++ b/apps/web/src/modules/contacts/components/ContactsView.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Plus, Search, Users, X } from "lucide-react";
 import { Button } from "@/components/ui/Button";
 import type { ContactRow } from "@/lib/contacts/db";
@@ -85,8 +85,16 @@ export function ContactsView({
     setLastPatch(null);
   }
 
-  // Debounced server search/refresh.
+  // Debounced server search/refresh. Skip the very first run: the server
+  // already streamed `initialContacts` for the empty query, so a mount-time
+  // fetch just re-requests the same 200 rows and re-renders the whole list.
+  // Clearing the search box later still refetches (didMount is already true).
+  const didMount = useRef(false);
   useEffect(() => {
+    if (!didMount.current) {
+      didMount.current = true;
+      if (!q.trim()) return;
+    }
     const t = setTimeout(() => {
       listContacts({ q: q.trim() || undefined, limit: 200 })
         .then(setContacts)

--- a/apps/web/src/modules/pipeline/components/CustomizePanel.tsx
+++ b/apps/web/src/modules/pipeline/components/CustomizePanel.tsx
@@ -155,13 +155,19 @@ export function CustomizePanel({
   }
 
   function buildStages(): PipelineStage[] {
+    const rows = stages.filter((r) => r.label.trim());
+    // Reserve every EXISTING stage key up-front so a new / auto-slugged stage
+    // can never steal — and thereby rename — an established stage's key. A
+    // renamed stage key orphans every lead sitting in that stage (leads store
+    // the stage key). Same guard buildFields() uses for field keys.
     const taken = new Set<string>();
+    for (const r of rows) if (r.key) taken.add(r.key);
     const out: PipelineStage[] = [];
-    for (const r of stages) {
-      if (!r.label.trim()) continue;
-      let key = r.key || slugifyKey(r.label) || "stage";
-      key = uniqueKey(key, taken);
-      taken.add(key);
+    for (const r of rows) {
+      // Existing stages keep their persisted key; only new stages (no r.key)
+      // get a freshly-slugged, de-duplicated key.
+      const key = r.key || uniqueKey(slugifyKey(r.label) || "stage", taken);
+      if (!r.key) taken.add(key);
       const st: PipelineStage = { key, label: r.label.trim(), type: r.type };
       if (r.color) st.color = r.color;
       const rd = Number(r.rottingDays);


### PR DESCRIPTION
Two commits from the verified hunt: one data-loss fix, one performance batch (your "extra speed" ask).

## 1 · Pipeline stage-rename data-loss
`buildStages()` reserved stage keys **incrementally**, so a new/auto-slugged stage could grab a key an existing stage (later in the list) also wanted — pushing the existing stage through `uniqueKey()` and **renaming its key**. Leads store their stage by key, so every lead in the renamed stage was orphaned. Now reserves all existing stage keys up-front and only slugs new stages — the exact guard `buildFields()` already uses.

## 2 · Performance batch
| Area | Before | After |
|------|--------|-------|
| `folders/duplicate` | N sequential folder inserts + one insert per file (~700 round-trips for a 200-folder/500-file tree) | one batched folder insert + one batched file insert (blob copies stay per-object) |
| `messages/threads/:id` | unbounded fetch, grew with thread length | cap at most-recent 200 (desc+limit, flipped to oldest-first) |
| `briefing` | mentions + activity queries back-to-back | `Promise.all` |
| `ContactsView` | debounced effect refetched all 200 rows on mount | skip the mount run (server already streamed them) |
| `SessionGuard` | `removeChannel` returned from `.then()` (React never sees it) → realtime channel leaked every unmount | hoist channel ref so the effect cleanup removes it |

## Test plan
- `tsc --noEmit` + eslint clean on all six files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)