### PR TITLE
perf(messages): coalesce realtime refetch storms + ratelimit XFF note

### DIFF
--- a/apps/web/src/components/dashboard/MessagesCard.tsx
+++ b/apps/web/src/components/dashboard/MessagesCard.tsx
@@ -28,6 +28,7 @@ import {
 import { DashboardCard } from "./DashboardCard";
 import { cn } from "@/lib/utils";
 import { useRealtimeTable } from "@/lib/supabase/realtime";
+import { useCoalescedCallback } from "@/lib/use-coalesced-callback";
 import { PresenceDot } from "../presence/PresenceDot";
 import { uploadSignalMedia } from "@/lib/signal/upload";
 import {
@@ -152,17 +153,23 @@ export function MessagesCard() {
     void load();
   }, [load]);
 
+  // Coalesce realtime-driven reloads: three tables each fire on every insert/
+  // update (Signal delivery + read receipts alone are a burst per message), and
+  // each used to run a full inbox refetch. One trailing refetch per quiet window
+  // instead — still authoritative, just not a storm.
+  const scheduleLoad = useCoalescedCallback(() => void load(), 250);
+
   useRealtimeTable<{ id: string }>(
     { table: "messages", channelKey: "dash:messages" },
-    { onInsert: () => void load() },
+    { onInsert: scheduleLoad },
   );
   useRealtimeTable<{ id: string }>(
     { table: "message_threads", channelKey: "dash:threads" },
-    { onInsert: () => void load(), onUpdate: () => void load() },
+    { onInsert: scheduleLoad, onUpdate: scheduleLoad },
   );
   useRealtimeTable<{ id: string }>(
     { table: "signal_messages", channelKey: "dash:sigmsgs" },
-    { onInsert: () => void load(), onUpdate: () => void load() },
+    { onInsert: scheduleLoad, onUpdate: scheduleLoad },
   );
 
   // Signal-only: every conversation goes through Signal, so the inbox shows
@@ -591,13 +598,17 @@ function ThreadQuickView({
     [],
   );
 
+  // The open conversation gets an UPDATE per delivery/read receipt on top of
+  // real messages — coalesce so a receipt burst is one refetch, not one each.
+  // 200ms keeps newly-arrived messages feeling instant.
+  const scheduleLoad = useCoalescedCallback(() => void load(), 200);
   useRealtimeTable<{ id: string }>(
     {
       table: isSignal ? "signal_messages" : "messages",
       filter: `thread_id=eq.${thread.id}`,
       channelKey: `dashqv:${thread.id}`,
     },
-    { onInsert: () => void load(), onUpdate: () => void load() },
+    { onInsert: scheduleLoad, onUpdate: scheduleLoad },
   );
 
   // ── attachments (Signal only) ──────────────────────────────────────────────

--- a/apps/web/src/components/messages/MessagesInbox.tsx
+++ b/apps/web/src/components/messages/MessagesInbox.tsx
@@ -15,6 +15,7 @@ import {
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useRealtimeTable } from "@/lib/supabase/realtime";
+import { useCoalescedCallback } from "@/lib/use-coalesced-callback";
 import { createClient } from "@/lib/supabase/client";
 import { SignalThreadView } from "./SignalThreadView";
 import { SignalContactPicker } from "./SignalContactPicker";
@@ -172,6 +173,15 @@ export function MessagesInbox() {
     if (activeId && !activeIsSignal) void loadMessages(activeId);
   }, [activeId, activeIsSignal, loadMessages]);
 
+  // Coalesce realtime-driven reloads so a burst of inserts/updates (e.g. a
+  // sync backfill or receipt storm) collapses into one refetch instead of one
+  // per event. Both stay authoritative full reloads — no incremental-patch
+  // desync risk.
+  const scheduleActiveMessages = useCoalescedCallback(() => {
+    if (activeId && !activeIsSignal) void loadMessages(activeId);
+  }, 200);
+  const scheduleThreads = useCoalescedCallback(() => void loadThreads(), 250);
+
   // Realtime: any message insert under the active (native) thread appends in
   // place. Signal threads have their own realtime inside SignalThreadView.
   useRealtimeTable<{ id: string; thread_id: string }>(
@@ -183,8 +193,8 @@ export function MessagesInbox() {
     },
     {
       onInsert: () => {
-        if (activeId && !activeIsSignal) void loadMessages(activeId);
-        void loadThreads();
+        scheduleActiveMessages();
+        scheduleThreads();
       },
     },
   );
@@ -195,8 +205,8 @@ export function MessagesInbox() {
       channelKey: "msg:threads",
     },
     {
-      onInsert: () => void loadThreads(),
-      onUpdate: () => void loadThreads(),
+      onInsert: scheduleThreads,
+      onUpdate: scheduleThreads,
     },
   );
 

