### PR TITLE
fix(security): enable RLS on calendar_event_writes + migration RLS guard

### DIFF
--- a/apps/web/src/lib/migrations-rls-guard.test.ts
+++ b/apps/web/src/lib/migrations-rls-guard.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import { readdirSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+/**
+ * Static guard: every table CREATEd in a migration must also have row-level
+ * security enabled somewhere in the migration history.
+ *
+ * This exists because calendar_event_writes shipped in
+ * 20260426070000_calendar_write.sql with no `ENABLE ROW LEVEL SECURITY` and no
+ * policies — a cross-tenant read/write hole via PostgREST's default grants that
+ * the DB-backed RLS suite never caught (it only tests tables it knows about).
+ * A pure-SQL scan catches the whole class the moment a new table is added.
+ *
+ * If you intentionally add a table that must NOT have RLS (extremely rare —
+ * effectively never for a public, user-reachable table), add it to ALLOWLIST
+ * with a comment justifying why.
+ */
+
+const ALLOWLIST = new Set<string>([
+  // (empty) — no table in the schema is intentionally RLS-free.
+]);
+
+const migrationsDir = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../../../supabase/migrations",
+);
+
+function collect() {
+  const files = readdirSync(migrationsDir)
+    .filter((f) => f.endsWith(".sql"))
+    .sort();
+  const sql = files.map((f) => readFileSync(join(migrationsDir, f), "utf8")).join("\n");
+
+  const created = new Set<string>();
+  const dropped = new Set<string>();
+  const rlsEnabled = new Set<string>();
+
+  const normalize = (raw: string) => raw.replace(/"/g, "").trim().toLowerCase();
+  // optional schema qualifier, e.g. public."foo".
+  const SCHEMA = '(?:"?[a-z_][a-z0-9_]*"?\\.)?';
+
+  // CREATE TABLE [IF NOT EXISTS] <name>
+  const createRe = new RegExp(
+    `create\\s+table\\s+(?:if\\s+not\\s+exists\\s+)?${SCHEMA}"?([a-z_][a-z0-9_]*)"?`,
+    "gi",
+  );
+  for (const m of sql.matchAll(createRe)) created.add(normalize(m[1]));
+
+  const dropRe = new RegExp(
+    `drop\\s+table\\s+(?:if\\s+exists\\s+)?${SCHEMA}"?([a-z_][a-z0-9_]*)"?`,
+    "gi",
+  );
+  for (const m of sql.matchAll(dropRe)) dropped.add(normalize(m[1]));
+
+  // ALTER TABLE [ONLY] <name> ENABLE ROW LEVEL SECURITY — the name must be
+  // immediately followed (within the same statement) by ENABLE ROW LEVEL
+  // SECURITY. A statement-crossing wildcard would mis-pair distant ALTERs.
+  const rlsRe = new RegExp(
+    `alter\\s+table\\s+(?:only\\s+)?${SCHEMA}"?([a-z_][a-z0-9_]*)"?\\s+enable\\s+row\\s+level\\s+security`,
+    "gi",
+  );
+  for (const m of sql.matchAll(rlsRe)) rlsEnabled.add(normalize(m[1]));
+
+  return { files, created, dropped, rlsEnabled };
+}
+
+describe("migrations RLS coverage", () => {
+  it("has migration files to scan", () => {
+    const { files } = collect();
+    expect(files.length).toBeGreaterThan(50);
+  });
+
+  it("every created (and not-dropped) table has RLS enabled", () => {
+    const { created, dropped, rlsEnabled } = collect();
+    const missing = [...created].filter(
+      (t) => !dropped.has(t) && !rlsEnabled.has(t) && !ALLOWLIST.has(t),
+    );
+    expect(
+      missing,
+      `Tables created in migrations without ENABLE ROW LEVEL SECURITY: ${missing.join(", ")}`,
+    ).toEqual([]);
+  });
+});

--- a/supabase/migrations/20260719120000_calendar_event_writes_rls.sql
+++ b/supabase/migrations/20260719120000_calendar_event_writes_rls.sql
@@ -1,0 +1,31 @@
+-- Fix: calendar_event_writes (created in 20260426070000_calendar_write.sql)
+-- shipped WITHOUT row-level security — the only table in the schema missing it.
+--
+-- On Supabase's hosted platform the `authenticated` role holds default grants
+-- on public tables, so with RLS disabled any signed-in user could read (and
+-- write) EVERY row via PostgREST: a cross-tenant leak of other users'
+-- task <-> calendar-event mappings, provider event ids, and connection ids,
+-- plus the ability to delete/rewrite them and break another user's calendar
+-- sync de-duplication.
+--
+-- Enable RLS and scope reads to the owner of the parent calendar_connection,
+-- mirroring calendar_events (20260424040000_calendar_sync.sql). All writes to
+-- this table go through the service-role sync writer, which bypasses RLS, so
+-- no user-level INSERT/UPDATE/DELETE policy is needed (default-deny is correct
+-- and least-privilege).
+
+ALTER TABLE calendar_event_writes ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "calendar_event_writes_select" ON calendar_event_writes
+  FOR SELECT TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM calendar_connections cc
+      WHERE cc.id = calendar_event_writes.connection_id
+        AND cc.user_id = auth.uid()
+    )
+  );
+
+-- ROLLBACK:
+-- DROP POLICY "calendar_event_writes_select" ON calendar_event_writes;
+-- ALTER TABLE calendar_event_writes DISABLE ROW LEVEL SECURITY;


### PR DESCRIPTION
Found by the 100-point system-check verification workflow — the one real bug in an otherwise all-green sweep.

## The hole
`calendar_event_writes` (from `20260426070000_calendar_write.sql`) is the **only table in the schema that shipped without `ENABLE ROW LEVEL SECURITY`** and has zero policies. On Supabase's hosted platform the `authenticated` role holds default grants on public tables, so with RLS off **any signed-in user could read and write every row via PostgREST** — a cross-tenant leak of other users' task↔calendar-event mappings, provider event ids, and connection ids, plus the ability to break another user's calendar-sync de-duplication. Severity: medium (sync-bookkeeping data, not primary content, but a genuine cross-tenant boundary).

## The fix
- Enable RLS; scope `SELECT` to the owner of the parent `calendar_connection` (mirrors `calendar_events`).
- No user-level write policy — the sync writer uses the service role (bypasses RLS), so default-deny for user writes is correct and least-privilege.
- The table has **no app-code readers/writers today** (write-back feature's writer is service-role), so enabling RLS breaks nothing.

## Regression guard (why this slipped through)
The DB-backed RLS suite only tests tables it explicitly knows about, so a brand-new RLS-less table was invisible to it. Added a **static** guard test (`migrations-rls-guard.test.ts`, no DB) that scans every migration and fails if a `CREATE TABLE` lacks a matching `ENABLE ROW LEVEL SECURITY`.
- ✅ Passes with this fix.
- ✅ Flags **exactly** `calendar_event_writes` when the fix migration is removed (verified — no false positives after fixing a statement-crossing regex).

## Test plan
- `tsc` + eslint clean; guard test green in the main vitest suite.
- CI "Database migrations + RLS tests" will apply the migration to a fresh DB.

## ⚠️ Deploy note
This is a **migration** — merging to main auto-applies it to **sandbox**. Production needs the gated `deploy-prod` run (your migrate approval). Recommend bundling it with the messaging-perf promote (#382) on the next prod push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)