### PR TITLE
fix(tasks): header breadcrumb + settings gear + filtered count

### DIFF
--- a/apps/web/src/app/p/[ticker]/page.tsx
+++ b/apps/web/src/app/p/[ticker]/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import Link from "next/link";
-import { CheckSquare, Users } from "lucide-react";
+import { CheckSquare, Users, Settings } from "lucide-react";
 import { createClient as createAdminClient } from "@supabase/supabase-js";
 import type { Database } from "@rokki/db";
 import { createClient } from "@/lib/supabase/server";
@@ -239,10 +239,18 @@ export default async function ProjectTerminalPage({ params }: Props) {
           ) : null}
           <span className="text-text-3">/</span>
           <span className="text-text-0 font-medium">{p.name}</span>
-          {/* The settings cog used to live here. Removed in favour of
-              the F5 Settings tab in the function-key bar, so Settings
-              now reads as a peer of Files / Tasks / Team instead of a
-              hidden cog tucked next to the breadcrumb. */}
+          {/* Settings gear — restored next to the terminal name. The F5
+              Settings tab still works, but users kept looking for the cog
+              here to rename / manage a terminal, so give it back a visible
+              affordance in the breadcrumb. */}
+          <Link
+            href={`/p/${p.slug}/settings`}
+            aria-label="Terminal settings"
+            title="Terminal settings"
+            className="text-text-3 transition-colors hover:text-text-0"
+          >
+            <Settings className="h-3.5 w-3.5" />
+          </Link>
           <span className="ml-auto flex items-center gap-3">
             <TerminalPresence
               terminalId={p.id}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -117,6 +117,21 @@ export default async function DashboardPage({ searchParams }: Props) {
       ? params.focus
       : null;
 
+  // When a terminal focus filter is active, label the Tasks card header with
+  // its "Space → Terminal" context instead of the generic "Tasks", so it's
+  // obvious what the filtered list is scoped to.
+  const focusTerminal = focusTerminalId
+    ? terminals.find((t) => t.id === focusTerminalId)
+    : null;
+  const focusSpace = focusTerminal
+    ? spaces.find((s) => s.id === focusTerminal.space_id)
+    : null;
+  const tasksScopeLabel = focusTerminal
+    ? focusSpace
+      ? `${focusSpace.name} → ${focusTerminal.name}`
+      : focusTerminal.name
+    : null;
+
   // Week card filter state. URL is the source of truth so deep links
   // and browser-back work for free.
   const weekRange: WeekRange =
@@ -177,6 +192,7 @@ export default async function DashboardPage({ searchParams }: Props) {
             terminalNameById={terminalNameById}
             createDisabled={terminals.length === 0}
             scopeTerminalId={focusTerminalId}
+            scopeLabel={tasksScopeLabel}
           />
         </Suspense>
       }

--- a/apps/web/src/components/TaskListToolbar.tsx
+++ b/apps/web/src/components/TaskListToolbar.tsx
@@ -84,12 +84,17 @@ export function TaskListToolbar({
           box lines up header-for-header with Schedule and Messages. The
           list controls live in the compact strip below (row 2). */}
       <div className="flex h-[var(--rk-card-header-h)] flex-shrink-0 items-center justify-between border-b border-border px-3">
-        <div className="flex items-center gap-2">
+        <div className="flex min-w-0 items-center gap-2">
           {handle}
-          <h2 className="text-xs font-semibold uppercase tracking-wide text-text-2">
+          <h2
+            title={title}
+            className="truncate text-xs font-semibold uppercase tracking-wide text-text-2"
+          >
             {title}
           </h2>
-          <span className="font-mono text-2xs text-text-3">{count}</span>
+          <span className="flex-shrink-0 font-mono text-2xs text-text-3">
+            {count}
+          </span>
         </div>
         <div className="flex items-center gap-2">
           {minimize}

--- a/apps/web/src/components/TasksPane.tsx
+++ b/apps/web/src/components/TasksPane.tsx
@@ -106,6 +106,10 @@ function hideDoneStorageKey(projectId: string): string {
   return `rokki_tasks_hide_done:${projectId}`;
 }
 
+function starredOnlyStorageKey(projectId: string): string {
+  return `rokki_tasks_starred_only:${projectId}`;
+}
+
 function collapsedGroupsStorageKey(projectId: string): string {
   return `rokki_tasks_collapsed_groups:${projectId}`;
 }
@@ -254,6 +258,30 @@ export function TasksPane({ ticker, projectId, currentUserId }: TasksPaneProps) 
       /* ignore */
     }
   }, [projectId, hideDone]);