--- a/apps/web/src/lib/ratelimit.ts
+++ b/apps/web/src/lib/ratelimit.ts
@@ -67,7 +67,14 @@ export async function rateLimitCheck(opts: CheckOpts): Promise<RateLimitResult> 
  * will usually be the IP.
  */
 export function rateLimitToken(request: Request, extra?: string): string {
+  // On Vercel (our host) this is NOT client-spoofable: Vercel's edge OVERWRITES
+  // x-forwarded-for with the real client IP and drops any client-supplied value
+  // (https://vercel.com/docs/headers/request-headers), so the leftmost entry is
+  // trusted. Prefer x-real-ip (Vercel-set, single value) and fall back to the
+  // first x-forwarded-for entry. If we ever move off Vercel behind an untrusted
+  // proxy, revisit — the leftmost XFF entry would then be attacker-controlled.
+  const realIp = request.headers.get("x-real-ip")?.trim();
   const fwd = request.headers.get("x-forwarded-for") ?? "";
-  const ip = fwd.split(",")[0]?.trim() || "unknown";
+  const ip = realIp || fwd.split(",")[0]?.trim() || "unknown";
   return extra ? `${ip}:${extra}` : ip;
 }

--- a/apps/web/src/lib/use-coalesced-callback.ts
+++ b/apps/web/src/lib/use-coalesced-callback.ts
@@ -1,0 +1,36 @@
+import { useCallback, useEffect, useRef } from "react";
+
+/**
+ * Wrap a callback so a burst of calls collapses into a single trailing
+ * invocation after `delayMs` of quiet.
+ *
+ * Built for realtime-event refetch storms: Signal delivery/read receipts fire
+ * many rapid UPDATEs, and each one used to trigger a full conversation/inbox
+ * refetch. Coalescing keeps the refetch authoritative (we still re-pull the
+ * whole list — no risk of an incremental-patch desync) while cutting N refetches
+ * down to one. The returned function identity is stable, so it's safe to use in
+ * effect deps and realtime handlers.
+ */
+export function useCoalescedCallback(
+  fn: () => void,
+  delayMs = 250,
+): () => void {
+  const fnRef = useRef(fn);
+  fnRef.current = fn;
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(
+    () => () => {
+      if (timer.current) clearTimeout(timer.current);
+    },
+    [],
+  );
+
+  return useCallback(() => {
+    if (timer.current) clearTimeout(timer.current);
+    timer.current = setTimeout(() => {
+      timer.current = null;
+      fnRef.current();
+    }, delayMs);
+  }, [delayMs]);
+}


### PR DESCRIPTION
The two deferred items.

## 1 · Messaging performance cluster
Every messaging realtime handler ran a **full refetch on every insert/update**. Signal delivery + read receipts fire a burst of UPDATEs per message, so three surfaces hammered the API with one full reload per event:
- Dashboard `MessagesCard` (3 table subscriptions → `load()` each event)
- `ThreadQuickView` (open conversation → full conversation refetch per receipt)
- Full-page `MessagesInbox` (`loadMessages` + `loadThreads` per event)

New `useCoalescedCallback` (trailing debounce, stable identity) routes all realtime reloads through a 200–250ms quiet window. **Still authoritative full reloads** — deliberately *not* switched to incremental patching, so there's no desync risk in a sensitive module — just one refetch per burst instead of N.

## 2 · Rate-limit XFF (deferred security item, resolved)
Researched Vercel's behavior: its edge **overwrites `x-forwarded-for`** with the real client IP and drops client-supplied values ([docs](https://vercel.com/docs/headers/request-headers)), so the leftmost entry is **not spoofable on our host** — the earlier flag was a false positive. Documented it and added an `x-real-ip` preference (belt-and-suspenders), with a note to revisit if we ever move behind an untrusted proxy. No trust-model change.

## Test plan
- `tsc --noEmit` + eslint clean.
- **All 50 messaging tests pass** (MessagesCard + messages/ suites) with the coalescing integrated.
- ⚠️ **Not browser-verified** — no dev session available and I don't enter credentials. Recommend a quick live check on sandbox (open a Signal thread, confirm messages still arrive promptly + receipts update) before this rides to prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)