+
+  // Hydrate + persist the starred-only filter per project — it was the one
+  // filter that reset on every reload (sort, group, hide-done all persisted).
+  useEffect(() => {
+    try {
+      const saved = window.localStorage.getItem(
+        starredOnlyStorageKey(projectId),
+      );
+      if (saved === "1") setStarredOnly(true);
+    } catch {
+      /* ignore */
+    }
+  }, [projectId]);
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(
+        starredOnlyStorageKey(projectId),
+        starredOnly ? "1" : "0",
+      );
+    } catch {
+      /* ignore */
+    }
+  }, [projectId, starredOnly]);
 
   // Hydrate + persist collapsed-group state per project.
   useEffect(() => {
@@ -847,11 +875,25 @@ export function TasksPane({ ticker, projectId, currentUserId }: TasksPaneProps) 
 
   const commentTask = tasks.find((t) => t.id === commentTaskId) ?? null;
 
+  // The visible list after hide-done → starred-only → text filter. Hoisted out
+  // of the render body so the toolbar count reflects what's actually shown
+  // (it used to read tasks.length — the unfiltered total — so the header said
+  // "47" while the list showed 3).
+  const visibleTasks = useMemo(() => {
+    const afterDone = hideDone
+      ? tasks.filter((t) => t.status !== "done")
+      : tasks;
+    const afterStar = starredOnly
+      ? afterDone.filter((t) => t.starred)
+      : afterDone;
+    return filterTasks(afterStar, query, ticker);
+  }, [tasks, hideDone, starredOnly, query, ticker]);
+
   return (
     <div className="flex h-full">
       <div className="flex h-full flex-1 flex-col">
       <TaskListToolbar
-        count={tasks.length}
+        count={visibleTasks.length}
         sortMode={sortMode}
         onSortMode={setSortMode}
         groupMode={groupMode}
@@ -890,15 +932,9 @@ export function TasksPane({ ticker, projectId, currentUserId }: TasksPaneProps) 
             // bucket semantics — disable it when grouped OR filtered to
             // avoid a confusing "drag worked but the row didn't move"
             // UX.
-            // Hide-done step runs before the search filter so the "X
-            // tasks match" count reflects only what's visible.
-            const visibleSource = hideDone
-              ? tasks.filter((t) => t.status !== "done")
-              : tasks;
-            const starScoped = starredOnly
-              ? visibleSource.filter((t) => t.starred)
-              : visibleSource;
-            const filtered = filterTasks(starScoped, query, ticker);
+            // Same visible list the toolbar count is derived from
+            // (hide-done → starred-only → text filter), computed once above.
+            const filtered = visibleTasks;
             const dragEnabled =
               sortMode === "manual" && groupMode === "none" && !query.trim();
             const groups = groupTasks(filtered, groupMode);

--- a/apps/web/src/components/dashboard/TasksCard.tsx
+++ b/apps/web/src/components/dashboard/TasksCard.tsx
@@ -59,6 +59,11 @@ interface TasksCardProps {
   /** Disable the create button (e.g. user has zero terminals). */
   createDisabled?: boolean;
   /**
+   * Scope label for the header ("Space → Terminal") when a dashboard focus
+   * filter is active. Falls back to the generic "Tasks" title when null.
+   */
+  scopeLabel?: string | null;
+  /**
    * When true, render every visible task (no ROW_LIMIT truncation,
    * no "X more" footer). The card body scrolls inside whatever
    * height the parent gives it — meant for full-page views like
@@ -97,6 +102,7 @@ export function TasksCard({
   terminalNameById,
   createHref = "/?new=task",
   createDisabled,
+  scopeLabel,
   expanded = false,
 }: TasksCardProps) {
   // The cap is gone. Zack: "I could just keep on scrolling through
@@ -282,6 +288,7 @@ export function TasksCard({
     // byte-for-byte the same interface as the in-terminal TasksPane.
     <section className="flex h-full min-h-0 flex-col overflow-hidden rounded-[var(--rk-card-radius)] border border-border-strong bg-bg-1 shadow-sm">
       <TaskListToolbar
+        title={scopeLabel ?? undefined}
         count={visibleAssigned.length}
         sortMode={sortMode}
         onSortMode={setSortMode}

--- a/apps/web/src/components/dashboard/TasksCardServer.tsx
+++ b/apps/web/src/components/dashboard/TasksCardServer.tsx
@@ -16,6 +16,11 @@ interface Props {
    * `TasksCard`. Null/undefined = no filter (show everything).
    */
   scopeTerminalId?: string | null;
+  /**
+   * Human label for the active scope ("Space → Terminal"), shown in the card
+   * header when a focus filter is active. Null = generic "Tasks" header.
+   */
+  scopeLabel?: string | null;
 }
 
 /**
@@ -41,6 +46,7 @@ export async function TasksCardServer({
   terminalNameById,
   createDisabled,
   scopeTerminalId,
+  scopeLabel,
 }: Props) {
   const supabase = await createClient();
   const [assignedRaw, delegatedRaw] = await Promise.all([
@@ -60,6 +66,7 @@ export async function TasksCardServer({
       tickerById={tickerById}
       terminalNameById={terminalNameById}
       createDisabled={createDisabled}
+      scopeLabel={scopeLabel}
     />
   );
 }


### PR DESCRIPTION
Three reported issues, all in the Tasks/terminal UI:

1. **Dashboard task header** — when you focus-filter tasks by a terminal, the header showed a generic "Tasks". Now shows **"Space → Terminal"**. Computed at the page level (where spaces + terminals + focus are all available) and passed down as one `scopeLabel`; the shared toolbar title truncates long labels so the count/controls stay put.
2. **Terminal settings unreachable** — the settings page + rename control work fine, but the discoverable **gear icon was removed** (commit 57f0918) in favour of an F5 tab users couldn't find. Restored a Settings gear in the terminal breadcrumb → `/p/<slug>/settings`.
3. **Tasks filtered count wrong** — the in-terminal header showed `tasks.length` (unfiltered total) while the list rendered the hide-done/starred/search-filtered subset, so the count didn't match what you saw ("not sure if it's working"). Hoisted the visible list into a `useMemo` and count that. Also **persisted the starred-only filter** per terminal (it was the one filter that reset on reload).

Note: in-terminal Auto/Manual sort both work (Auto = server triage sort via refetch; Manual = drag-reorder via the `position` column). Dashboard Manual stays disabled by design — manual order is per-terminal and the dashboard spans terminals.

## Test plan
- `tsc --noEmit` + eslint clean on all 6 files; dev server compiles with no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)